### PR TITLE
Reduce GitHub GraphQL rate-limit pressure in PR status polling

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/PrButton.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/PrButton.tsx
@@ -17,7 +17,13 @@ import { PrPromptDialog } from "./PrPromptDialog.tsx";
 
 export type GitProvider = "gitlab" | "github" | null;
 
-export type PrErrorCategory = "cli_missing" | "not_authenticated" | "no_access" | "network_error" | "transient";
+export type PrErrorCategory =
+  | "cli_missing"
+  | "not_authenticated"
+  | "no_access"
+  | "network_error"
+  | "rate_limited"
+  | "transient";
 
 export type EffectiveError = {
   category: PrErrorCategory;
@@ -77,6 +83,18 @@ const ERROR_CONTENT: Record<string, Record<string, ErrorContent>> = {
     github: {
       title: "Can't connect to GitHub",
       description: "DNS resolution failed. Check your network connection.",
+      command: null,
+    },
+  },
+  rate_limited: {
+    gitlab: {
+      title: "Rate limited by GitLab",
+      description: "Too many API requests. Status updates are paused and will resume automatically.",
+      command: null,
+    },
+    github: {
+      title: "Rate limited by GitHub",
+      description: "Too many API requests. Status updates are paused and will resume automatically.",
       command: null,
     },
   },

--- a/sculptor/sculptor/web/cli_status_utils.py
+++ b/sculptor/sculptor/web/cli_status_utils.py
@@ -14,9 +14,13 @@ from imbue_core.processes.local_process import run_blocking
 from imbue_core.subprocess_utils import FinishedProcess
 from imbue_core.subprocess_utils import ProcessSetupError
 
-CliErrorCategory = Literal["not_authenticated", "no_access", "network_error", "transient"]
+CliErrorCategory = Literal["not_authenticated", "no_access", "network_error", "rate_limited", "transient"]
 
-PERMANENT_CLI_ERRORS = frozenset({"not_authenticated", "no_access", "network_error"})
+# Errors we never retry immediately. The first three are permanent (a retry
+# would fail the same way); ``rate_limited`` is temporary but a retry would
+# only deepen the throttling, so the poller backs off via a host-level
+# cooldown instead (see PrPollingService).
+NON_RETRYABLE_CLI_ERRORS = frozenset({"not_authenticated", "no_access", "network_error", "rate_limited"})
 
 _CLI_COMMAND_TIMEOUT = 30.0
 
@@ -36,6 +40,13 @@ def classify_cli_error(stderr: str) -> CliErrorCategory:
     works for both providers.
     """
     lower = stderr.lower()
+    # Rate limits are checked first: GitHub returns them as an HTTP 403 ("API
+    # rate limit exceeded") and the secondary-limit message mentions neither
+    # "auth" nor a bare status code, so without this they'd be misclassified
+    # as "no_access" (permanent, shown to the user as an access problem) when
+    # they are really a temporary throttle to wait out.
+    if any(keyword in lower for keyword in ("rate limit", "ratelimit", "secondary rate")):
+        return "rate_limited"
     if any(
         keyword in lower
         for keyword in ("auth", "not logged into", "not logged", "log in", "authentication", "token", "401")
@@ -76,7 +87,7 @@ def run_cli_with_retry(cmd: list[str], working_dir: Path) -> FinishedProcess:
         raise CliStatusError("transient", f"CLI process failed to start: {e}") from e
     if result.returncode != 0:
         category = classify_cli_error(result.stderr)
-        if category in PERMANENT_CLI_ERRORS:
+        if category in NON_RETRYABLE_CLI_ERRORS:
             logger.debug("{} command failed ({}), not retrying: {}", cmd[0], category, result.stderr.strip())
             return result
         logger.debug("{} command failed ({}), retrying: {}", cmd[0], category, result.stderr.strip())

--- a/sculptor/sculptor/web/cli_status_utils_test.py
+++ b/sculptor/sculptor/web/cli_status_utils_test.py
@@ -67,6 +67,31 @@ def test_classify_cli_error_dns_keyword_returns_network_error() -> None:
     assert classify_cli_error("DNS lookup failed for api.github.com") == "network_error"
 
 
+# --- classify_cli_error: rate_limited ---
+
+
+def test_classify_cli_error_primary_rate_limit_returns_rate_limited() -> None:
+    """GitHub's primary GraphQL limit comes back as HTTP 403 'API rate limit exceeded'."""
+    assert classify_cli_error("HTTP 403: API rate limit exceeded for user ID 12345") == "rate_limited"
+
+
+def test_classify_cli_error_graphql_rate_limit_returns_rate_limited() -> None:
+    assert classify_cli_error("GraphQL: API rate limit exceeded (repository.pullRequests)") == "rate_limited"
+
+
+def test_classify_cli_error_secondary_rate_limit_returns_rate_limited() -> None:
+    assert classify_cli_error("You have exceeded a secondary rate limit. Please wait a few minutes.") == "rate_limited"
+
+
+def test_classify_cli_error_ratelimit_header_returns_rate_limited() -> None:
+    assert classify_cli_error("x-ratelimit-remaining: 0") == "rate_limited"
+
+
+def test_classify_cli_error_rate_limit_takes_priority_over_403() -> None:
+    """A rate-limit 403 must classify as rate_limited, not no_access."""
+    assert classify_cli_error("HTTP 403 Forbidden: API rate limit exceeded") == "rate_limited"
+
+
 # --- classify_cli_error: transient ---
 
 

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -81,9 +81,9 @@ class PrStatusInfo(SerializableModel):
     pipeline_updated_at: str | None = None
     approvals: list[PrApproval] = Field(default_factory=list)
     unresolved_comments: list[PrComment] = Field(default_factory=list)
-    error_category: Literal["cli_missing", "not_authenticated", "no_access", "network_error", "transient"] | None = (
-        None
-    )
+    error_category: (
+        Literal["cli_missing", "not_authenticated", "no_access", "network_error", "rate_limited", "transient"] | None
+    ) = None
     error_provider: Literal["gitlab", "github"] | None = None
     error_message: str | None = None
     mismatched_pr_iid: int | None = None

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -60,20 +60,93 @@ _DISABLED_RECHECK_SECONDS = 60.0
 # very low and the closed multiplier to 1, we never schedule polls closer
 # together than this. Matches the UI's minimum.
 _MIN_POLL_INTERVAL_SECONDS = 10.0
+# Minimum spacing between the *start* of any two API-backed polls, enforced
+# globally across the whole worker pool. GitHub's GraphQL guidance is to avoid
+# concurrent requests; staggering poll starts keeps the workers from firing
+# gh/glab simultaneously and smooths bursts under the per-minute limit. The
+# ``gh``/``glab`` commands we run are GraphQL-backed, so each poll spends real
+# GraphQL points — spacing them is what keeps a fleet of workspaces under the
+# hourly budget.
+_GLOBAL_MIN_POLL_SPACING_SECONDS = 1.5
+# How long to suppress all polls for a provider after it returns a rate-limit
+# error. The next poll re-checks and re-applies the cooldown if the host is
+# still throttling, so this is a probe interval rather than a guess at the
+# exact reset time.
+_RATE_LIMIT_COOLDOWN_SECONDS = 60.0
+# Terminal PR states (merged/closed) never change again, so poll them rarely
+# even while the workspace is open.
+_TERMINAL_STATE_MULTIPLIER = 10
 
 
-def _compute_poll_delay(config: UserConfig, *, is_open: bool) -> float:
+def _compute_poll_delay(config: UserConfig, *, is_open: bool, pr_state: str) -> float:
     """Compute the next-poll delay for a workspace from the user's settings.
 
     Closed workspaces get ``pr_poll_interval_seconds * pr_poll_closed_multiplier``.
-    Both factors are read from ``UserConfig`` per call so the new delay is
-    picked up on the very next poll cycle after a settings change.
+    Terminal PRs (merged/closed) back off by ``_TERMINAL_STATE_MULTIPLIER``
+    regardless of whether the workspace is open, since their status can't
+    change. The largest applicable multiplier wins. All factors are read from
+    ``UserConfig`` per call so a new delay is picked up on the very next poll
+    cycle after a settings change.
     """
     base = max(float(config.pr_poll_interval_seconds), _MIN_POLL_INTERVAL_SECONDS)
-    if is_open:
-        return base
-    multiplier = max(1, config.pr_poll_closed_multiplier)
+    multiplier = 1.0
+    if not is_open:
+        multiplier = max(multiplier, float(max(1, config.pr_poll_closed_multiplier)))
+    if pr_state in ("merged", "closed"):
+        multiplier = max(multiplier, float(_TERMINAL_STATE_MULTIPLIER))
     return base * multiplier
+
+
+class _CooldownDeferred:
+    """Sentinel result meaning a poll was skipped because its provider is in
+    rate-limit cooldown. Carries how long to wait before trying again so the
+    worker can re-enqueue without touching the cache or hitting the API."""
+
+    __slots__ = ("retry_after",)
+
+    def __init__(self, retry_after: float) -> None:
+        self.retry_after = retry_after
+
+
+class _HostThrottle:
+    """Thread-safe, process-global throttle shared by all poll workers.
+
+    GitHub's GraphQL rate limit is per authenticated user — one budget shared
+    across every workspace and repo — so throttling has to be global, not
+    per-workspace. Two responsibilities:
+
+    - **Spacing**: ``reserve_slot`` hands out start times at least
+      ``min_interval`` apart, so concurrent workers stagger their gh/glab
+      calls instead of firing them at once.
+    - **Cooldown**: when a provider returns a rate-limit error,
+      ``enter_cooldown`` suppresses every poll for that provider until the
+      cooldown expires (queried via ``cooldown_remaining``).
+    """
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = min_interval
+        self._lock = threading.Lock()
+        self._next_allowed_start = 0.0
+        self._cooldown_until: dict[str, float] = {}
+
+    def cooldown_remaining(self, provider: str) -> float:
+        with self._lock:
+            return max(0.0, self._cooldown_until.get(provider, 0.0) - time.monotonic())
+
+    def enter_cooldown(self, provider: str, seconds: float) -> None:
+        with self._lock:
+            until = time.monotonic() + seconds
+            # Extend an existing cooldown, never shorten it.
+            if until > self._cooldown_until.get(provider, 0.0):
+                self._cooldown_until[provider] = until
+
+    def reserve_slot(self) -> float:
+        """Reserve the next global spacing slot; return seconds to wait before starting."""
+        with self._lock:
+            now = time.monotonic()
+            start = max(now, self._next_allowed_start)
+            self._next_allowed_start = start + self._min_interval
+            return start - now
 
 
 @dataclass(frozen=True)
@@ -203,6 +276,10 @@ class PrPollingService(Service):
     _worker_sleep_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
     _gh_available: bool | None = PrivateAttr(default=None)
     _glab_available: bool | None = PrivateAttr(default=None)
+    # Process-global throttle/cooldown shared by every worker. The gh/glab
+    # commands are GraphQL-backed and the rate limit is per-user, so spacing
+    # and cooldown must be coordinated across the whole pool, not per workspace.
+    _throttle: _HostThrottle = PrivateAttr(default_factory=lambda: _HostThrottle(_GLOBAL_MIN_POLL_SPACING_SECONDS))
 
     def __init__(
         self,
@@ -495,6 +572,13 @@ class PrPollingService(Service):
         if state.is_deleted:
             return
 
+        # Provider is in rate-limit cooldown — the poll was skipped without
+        # hitting the API. Leave the cached status untouched and retry once
+        # the cooldown expires.
+        if isinstance(result, _CooldownDeferred):
+            self._enqueue(job.workspace_id, delay=max(result.retry_after, _MIN_POLL_INTERVAL_SECONDS))
+            return
+
         # None means workspace wasn't ready (no working_dir yet) — retry soon.
         if result is None:
             self._enqueue(job.workspace_id, delay=_NOT_READY_RETRY_SECONDS)
@@ -509,7 +593,13 @@ class PrPollingService(Service):
                 for queue in self._observers:
                     queue.put(result)
 
-        self._enqueue(job.workspace_id, delay=_compute_poll_delay(config, is_open=state.is_open))
+        if result.error_category == "rate_limited" and result.error_provider is not None:
+            # A host cooldown was just set for this provider — wait it out
+            # rather than re-polling at the base interval.
+            delay = max(self._throttle.cooldown_remaining(result.error_provider), _MIN_POLL_INTERVAL_SECONDS)
+        else:
+            delay = _compute_poll_delay(config, is_open=state.is_open, pr_state=result.pr_state)
+        self._enqueue(job.workspace_id, delay=delay)
 
     def _wake_sleepiest_worker(self, delay: float) -> None:
         """Wake the worker sleeping the longest, but only if the new job is more urgent.
@@ -533,7 +623,9 @@ class PrPollingService(Service):
         with self._pending_lock:
             self._pending.discard(workspace_id)
 
-    def _execute_poll(self, workspace_id: WorkspaceID, state: _WorkspacePollState) -> PrStatusInfo | None:
+    def _execute_poll(
+        self, workspace_id: WorkspaceID, state: _WorkspacePollState
+    ) -> PrStatusInfo | _CooldownDeferred | None:
         try:
             status = self._fetch_status(workspace_id, state)
             state.first_failure = None
@@ -554,7 +646,33 @@ class PrPollingService(Service):
             )
             return None
 
-    def _fetch_status(self, workspace_id: WorkspaceID, state: _WorkspacePollState) -> PrStatusInfo | None:
+    def _respect_throttle(self, provider: str) -> _CooldownDeferred | None:
+        """Apply the global throttle before an API-backed poll.
+
+        Returns a ``_CooldownDeferred`` if ``provider`` is currently in
+        rate-limit cooldown — the caller should skip the poll (making no API
+        call) and re-enqueue. Otherwise reserves a global spacing slot and
+        waits until it's due (an interruptible wait so ``stop()`` wakes it
+        immediately), then returns None to signal "go ahead".
+        """
+        remaining = self._throttle.cooldown_remaining(provider)
+        if remaining > 0:
+            logger.trace("PR poll: {} in rate-limit cooldown, deferring {:.1f}s", provider, remaining)
+            return _CooldownDeferred(remaining)
+        wait = self._throttle.reserve_slot()
+        if wait > 0:
+            self._shutdown_event.wait(timeout=wait)
+        return None
+
+    def _note_rate_limit(self, status: PrStatusInfo, provider: str) -> None:
+        """Start a host cooldown for ``provider`` if the poll was rate-limited."""
+        if status.error_category == "rate_limited":
+            self._throttle.enter_cooldown(provider, _RATE_LIMIT_COOLDOWN_SECONDS)
+            logger.debug("PR poll: {} rate-limited, cooling down {:.0f}s", provider, _RATE_LIMIT_COOLDOWN_SECONDS)
+
+    def _fetch_status(
+        self, workspace_id: WorkspaceID, state: _WorkspacePollState
+    ) -> PrStatusInfo | _CooldownDeferred | None:
         working_dir = state.working_dir
 
         # Re-read from DB if working_dir not yet available (environment may have initialized)
@@ -602,12 +720,17 @@ class PrPollingService(Service):
                     error_provider="github",
                     error_message="gh CLI not found in PATH",
                 )
-            return fetch_pr_status(
+            deferred = self._respect_throttle("github")
+            if deferred is not None:
+                return deferred
+            status = fetch_pr_status(
                 workspace_id=workspace_id,
                 working_dir=working_dir,
                 current_branch=current_branch,
                 target_branch=target_branch,
             )
+            self._note_rate_limit(status, "github")
+            return status
 
         if origin_url is not None and _is_gitlab_url(origin_url):
             if not self._is_glab_available():
@@ -618,11 +741,16 @@ class PrPollingService(Service):
                     error_provider="gitlab",
                     error_message="glab CLI not found in PATH",
                 )
-            return fetch_mr_status(
+            deferred = self._respect_throttle("gitlab")
+            if deferred is not None:
+                return deferred
+            status = fetch_mr_status(
                 workspace_id=workspace_id,
                 working_dir=working_dir,
                 current_branch=current_branch,
                 target_branch=target_branch,
             )
+            self._note_rate_limit(status, "gitlab")
+            return status
 
         return PrStatusInfo(workspace_id=workspace_id, pr_state="none")

--- a/sculptor/sculptor/web/pr_polling_service_test.py
+++ b/sculptor/sculptor/web/pr_polling_service_test.py
@@ -11,9 +11,14 @@ from sculptor.web.data_types import StreamingUpdateSourceTypes
 from sculptor.web.derived import PrStatusInfo
 from sculptor.web.derived import WorkspaceBranchInfo
 from sculptor.web.pr_polling_service import PrPollingService
+from sculptor.web.pr_polling_service import _CooldownDeferred
 from sculptor.web.pr_polling_service import _DISABLED_RECHECK_SECONDS
+from sculptor.web.pr_polling_service import _GLOBAL_MIN_POLL_SPACING_SECONDS
+from sculptor.web.pr_polling_service import _HostThrottle
 from sculptor.web.pr_polling_service import _MIN_POLL_INTERVAL_SECONDS
 from sculptor.web.pr_polling_service import _PollJob
+from sculptor.web.pr_polling_service import _RATE_LIMIT_COOLDOWN_SECONDS
+from sculptor.web.pr_polling_service import _TERMINAL_STATE_MULTIPLIER
 from sculptor.web.pr_polling_service import _WorkspacePollState
 from sculptor.web.pr_polling_service import _compute_poll_delay
 from sculptor.web.streams import _notify_pr_polling_service
@@ -45,6 +50,7 @@ def _make_service() -> PrPollingService:
     svc._worker_sleep_lock = threading.Lock()
     svc._gh_available = None
     svc._glab_available = None
+    svc._throttle = _HostThrottle(_GLOBAL_MIN_POLL_SPACING_SECONDS)
     object.__setattr__(svc, "_data_model_service", MagicMock())
     object.__setattr__(svc, "_workspace_service", MagicMock())
     return svc
@@ -372,24 +378,42 @@ def _make_user_config(
 
 def test_compute_poll_delay_open_uses_base_interval() -> None:
     config = _make_user_config(pr_poll_interval_seconds=45)
-    assert _compute_poll_delay(config, is_open=True) == 45.0
+    assert _compute_poll_delay(config, is_open=True, pr_state="open") == 45.0
 
 
 def test_compute_poll_delay_closed_multiplies_base() -> None:
     config = _make_user_config(pr_poll_interval_seconds=20, pr_poll_closed_multiplier=10)
-    assert _compute_poll_delay(config, is_open=False) == 200.0
+    assert _compute_poll_delay(config, is_open=False, pr_state="open") == 200.0
 
 
 def test_compute_poll_delay_floors_base_at_minimum() -> None:
     """Even with a sub-minimum interval, never schedule polls closer than the floor."""
     config = _make_user_config(pr_poll_interval_seconds=1)
-    assert _compute_poll_delay(config, is_open=True) == _MIN_POLL_INTERVAL_SECONDS
+    assert _compute_poll_delay(config, is_open=True, pr_state="open") == _MIN_POLL_INTERVAL_SECONDS
 
 
 def test_compute_poll_delay_multiplier_floors_at_one() -> None:
     """A zero or negative multiplier shouldn't make closed polls more frequent than open."""
     config = _make_user_config(pr_poll_interval_seconds=20, pr_poll_closed_multiplier=0)
-    assert _compute_poll_delay(config, is_open=False) == 20.0
+    assert _compute_poll_delay(config, is_open=False, pr_state="open") == 20.0
+
+
+def test_compute_poll_delay_terminal_state_backs_off_when_open() -> None:
+    """A merged/closed PR can't change, so an open workspace still polls it rarely."""
+    config = _make_user_config(pr_poll_interval_seconds=30)
+    expected = 30.0 * _TERMINAL_STATE_MULTIPLIER
+    assert _compute_poll_delay(config, is_open=True, pr_state="merged") == expected
+    assert _compute_poll_delay(config, is_open=True, pr_state="closed") == expected
+
+
+def test_compute_poll_delay_terminal_state_takes_largest_multiplier() -> None:
+    """Closed workspace + terminal PR uses whichever multiplier is larger."""
+    # Closed multiplier (2) would give 60; terminal multiplier wins.
+    config = _make_user_config(pr_poll_interval_seconds=30, pr_poll_closed_multiplier=2)
+    assert _compute_poll_delay(config, is_open=False, pr_state="merged") == 30.0 * _TERMINAL_STATE_MULTIPLIER
+    # A huge closed multiplier beats the terminal multiplier.
+    config2 = _make_user_config(pr_poll_interval_seconds=30, pr_poll_closed_multiplier=100)
+    assert _compute_poll_delay(config2, is_open=False, pr_state="merged") == 30.0 * 100
 
 
 # ---------------------------------------------------------------------------
@@ -535,3 +559,119 @@ def test_poll_dynamic_config_re_read_per_cycle() -> None:
         rescheduled = svc._job_queue.get_nowait()
         delay_b = rescheduled.scheduled_time - time.monotonic()
         assert 119 <= delay_b <= 121
+
+
+# ---------------------------------------------------------------------------
+# Global throttle: spacing + per-provider cooldown
+# ---------------------------------------------------------------------------
+
+
+def test_host_throttle_reserve_slot_spaces_starts() -> None:
+    """Consecutive reservations are spaced at least min_interval apart."""
+    throttle = _HostThrottle(min_interval=2.0)
+    # First reservation is due immediately.
+    assert throttle.reserve_slot() == 0.0
+    # The next two are pushed out by min_interval each (no real time elapsed).
+    second = throttle.reserve_slot()
+    third = throttle.reserve_slot()
+    assert 1.9 <= second <= 2.0
+    assert 3.9 <= third <= 4.0
+
+
+def test_host_throttle_cooldown_remaining_tracks_window() -> None:
+    throttle = _HostThrottle(min_interval=1.0)
+    assert throttle.cooldown_remaining("github") == 0.0
+    throttle.enter_cooldown("github", 30.0)
+    assert 29.0 <= throttle.cooldown_remaining("github") <= 30.0
+    # Cooldown is per-provider.
+    assert throttle.cooldown_remaining("gitlab") == 0.0
+
+
+def test_host_throttle_enter_cooldown_never_shortens() -> None:
+    throttle = _HostThrottle(min_interval=1.0)
+    throttle.enter_cooldown("github", 60.0)
+    # A shorter cooldown must not clobber the longer one already in effect.
+    throttle.enter_cooldown("github", 5.0)
+    assert throttle.cooldown_remaining("github") > 50.0
+
+
+def test_respect_throttle_defers_when_provider_in_cooldown() -> None:
+    """When a provider is cooling down, no slot is reserved and a deferral is returned."""
+    svc = _make_service()
+    svc._throttle.enter_cooldown("github", 45.0)
+
+    result = svc._respect_throttle("github")
+
+    assert isinstance(result, _CooldownDeferred)
+    assert 44.0 <= result.retry_after <= 45.0
+
+
+def test_respect_throttle_allows_when_not_in_cooldown() -> None:
+    svc = _make_service()
+    # First call is due immediately, so it returns None (proceed) without sleeping.
+    assert svc._respect_throttle("github") is None
+
+
+def test_note_rate_limit_starts_cooldown_only_for_rate_limited() -> None:
+    svc = _make_service()
+    workspace_id = WorkspaceID()
+
+    ok = PrStatusInfo(workspace_id=workspace_id, pr_state="open")
+    svc._note_rate_limit(ok, "github")
+    assert svc._throttle.cooldown_remaining("github") == 0.0
+
+    limited = PrStatusInfo(
+        workspace_id=workspace_id, pr_state="none", error_category="rate_limited", error_provider="github"
+    )
+    svc._note_rate_limit(limited, "github")
+    assert svc._throttle.cooldown_remaining("github") > 0.0
+
+
+def test_cooldown_deferred_result_does_not_overwrite_cache() -> None:
+    """A deferred poll leaves the last-known status in place and re-enqueues after the cooldown."""
+    svc = _make_service()
+    workspace_id = WorkspaceID()
+    _add_workspace_poll_state(svc, workspace_id)
+    state = svc._workspace_poll_state[workspace_id]
+    svc._pending.add(workspace_id)
+
+    last_known = PrStatusInfo(workspace_id=workspace_id, pr_state="open", pr_iid=7)
+    svc._cache[workspace_id] = last_known
+
+    config = _make_user_config()
+    deferred = _CooldownDeferred(retry_after=40.0)
+
+    with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=config):
+        with patch.object(PrPollingService, "_execute_poll", return_value=deferred):
+            svc._poll_and_handle_result(_PollJob(0.0, workspace_id), state)
+
+    # Cache is untouched, and the workspace is re-enqueued after the cooldown.
+    assert svc._cache[workspace_id] == last_known
+    rescheduled = svc._job_queue.get_nowait()
+    delay = rescheduled.scheduled_time - time.monotonic()
+    assert 39 <= delay <= 41
+
+
+def test_rate_limited_result_re_enqueues_after_cooldown() -> None:
+    """A rate-limited result waits out the host cooldown instead of the base interval."""
+    svc = _make_service()
+    workspace_id = WorkspaceID()
+    _add_workspace_poll_state(svc, workspace_id)
+    state = svc._workspace_poll_state[workspace_id]
+    svc._pending.add(workspace_id)
+
+    # Simulate the cooldown the poll would have set via _note_rate_limit.
+    svc._throttle.enter_cooldown("github", _RATE_LIMIT_COOLDOWN_SECONDS)
+    limited = PrStatusInfo(
+        workspace_id=workspace_id, pr_state="none", error_category="rate_limited", error_provider="github"
+    )
+    config = _make_user_config(pr_poll_interval_seconds=30)
+
+    with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=config):
+        with patch.object(PrPollingService, "_execute_poll", return_value=limited):
+            svc._poll_and_handle_result(_PollJob(0.0, workspace_id), state)
+
+    rescheduled = svc._job_queue.get_nowait()
+    delay = rescheduled.scheduled_time - time.monotonic()
+    # Re-enqueued at ~the remaining cooldown (60s), not the 30s base interval.
+    assert _RATE_LIMIT_COOLDOWN_SECONDS - 2 <= delay <= _RATE_LIMIT_COOLDOWN_SECONDS

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -127,9 +127,7 @@ def _build_open_pr_status(
 ) -> PrStatusInfo:
     """Build a full PrStatusInfo for an open PR (checks, reviews, comments)."""
     pr_number = pr_data["number"]
-    pipeline_status = _fetch_check_status(working_dir, pr_number)
-    approvals = _fetch_reviews(working_dir, pr_number)
-    unresolved_comments = _fetch_review_comments(working_dir, pr_number)
+    details = _fetch_pr_details(working_dir, pr_number)
 
     return PrStatusInfo(
         workspace_id=workspace_id,
@@ -137,9 +135,9 @@ def _build_open_pr_status(
         pr_iid=pr_number,
         pr_title=pr_data.get("title"),
         pr_web_url=pr_data.get("url"),
-        pipeline_status=pipeline_status,
-        approvals=approvals,
-        unresolved_comments=unresolved_comments,
+        pipeline_status=_parse_check_status(details),
+        approvals=_parse_reviews(details),
+        unresolved_comments=_parse_review_comments(details),
     )
 
 
@@ -180,16 +178,41 @@ def _find_all_prs(working_dir: Path, source_branch: str) -> list[dict]:
     return prs
 
 
-def _fetch_check_status(working_dir: Path, pr_number: int) -> Literal["running", "passed", "failed"] | None:
+def _fetch_pr_details(working_dir: Path, pr_number: int) -> dict:
+    """Fetch checks, reviews, and review threads for an open PR in one call.
+
+    ``gh pr view`` issues a single GraphQL request no matter how many
+    ``--json`` fields are requested, so bundling ``statusCheckRollup``,
+    ``reviews``, and ``reviewThreads`` into one invocation collapses what
+    used to be three separate GraphQL round trips into one. That detail
+    fetch is the dominant per-poll cost for a workspace with an open PR, so
+    this roughly halves the GraphQL points spent polling it.
+
+    On a non-rate-limit failure this returns an empty dict so the caller
+    still reports the open PR (just without check/review detail), matching
+    the previous best-effort behaviour. A rate-limit failure is re-raised as
+    ``CliStatusError`` so the poller can surface it and back off instead of
+    silently dropping the signal.
+    """
     result = run_cli_with_retry(
-        ["gh", "pr", "view", str(pr_number), "--json", "statusCheckRollup"],
+        ["gh", "pr", "view", str(pr_number), "--json", "statusCheckRollup,reviews,reviewThreads"],
         working_dir,
     )
     if result.returncode != 0:
-        logger.debug("gh pr view checks failed: {}", result.stderr)
-        return None
-    data = json.loads(result.stdout)
-    checks = data.get("statusCheckRollup", [])
+        category = classify_cli_error(result.stderr)
+        if category == "rate_limited":
+            raise CliStatusError(category, result.stderr)
+        logger.debug("gh pr view details failed ({}): {}", category, result.stderr)
+        return {}
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.debug("Invalid JSON from gh pr view details: {}", result.stdout[:200])
+        return {}
+
+
+def _parse_check_status(details: dict) -> Literal["running", "passed", "failed"] | None:
+    checks = details.get("statusCheckRollup", [])
     if not checks:
         return None
 
@@ -210,16 +233,8 @@ def _fetch_check_status(working_dir: Path, pr_number: int) -> Literal["running",
     return "passed"
 
 
-def _fetch_reviews(working_dir: Path, pr_number: int) -> list[PrApproval]:
-    result = run_cli_with_retry(
-        ["gh", "pr", "view", str(pr_number), "--json", "reviews"],
-        working_dir,
-    )
-    if result.returncode != 0:
-        logger.debug("gh pr view reviews failed: {}", result.stderr)
-        return []
-    data = json.loads(result.stdout)
-    reviews = data.get("reviews", [])
+def _parse_reviews(details: dict) -> list[PrApproval]:
+    reviews = details.get("reviews", [])
     # Keep only the latest review per author
     latest_by_author: dict[str, PrApproval] = {}
     for review in reviews:
@@ -231,16 +246,8 @@ def _fetch_reviews(working_dir: Path, pr_number: int) -> list[PrApproval]:
     return list(latest_by_author.values())
 
 
-def _fetch_review_comments(working_dir: Path, pr_number: int) -> list[PrComment]:
-    result = run_cli_with_retry(
-        ["gh", "pr", "view", str(pr_number), "--json", "reviewThreads"],
-        working_dir,
-    )
-    if result.returncode != 0:
-        logger.debug("gh pr view reviewThreads failed: {}", result.stderr)
-        return []
-    data = json.loads(result.stdout)
-    threads = data.get("reviewThreads", [])
+def _parse_review_comments(details: dict) -> list[PrComment]:
+    threads = details.get("reviewThreads", [])
     comments: list[PrComment] = []
     for thread in threads:
         if thread.get("isResolved"):

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -7,9 +7,9 @@ from sculptor.primitives.ids import WorkspaceID
 from sculptor.web.pr_status import fetch_pr_status
 
 
-def _make_finished(stdout: str, returncode: int = 0) -> FinishedProcess:
+def _make_finished(stdout: str, returncode: int = 0, stderr: str = "") -> FinishedProcess:
     return FinishedProcess(
-        stdout=stdout, stderr="", returncode=returncode, command=("gh",), is_output_already_logged=False
+        stdout=stdout, stderr=stderr, returncode=returncode, command=("gh",), is_output_already_logged=False
     )
 
 
@@ -47,21 +47,17 @@ def _patch_cli(side_effect):  # noqa: ANN001
 def _pr_list_handler(prs: list[dict]):  # noqa: ANN001
     """Build a cli_handler for the single `gh pr list --state=all` call.
 
-    The backend now issues exactly one `gh pr list` query (across all states)
-    and then, for an open PR, follows up with per-PR detail calls
-    (statusCheckRollup / reviews / reviewThreads). This handler returns ``prs``
-    for the list call and empty results for the detail calls.
+    The backend issues exactly one `gh pr list` query (across all states) and
+    then, for an open PR, a single combined `gh pr view` detail call that
+    bundles statusCheckRollup / reviews / reviewThreads. This handler returns
+    ``prs`` for the list call and an empty combined object for the detail call.
     """
 
     def handler(cmd, _working_dir):  # noqa: ANN001
         if "list" in cmd:
             return _make_finished(json.dumps(prs))
-        if "statusCheckRollup" in str(cmd):
-            return _make_finished(json.dumps({"statusCheckRollup": []}))
-        if "reviews" in str(cmd):
-            return _make_finished(json.dumps({"reviews": []}))
-        if "reviewThreads" in str(cmd):
-            return _make_finished(json.dumps({"reviewThreads": []}))
+        if "view" in cmd:
+            return _make_finished(json.dumps({"statusCheckRollup": [], "reviews": [], "reviewThreads": []}))
         return _make_finished("[]")
 
     return handler
@@ -194,3 +190,100 @@ def test_merged_takes_precedence_over_closed() -> None:
 
     assert result.pr_state == "merged"
     assert result.pr_iid == 820
+
+
+# ---------------------------------------------------------------------------
+# Open PR detail is fetched in a single combined `gh pr view` call
+# ---------------------------------------------------------------------------
+
+
+def test_open_pr_details_fetched_in_single_view_call() -> None:
+    view_calls: list[list] = []
+
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        if "list" in cmd:
+            return _make_finished(json.dumps([_open_pr(42)]))
+        if "view" in cmd:
+            view_calls.append(cmd)
+            return _make_finished(
+                json.dumps(
+                    {
+                        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+                        "reviews": [{"state": "APPROVED", "author": {"login": "alice"}}],
+                        "reviewThreads": [
+                            {
+                                "isResolved": False,
+                                "comments": [{"author": {"login": "bob"}, "path": "a.py", "line": 3, "body": "fix"}],
+                            }
+                        ],
+                    }
+                )
+            )
+        return _make_finished("[]")
+
+    with _patch_cli(handler):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.pipeline_status == "passed"
+    assert [a.name for a in result.approvals] == ["alice"]
+    assert len(result.unresolved_comments) == 1
+    # Exactly one `gh pr view`, and it bundles all three JSON fields in one call.
+    assert len(view_calls) == 1
+    assert view_calls[0][-1] == "statusCheckRollup,reviews,reviewThreads"
+
+
+# ---------------------------------------------------------------------------
+# A non-rate-limit failure on the detail call still reports the open PR
+# ---------------------------------------------------------------------------
+
+
+def test_open_pr_detail_failure_degrades_gracefully() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        if "list" in cmd:
+            return _make_finished(json.dumps([_open_pr(60)]))
+        if "view" in cmd:
+            return _make_finished("", returncode=1, stderr="HTTP 500 Internal Server Error")
+        return _make_finished("[]")
+
+    with _patch_cli(handler):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.pr_iid == 60
+    assert result.pipeline_status is None
+    assert result.error_category is None
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit errors surface as a rate_limited category (list and detail calls)
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_on_list_surfaces_error() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        if "list" in cmd:
+            return _make_finished("", returncode=1, stderr="API rate limit exceeded")
+        return _make_finished("[]")
+
+    with _patch_cli(handler):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pr_state == "none"
+    assert result.error_category == "rate_limited"
+    assert result.error_provider == "github"
+
+
+def test_rate_limit_on_detail_surfaces_error() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        if "list" in cmd:
+            return _make_finished(json.dumps([_open_pr(70)]))
+        if "view" in cmd:
+            return _make_finished("", returncode=1, stderr="HTTP 403: API rate limit exceeded for user")
+        return _make_finished("[]")
+
+    with _patch_cli(handler):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.error_category == "rate_limited"
+    assert result.error_provider == "github"

--- a/sculptor/tests/integration/frontend/test_backend_pr_polling.py
+++ b/sculptor/tests/integration/frontend/test_backend_pr_polling.py
@@ -29,17 +29,15 @@ _FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
 
 # Fake gh CLI that always returns an open PR for "pr list" queries.
 # The backend issues a single `gh pr list --state=all` query and dispatches on
-# each row's "state" field, so the PR object must carry "state": "OPEN".
+# each row's "state" field, so the PR object must carry "state": "OPEN". For an
+# open PR it then issues a single combined `gh pr view --json
+# statusCheckRollup,reviews,reviewThreads` detail call.
 _FAKE_GH_OPEN_PR_SCRIPT = """\
 #!/bin/bash
 if [[ "$*" == *"pr list"* ]]; then
     echo '[{"number": 42, "title": "Test PR", "url": "https://github.com/test/repo/pull/42", "baseRefName": "main", "state": "OPEN"}]'
-elif [[ "$*" == *"statusCheckRollup"* ]]; then
-    echo '{"statusCheckRollup": []}'
-elif [[ "$*" == *"reviews"* ]]; then
-    echo '{"reviews": []}'
-elif [[ "$*" == *"reviewThreads"* ]]; then
-    echo '{"reviewThreads": []}'
+elif [[ "$*" == *"pr view"* ]]; then
+    echo '{"statusCheckRollup": [], "reviews": [], "reviewThreads": []}'
 fi
 """
 
@@ -66,12 +64,8 @@ case "$MODE" in
     open_pr)
         if [[ "$*" == *"pr list"* ]]; then
             echo '[{{"number": 42, "title": "Test PR", "url": "https://github.com/test/repo/pull/42", "baseRefName": "main", "state": "OPEN"}}]'
-        elif [[ "$*" == *"statusCheckRollup"* ]]; then
-            echo '{{"statusCheckRollup": []}}'
-        elif [[ "$*" == *"reviews"* ]]; then
-            echo '{{"reviews": []}}'
-        elif [[ "$*" == *"reviewThreads"* ]]; then
-            echo '{{"reviewThreads": []}}'
+        elif [[ "$*" == *"pr view"* ]]; then
+            echo '{{"statusCheckRollup": [], "reviews": [], "reviewThreads": []}}'
         fi
         ;;
 esac


### PR DESCRIPTION
## Problem

The workspace PR button is driven by a background poller that fetches PR/MR status through the `gh`/`glab` CLIs. On GitHub, `gh pr list` and `gh pr view --json …` are GraphQL queries under the hood, so each poll spends GitHub GraphQL points (5,000/hr per user — a budget shared with everything else you do via `gh`). For a workspace with an open PR, a single poll fired **four** GraphQL requests (one `gh pr list` plus three single-field `gh pr view` calls) every 30s, with no rate-limit handling and a worker pool that could fire them concurrently. With a handful of open workspaces this exhausts the hourly budget and the PR button gets stuck.

## Changes

- **Combine the three `gh pr view` calls into one.** `gh pr view` issues a single GraphQL request regardless of how many `--json` fields are requested, so bundling `statusCheckRollup,reviews,reviewThreads` halves the requests per open-PR poll (4 → 2), behaviour-identical.
- **Rate-limit awareness.** GitHub returns rate limits as HTTP 403, which were previously misclassified as "no access" (permanent) and retried immediately. A new `rate_limited` category is detected first, surfaced in the PR button as a clear "rate limited — updates paused, will resume" state, and is no longer retried on the spot.
- **Global throttle + host cooldown.** A process-wide throttle shared across poll workers staggers API-backed poll starts (GitHub's guidance is to avoid concurrent requests) and, on a rate-limit response, cools down all polling for that host until the limit resets.
- **Adaptive cadence.** Terminal PRs (merged/closed) can't change, so they back off to a much longer interval even while the workspace is open.

## Testing

Unit coverage added for the combined call, rate-limit classification and surfacing, the throttle/cooldown, and the adaptive cadence. `just format`, `just check` (typecheck/lint/ratchets), and the full `just test-unit` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
