### PR TITLE
pi: light the compaction chrome truthfully (supports_compaction)

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/StatusPill.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/StatusPill.tsx
@@ -32,7 +32,10 @@ import { useElapsedTime } from "./useElapsedTime.ts";
 
 type StatusPillProps = {
   taskStatus: TaskStatus | null;
-  // CAPABILITY-GAP: supportsCompaction — `isAutoCompacting` drives a "Compacting" state in the pill that is meaningful only for harnesses that compact context (Claude). Pi never sets this.
+  // `isAutoCompacting` drives the "Compacting" pill state. Every harness that
+  // compacts (Claude and pi) feeds it truthfully via the AutoCompacting*
+  // message pair → the `is_auto_compacting` derivation, so the chrome is
+  // per-harness-correct and needs no capability gate here.
   isAutoCompacting: boolean;
   isStreaming: boolean;
   inProgressChatMessage: ChatMessage | null;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/StatusPill.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/StatusPill.tsx
@@ -32,10 +32,9 @@ import { useElapsedTime } from "./useElapsedTime.ts";
 
 type StatusPillProps = {
   taskStatus: TaskStatus | null;
-  // `isAutoCompacting` drives the "Compacting" pill state. Every harness that
-  // compacts (Claude and pi) feeds it truthfully via the AutoCompacting*
-  // message pair → the `is_auto_compacting` derivation, so the chrome is
-  // per-harness-correct and needs no capability gate here.
+  // `isAutoCompacting` drives the "Compacting" pill state, fed by the
+  // AutoCompacting* message pair via the `is_auto_compacting` derivation. Every
+  // harness that compacts (Claude and pi) feeds it.
   isAutoCompacting: boolean;
   isStreaming: boolean;
   inProgressChatMessage: ChatMessage | null;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/TokenPopoverContent.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/TokenPopoverContent.tsx
@@ -27,7 +27,11 @@ export const TokenPopoverContent = ({
     }
   }
 
-  // CAPABILITY-GAP: supportsCompaction — the "Context" row displays the auto-compact threshold; harnesses without compaction (pi) never produce a threshold so the row already collapses, but the surrounding chrome should treat compaction as a per-harness capability rather than relying on null thresholds.
+  // DIVERGENCE (supportsCompaction, REQ-CAP-ALL-3): the "Context" row shows the
+  // auto-compact threshold. pi compacts (its "Compacting" pill chrome fires) but
+  // exposes no numeric threshold on the wire, so for pi `autoCompactThreshold` is
+  // null and this row stays absent. That empty threshold is an accepted
+  // per-harness divergence — not a gap to fill with a fabricated number.
   if (turnContextTokens != null && turnContextTokens > 0 && autoCompactThreshold != null && autoCompactThreshold > 0) {
     rows.push({
       label: "Context",

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/TokenPopoverContent.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/TokenPopoverContent.tsx
@@ -27,11 +27,9 @@ export const TokenPopoverContent = ({
     }
   }
 
-  // DIVERGENCE (supportsCompaction, REQ-CAP-ALL-3): the "Context" row shows the
-  // auto-compact threshold. pi compacts (its "Compacting" pill chrome fires) but
-  // exposes no numeric threshold on the wire, so for pi `autoCompactThreshold` is
-  // null and this row stays absent. That empty threshold is an accepted
-  // per-harness divergence — not a gap to fill with a fabricated number.
+  // The "Context" row shows the auto-compact threshold. pi compacts but exposes
+  // no numeric threshold on the wire, so for pi `autoCompactThreshold` is null
+  // and this row stays absent.
   if (turnContextTokens != null && turnContextTokens > 0 && autoCompactThreshold != null && autoCompactThreshold > 0) {
     rows.push({
       label: "Context",

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -852,8 +852,7 @@ class PiAgent(DefaultAgentWrapper):
             # is_auto_compacting stuck True — derived.py scans messages in
             # reverse for the latest AutoCompacting*. Emit the Done so the
             # "Compacting" pill always clears, on every exit path (normal
-            # agent_end, process exit, raised error, shutdown). Emitting Done
-            # twice is harmless; never emitting it is the dangerous direction.
+            # agent_end, process exit, raised error, shutdown).
             if state.compaction_open:
                 self._output_messages.put(AutoCompactingDoneAgentMessage(message_id=AgentMessageID()))
 
@@ -1260,15 +1259,13 @@ class PiAgent(DefaultAgentWrapper):
         """Map pi's compaction_end onto clearing the Compacting chrome.
 
         ALWAYS emits AutoCompactingDoneAgentMessage so the pill never sticks,
-        including the aborted / error_message cases (a stuck "Compacting" pill
-        is worse than a cleared one). We do NOT raise here: a genuine failure is
-        surfaced only if pi itself ends the run in error (the agent_end /
-        message_end error paths handle that) — we don't invent a failure pi
-        didn't report. `willRetry:true` (overflow) means pi re-runs the prompt;
-        the turn extends via the normal agent_end boundary, so this is
-        non-terminal. pi's `result.summary` is not rendered (Claude shows no
-        equivalent). Idempotent: a Done with no preceding start (resumed
-        mid-stream) is harmless.
+        including the aborted / error_message cases. We do NOT raise here: a
+        genuine failure is surfaced only if pi itself ends the run in error (the
+        agent_end / message_end error paths handle that). `willRetry:true`
+        (overflow) means pi re-runs the prompt; the turn extends via the normal
+        agent_end boundary, so this is non-terminal. pi's `result.summary` is not
+        rendered (Claude shows no equivalent). Idempotent: a Done with no
+        preceding start (resumed mid-stream) is harmless.
         """
         state.compaction_open = False
         self._output_messages.put(AutoCompactingDoneAgentMessage(message_id=AgentMessageID()))

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -87,6 +87,8 @@ from sculptor.common.plugin import get_plugin_dirs
 from sculptor.foundation.common import generate_id
 from sculptor.foundation.secrets_utils import Secret
 from sculptor.foundation.thread_utils import ObservableThread
+from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
+from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
 from sculptor.interfaces.agents.agent import ClearContextUserMessage
 from sculptor.interfaces.agents.agent import InterruptProcessUserMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
@@ -243,7 +245,14 @@ class _TurnState:
     the registry persists for the whole agent run (keyed by unique tool-call id).
     """
 
-    __slots__ = ("accumulated_text", "assistant_message_id", "first_message_id", "prompt_id", "tool_calls")
+    __slots__ = (
+        "accumulated_text",
+        "assistant_message_id",
+        "compaction_open",
+        "first_message_id",
+        "prompt_id",
+        "tool_calls",
+    )
 
     def __init__(self, prompt_id: str) -> None:
         self.prompt_id = prompt_id
@@ -251,6 +260,12 @@ class _TurnState:
         self.assistant_message_id = AssistantMessageID(generate_id())
         self.first_message_id = AgentMessageID()
         self.tool_calls: dict[str, _ToolCall] = {}
+        # True between a compaction_start and its matching compaction_end.
+        # Compaction spans assistant messages, so this is NOT reset in
+        # reset_accumulator. If the run exits while it is still open (process
+        # death or a raised error mid-compaction), _consume_until_turn_end
+        # emits the missing Done so is_auto_compacting cannot stick on True.
+        self.compaction_open = False
 
     def reset_accumulator(self) -> None:
         self.accumulated_text = ""
@@ -803,32 +818,44 @@ class PiAgent(DefaultAgentWrapper):
         out_queue = process.get_queue()
         state = _TurnState(prompt_id=prompt_id)
 
-        while not self._shutdown_event.is_set():
-            if process.is_finished() and out_queue.empty():
-                return
-            try:
-                line, is_stdout = out_queue.get(timeout=0.1)
-            except Empty:
-                continue
-            if not is_stdout:
-                continue
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                event = json.loads(stripped)
-            except json.JSONDecodeError:
-                logger.debug("PiAgent ignoring non-JSON stdout line: {}", stripped)
-                continue
-            if not isinstance(event, dict):
-                logger.debug("PiAgent ignoring non-object stdout payload: {}", event)
-                continue
-            # Parse once at the boundary: the three lanes pi multiplexes
-            # (`response`, `extension_ui_request`, session events) become typed
-            # variants. Unrecognized / malformed payloads parse to
-            # ParsedUnknownEvent and are discarded (RPC §5.3 forward-compat).
-            if self._dispatch_event(parse_rpc_message(event), state):
-                return
+        try:
+            while not self._shutdown_event.is_set():
+                if process.is_finished() and out_queue.empty():
+                    return
+                try:
+                    line, is_stdout = out_queue.get(timeout=0.1)
+                except Empty:
+                    continue
+                if not is_stdout:
+                    continue
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    event = json.loads(stripped)
+                except json.JSONDecodeError:
+                    logger.debug("PiAgent ignoring non-JSON stdout line: {}", stripped)
+                    continue
+                if not isinstance(event, dict):
+                    logger.debug("PiAgent ignoring non-object stdout payload: {}", event)
+                    continue
+                # Parse once at the boundary: the three lanes pi multiplexes
+                # (`response`, `extension_ui_request`, session events) become typed
+                # variants. Unrecognized / malformed payloads parse to
+                # ParsedUnknownEvent and are discarded (RPC §5.3 forward-compat).
+                if self._dispatch_event(parse_rpc_message(event), state):
+                    return
+        finally:
+            # Stick-prevention: a compaction_start with no matching
+            # compaction_end (process died mid-compaction, or a PiCrashError
+            # raised before the end arrived) would otherwise leave
+            # is_auto_compacting stuck True — derived.py scans messages in
+            # reverse for the latest AutoCompacting*. Emit the Done so the
+            # "Compacting" pill always clears, on every exit path (normal
+            # agent_end, process exit, raised error, shutdown). Emitting Done
+            # twice is harmless; never emitting it is the dangerous direction.
+            if state.compaction_open:
+                self._output_messages.put(AutoCompactingDoneAgentMessage(message_id=AgentMessageID()))
 
     def _handle_response_event(self, parsed: RpcResponse, state: _TurnState) -> None:
         """Process a top-level `response` envelope (correlated by `id`, RPC §5.1).
@@ -894,20 +921,24 @@ class PiAgent(DefaultAgentWrapper):
             case ParsedToolExecutionEnd():
                 self._handle_tool_execution_end(parsed, state)
                 return False
+            case ParsedCompactionStart():
+                self._handle_compaction_start(state)
+                return False
+            case ParsedCompactionEnd():
+                self._handle_compaction_end(state)
+                return False
             case (
                 ParsedTurnStart()
                 | ParsedTurnEnd()
                 | ParsedMessageStart()
                 | ParsedQueueUpdate()
-                | ParsedCompactionStart()
-                | ParsedCompactionEnd()
                 | ParsedAutoRetryStart()
                 | ParsedSessionInfoChanged()
                 | ParsedThinkingLevelChanged()
                 | ParsedUnknownEvent()
             ):
-                # Events this harness does not consume (turn/queue/compaction/
-                # retry/session notices) plus any unrecognized type.
+                # Events this harness does not consume (turn/queue/retry/session
+                # notices) plus any unrecognized type.
                 logger.debug("PiAgent ignoring unconsumed event: {}", type(parsed).__name__)
                 return False
             case _ as unreachable:
@@ -1211,6 +1242,36 @@ class PiAgent(DefaultAgentWrapper):
             text = parsed.final_error or state.accumulated_text or "pi exhausted retries"
             raise PiCrashError(text, exit_code=None, metadata=None)
         # Successful retry — a new agent run is about to begin; do not yield.
+
+    def _handle_compaction_start(self, state: _TurnState) -> None:
+        """Map pi's compaction_start onto the Compacting chrome.
+
+        Emits AutoCompactingAgentMessage so is_auto_compacting flips True and
+        the StatusPill shows "Compacting...". pi's `reason`
+        (manual/threshold/overflow) is deliberately not surfaced — Sculptor's
+        chrome is a single Compacting state with no per-reason distinction
+        (Claude parity). Arms the stick-prevention Done in
+        _consume_until_turn_end via `compaction_open`.
+        """
+        state.compaction_open = True
+        self._output_messages.put(AutoCompactingAgentMessage(message_id=AgentMessageID()))
+
+    def _handle_compaction_end(self, state: _TurnState) -> None:
+        """Map pi's compaction_end onto clearing the Compacting chrome.
+
+        ALWAYS emits AutoCompactingDoneAgentMessage so the pill never sticks,
+        including the aborted / error_message cases (a stuck "Compacting" pill
+        is worse than a cleared one). We do NOT raise here: a genuine failure is
+        surfaced only if pi itself ends the run in error (the agent_end /
+        message_end error paths handle that) — we don't invent a failure pi
+        didn't report. `willRetry:true` (overflow) means pi re-runs the prompt;
+        the turn extends via the normal agent_end boundary, so this is
+        non-terminal. pi's `result.summary` is not rendered (Claude shows no
+        equivalent). Idempotent: a Done with no preceding start (resumed
+        mid-stream) is harmless.
+        """
+        state.compaction_open = False
+        self._output_messages.put(AutoCompactingDoneAgentMessage(message_id=AgentMessageID()))
 
     def _handle_extension_error(self, parsed: ParsedExtensionError) -> None:
         # Non-terminal: extensions are not loaded in pi-basic but pi could

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -33,6 +33,8 @@ from sculptor.agents.pi_agent.output_processor import ParsedUnknownEvent
 from sculptor.agents.pi_agent.output_processor import extract_tool_call_blocks
 from sculptor.agents.pi_agent.output_processor import parse_rpc_message
 from sculptor.foundation.async_monkey_patches_test import expect_exact_logged_errors
+from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
+from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
 from sculptor.interfaces.agents.agent import ClearContextUserMessage
 from sculptor.interfaces.agents.agent import InterruptProcessUserMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
@@ -1343,6 +1345,131 @@ def _drain(queue: Queue) -> list:
     return out
 
 
+# --- Compaction chrome (compaction_start/end → AutoCompacting* pair) --------
+
+
+def test_compaction_start_then_end_shows_then_clears_the_pill() -> None:
+    """A compaction_start→end pair emits AutoCompacting then Done (pill shows, then clears)."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event({"type": "compaction_start", "reason": "threshold"}),
+            _event({"type": "compaction_end", "reason": "threshold", "aborted": False, "willRetry": False}),
+            _event(_text_delta_update("done.", "done.")),
+            _event({"type": "message_end", "message": _assistant_msg("done.")}),
+            _event({"type": "agent_end", "messages": [_assistant_msg("done.")], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    emitted = _drain(agent._output_messages)
+    compacting = [i for i, m in enumerate(emitted) if isinstance(m, AutoCompactingAgentMessage)]
+    done = [i for i, m in enumerate(emitted) if isinstance(m, AutoCompactingDoneAgentMessage)]
+    assert len(compacting) == 1
+    # Exactly one Done — the explicit end, with no duplicate from stick-prevention.
+    assert len(done) == 1
+    # Shows before it clears.
+    assert compacting[0] < done[0]
+    finals = [m for m in emitted if isinstance(m, ResponseBlockAgentMessage)]
+    assert finals and finals[0].content == (TextBlock(text="done."),)
+
+
+@pytest.mark.parametrize(
+    "end_payload",
+    [
+        {"type": "compaction_end", "reason": "manual", "aborted": True, "willRetry": False},
+        {
+            "type": "compaction_end",
+            "reason": "threshold",
+            "aborted": False,
+            "willRetry": False,
+            "errorMessage": "compaction failed",
+        },
+    ],
+    ids=["aborted", "error_message"],
+)
+def test_compaction_end_aborted_or_errored_still_clears_without_inventing_failure(end_payload: dict[str, Any]) -> None:
+    """aborted / error_message on compaction_end must still clear the pill and must not raise.
+
+    A compaction failure is surfaced only if pi itself ends the run in error
+    (the agent_end / message_end paths) — the compaction handler never invents one.
+    """
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "compaction_start", "reason": end_payload["reason"]}),
+            _event(end_payload),
+            _event({"type": "agent_end", "messages": [], "willRetry": False}),
+        ]
+    )
+    # Must not raise.
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    emitted = _drain(agent._output_messages)
+    assert len([m for m in emitted if isinstance(m, AutoCompactingDoneAgentMessage)]) == 1
+    # No failure invented (a failed compaction is not turn-terminal on its own).
+    assert not [m for m in emitted if isinstance(m, ResponseBlockAgentMessage)]
+
+
+def test_compaction_start_without_end_emits_done_on_process_exit() -> None:
+    """Process dies mid-compaction (start, no end, no agent_end): the pill must not stick."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event({"type": "compaction_start", "reason": "threshold"}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    emitted = _drain(agent._output_messages)
+    assert any(isinstance(m, AutoCompactingAgentMessage) for m in emitted)
+    # Stick-prevention: a Done is synthesized on exit so is_auto_compacting clears.
+    assert any(isinstance(m, AutoCompactingDoneAgentMessage) for m in emitted)
+
+
+def test_compaction_end_without_start_emits_done_idempotently() -> None:
+    """A compaction_end with no preceding start (resumed mid-stream) emits Done harmlessly."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "compaction_end", "reason": "threshold", "aborted": False, "willRetry": False}),
+            _event({"type": "agent_end", "messages": [], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    emitted = _drain(agent._output_messages)
+    assert len([m for m in emitted if isinstance(m, AutoCompactingDoneAgentMessage)]) == 1
+    assert not any(isinstance(m, AutoCompactingAgentMessage) for m in emitted)
+
+
+def test_compaction_end_with_will_retry_extends_the_turn() -> None:
+    """overflow compaction (willRetry:true) clears the pill but does not end the turn — pi re-runs the prompt."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event({"type": "compaction_start", "reason": "overflow"}),
+            _event({"type": "compaction_end", "reason": "overflow", "aborted": False, "willRetry": True}),
+            # The turn continues: pi re-runs and streams the real response.
+            _event(_text_delta_update("after retry", "after retry")),
+            _event({"type": "message_end", "message": _assistant_msg("after retry")}),
+            _event({"type": "agent_end", "messages": [_assistant_msg("after retry")], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    emitted = _drain(agent._output_messages)
+    # Compaction cycled (shows then clears) ...
+    assert any(isinstance(m, AutoCompactingAgentMessage) for m in emitted)
+    assert len([m for m in emitted if isinstance(m, AutoCompactingDoneAgentMessage)]) == 1
+    # ... and the turn extended past it to deliver the post-compaction response.
+    finals = [m for m in emitted if isinstance(m, ResponseBlockAgentMessage)]
+    assert finals and finals[-1].content == (TextBlock(text="after retry"),)
+
+
 # Wire-shape fixtures for every documented event type (RPC §5/§7/§9), lifted
 # from the protocol doc's examples. Each must parse to a typed variant whose
 # discriminator matches.
@@ -1392,13 +1519,13 @@ def test_parse_rpc_message_returns_unknown_for_missing_or_malformed_shape() -> N
 
 # Events pi-basic does not consume: each must be discarded (no emitted message,
 # no PiCrashError), and the turn must still end at the following agent_end.
+# compaction_start/end are deliberately ABSENT — they now emit the
+# AutoCompacting* chrome pair (see the compaction tests above), not discarded.
 _DISCARDED_EVENTS: list[dict[str, Any]] = [
     {"type": "turn_start"},
     {"type": "turn_end", "message": _assistant_msg("x"), "toolResults": []},
     {"type": "message_start", "message": _assistant_msg("x", stop_reason="")},
     {"type": "queue_update", "steering": ["a"], "followUp": []},
-    {"type": "compaction_start", "reason": "threshold"},
-    {"type": "compaction_end", "reason": "threshold", "aborted": False, "willRetry": False},
     {"type": "auto_retry_start", "attempt": 1, "maxAttempts": 3, "delayMs": 1, "errorMessage": "e"},
     {"type": "session_info_changed", "name": "s"},
     {"type": "thinking_level_changed", "level": "high"},

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -1519,8 +1519,8 @@ def test_parse_rpc_message_returns_unknown_for_missing_or_malformed_shape() -> N
 
 # Events pi-basic does not consume: each must be discarded (no emitted message,
 # no PiCrashError), and the turn must still end at the following agent_end.
-# compaction_start/end are deliberately ABSENT — they now emit the
-# AutoCompacting* chrome pair (see the compaction tests above), not discarded.
+# compaction_start/end are deliberately ABSENT — they emit the AutoCompacting*
+# chrome pair (see the compaction tests above) rather than being discarded.
 _DISCARDED_EVENTS: list[dict[str, Any]] = [
     {"type": "turn_start"},
     {"type": "turn_end", "message": _assistant_msg("x"), "toolResults": []},

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -80,10 +80,9 @@ class PiHarness(Harness):
             supports_context_reset=False,
             # Pi emits compaction_start/end (agent_wrapper maps them onto the
             # AutoCompacting* message pair → StatusPill "Compacting"), and
-            # autoCompactionEnabled defaults true — the compaction chrome is
-            # truthful. The TokenPopover threshold row stays empty: pi exposes
-            # no numeric auto-compact threshold on the wire (recorded
-            # divergence, REQ-CAP-ALL-3).
+            # autoCompactionEnabled defaults true. The TokenPopover threshold row
+            # stays empty: pi exposes no numeric auto-compact threshold on the
+            # wire.
             supports_compaction=True,
             supports_background_tasks=False,
             # Pi persists a per-task JSONL session and relaunches against it with

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -1,7 +1,7 @@
 """The pi harness — non-Claude implementor of `Harness`.
 
 Pi ships as a degraded harness: no AskUserQuestion, no plan mode, no
-sub-agents, no compaction. It DOES render tool calls
+sub-agents. It DOES render tool calls
 (`supports_tool_use_rendering=True`): pi's tool-execution lane is adapted onto
 Sculptor's harness-agnostic tool blocks (see `agent_wrapper` / `tool_rendering`).
 Session resume IS supported — pi persists a per-task JSONL session
@@ -10,8 +10,9 @@ Session resume IS supported — pi persists a per-task JSONL session
 workspace's skill directories via `--skill` flags and follows an invoked skill
 (see `agent_wrapper._build_skill_launch_args` / `_rewrite_skill_invocation`).
 It also carries file references, image input, and file attachments (delivered
-by prompt assembly). The `capabilities()` override is the truthful declaration
-that consumers gate on.
+by prompt assembly), and compacts context — `compaction_start/end` events drive
+the StatusPill "Compacting" chrome. The `capabilities()` override is the
+truthful declaration that consumers gate on.
 
 Agent construction is owned by the registry
 (`harness_registry.create_agent_for_run`), not this module, so the pi
@@ -77,7 +78,13 @@ class PiHarness(Harness):
             # Pi drops ClearContextUserMessage (see agent_wrapper._push_message),
             # so the `/clear` context-reset path is unavailable — false.
             supports_context_reset=False,
-            supports_compaction=False,
+            # Pi emits compaction_start/end (agent_wrapper maps them onto the
+            # AutoCompacting* message pair → StatusPill "Compacting"), and
+            # autoCompactionEnabled defaults true — the compaction chrome is
+            # truthful. The TokenPopover threshold row stays empty: pi exposes
+            # no numeric auto-compact threshold on the wire (recorded
+            # divergence, REQ-CAP-ALL-3).
+            supports_compaction=True,
             supports_background_tasks=False,
             # Pi persists a per-task JSONL session and relaunches against it with
             # --session-dir/--session-id (see agent_wrapper.PiAgent.start), so a

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -15,7 +15,7 @@ def test_pi_harness_capabilities() -> None:
         supports_image_input=True,
         supports_fast_mode=False,
         supports_context_reset=False,
-        supports_compaction=False,
+        supports_compaction=True,
         supports_background_tasks=False,
         supports_session_resume=True,
         supports_tool_use_rendering=True,

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -310,6 +310,57 @@ def _emit_aborted_agent_end(text: str) -> None:
     )
 
 
+def _emit_compaction_start(reason: str) -> None:
+    _emit({"type": "compaction_start", "reason": reason})
+
+
+def _emit_compaction_end(reason: str, aborted: bool, will_retry: bool) -> None:
+    # `result` mirrors real pi's manual-compact result shape (feasibility §5);
+    # PiAgent does not read it (Claude renders no equivalent), but FakePi emits
+    # it for wire fidelity.
+    _emit(
+        {
+            "type": "compaction_end",
+            "reason": reason,
+            "aborted": aborted,
+            "willRetry": will_retry,
+            "result": {"summary": "", "firstKeptEntryId": "", "tokensBefore": 0, "details": {}},
+        }
+    )
+
+
+def _handle_compaction(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
+    """Emit a compaction_start/end pair mid-turn.
+
+    Mirrors real pi's compaction wire shape (feasibility §5): manual,
+    threshold, and overflow all reuse the same two events, differing only in
+    ``reason`` (and overflow's ``willRetry:true``). The pair drives Sculptor's
+    AutoCompacting* messages → the StatusPill "Compacting" chrome.
+
+    Optional ``wait_path`` blocks between start and end on a sentinel file (as
+    ``fake_pi:wait_for_file`` does) so an integration test can observe the
+    "Compacting" pill while compaction is held open, then release it and watch
+    the pill clear. The compaction events carry no text, so the surrounding
+    turn still falls back to the default response when no text directive runs.
+    """
+    reason = str(args.get("reason", "threshold"))
+    aborted = bool(args.get("aborted", False))
+    will_retry = bool(args.get("will_retry", False))
+    _emit_compaction_start(reason)
+    wait_path = args.get("wait_path")
+    if wait_path:
+        timeout_seconds = float(args.get("timeout_seconds", 120))
+        sentinel = Path(wait_path)
+        deadline = time.monotonic() + timeout_seconds
+        while not sentinel.exists():
+            if abort_event.is_set():
+                raise _TurnAborted()
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"fake_pi:compaction timed out after {timeout_seconds}s waiting for {sentinel}")
+            time.sleep(0.05)
+    _emit_compaction_end(reason, aborted=aborted, will_retry=will_retry)
+
+
 def _handle_emit_text(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     text = args.get("text", "")
     accumulated = builder.full_text + text
@@ -466,6 +517,7 @@ _COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, Event, _SessionState]
     "wait_for_file": _handle_wait_for_file,
     "recall": _handle_recall,
     "report_inputs": _handle_report_inputs,
+    "compaction": _handle_compaction,
 }
 
 

--- a/sculptor/sculptor/testing/fake_pi_test.py
+++ b/sculptor/sculptor/testing/fake_pi_test.py
@@ -211,6 +211,52 @@ def test_fake_pi_rpc_tool_call_error_result_sets_is_error() -> None:
     assert end["result"]["content"][0]["text"] == "ENOENT"
 
 
+def test_fake_pi_rpc_compaction_directive_emits_start_end_pair_mid_turn() -> None:
+    """fake_pi:compaction emits a compaction_start/end pair between text directives."""
+    prompt = (
+        'fake_pi:emit_text `{"text": "before"}` '
+        'fake_pi:compaction `{"reason": "threshold"}` '
+        'fake_pi:emit_text `{"text": "after"}`'
+    )
+    result = _run_fake_pi(
+        ["--mode", "rpc", "--no-session", "--append-system-prompt", ""],
+        stdin_input=_send_prompt(prompt),
+    )
+
+    assert result.returncode == 0
+    events = _parse_jsonl(result.stdout)
+    starts = _by_type(events, "compaction_start")
+    ends = _by_type(events, "compaction_end")
+    assert len(starts) == 1
+    assert starts[0]["reason"] == "threshold"
+    assert len(ends) == 1
+    assert ends[0]["reason"] == "threshold"
+    assert ends[0]["aborted"] is False
+    assert ends[0]["willRetry"] is False
+    # The pair lands mid-turn: start before end, both before the agent_end boundary.
+    types = [e["type"] for e in events]
+    assert types.index("compaction_start") < types.index("compaction_end") < types.index("agent_end")
+    # The surrounding text directives still stream in order.
+    deltas = [e["assistantMessageEvent"]["delta"] for e in events if e.get("type") == "message_update"]
+    assert deltas == ["before", "after"]
+
+
+def test_fake_pi_rpc_compaction_directive_passes_through_overflow_flags() -> None:
+    """The overflow case (willRetry/aborted) is forwarded onto compaction_end."""
+    prompt = 'fake_pi:compaction `{"reason": "overflow", "will_retry": true, "aborted": true}`'
+    result = _run_fake_pi(
+        ["--mode", "rpc", "--no-session", "--append-system-prompt", ""],
+        stdin_input=_send_prompt(prompt),
+    )
+
+    assert result.returncode == 0
+    events = _parse_jsonl(result.stdout)
+    end = _by_type(events, "compaction_end")[0]
+    assert end["reason"] == "overflow"
+    assert end["willRetry"] is True
+    assert end["aborted"] is True
+
+
 def test_fake_pi_rpc_error_directive_emits_failure_response_and_no_session_events() -> None:
     prompt = 'fake_pi:error `{"message": "boom"}`'
     result = _run_fake_pi(

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -358,11 +358,38 @@ def test_clear_pseudo_skill_gated_on_context_reset(
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to keep compaction chrome absent for harnesses that do not compact context")
-def test_compaction_chrome_absent_under_pi(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
-    """Compaction is status-only chrome (no disabled-with-tooltip treatment); for
-    pi the compaction bar/button are absent."""
-    _create_workspace_for_harness(sculptor_instance_, harness, "Compaction Chrome Gate")
-    if harness.workspace_harness == HarnessName.PI:
-        expect(sculptor_instance_.page.get_by_test_id(ElementIDs.COMPACTION_BAR)).to_have_count(0)
-        expect(sculptor_instance_.page.get_by_test_id(ElementIDs.COMPACTION_BUTTON)).to_have_count(0)
+@user_story("to show truthful compaction chrome under harnesses that compact context")
+def test_compaction_chrome_truthful_under_pi(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
+    """Compaction is status-only chrome — the StatusPill "Compacting" state.
+
+    Under pi, a scripted compaction held open shows the Compacting pill while
+    active, and the pill clears once compaction ends and the turn finishes.
+    Claude is unchanged: it has no manual /compact surface to script here (parity
+    bar), so its branch only confirms the harness path is healthy — the pi branch
+    carries this test's claim. (Pi's deterministic show-then-clear and the
+    stuck-pill edges are covered at unit level in ``agent_wrapper_test``.)
+    """
+    page = sculptor_instance_.page
+    if harness.workspace_harness != HarnessName.PI:
+        _create_workspace_for_harness(sculptor_instance_, harness, "Compaction Chrome")
+        return
+
+    install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
+    release_path = Path(tempfile.gettempdir()) / f"pi_compaction_{uuid.uuid4().hex}"
+    label = page.get_by_test_id(ElementIDs.STATUS_PILL_LABEL)
+    try:
+        start_task_and_wait_for_ready(
+            sculptor_page=page,
+            workspace_name="Compaction Chrome",
+            model_name=None,
+            harness=HarnessName.PI,
+            # The compaction is held open on the sentinel so the Compacting pill
+            # state is observable deterministically (no wall-clock race).
+            prompt=f'fake_pi:compaction `{{"reason": "threshold", "wait_path": "{release_path}"}}`',
+            wait_for_agent_to_finish=False,
+        )
+        expect(label).to_contain_text("Compacting", timeout=15000)
+    finally:
+        release_path.touch()
+    # Once compaction ends, the turn finishes and the Compacting chrome clears.
+    expect(page.get_by_test_id(ElementIDs.STATUS_PILL)).to_have_count(0, timeout=15000)

--- a/sculptor/tests/integration/real_pi/test_compaction.py
+++ b/sculptor/tests/integration/real_pi/test_compaction.py
@@ -1,24 +1,17 @@
 """Real pi integration test: compaction chrome truthfulness.
 
-HONEST SCOPING (REQ-TEST-1 divergence clause). The deterministic contract —
-a compaction shows the "Compacting" StatusPill while active and clears it
-after, across all reasons and the stuck-pill edges — is carried by the
-deterministic tiers:
-
-- unit: ``agent_wrapper_test`` (start→AutoCompacting; end→Done;
-  aborted/error end still clears; willRetry extends the turn; start-without-end
-  synthesizes a Done so the pill can't stick),
-- fake_pi integration: ``test_pi_capability_gating.test_compaction_chrome_truthful_under_pi``
-  (a scripted compaction held open shows then clears the pill under pi).
-
-A REAL threshold compaction can't be triggered cheaply or reliably (it depends
+A real threshold compaction can't be triggered cheaply or reliably (it depends
 on the upstream model filling the context window), and Sculptor exposes no
-manual ``/compact`` surface to force one (Claude has none either — parity bar).
-So this real-pi test mirrors the *chrome-truthfulness* contract at the altitude
-real pi can guarantee: a normal turn against real pi completes cleanly with no
-error, and the compaction chrome never gets stuck on "Compacting". If the turn
-happens to compact opportunistically, the same assertions still hold — the pill
-must have cycled back to clear by the time the turn finishes.
+manual ``/compact`` surface to force one. The deterministic contract — a
+compaction shows the "Compacting" StatusPill while active and clears it after,
+across all reasons and the stuck-pill edges — is covered at the unit tier
+(``agent_wrapper_test``) and the fake_pi integration tier
+(``test_pi_capability_gating.test_compaction_chrome_truthful_under_pi``).
+
+This real-pi test covers what real pi can guarantee: a normal turn completes
+cleanly with no error and the compaction chrome never gets stuck on
+"Compacting". If the turn happens to compact opportunistically, the same
+assertions still hold.
 """
 
 import pytest
@@ -44,6 +37,5 @@ def test_compaction_chrome_does_not_stick_after_real_turn(sculptor_instance_: Sc
     expect(chat_panel.get_error_block()).to_have_count(0)
     # Chrome truthfulness: whether or not pi compacted during the turn, the
     # "Compacting" StatusPill must not be stuck once the turn has finished
-    # (create_pi_workspace_and_send waits for the turn to complete). A stuck
-    # pill is the dangerous failure mode this capability must avoid.
+    # (create_pi_workspace_and_send waits for the turn to complete).
     expect(sculptor_instance_.page.get_by_test_id(ElementIDs.STATUS_PILL_LABEL)).to_have_count(0)

--- a/sculptor/tests/integration/real_pi/test_compaction.py
+++ b/sculptor/tests/integration/real_pi/test_compaction.py
@@ -1,0 +1,49 @@
+"""Real pi integration test: compaction chrome truthfulness.
+
+HONEST SCOPING (REQ-TEST-1 divergence clause). The deterministic contract —
+a compaction shows the "Compacting" StatusPill while active and clears it
+after, across all reasons and the stuck-pill edges — is carried by the
+deterministic tiers:
+
+- unit: ``agent_wrapper_test`` (start→AutoCompacting; end→Done;
+  aborted/error end still clears; willRetry extends the turn; start-without-end
+  synthesizes a Done so the pill can't stick),
+- fake_pi integration: ``test_pi_capability_gating.test_compaction_chrome_truthful_under_pi``
+  (a scripted compaction held open shows then clears the pill under pi).
+
+A REAL threshold compaction can't be triggered cheaply or reliably (it depends
+on the upstream model filling the context window), and Sculptor exposes no
+manual ``/compact`` surface to force one (Claude has none either — parity bar).
+So this real-pi test mirrors the *chrome-truthfulness* contract at the altitude
+real pi can guarantee: a normal turn against real pi completes cleanly with no
+error, and the compaction chrome never gets stuck on "Compacting". If the turn
+happens to compact opportunistically, the same assertions still hold — the pill
+must have cycled back to clear by the time the turn finishes.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.constants import ElementIDs
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import create_pi_workspace_and_send
+from tests.integration.real_pi.helpers import real_pi
+
+
+@real_pi
+@pytest.mark.timeout(300)
+def test_compaction_chrome_does_not_stick_after_real_turn(sculptor_instance_: SculptorInstance) -> None:
+    """A real pi turn completes with no error and leaves the Compacting chrome cleared."""
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_,
+        "List the first five prime numbers, each on its own line, then stop.",
+    )
+    chat_panel = task_page.get_chat_panel()
+    # The turn produced a real response and surfaced no error.
+    expect(chat_panel.get_assistant_messages().last).not_to_be_empty()
+    expect(chat_panel.get_error_block()).to_have_count(0)
+    # Chrome truthfulness: whether or not pi compacted during the turn, the
+    # "Compacting" StatusPill must not be stuck once the turn has finished
+    # (create_pi_workspace_and_send waits for the turn to complete). A stuck
+    # pill is the dangerous failure mode this capability must avoid.
+    expect(sculptor_instance_.page.get_by_test_id(ElementIDs.STATUS_PILL_LABEL)).to_have_count(0)


### PR DESCRIPTION
## What

The pi harness emits `compaction_start` / `compaction_end` events when it compacts conversation context. This wires those events onto Sculptor's existing compaction chrome — the `AutoCompacting*` ephemeral message pair that drives the StatusPill "Compacting" state — and flips `supports_compaction` to `true` for pi.

## Why

Previously the pi harness declared `supports_compaction=false` and routed pi's compaction events to the dispatcher's discard arm, so a user never saw that pi was compacting. The events already exist on the wire and pi enables auto-compaction by default, so the chrome can be made truthful with a purely Sculptor-side adapter — no changes to pi itself.

## How

- **agent_wrapper**: route `compaction_start` → `AutoCompactingAgentMessage` and `compaction_end` → `AutoCompactingDoneAgentMessage` (moved out of the enumerated discard arm). Truthfulness edges:
  - an aborted or errored `compaction_end` still emits `Done` so the pill clears — a stuck "Compacting" pill is the dangerous failure mode — and never invents a turn failure pi did not report;
  - the overflow case (`willRetry`) is non-terminal, so the turn extends while pi re-runs the prompt;
  - a `compaction_start` with no matching end (process death or a mid-compaction error) synthesizes a `Done` on exit, so `is_auto_compacting` can never stick on `true`.
- **harness**: `supports_compaction=true`. The token-popover "Context" threshold row stays empty for pi — pi exposes no numeric auto-compact threshold on the wire — which is a recorded per-harness divergence, not a gap.
- **frontend markers**: the StatusPill capability-gap marker is resolved (the pill is now truthful for every harness that compacts); the token-popover marker becomes a recorded divergence note. No behavioral change — comments only.
- **fake_pi**: a new `compaction` directive (with an optional hold on a sentinel file) lets tests script the pill state deterministically.

## Tests

- **Unit**: every mapping arm plus the stuck-pill edges (`agent_wrapper_test`, `harness_test`, `fake_pi_test`).
- **Integration**: the capability-gating test now asserts truthful "Compacting" chrome under pi — shown while a scripted compaction is held open, cleared after. `2 passed` (pi + Claude branches).
- **Real pi**: a chrome-truthfulness test. Honest scoping (per the divergence clause): a real threshold compaction cannot be triggered cheaply and there is no manual `/compact` surface, so the deterministic tiers carry the contract while the real-pi test asserts a real turn completes cleanly and never leaves the pill stuck.

## Notes

- This branch was migrated onto the open-source history. Its design doc is preserved at `agent_docs/pi-capabilities/implementation_plan/05_01_compaction.md` (the new top-level `agent_docs/` location).

(Sent by Claude)
