### PR TITLE
[SCU-1491] pi-capabilities: support skills under the pi harness

### DIFF
--- a/sculptor/frontend/src/components/TipTapConfig.ts
+++ b/sculptor/frontend/src/components/TipTapConfig.ts
@@ -338,7 +338,11 @@ export const createTipTapExtensions = ({
             suggestions: [
               // CAPABILITY-GAP: supportsFileReferences — the @-mention file/folder picker resolves path references the agent reads itself; both Claude and pi report true today, so no harness suppresses it yet. createTipTapExtensions has no taskID, so gate here (thread the capability through Editor) when a harness reports !supportsFileReferences.
               ...(workspaceID && projectID ? [createFileSuggestion(projectID, workspaceID)] : []),
-              // CAPABILITY-GAP: supportsSkills — slash-command skill picker fetches the full skill list regardless of harness; pi has no skills layer, so the items should be suppressed at the picker source when the active task's harness reports !supportsSkills.
+              // The slash-command skill picker fetches the full discover_skills
+              // list regardless of harness, and stays harness-agnostic by
+              // design: pi now supports skills (supports_skills=True), and
+              // PiAgent rewrites a picked `/name` into pi's `/skill:<name>`
+              // form, so the same picker text works for both harnesses.
               ...(workspaceID
                 ? [createSkillSuggestion({ workspaceID })]
                 : projectID

--- a/sculptor/frontend/src/components/TipTapConfig.ts
+++ b/sculptor/frontend/src/components/TipTapConfig.ts
@@ -338,11 +338,10 @@ export const createTipTapExtensions = ({
             suggestions: [
               // CAPABILITY-GAP: supportsFileReferences — the @-mention file/folder picker resolves path references the agent reads itself; both Claude and pi report true today, so no harness suppresses it yet. createTipTapExtensions has no taskID, so gate here (thread the capability through Editor) when a harness reports !supportsFileReferences.
               ...(workspaceID && projectID ? [createFileSuggestion(projectID, workspaceID)] : []),
-              // The slash-command skill picker fetches the full discover_skills
-              // list regardless of harness, and stays harness-agnostic by
-              // design: pi now supports skills (supports_skills=True), and
-              // PiAgent rewrites a picked `/name` into pi's `/skill:<name>`
-              // form, so the same picker text works for both harnesses.
+              // The slash-command skill picker is harness-agnostic: it fetches
+              // the full discover_skills list for every harness and sends a
+              // picked `/name` unchanged. PiAgent rewrites that into pi's
+              // `/skill:<name>` form, so the same picker text works for both.
               ...(workspaceID
                 ? [createSkillSuggestion({ workspaceID })]
                 : projectID

--- a/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.test.tsx
@@ -23,9 +23,7 @@ vi.mock("~/common/state/hooks/useSkills", () => ({
   useSkills: (): { skills: ReadonlyArray<SkillEntry>; isLoading: boolean; error: string | null } => mockUseSkills(),
 }));
 
-// Mock the capability hook so a test can drive the skills gate directly. No
-// shipping harness reports supports_skills=False, so the gated-off state can
-// only be exercised here (the integration test covers the supported state).
+// Mock the capability hook so a test can drive the skills gate directly.
 vi.mock("~/common/state/hooks/useTaskHelpers", () => ({
   useTaskSupportsSkills: (): boolean | undefined => mockUseTaskSupportsSkills(),
 }));
@@ -116,8 +114,6 @@ describe("SkillsPanel — render states", () => {
   });
 
   it("collapses to the unavailable empty state when the harness does not support skills", () => {
-    // REQ-TEST-4 gated-off coverage: even with skills available, a
-    // !supportsSkills harness shows no chips and the unavailable copy.
     mockUseTaskSupportsSkills.mockReturnValue(false);
     renderSkillsPanel({ skills: [customSkill(), builtinSkill()] });
     expect(document.querySelectorAll('[data-testid="SKILL_CHIP"]')).toHaveLength(0);

--- a/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.test.tsx
@@ -10,16 +10,24 @@ import type { SkillEntry } from "~/common/state/hooks/useSkills";
 
 import { SkillsPanel } from "./SkillsPanel";
 
-// `vi.mock` is hoisted to the top of the file, so the spy binding has to
-// live inside `vi.hoisted` to be available when the mock factory runs.
-const { mockUseSkills } = vi.hoisted(() => ({
+// `vi.mock` is hoisted to the top of the file, so the spy bindings have to
+// live inside `vi.hoisted` to be available when the mock factories run.
+const { mockUseSkills, mockUseTaskSupportsSkills } = vi.hoisted(() => ({
   mockUseSkills: vi.fn<() => { skills: ReadonlyArray<SkillEntry>; isLoading: boolean; error: string | null }>(),
+  mockUseTaskSupportsSkills: vi.fn<() => boolean | undefined>(),
 }));
 
 // Mock the data hook so we can drive the panel from tests without an HTTP
 // stub. The real hook is exercised separately in useSkills.test.ts.
 vi.mock("~/common/state/hooks/useSkills", () => ({
   useSkills: (): { skills: ReadonlyArray<SkillEntry>; isLoading: boolean; error: string | null } => mockUseSkills(),
+}));
+
+// Mock the capability hook so a test can drive the skills gate directly. No
+// shipping harness reports supports_skills=False, so the gated-off state can
+// only be exercised here (the integration test covers the supported state).
+vi.mock("~/common/state/hooks/useTaskHelpers", () => ({
+  useTaskSupportsSkills: (): boolean | undefined => mockUseTaskSupportsSkills(),
 }));
 
 const customSkill = (overrides: Partial<SkillEntry> = {}): SkillEntry => ({
@@ -79,6 +87,9 @@ const renderSkillsPanel = (
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default to a skills-supporting harness so the listing/search/insert tests
+  // render the skills they pass in; the gated-off test overrides this.
+  mockUseTaskSupportsSkills.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -102,6 +113,16 @@ describe("SkillsPanel — render states", () => {
     expect(screen.getByText("No skills found")).toBeInTheDocument();
     // Empty-state hint points the user at .claude/skills/.
     expect(screen.getByText((c) => c.includes(".claude/skills/"))).toBeInTheDocument();
+  });
+
+  it("collapses to the unavailable empty state when the harness does not support skills", () => {
+    // REQ-TEST-4 gated-off coverage: even with skills available, a
+    // !supportsSkills harness shows no chips and the unavailable copy.
+    mockUseTaskSupportsSkills.mockReturnValue(false);
+    renderSkillsPanel({ skills: [customSkill(), builtinSkill()] });
+    expect(document.querySelectorAll('[data-testid="SKILL_CHIP"]')).toHaveLength(0);
+    expect(screen.getByText("Skills unavailable")).toBeInTheDocument();
+    expect(screen.getByText("This harness does not support skills.")).toBeInTheDocument();
   });
 
   it("shows the no-matches empty state when search filters everything out", () => {

--- a/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.tsx
@@ -58,9 +58,11 @@ export const SkillsPanel = (): ReactElement => {
   const { workspaceID } = useWorkspacePageParams();
   const { taskID } = useImbueParams();
   const openFileViewTab = useSetAtom(openFileViewTabAtom);
-  // Pi has no skills layer: the panel collapses to an empty state
-  // so the user sees a clear signal instead of stale Claude content. `?? true`
-  // keeps existing behavior before the task has loaded.
+  // A harness that doesn't support skills collapses the panel to an empty
+  // state so the user sees a clear signal instead of stale skill content. Both
+  // shipping harnesses (Claude and pi) support skills today, so this guards
+  // against a future non-supporting harness. `?? true` keeps the panel
+  // populated before the task's capabilities have loaded.
   const canRenderSkills = useTaskSupportsSkills(taskID ?? "") ?? true;
   const skills = useMemo(() => (canRenderSkills ? rawSkills : []), [canRenderSkills, rawSkills]);
 

--- a/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/SkillsPanel.tsx
@@ -59,10 +59,9 @@ export const SkillsPanel = (): ReactElement => {
   const { taskID } = useImbueParams();
   const openFileViewTab = useSetAtom(openFileViewTabAtom);
   // A harness that doesn't support skills collapses the panel to an empty
-  // state so the user sees a clear signal instead of stale skill content. Both
-  // shipping harnesses (Claude and pi) support skills today, so this guards
-  // against a future non-supporting harness. `?? true` keeps the panel
-  // populated before the task's capabilities have loaded.
+  // state so the user sees a clear signal instead of stale skill content.
+  // `?? true` keeps the panel populated before the task's capabilities have
+  // loaded.
   const canRenderSkills = useTaskSupportsSkills(taskID ?? "") ?? true;
   const skills = useMemo(() => (canRenderSkills ? rawSkills : []), [canRenderSkills, rawSkills]);
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -198,12 +198,11 @@ def _rewrite_skill_invocation(text: str, discovered_skill_names: frozenset[str])
     (the set the slash picker offers), rewrite `/name [args]` →
     `/skill:<name> [args]`; otherwise the text is passed through untouched.
 
-    Gating on the discovered set is what keeps the rewrite safe: pseudo-skills
-    (`/clear`, `/copy`, `/btw`) are parsed frontend-side and never reach here
-    nor appear in that set, and ordinary text that merely starts with `/` is
-    left alone. A plugin-namespaced name (`<plugin>:<skill>`) is reduced to its
-    bare `<skill>` because pi registers plugin skills un-namespaced (tracked as
-    a FOLLOWUPS divergence in the tranche MR).
+    Pseudo-skills (`/clear`, `/copy`, `/btw`) are parsed frontend-side and
+    never reach here nor appear in the discovered set, so they pass through;
+    ordinary text that merely starts with `/` is left alone. A plugin-namespaced
+    name (`<plugin>:<skill>`) is reduced to its bare `<skill>` because pi
+    registers plugin skills un-namespaced.
     """
     if not text.startswith("/"):
         return text
@@ -494,9 +493,8 @@ class PiAgent(DefaultAgentWrapper):
         discovery directly. Loose `.claude/commands/*.md` files are not a shape
         pi discovers, so they are wrapped in synthesized SKILL.md dirs (see
         `_synthesize_command_skills`). Missing source dirs are skipped quietly
-        (a repo without `.claude/skills` is normal); flag order is deterministic
-        (the helper's discovery order) so `get_commands`-based debugging is
-        stable.
+        (a repo without `.claude/skills` is normal); flag order follows the
+        helper's discovery order.
         """
         sources = get_skill_source_directories(
             self.environment.get_working_directory(),

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1,12 +1,13 @@
 """PiAgent — `DefaultAgentWrapper` subclass wrapping `pi --mode rpc`.
 
 The agent spawns a long-lived `pi --mode rpc --session-dir <dir>
---session-id <id> --append-system-prompt <prompt>` subprocess and pumps
-user turns over JSONL stdin/stdout. The session flags persist the
-conversation as a JSONL file under a per-task dir and pin its id
-Sculptor-side, so relaunching after an agent-process restart resumes the
-full conversation (`supports_session_resume`). Pi's stdout multiplexes
-three channels
+--session-id <id> --append-system-prompt <prompt> [--skill <dir> ...]`
+subprocess and pumps user turns over JSONL stdin/stdout. The session flags
+persist the conversation as a JSONL file under a per-task dir and pin its id
+Sculptor-side, so relaunching after an agent-process restart resumes the full
+conversation (`supports_session_resume`). The `--skill` flags point pi at the
+workspace's Claude-visible skill sources so its skill set matches the slash
+picker's (`supports_skills`). Pi's stdout multiplexes three channels
 (`response`, `extension_ui_request`, and the `AgentSessionEvent` union);
 the dispatcher distinguishes them by top-level `type`. Pi's tool calls
 render as rich tool blocks (`supports_tool_use_rendering=True`): the
@@ -27,8 +28,11 @@ from __future__ import annotations
 import json
 import os
 import queue
+import re
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from queue import Empty
 from queue import Queue
 from threading import Event
@@ -75,6 +79,7 @@ from sculptor.agents.pi_agent.output_processor import parse_rpc_message
 from sculptor.agents.pi_agent.tool_rendering import build_tool_result_content
 from sculptor.agents.pi_agent.tool_rendering import extract_text_from_tool_payload
 from sculptor.agents.pi_agent.tool_rendering import map_pi_tool_call
+from sculptor.common.plugin import get_plugin_dirs
 from sculptor.foundation.common import generate_id
 from sculptor.foundation.secrets_utils import Secret
 from sculptor.foundation.thread_utils import ObservableThread
@@ -105,6 +110,10 @@ from sculptor.state.claude_state import get_tool_invocation_string
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import Message
 from sculptor.state.messages import ResponseBlockAgentMessage
+from sculptor.web.skills import SkillSourceKind
+from sculptor.web.skills import discover_skills
+from sculptor.web.skills import get_skill_source_directories
+from sculptor.web.skills import parse_command_frontmatter
 
 # Pi's file-mutating tools, keyed by their lowercase RPC `toolName`
 # (pi 0.78.0 `packages/coding-agent/src/core/tools/{edit,write,bash}.ts`;
@@ -173,6 +182,54 @@ class _ToolCall:
     partial_text: str = ""
 
 
+# Matches a leading slash-command token (`/name`) and captures the remainder
+# (args), DOTALL so multi-line prompts keep their tail. `\S+` lets the name
+# carry a `:` so a plugin-namespaced `/sculptor-workflow:fix-bug` is captured
+# whole before the namespace is stripped.
+_SKILL_INVOCATION_RE = re.compile(r"^/(\S+)(.*)$", re.DOTALL)
+
+
+def _rewrite_skill_invocation(text: str, discovered_skill_names: frozenset[str]) -> str:
+    """Rewrite a leading Sculptor skill invocation into pi's `/skill:<name>` shape.
+
+    The frontend stays harness-agnostic: it sends a picked skill as the same
+    `/name [args]` text it sends Claude. pi instead invokes a skill as
+    `/skill:<name>`. When `name` is one of the workspace's discovered skills
+    (the set the slash picker offers), rewrite `/name [args]` →
+    `/skill:<name> [args]`; otherwise the text is passed through untouched.
+
+    Gating on the discovered set is what keeps the rewrite safe: pseudo-skills
+    (`/clear`, `/copy`, `/btw`) are parsed frontend-side and never reach here
+    nor appear in that set, and ordinary text that merely starts with `/` is
+    left alone. A plugin-namespaced name (`<plugin>:<skill>`) is reduced to its
+    bare `<skill>` because pi registers plugin skills un-namespaced (tracked as
+    a FOLLOWUPS divergence in the tranche MR).
+    """
+    if not text.startswith("/"):
+        return text
+    match = _SKILL_INVOCATION_RE.match(text)
+    if match is None:
+        return text
+    name, rest = match.group(1), match.group(2)
+    if name not in discovered_skill_names:
+        return text
+    bare_name = name.rsplit(":", 1)[-1]
+    return f"/skill:{bare_name}{rest}"
+
+
+def _render_synthesized_skill(name: str, description: str, body: str) -> str:
+    """Render a SKILL.md that wraps a loose `.claude/commands/*.md` command.
+
+    pi only discovers skills as `SKILL.md` directories, so a loose command file
+    is wrapped in one. `name`/`description` are JSON-encoded (valid YAML flow
+    scalars) so colons, quotes, or stray characters in either can't break the
+    frontmatter; the description is flattened to one line because pi refuses to
+    load a skill whose description is missing.
+    """
+    flat_description = " ".join(description.split())
+    return f"---\nname: {json.dumps(name)}\ndescription: {json.dumps(flat_description)}\n---\n\n{body}"
+
+
 class _TurnState:
     """Per-turn streaming accumulator state.
 
@@ -221,6 +278,10 @@ class PiAgent(DefaultAgentWrapper):
     # The current escalation timer's cancel signal (one per interrupt). Set when
     # the turn ends so the grace-window thread stands down without SIGTERM.
     _escalation_cancel: Event | None = PrivateAttr(default=None)
+    # The workspace's discovered skill names (the same set the slash picker
+    # offers), captured at launch so `_run_prompt_turn` can rewrite a picked
+    # `/name` into pi's `/skill:<name>` form. Empty until `start()`.
+    _discovered_skill_names: frozenset[str] = PrivateAttr(default_factory=frozenset)
 
     def start(self, secrets: Mapping[str, str | Secret]) -> None:
         # Resolve and validate the pi binary BEFORE super().start so the
@@ -268,6 +329,12 @@ class PiAgent(DefaultAgentWrapper):
             )
 
         system_prompt = self._build_system_prompt()
+        # Point pi at the workspace's Claude-visible skill sources (--skill) and
+        # capture the picker's skill names so invocations can be rewritten to
+        # pi's /skill: shape. Both derive from the same discover_skills roots so
+        # the picker list and pi's loaded set stay in lockstep.
+        skill_args = self._build_skill_launch_args()
+        self._discovered_skill_names = self._discover_skill_names()
         # `--session-id` (Sculptor-pinned id, "creating it if missing") is the
         # resume lever, chosen over `--session <id>`: it never errors on an
         # absent/corrupt session (real pi 0.78.0 exits non-zero for an unknown
@@ -284,6 +351,7 @@ class PiAgent(DefaultAgentWrapper):
             self._session_id,
             "--append-system-prompt",
             system_prompt,
+            *skill_args,
         ]
         self._process = self.environment.run_process_in_background(
             command,
@@ -403,6 +471,87 @@ class PiAgent(DefaultAgentWrapper):
         if self.system_prompt:
             parts.append(f"<User instructions>\n{self.system_prompt.strip()}\n</User instructions>")
         return "\n\n".join(parts)
+
+    def _discover_skill_names(self) -> frozenset[str]:
+        """The workspace's discovered skill names, matching the slash picker.
+
+        Sourced from `discover_skills` (the same authority the `/api/v1/skills`
+        endpoint serves the picker), so the rewrite accepts exactly the names a
+        user can pick. The names may be plugin-namespaced (`<plugin>:<skill>`);
+        `_rewrite_skill_invocation` reduces those to bare names for pi.
+        """
+        skills = discover_skills(self.environment.get_working_directory(), get_plugin_dirs())
+        return frozenset(skill.name for skill in skills)
+
+    def _build_skill_launch_args(self) -> list[str]:
+        """Build the repeatable `--skill <path>` flags pointing pi at the
+        workspace's Claude-visible skill sources.
+
+        Sources come from `get_skill_source_directories` — the same roots
+        `discover_skills` (and so the picker) scans — resolved against this
+        agent's environment paths. SKILL.md-directory sources (repo/home
+        `.claude/skills`, plugin `skills/`) map onto pi's agentskills.io
+        discovery directly. Loose `.claude/commands/*.md` files are not a shape
+        pi discovers, so they are wrapped in synthesized SKILL.md dirs (see
+        `_synthesize_command_skills`). Missing source dirs are skipped quietly
+        (a repo without `.claude/skills` is normal); flag order is deterministic
+        (the helper's discovery order) so `get_commands`-based debugging is
+        stable.
+        """
+        sources = get_skill_source_directories(
+            self.environment.get_working_directory(),
+            plugin_dirs=get_plugin_dirs(),
+            home_path=self.environment.get_user_home_directory(),
+        )
+        args: list[str] = []
+        command_files: list[Path] = []
+        for source in sources:
+            if not source.path.is_dir():
+                continue
+            if source.kind is SkillSourceKind.SKILL_DIR:
+                args += ["--skill", str(source.path)]
+            else:
+                command_files += sorted(source.path.glob("*.md"))
+        synthesized_dir = self._synthesize_command_skills(command_files)
+        if synthesized_dir is not None:
+            args += ["--skill", str(synthesized_dir)]
+        return args
+
+    def _synthesize_command_skills(self, command_files: Sequence[Path]) -> Path | None:
+        """Wrap loose command-style `.md` files in synthesized SKILL.md dirs pi can load.
+
+        pi discovers skills only as `SKILL.md` directories, not the loose `.md`
+        command files Claude also supports (`.claude/commands/*.md`). For each
+        such file write a `<state>/pi_skills/<name>/SKILL.md` wrapper and return
+        the `pi_skills` parent to hand to a single `--skill`, or None when there
+        are no command files. The wrappers live under the per-task state dir —
+        outside the repo and outside `~/.claude` — so neither `discover_skills`
+        (the picker source) nor pi's own ancestor auto-discovery lists them a
+        second time; only the explicit `--skill` loads them. The file stem is
+        the skill name (matching `discover_skills`), the body is carried
+        through, and a description is synthesized when the command file has none
+        (pi refuses to load a skill with no description). First name wins,
+        matching `discover_skills`' cross-source precedence.
+        """
+        if not command_files:
+            return None
+        skills_root = self.environment.get_state_path() / "pi_skills"
+        seen_names: set[str] = set()
+        for command_file in command_files:
+            name = command_file.stem
+            if name in seen_names:
+                continue
+            try:
+                body = command_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                logger.debug("PiAgent skipping unreadable command file {}: {}", command_file, e)
+                continue
+            seen_names.add(name)
+            description = parse_command_frontmatter(body) or f"Project command '{name}' (from {command_file.name})."
+            skill_md = skills_root / name / "SKILL.md"
+            skill_md.parent.mkdir(parents=True, exist_ok=True)
+            skill_md.write_text(_render_synthesized_skill(name, description, body), encoding="utf-8")
+        return skills_root if seen_names else None
 
     def _collect_api_key_secrets(self) -> dict[str, Secret]:
         config = get_user_config_instance()
@@ -600,7 +749,8 @@ class PiAgent(DefaultAgentWrapper):
             self._cancel_interrupt_escalation()
             prompt_id = generate_id()
             self._turn_in_flight.set()
-            self._send_rpc({"type": "prompt", "id": prompt_id, "message": message.text})
+            prompt_text = _rewrite_skill_invocation(message.text, self._discovered_skill_names)
+            self._send_rpc({"type": "prompt", "id": prompt_id, "message": prompt_text})
             try:
                 self._consume_until_turn_end(prompt_id)
             finally:

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -1241,8 +1241,6 @@ def _drain(queue: Queue) -> list:
     return out
 
 
-# --- Typed protocol module: parse + dispatch coverage ----------------------
-
 # Wire-shape fixtures for every documented event type (RPC §5/§7/§9), lifted
 # from the protocol doc's examples. Each must parse to a typed variant whose
 # discriminator matches.
@@ -1333,8 +1331,6 @@ def test_extract_tool_call_blocks_returns_only_tool_call_blocks() -> None:
     assert blocks[0]["type"] == "toolCall"
 
 
-# --- skill-invocation rewrite (_rewrite_skill_invocation) ---
-
 _DISCOVERED = frozenset({"fix-bug", "sculptor-workflow:review", "write-release-notes"})
 
 
@@ -1378,9 +1374,6 @@ def test_rewrite_skill_invocation_handles_multiline_prompt() -> None:
 
 def test_rewrite_skill_invocation_empty_discovered_set_is_noop() -> None:
     assert _rewrite_skill_invocation("/fix-bug", frozenset()) == "/fix-bug"
-
-
-# --- launch-flag assembly (_build_skill_launch_args / _synthesize_command_skills) ---
 
 
 def _agent_with_skill_dirs(

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -24,6 +24,8 @@ import pytest
 from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_DIR_NAME
 from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_ID_STATE_FILE
 from sculptor.agents.pi_agent.agent_wrapper import PiAgent
+from sculptor.agents.pi_agent.agent_wrapper import _render_synthesized_skill
+from sculptor.agents.pi_agent.agent_wrapper import _rewrite_skill_invocation
 from sculptor.agents.pi_agent.harness import PI_HARNESS
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import ParsedUnknownEvent
@@ -1329,3 +1331,151 @@ def test_extract_tool_call_blocks_returns_only_tool_call_blocks() -> None:
     blocks = extract_tool_call_blocks(message)
     assert len(blocks) == 1
     assert blocks[0]["type"] == "toolCall"
+
+
+# --- skill-invocation rewrite (_rewrite_skill_invocation) ---
+
+_DISCOVERED = frozenset({"fix-bug", "sculptor-workflow:review", "write-release-notes"})
+
+
+def test_rewrite_skill_invocation_rewrites_a_discovered_skill() -> None:
+    assert _rewrite_skill_invocation("/fix-bug", _DISCOVERED) == "/skill:fix-bug"
+
+
+def test_rewrite_skill_invocation_preserves_arguments() -> None:
+    assert _rewrite_skill_invocation("/fix-bug the login flow", _DISCOVERED) == "/skill:fix-bug the login flow"
+
+
+def test_rewrite_skill_invocation_strips_plugin_namespace() -> None:
+    # pi registers plugin skills un-namespaced, so the <plugin>: prefix the
+    # picker shows is dropped when rewriting to pi's shape.
+    assert _rewrite_skill_invocation("/sculptor-workflow:review", _DISCOVERED) == "/skill:review"
+
+
+def test_rewrite_skill_invocation_leaves_unknown_name_untouched() -> None:
+    assert _rewrite_skill_invocation("/not-a-skill", _DISCOVERED) == "/not-a-skill"
+
+
+def test_rewrite_skill_invocation_ignores_pseudo_skills() -> None:
+    # Pseudo-skills are handled frontend-side and never appear in the discovered
+    # set, so they are never rewritten even if one reaches the prompt.
+    for pseudo in ("/clear", "/copy", "/btw why is the sky blue"):
+        assert _rewrite_skill_invocation(pseudo, _DISCOVERED) == pseudo
+
+
+def test_rewrite_skill_invocation_leaves_plain_slash_text_untouched() -> None:
+    # A leading slash that is not a discovered skill name (e.g. a path) passes through.
+    assert _rewrite_skill_invocation("/usr/local/bin matters", _DISCOVERED) == "/usr/local/bin matters"
+
+
+def test_rewrite_skill_invocation_leaves_non_slash_text_untouched() -> None:
+    assert _rewrite_skill_invocation("fix-bug please", _DISCOVERED) == "fix-bug please"
+
+
+def test_rewrite_skill_invocation_handles_multiline_prompt() -> None:
+    assert _rewrite_skill_invocation("/fix-bug\nextra context", _DISCOVERED) == "/skill:fix-bug\nextra context"
+
+
+def test_rewrite_skill_invocation_empty_discovered_set_is_noop() -> None:
+    assert _rewrite_skill_invocation("/fix-bug", frozenset()) == "/fix-bug"
+
+
+# --- launch-flag assembly (_build_skill_launch_args / _synthesize_command_skills) ---
+
+
+def _agent_with_skill_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    working_dir: Path,
+    home_dir: Path,
+    state_dir: Path,
+    plugin_dirs: list[Path],
+) -> PiAgent:
+    env = MagicMock(spec=AgentExecutionEnvironment)
+    env.get_working_directory.return_value = working_dir
+    env.get_user_home_directory.return_value = home_dir
+    env.get_state_path.return_value = state_dir
+    # Patch where it's looked up: agent_wrapper imports get_plugin_dirs at module level.
+    monkeypatch.setattr("sculptor.agents.pi_agent.agent_wrapper.get_plugin_dirs", lambda: plugin_dirs)
+    return _make_agent(environment=env)
+
+
+def _write_skill(skills_dir: Path, name: str) -> None:
+    skill_md = skills_dir / name / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text(f"---\nname: {name}\ndescription: {name} skill\n---\nBody\n")
+
+
+def test_build_skill_launch_args_passes_existing_skill_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    _write_skill(repo / ".claude" / "skills", "fix-bug")
+    _write_skill(home / ".claude" / "skills", "deploy")
+    agent = _agent_with_skill_dirs(monkeypatch, repo, home, tmp_path / "state", plugin_dirs=[])
+
+    args = agent._build_skill_launch_args()
+
+    # Repo skills dir precedes home skills dir (discovery order); the absent
+    # .claude/commands dirs are skipped quietly.
+    assert args == [
+        "--skill",
+        str(repo / ".claude" / "skills"),
+        "--skill",
+        str(home / ".claude" / "skills"),
+    ]
+
+
+def test_build_skill_launch_args_puts_plugin_skills_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    plugin = tmp_path / "plugin"
+    _write_skill(plugin / "skills", "help")
+    _write_skill(repo / ".claude" / "skills", "fix-bug")
+    agent = _agent_with_skill_dirs(monkeypatch, repo, home, tmp_path / "state", plugin_dirs=[plugin])
+
+    args = agent._build_skill_launch_args()
+
+    assert args[:2] == ["--skill", str(plugin / "skills")]
+    assert args[2:] == ["--skill", str(repo / ".claude" / "skills")]
+
+
+def test_build_skill_launch_args_no_sources_is_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    agent = _agent_with_skill_dirs(
+        monkeypatch, tmp_path / "repo", tmp_path / "home", tmp_path / "state", plugin_dirs=[]
+    )
+    assert agent._build_skill_launch_args() == []
+
+
+def test_build_skill_launch_args_synthesizes_loose_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    state = tmp_path / "state"
+    commands_dir = repo / ".claude" / "commands"
+    commands_dir.mkdir(parents=True)
+    (commands_dir / "fix-style.md").write_text("---\ndescription: Fix style issues\n---\nDo the thing.\n")
+    (commands_dir / "no-frontmatter.md").write_text("Just a body.\n")
+    agent = _agent_with_skill_dirs(monkeypatch, repo, home, state, plugin_dirs=[])
+
+    args = agent._build_skill_launch_args()
+
+    # The synthesized wrapper dir is passed as a single --skill, under the state
+    # dir (not under .claude), so discover_skills never lists it a second time.
+    synthesized_root = state / "pi_skills"
+    assert args == ["--skill", str(synthesized_root)]
+    # Each loose command becomes a SKILL.md directory named after the file stem.
+    fix_style = (synthesized_root / "fix-style" / "SKILL.md").read_text()
+    assert "Do the thing." in fix_style
+    assert '"fix-style"' in fix_style
+    assert '"Fix style issues"' in fix_style
+    # A command with no frontmatter still loads — a description is synthesized
+    # (pi refuses a skill with none).
+    no_fm = (synthesized_root / "no-frontmatter" / "SKILL.md").read_text()
+    assert "Just a body." in no_fm
+    assert "no-frontmatter" in no_fm
+
+
+def test_render_synthesized_skill_escapes_frontmatter() -> None:
+    # Colons / newlines in the description must not break the YAML frontmatter.
+    rendered = _render_synthesized_skill("my-cmd", "Does X: then\nY", "Body text")
+    assert '\nname: "my-cmd"\n' in rendered
+    assert '\ndescription: "Does X: then Y"\n' in rendered
+    assert rendered.endswith("Body text")

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -6,8 +6,11 @@ sub-agents, no compaction. It DOES render tool calls
 Sculptor's harness-agnostic tool blocks (see `agent_wrapper` / `tool_rendering`).
 Session resume IS supported — pi persists a per-task JSONL session
 (`--session-dir`/`--session-id`) that a relaunched process resumes (see
-`agent_wrapper.PiAgent`). The `capabilities()` override is the truthful
-declaration that consumers gate on.
+`agent_wrapper.PiAgent`). Skills ARE supported — pi is pointed at the
+workspace's skill directories via `--skill` flags and follows an invoked skill
+(see `agent_wrapper._build_skill_launch_args` / `_rewrite_skill_invocation`).
+The `capabilities()` override is the truthful declaration that consumers gate
+on.
 
 Agent construction is owned by the registry
 (`harness_registry.create_agent_for_run`), not this module, so the pi
@@ -58,7 +61,11 @@ class PiHarness(Harness):
     def capabilities(self) -> HarnessCapabilities:
         return HarnessCapabilities(
             supports_interactive_backchannel=False,
-            supports_skills=False,
+            # Pi reads the workspace's Claude-visible skills via repeatable
+            # --skill flags (agent_wrapper._build_skill_launch_args), enumerates
+            # them through its own skills layer, and follows a picked skill
+            # rewritten to /skill:<name> (agent_wrapper._rewrite_skill_invocation).
+            supports_skills=True,
             supports_sub_agents=False,
             supports_image_input=False,
             supports_fast_mode=False,

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -10,7 +10,7 @@ def test_pi_harness_capabilities() -> None:
     # pi-side mechanism for it (see PiHarness.capabilities for the per-flag why).
     assert PI_HARNESS.capabilities() == HarnessCapabilities(
         supports_interactive_backchannel=False,
-        supports_skills=False,
+        supports_skills=True,
         supports_sub_agents=False,
         supports_image_input=False,
         supports_fast_mode=False,

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -76,6 +76,19 @@ _COMMAND_REGEX = re.compile(r"fake_pi:\S+(?:\s+`[^`]*`)?")
 
 _DEFAULT_RESPONSE_TEXT = "[FakePi] Task completed."
 
+# A prompt rewritten to pi's skill-invocation shape (`/skill:<name> [args]`).
+# When such a prompt carries no `fake_pi:` directive, FakePi echoes that it
+# "followed" the skill so tests can assert PiAgent rewrote a picked `/name`
+# into `/skill:<name>` (FakePi only ever sees the already-rewritten text).
+_SKILL_INVOCATION_REGEX = re.compile(r"^/skill:(\S+)")
+_SKILL_FOLLOWED_PREFIX = "[FakePi] followed skill: "
+
+
+def _skill_invocation_name(prompt_text: str) -> str | None:
+    """Return the skill name if ``prompt_text`` is a ``/skill:<name>`` invocation."""
+    match = _SKILL_INVOCATION_REGEX.match(prompt_text.strip())
+    return match.group(1) if match else None
+
 
 class UnknownFakePiCommandError(ValueError):
     """Raised when an unknown ``fake_pi:`` directive is encountered."""
@@ -117,6 +130,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--session-dir", default=None)
     parser.add_argument("--session-id", default=None)
     parser.add_argument("--append-system-prompt", default="")
+    # PiAgent passes the workspace's skill source dirs as repeatable --skill
+    # flags. Parse them first-class (rather than swallowing them into _extra) so
+    # tests can assert which paths were handed to pi.
+    parser.add_argument("--skill", action="append", default=[], dest="skill")
     parsed, _extra = parser.parse_known_args(argv)
     return parsed
 
@@ -509,8 +526,10 @@ def _run_turn(
         state.record_turn(prompt_text)
         return
     if not builder.has_text:
-        _emit_text_delta(_DEFAULT_RESPONSE_TEXT, _DEFAULT_RESPONSE_TEXT)
-        builder.emit(_DEFAULT_RESPONSE_TEXT)
+        skill_name = _skill_invocation_name(prompt_text)
+        fallback = f"{_SKILL_FOLLOWED_PREFIX}{skill_name}" if skill_name is not None else _DEFAULT_RESPONSE_TEXT
+        _emit_text_delta(fallback, fallback)
+        builder.emit(fallback)
     full_text = builder.full_text
     _emit_message_end(full_text)
     _emit_agent_end(full_text)

--- a/sculptor/sculptor/testing/fake_pi_test.py
+++ b/sculptor/sculptor/testing/fake_pi_test.py
@@ -30,6 +30,7 @@ from sculptor.agents.pi_agent.output_processor import ParsedMessageEnd
 from sculptor.agents.pi_agent.output_processor import ParsedMessageUpdate
 from sculptor.agents.pi_agent.output_processor import RpcResponse
 from sculptor.services.dependency_management_service import PI_VERSION_RANGE
+from sculptor.testing.fake_pi import _parse_args
 from sculptor.testing.fake_pi import install_fake_pi_binary
 
 _FAKE_PI_MODULE = "sculptor.testing.fake_pi"
@@ -235,6 +236,40 @@ def test_fake_pi_rpc_default_response_when_no_directives_present() -> None:
     assert "FakePi" in update.assistant_message_event.get("delta", "")
     ParsedMessageEnd.model_validate(_by_type(events, "message_end")[-1])
     ParsedAgentEnd.model_validate(_by_type(events, "agent_end")[0])
+
+
+def test_fake_pi_parses_repeatable_skill_flags() -> None:
+    # PiAgent hands pi the workspace's skill dirs as repeatable --skill flags;
+    # FakePi parses them first-class so tests can assert what was passed.
+    parsed = _parse_args(
+        ["--mode", "rpc", "--no-session", "--append-system-prompt", "", "--skill", "/a/skills", "--skill", "/b/skills"]
+    )
+    assert parsed.skill == ["/a/skills", "/b/skills"]
+
+
+def test_fake_pi_accepts_skill_flags_and_runs_a_turn() -> None:
+    result = _run_fake_pi(
+        ["--mode", "rpc", "--no-session", "--append-system-prompt", "", "--skill", "/some/skills"],
+        stdin_input=_send_prompt("hello"),
+    )
+    assert result.returncode == 0
+    events = _parse_jsonl(result.stdout)
+    RpcResponse.model_validate(events[0])
+    ParsedAgentEnd.model_validate(_by_type(events, "agent_end")[0])
+
+
+def test_fake_pi_echoes_followed_skill_for_skill_invocation() -> None:
+    # A prompt already rewritten to pi's /skill:<name> shape (with no fake_pi:
+    # directive) makes FakePi echo that it "followed" the skill, so an
+    # integration test can assert PiAgent rewrote a picked /name into /skill:.
+    result = _run_fake_pi(
+        ["--mode", "rpc", "--no-session", "--append-system-prompt", ""],
+        stdin_input=_send_prompt("/skill:fix-bug the login flow"),
+    )
+    assert result.returncode == 0
+    events = _parse_jsonl(result.stdout)
+    update = _first_update(events)
+    assert "followed skill: fix-bug" in update.assistant_message_event.get("delta", "")
 
 
 def test_fake_pi_rpc_directives_in_system_prompt_drive_turn() -> None:

--- a/sculptor/sculptor/web/skills.py
+++ b/sculptor/sculptor/web/skills.py
@@ -72,7 +72,7 @@ def parse_command_frontmatter(content: str) -> str | None:
     Commands use a simpler format than skills: the filename is the command name,
     and the frontmatter may optionally contain a description field. Public
     because the pi agent reuses it when wrapping loose commands in synthesized
-    SKILL.md files, keeping the description consistent with the picker's.
+    SKILL.md files.
     """
     if not content.startswith("---"):
         return None

--- a/sculptor/sculptor/web/skills.py
+++ b/sculptor/sculptor/web/skills.py
@@ -7,8 +7,10 @@ and the user's home directory (~/.claude).
 
 import json
 from collections.abc import Sequence
+from enum import Enum
 from pathlib import Path
 from typing import Literal
+from typing import NamedTuple
 
 import yaml
 from loguru import logger
@@ -64,11 +66,13 @@ def _parse_skill_frontmatter(content: str) -> tuple[str | None, str | None]:
     return name, description
 
 
-def _parse_command_frontmatter(content: str) -> str | None:
+def parse_command_frontmatter(content: str) -> str | None:
     """Extract description from a command markdown file's YAML frontmatter.
 
     Commands use a simpler format than skills: the filename is the command name,
-    and the frontmatter may optionally contain a description field.
+    and the frontmatter may optionally contain a description field. Public
+    because the pi agent reuses it when wrapping loose commands in synthesized
+    SKILL.md files, keeping the description consistent with the picker's.
     """
     if not content.startswith("---"):
         return None
@@ -144,16 +148,72 @@ def _scan_commands_directory(commands_dir: Path, source: Literal["custom", "plug
             logger.debug("Failed to read {}: {}", command_file, e)
             continue
         name = command_file.stem
-        description = _parse_command_frontmatter(content) or ""
+        description = parse_command_frontmatter(content) or ""
         skills.append(SkillInfo(name=name, description=description, source=source, file_path=str(command_file)))
 
     return skills
 
 
+class SkillSourceKind(Enum):
+    """Layout of a skill-source directory, so callers read it correctly.
+
+    ``SKILL_DIR`` holds ``<name>/SKILL.md`` subdirectories (the agentskills.io
+    standard). ``COMMAND_FILES`` holds loose ``<name>.md`` command files with no
+    ``SKILL.md`` — Claude's legacy command format.
+    """
+
+    SKILL_DIR = "skill_dir"
+    COMMAND_FILES = "command_files"
+
+
+class SkillSourceDirectory(NamedTuple):
+    """One directory Sculptor looks in for skills, plus how to read it.
+
+    ``namespace`` is the plugin-name prefix applied to discovered skill names
+    (plugin sources only); ``None`` for repo/home sources.
+    """
+
+    path: Path
+    kind: SkillSourceKind
+    namespace: str | None
+
+
+def get_skill_source_directories(
+    repo_path: Path,
+    plugin_dirs: Sequence[Path] = (),
+    home_path: Path | None = None,
+) -> list[SkillSourceDirectory]:
+    """Return every skill/command source directory, in discovery order.
+
+    The single source of truth for *where* Sculptor looks for skills:
+    ``discover_skills`` scans exactly these directories (in this order,
+    first-name-wins), and the pi agent points pi at the same directories via
+    ``--skill`` so the slash-picker list and pi's loaded skill set stay in
+    lockstep. Directories are returned whether or not they exist on disk;
+    callers that act on them (scan, or hand to a subprocess) should skip the
+    missing ones.
+
+    ``home_path`` overrides ``Path.home()`` for the user-global sources, so the
+    pi agent can pass its environment's home and have the paths resolve inside
+    that environment.
+    """
+    home = Path.home() if home_path is None else home_path
+    directories: list[SkillSourceDirectory] = []
+    for plugin_dir in plugin_dirs:
+        directories.append(
+            SkillSourceDirectory(plugin_dir / "skills", SkillSourceKind.SKILL_DIR, _get_plugin_namespace(plugin_dir))
+        )
+    directories.append(SkillSourceDirectory(repo_path / ".claude" / "skills", SkillSourceKind.SKILL_DIR, None))
+    directories.append(SkillSourceDirectory(repo_path / ".claude" / "commands", SkillSourceKind.COMMAND_FILES, None))
+    directories.append(SkillSourceDirectory(home / ".claude" / "skills", SkillSourceKind.SKILL_DIR, None))
+    directories.append(SkillSourceDirectory(home / ".claude" / "commands", SkillSourceKind.COMMAND_FILES, None))
+    return directories
+
+
 def discover_skills(repo_path: Path, plugin_dirs: Sequence[Path] = ()) -> list[SkillInfo]:
     """Discover all skills and commands from the plugins, repo, and home directory.
 
-    Searches these locations in order:
+    Searches the directories from ``get_skill_source_directories`` in order:
     0. <plugin>/skills/          (plugin skills, namespaced with the
                                   plugin's name from .claude-plugin/plugin.json)
     1. <repo>/.claude/skills/    (directory-based, SKILL.md)
@@ -169,32 +229,29 @@ def discover_skills(repo_path: Path, plugin_dirs: Sequence[Path] = ()) -> list[S
     seen_names: set[str] = set()
     all_skills: list[SkillInfo] = []
 
-    for plugin_dir in plugin_dirs:
-        namespace = _get_plugin_namespace(plugin_dir)
-        for skill in _scan_skills_directory(plugin_dir / "skills", source="plugin"):
-            namespaced = SkillInfo(
-                name=f"{namespace}:{skill.name}",
-                description=skill.description,
-                source=skill.source,
-                file_path=skill.file_path,
+    for source in get_skill_source_directories(repo_path, plugin_dirs):
+        if source.kind is SkillSourceKind.SKILL_DIR:
+            scanned = _scan_skills_directory(
+                source.path, source="plugin" if source.namespace is not None else "custom"
             )
-            if namespaced.name in seen_names:
+        else:
+            scanned = _scan_commands_directory(source.path)
+        for skill in scanned:
+            name = f"{source.namespace}:{skill.name}" if source.namespace is not None else skill.name
+            if name in seen_names:
                 continue
-            seen_names.add(namespaced.name)
-            all_skills.append(namespaced)
-
-    search_paths = [
-        (repo_path / ".claude" / "skills", _scan_skills_directory),
-        (repo_path / ".claude" / "commands", _scan_commands_directory),
-        (Path.home() / ".claude" / "skills", _scan_skills_directory),
-        (Path.home() / ".claude" / "commands", _scan_commands_directory),
-    ]
-
-    for directory, scanner in search_paths:
-        for skill in scanner(directory):
-            if skill.name not in seen_names:
-                seen_names.add(skill.name)
+            seen_names.add(name)
+            if source.namespace is None:
                 all_skills.append(skill)
+            else:
+                all_skills.append(
+                    SkillInfo(
+                        name=name,
+                        description=skill.description,
+                        source=skill.source,
+                        file_path=skill.file_path,
+                    )
+                )
 
     all_skills.sort(key=lambda s: s.name)
     return all_skills

--- a/sculptor/sculptor/web/skills_test.py
+++ b/sculptor/sculptor/web/skills_test.py
@@ -18,8 +18,6 @@ from sculptor.web.skills import discover_skills
 from sculptor.web.skills import get_skill_source_directories
 from sculptor.web.skills import parse_command_frontmatter
 
-# --- _parse_skill_frontmatter tests ---
-
 
 def test_parse_skill_frontmatter_extracts_name_and_description() -> None:
     content = "---\nname: fix-bug\ndescription: Fix a bug using TDD\n---\nBody content\n"
@@ -84,9 +82,6 @@ def test_parse_skill_frontmatter_drops_non_str_description() -> None:
     assert description is None
 
 
-# --- _parse_command_frontmatter tests ---
-
-
 def test_parse_command_frontmatter_extracts_description() -> None:
     content = "---\ndescription: Identify style issues\n---\nBody content\n"
     description = parse_command_frontmatter(content)
@@ -121,9 +116,6 @@ def test_parse_command_frontmatter_returns_none_for_non_dict_yaml() -> None:
     content = "---\n- a list\n---\n"
     description = parse_command_frontmatter(content)
     assert description is None
-
-
-# --- _scan_skills_directory tests ---
 
 
 def test_scan_skills_directory_finds_valid_skills(tmp_path: Path) -> None:
@@ -218,9 +210,6 @@ def test_scan_skills_directory_uses_empty_description_when_missing(tmp_path: Pat
     assert result == [SkillInfo(name="no-desc", description="", source="custom", file_path=str(skill / "SKILL.md"))]
 
 
-# --- _scan_commands_directory tests ---
-
-
 def test_scan_commands_directory_finds_markdown_commands(tmp_path: Path) -> None:
     commands_dir = tmp_path / ".claude" / "commands"
     commands_dir.mkdir(parents=True)
@@ -280,9 +269,6 @@ def test_scan_commands_directory_ignores_subdirectories(tmp_path: Path) -> None:
 def test_scan_commands_directory_returns_empty_for_missing_directory(tmp_path: Path) -> None:
     result = _scan_commands_directory(tmp_path / "nonexistent")
     assert result == []
-
-
-# --- discover_skills tests ---
 
 
 def test_discover_skills_combines_skills_and_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -486,9 +472,6 @@ def test_discover_skills_plugin_does_not_shadow_unprefixed_repo_skill(
     result = discover_skills(repo_dir, plugin_dirs=[plugin_dir])
     names = sorted(s.name for s in result)
     assert names == ["fix-bug", "sculptor:fix-bug"]
-
-
-# --- get_skill_source_directories tests ---
 
 
 def test_get_skill_source_directories_lists_repo_and_home_in_order() -> None:

--- a/sculptor/sculptor/web/skills_test.py
+++ b/sculptor/sculptor/web/skills_test.py
@@ -10,11 +10,13 @@ from pathlib import Path
 import pytest
 
 from sculptor.web.data_types import SkillInfo
-from sculptor.web.skills import _parse_command_frontmatter
+from sculptor.web.skills import SkillSourceKind
 from sculptor.web.skills import _parse_skill_frontmatter
 from sculptor.web.skills import _scan_commands_directory
 from sculptor.web.skills import _scan_skills_directory
 from sculptor.web.skills import discover_skills
+from sculptor.web.skills import get_skill_source_directories
+from sculptor.web.skills import parse_command_frontmatter
 
 # --- _parse_skill_frontmatter tests ---
 
@@ -87,37 +89,37 @@ def test_parse_skill_frontmatter_drops_non_str_description() -> None:
 
 def test_parse_command_frontmatter_extracts_description() -> None:
     content = "---\ndescription: Identify style issues\n---\nBody content\n"
-    description = _parse_command_frontmatter(content)
+    description = parse_command_frontmatter(content)
     assert description == "Identify style issues"
 
 
 def test_parse_command_frontmatter_strips_multiline_description() -> None:
     content = "---\ndescription: |\n  Fix ratchet violations\n  in the codebase.\n---\nBody\n"
-    description = _parse_command_frontmatter(content)
+    description = parse_command_frontmatter(content)
     assert description == "Fix ratchet violations\nin the codebase."
 
 
 def test_parse_command_frontmatter_returns_none_without_frontmatter() -> None:
     content = "Just a markdown file\n"
-    description = _parse_command_frontmatter(content)
+    description = parse_command_frontmatter(content)
     assert description is None
 
 
 def test_parse_command_frontmatter_returns_none_without_description() -> None:
     content = "---\nargument-hint: <file>\n---\nBody\n"
-    description = _parse_command_frontmatter(content)
+    description = parse_command_frontmatter(content)
     assert description is None
 
 
 def test_parse_command_frontmatter_returns_none_for_invalid_yaml() -> None:
     content = "---\n: bad: yaml: [[\n---\n"
-    description = _parse_command_frontmatter(content)
+    description = parse_command_frontmatter(content)
     assert description is None
 
 
 def test_parse_command_frontmatter_returns_none_for_non_dict_yaml() -> None:
     content = "---\n- a list\n---\n"
-    description = _parse_command_frontmatter(content)
+    description = parse_command_frontmatter(content)
     assert description is None
 
 
@@ -484,6 +486,53 @@ def test_discover_skills_plugin_does_not_shadow_unprefixed_repo_skill(
     result = discover_skills(repo_dir, plugin_dirs=[plugin_dir])
     names = sorted(s.name for s in result)
     assert names == ["fix-bug", "sculptor:fix-bug"]
+
+
+# --- get_skill_source_directories tests ---
+
+
+def test_get_skill_source_directories_lists_repo_and_home_in_order() -> None:
+    """The repo/home sources appear in discover order with the right kinds."""
+    repo = Path("/repo")
+    home = Path("/home/dev")
+    result = get_skill_source_directories(repo, home_path=home)
+    assert result == [
+        (repo / ".claude" / "skills", SkillSourceKind.SKILL_DIR, None),
+        (repo / ".claude" / "commands", SkillSourceKind.COMMAND_FILES, None),
+        (home / ".claude" / "skills", SkillSourceKind.SKILL_DIR, None),
+        (home / ".claude" / "commands", SkillSourceKind.COMMAND_FILES, None),
+    ]
+
+
+def test_get_skill_source_directories_puts_plugins_first_with_namespace(tmp_path: Path) -> None:
+    """Plugin `skills/` dirs come first, tagged SKILL_DIR with the plugin namespace."""
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin_json(plugin_dir, "sculptor")
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+
+    result = get_skill_source_directories(repo, plugin_dirs=[plugin_dir], home_path=home)
+
+    assert result[0] == (plugin_dir / "skills", SkillSourceKind.SKILL_DIR, "sculptor")
+    # The repo/home sources follow the plugin source.
+    assert [s.path for s in result[1:]] == [
+        repo / ".claude" / "skills",
+        repo / ".claude" / "commands",
+        home / ".claude" / "skills",
+        home / ".claude" / "commands",
+    ]
+
+
+def test_get_skill_source_directories_defaults_home_to_path_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Omitting home_path falls back to Path.home() (matches discover_skills)."""
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    result = get_skill_source_directories(tmp_path / "repo")
+    home_sources = [s.path for s in result if str(s.path).startswith(str(fake_home))]
+    assert home_sources == [fake_home / ".claude" / "skills", fake_home / ".claude" / "commands"]
 
 
 def test_discover_skills_namespaces_multiple_plugins_separately(

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -202,8 +202,7 @@ def test_chat_remains_usable_when_uploads_gated(
 
 def _create_skill_in_directory(project_path: Path, skill_name: str, description: str) -> None:
     """Commit a custom skill to the project's .claude/skills/ so the workspace
-    clone (and pi's --skill flags) include it. Mirrors the helper in
-    test_skills_panel.py / test_skill_autocomplete.py."""
+    clone (and pi's --skill flags) include it."""
     skill_dir = project_path / ".claude" / "skills" / skill_name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: {description}\n---\nInstructions.\n")
@@ -218,10 +217,8 @@ def test_skills_panel_and_picker_list_skills(sculptor_instance_: SculptorInstanc
     list the workspace's skills under pi exactly as under Claude (the picker is
     harness-agnostic; PiAgent rewrites a picked /name into pi's /skill:<name>).
 
-    This is the flipped gate-state test: it previously asserted the panel was
-    empty under pi. The gated-off (supports_skills=False) state is now covered
-    at the component level by SkillsPanel.test.tsx, since no shipping harness
-    reports False."""
+    The gated-off (supports_skills=False) state is covered at the component
+    level by SkillsPanel.test.tsx, since no shipping harness reports False."""
     skill_name = "skills-gate-custom"
     _create_skill_in_directory(sculptor_instance_.project_path, skill_name, "Skill for the pi skills gate test")
 

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -11,6 +11,7 @@ renders under Claude" baseline; the pi branch is the "this affordance is
 suppressed by the harness gate" claim.
 """
 
+import subprocess
 import tempfile
 import uuid
 from pathlib import Path
@@ -20,6 +21,7 @@ from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
 from sculptor.interfaces.agents.agent import HarnessName
+from sculptor.testing.elements.base import type_trigger_char
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.task_starter import FAKE_CLAUDE_MODEL_NAME
 from sculptor.testing.fake_pi import install_fake_pi_binary
@@ -28,6 +30,7 @@ from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
+from sculptor.testing.utils import get_playwright_modifier_key
 from tests.integration.frontend.conftest import HarnessTestConfig  # noqa: F401
 
 # Mirror of the frontend's CAPABILITY_UNSUPPORTED_COPY (components/useCapabilityGate.ts).
@@ -197,15 +200,59 @@ def test_chat_remains_usable_when_uploads_gated(
     expect(sculptor_instance_.page.get_by_test_id(ElementIDs.FILE_UPLOAD)).to_be_attached()
 
 
+def _create_skill_in_directory(project_path: Path, skill_name: str, description: str) -> None:
+    """Commit a custom skill to the project's .claude/skills/ so the workspace
+    clone (and pi's --skill flags) include it. Mirrors the helper in
+    test_skills_panel.py / test_skill_autocomplete.py."""
+    skill_dir = project_path / ".claude" / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: {description}\n---\nInstructions.\n")
+    subprocess.run(["git", "add", str(skill_dir)], cwd=project_path, check=True)
+    subprocess.run(["git", "commit", "-m", f"Add skill {skill_name}"], cwd=project_path, check=True)
+
+
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to render the skills panel empty under harnesses without skills support")
-def test_skills_panel_empty_under_pi(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
-    _create_workspace_for_harness(sculptor_instance_, harness, "Skills Panel Gate")
-    # SkillChip count is 0 under pi regardless of the panel's visibility.
-    # Under Claude the panel may or may not contain user-defined skills in
-    # this test repo, so the Claude branch is left unasserted.
-    if harness.workspace_harness == HarnessName.PI:
-        expect(sculptor_instance_.page.get_by_test_id(ElementIDs.SKILL_CHIP)).to_have_count(0)
+@user_story("to browse and pick the workspace's skills under any skills-supporting harness, including pi")
+def test_skills_panel_and_picker_list_skills(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
+    """Pi reports supports_skills=True, so the skills panel and the slash picker
+    list the workspace's skills under pi exactly as under Claude (the picker is
+    harness-agnostic; PiAgent rewrites a picked /name into pi's /skill:<name>).
+
+    This is the flipped gate-state test: it previously asserted the panel was
+    empty under pi. The gated-off (supports_skills=False) state is now covered
+    at the component level by SkillsPanel.test.tsx, since no shipping harness
+    reports False."""
+    skill_name = "skills-gate-custom"
+    _create_skill_in_directory(sculptor_instance_.project_path, skill_name, "Skill for the pi skills gate test")
+
+    task_page = _create_workspace_for_harness(sculptor_instance_, harness, "Skills Panel Gate")
+
+    # The side panel lists the seeded skill (this is the surface that reads the
+    # supports_skills flag) for both Claude and pi.
+    skills_panel = task_page.open_skills_panel()
+    expect(skills_panel.get_skill_chip(skill_name)).to_be_visible()
+
+    # The slash picker also surfaces it. The picker fetches the same
+    # discover_skills list for every harness; on slow CI the workspace clone's
+    # skills may not be discovered yet, so retry the trigger.
+    page = sculptor_instance_.page
+    chat_input = task_page.get_chat_panel().get_chat_input()
+    mention_list = page.get_by_test_id(ElementIDs.MENTION_LIST)
+    mod_key = get_playwright_modifier_key()
+    for attempt in range(5):
+        type_trigger_char(chat_input, "/")
+        chat_input.press_sequentially(skill_name)
+        try:
+            expect(mention_list).to_be_visible(timeout=10_000)
+            expect(mention_list).to_contain_text(skill_name, timeout=5_000)
+            break
+        except AssertionError:
+            if attempt == 4:
+                raise
+            page.keyboard.press("Escape")
+            page.keyboard.press(f"{mod_key}+a")
+            page.keyboard.press("Backspace")
+            page.wait_for_timeout(200)
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)

--- a/sculptor/tests/integration/real_pi/test_skills.py
+++ b/sculptor/tests/integration/real_pi/test_skills.py
@@ -8,12 +8,6 @@ the reply. This exercises the whole supports_skills mechanism — ``--skill``
 launch flags (``agent_wrapper._build_skill_launch_args``), the slash-picker
 list, and the ``/name`` → ``/skill:<name>`` rewrite
 (``agent_wrapper._rewrite_skill_invocation``).
-
-REQ-TEST-1 counterpart: the real_claude suite has no skills test (Claude's own
-skill layer is exercised by the deterministic fake-claude integration tests,
-e.g. test_skills_panel.py / test_skill_autocomplete.py). This real_pi test is
-the first cross-harness end-to-end skills check; the divergence is that there
-is no symmetric real_claude/test_skills.py to mirror.
 """
 
 import subprocess
@@ -30,8 +24,7 @@ from tests.integration.real_pi.helpers import RESPONSE_TIMEOUT_MS
 from tests.integration.real_pi.helpers import real_pi
 
 # A fixed sentinel the skill tells pi to emit. Narrow skill description +
-# explicit body so progressive disclosure can't auto-fire the skill un-invoked
-# (the supports_skills gotcha).
+# explicit body so progressive disclosure can't auto-fire the skill un-invoked.
 _SENTINEL = "SKILL-OK-73194"
 _SKILL_NAME = "pi-skills-sentinel"
 _SKILL_DESCRIPTION = "Internal Sculptor integration-test sentinel; only run when explicitly invoked by name."

--- a/sculptor/tests/integration/real_pi/test_skills.py
+++ b/sculptor/tests/integration/real_pi/test_skills.py
@@ -1,0 +1,82 @@
+"""Real pi integration test: skills end-to-end.
+
+Seeds a custom skill into the workspace's ``.claude/skills/``, invokes it
+through the slash-picker path (the SkillsPanel chip), and verifies the real
+``pi --mode rpc`` subprocess + real upstream model *follows the SKILL.md*:
+the skill instructs pi to emit a sentinel string, and we assert it appears in
+the reply. This exercises the whole supports_skills mechanism — ``--skill``
+launch flags (``agent_wrapper._build_skill_launch_args``), the slash-picker
+list, and the ``/name`` → ``/skill:<name>`` rewrite
+(``agent_wrapper._rewrite_skill_invocation``).
+
+REQ-TEST-1 counterpart: the real_claude suite has no skills test (Claude's own
+skill layer is exercised by the deterministic fake-claude integration tests,
+e.g. test_skills_panel.py / test_skill_autocomplete.py). This real_pi test is
+the first cross-harness end-to-end skills check; the divergence is that there
+is no symmetric real_claude/test_skills.py to mirror.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.interfaces.agents.agent import HarnessName
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import RESPONSE_TIMEOUT_MS
+from tests.integration.real_pi.helpers import real_pi
+
+# A fixed sentinel the skill tells pi to emit. Narrow skill description +
+# explicit body so progressive disclosure can't auto-fire the skill un-invoked
+# (the supports_skills gotcha).
+_SENTINEL = "SKILL-OK-73194"
+_SKILL_NAME = "pi-skills-sentinel"
+_SKILL_DESCRIPTION = "Internal Sculptor integration-test sentinel; only run when explicitly invoked by name."
+_SKILL_BODY = f"When this skill is invoked, reply with exactly the text {_SENTINEL} and nothing else."
+
+
+def _commit_sentinel_skill(project_path: Path) -> None:
+    """Commit the sentinel skill to .claude/skills/ so the workspace checkout
+    (and pi's --skill flags) include it."""
+    skill_dir = project_path / ".claude" / "skills" / _SKILL_NAME
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {_SKILL_NAME}\ndescription: {_SKILL_DESCRIPTION}\n---\n{_SKILL_BODY}\n"
+    )
+    subprocess.run(["git", "add", str(skill_dir)], cwd=project_path, check=True)
+    subprocess.run(["git", "commit", "-m", f"Add skill {_SKILL_NAME}"], cwd=project_path, check=True)
+
+
+@real_pi
+@pytest.mark.timeout(300)
+def test_pi_follows_invoked_skill(sculptor_instance_: SculptorInstance) -> None:
+    """A skill picked from the SkillsPanel is followed by real pi end-to-end."""
+    _commit_sentinel_skill(sculptor_instance_.project_path)
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=sculptor_instance_.page,
+        workspace_name="Real Pi Skills",
+        model_name=None,
+        harness=HarnessName.PI,
+    )
+
+    # Invoke via the picker path: open the SkillsPanel and click the skill chip,
+    # which inserts a `/pi-skills-sentinel` mention into the editor. PiAgent
+    # rewrites the leading `/name` to pi's `/skill:<name>` form before sending.
+    skills_panel = task_page.open_skills_panel()
+    chip = skills_panel.get_skill_chip(_SKILL_NAME)
+    expect(chip).to_be_visible(timeout=30_000)
+    chip.click()
+
+    chat_panel = task_page.get_chat_panel()
+    expect(chat_panel.get_mention_spans()).to_contain_text(_SKILL_NAME)
+    send_button = chat_panel.get_send_button()
+    expect(send_button).to_be_enabled()
+    send_button.click()
+
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=RESPONSE_TIMEOUT_MS)
+    expect(chat_panel.get_assistant_messages().last).to_contain_text(_SENTINEL)
+    expect(chat_panel.get_error_block()).to_have_count(0)


### PR DESCRIPTION
## Summary

Enable **skills** for the `pi` harness. A pi workspace now discovers and runs the same skill set a Claude workspace shows — the slash picker and the skills panel list the workspace's skills, and invoking one causes pi to follow that skill. The `supports_skills` capability flips `True` for pi.

This is Sculptor-side only; the pi binary is not modified.

## How it works

- **`web/skills.py`** gains `get_skill_source_directories()` — the single source of truth for *where* skills live (plugin `skills/`, repo `.claude/skills`, repo `.claude/commands`, and the user-global equivalents under `~/.claude`). `discover_skills` (the authority behind the `/api/v1/skills` picker endpoint) is refactored onto it so the picker list and pi's loaded set stay in lockstep. Discovery behavior is unchanged (covered by the existing tests).
- **`PiAgent`** points pi at those directories with repeatable `--skill` launch flags:
  - `SKILL.md`-directory skills map onto pi's agentskills.io discovery directly.
  - Loose `.claude/commands/*.md` files are not a shape pi discovers, so each is wrapped in a synthesized `SKILL.md` directory under the per-task state dir, and that directory is passed via `--skill`. Because it lives outside `.claude`/`~/.claude`, the picker never lists it twice and a Claude workspace never sees it.
- **Invoking a skill** stays harness-agnostic on the frontend: a picked skill arrives as the same `/name [args]` text Claude receives. `PiAgent` rewrites a leading `/name` into pi's `/skill:<name>` form when `name` is a discovered skill — pseudo-skills (`/clear`, `/copy`, `/btw`) and ordinary slash text are left untouched.

## Known divergences

- **Plugin skills are un-namespaced in pi.** The picker shows a plugin skill as `sculptor-workflow:fix-bug`; pi registers the bare `skill:fix-bug`. The invocation rewrite strips the `<plugin>:` prefix so picking it works. This is fine while no two picker entries share a bare name; giving pi per-namespace skill identities is a sensible follow-up.
- **pi adds its own skill sources.** pi also auto-discovers its native skill locations (`~/.agents/skills`, `~/.pi/agent/skills`, …). Those extra skills appearing under pi is acceptable surplus, not a parity loss.

## Testing

- `just check` (lint, typecheck, ratchets, file-hygiene) — green
- `just test-unit` (backend + frontend) — green
- Integration (fake-pi) `test_pi_capability_gating.py` — the skills panel and slash picker list a seeded workspace skill under pi (18 passed)
- `just test-real-pi` — green: `real_pi/test_skills.py` seeds a sentinel skill, invokes it through the picker path, and the real pi model follows it; the basic-flow, file-edit, and session-resume real-pi tests pass too. (The skills test needed one rerun: an unrelated, pre-existing flake in pi-version parsing — pi's `--version` stderr can interleave a Bun CPU-feature warning whose embedded version is picked up instead of pi's — intermittently raises a version mismatch before the agent starts. Worth a follow-up to anchor the version parse on pi's own line; out of scope here.)
- `just test-real-claude` — could not run in this environment: it aborts at workspace-onboarding setup (`OnboardingWizard is showing instead of the expected app element`), a pre-existing test-harness env prerequisite unrelated to this change (it never reaches Claude). The only Claude-facing code here is the behavior-preserving `discover_skills` refactor, covered by its unit tests, the frontend unit tests, and the Claude branch of the gating integration test.

(Sent by Claude)
