### PR TITLE
pi-capabilities: interactive backchannel (AUQ + plan mode) for pi

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -306,10 +306,10 @@ export const ChatInput = ({
           message: promptDraft?.replace(/\u200B/g, "\u00A0").replace(/(\n\n\u00A0)+$/, ""),
           model: localModel,
           files: attachedFiles,
-          // CAPABILITY-GAP: supportsInteractiveBackchannel — the plan-mode
-          // toggle is gated disabled-with-tooltip for harnesses without the
-          // backchannel, so `isPlanFirst`/`isInPlanMode` stay false there and
-          // these fields are inert.
+          // The plan-mode toggle is gated (disabled-with-tooltip) for harnesses
+          // without the interactive backchannel, so `isPlanFirst`/`isInPlanMode`
+          // stay false there and these fields are inert; harnesses that support
+          // it (Claude, pi) drive plan mode through them.
           enter_plan_mode: isPlanFirst,
           exit_plan_mode: !isPlanFirst && isInPlanMode,
           fast_mode: modelCapabilities.supportsFastMode && isFastMode,

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatView.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatView.module.scss
@@ -336,6 +336,14 @@
   padding: var(--space-1) 0;
 }
 
+// Inline plan body for harnesses that pass the plan as the tool argument
+// (e.g. pi) rather than writing a plan file.
+.planInlineContent {
+  border-left: 1px solid var(--gray-a5);
+  margin-top: var(--space-1);
+  padding-left: var(--space-3);
+}
+
 // Tool group header
 .toolGroupHeader {
   align-items: baseline;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaExitPlanModeBlock.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaExitPlanModeBlock.tsx
@@ -8,13 +8,13 @@ import type { ToolUseBlock } from "~/api";
 import { ElementIds } from "~/api";
 import { useImbueParams, useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { useTaskDetailWithDefaults } from "~/common/state/hooks/useTaskDetail";
+import { MarkdownBlock } from "~/components/MarkdownBlock";
 import { openFileViewTabAtom } from "~/pages/workspace/components/diffPanel/atoms.ts";
 
 import styles from "./AlphaChatView.module.scss";
 import { PulsingDot } from "./pill-animations";
 
 const DISMISSED_ANSWER = "[Dismissed]";
-const PLAN_APPROVAL_QUESTION = "Claude has finished planning. How would you like to proceed?";
 const APPROVE_PLAN_ANSWER = "Approve plan";
 
 export const AlphaExitPlanModeBlock = ({ toolBlock }: { toolBlock: ToolUseBlock }): ReactElement => {
@@ -44,6 +44,18 @@ export const AlphaExitPlanModeBlock = ({ toolBlock }: { toolBlock: ToolUseBlock 
     if (planFilePath) openFileViewTab({ workspaceId: workspaceID, filePath: planFilePath });
   }, [planFilePath, workspaceID, openFileViewTab]);
 
+  // Harnesses that present the plan inline (e.g. pi) pass it as the tool's
+  // `plan` argument rather than writing a plan file; render it here so the user
+  // can actually read the plan. Harnesses with a plan file (Claude) keep the
+  // click-to-open link instead.
+  const planText = typeof toolBlock.input?.plan === "string" ? toolBlock.input.plan : undefined;
+  const planContent =
+    planText && !planFilePath ? (
+      <div className={styles.planInlineContent}>
+        <MarkdownBlock content={planText} />
+      </div>
+    ) : null;
+
   if (isPending) {
     return (
       <div className={styles.planBlock} data-testid={ElementIds.EXIT_PLAN_MODE_TOOL_BLOCK}>
@@ -55,12 +67,17 @@ export const AlphaExitPlanModeBlock = ({ toolBlock }: { toolBlock: ToolUseBlock 
           <PulsingDot />
           <span className={styles.toolName}>Plan ready for review</span>
         </div>
+        {planContent}
       </div>
     );
   }
 
   if (matchingAnswers) {
-    const answerValue = matchingAnswers.answers[PLAN_APPROVAL_QUESTION] ?? "";
+    // Look the answer up by the question's OWN stored text (it varies by harness
+    // and has changed over time) rather than a hardcoded string, so historical
+    // plan turns resolve too.
+    const planQuestion = matchingAnswers.questionData.questions[0]?.question ?? "";
+    const answerValue = matchingAnswers.answers[planQuestion] ?? "";
     const isDismissed = answerValue === DISMISSED_ANSWER;
     const isApproved = answerValue === APPROVE_PLAN_ANSWER;
 
@@ -77,6 +94,7 @@ export const AlphaExitPlanModeBlock = ({ toolBlock }: { toolBlock: ToolUseBlock 
               Approved
             </Badge>
           </div>
+          {planContent}
         </div>
       );
     }
@@ -131,6 +149,7 @@ export const AlphaExitPlanModeBlock = ({ toolBlock }: { toolBlock: ToolUseBlock 
       >
         <span className={styles.toolName}>Plan reviewed</span>
       </div>
+      {planContent}
     </div>
   );
 };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolGroup.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolGroup.tsx
@@ -11,12 +11,7 @@ import {
 } from "~/common/state/hooks/useTaskHelpers.ts";
 import type { SubagentMetadata, SubagentTreeNode } from "~/pages/workspace/utils/subagentTree.ts";
 import { SUBAGENT_TOOL_NAMES } from "~/pages/workspace/utils/subagentTree.ts";
-import {
-  isAskUserQuestionTool,
-  isEnterPlanModeTool,
-  isExitPlanModeTool,
-  isHiddenTool,
-} from "~/pages/workspace/utils/utils.ts";
+import { isEnterPlanModeTool, isHiddenTool } from "~/pages/workspace/utils/utils.ts";
 
 import { AlphaAskUserQuestionBlock } from "./AlphaAskUserQuestionBlock.tsx";
 import { AlphaExitPlanModeBlock } from "./AlphaExitPlanModeBlock.tsx";
@@ -33,18 +28,18 @@ const isTopLevelToolBlock = (block: ToolUseBlock | ToolResultBlock): boolean => 
   return isEnterPlanModeTool(toolName);
 };
 
-const isSpecialToolUse = (block: ToolUseBlock): boolean =>
-  isAskUserQuestionTool(block.name) || isExitPlanModeTool(block.name);
+// The harness stamps interactiveRole on backchannel tool blocks (server-side,
+// from Harness.classify_tool_ui_role) so rendering keys off the role rather than
+// a hardcoded set of tool names — each harness owns which of its tools are
+// ask-user-question / exit-plan-mode.
+const isSpecialToolUse = (block: ToolUseBlock): boolean => block.interactiveRole != null;
 
 // AUQ / ExitPlanMode tool_result blocks are consumed by the inline
 // AlphaAskUserQuestionBlock / AlphaExitPlanModeBlock via the
 // submittedQuestionAnswers lookup. Rendering them as a separate generic
 // tool-call card would duplicate what the inline block already shows.
-const isSpecialToolResult = (block: ToolUseBlock | ToolResultBlock): boolean => {
-  if (block.type !== "tool_result") return false;
-  const toolName = getToolName(block);
-  return isAskUserQuestionTool(toolName) || isExitPlanModeTool(toolName);
-};
+const isSpecialToolResult = (block: ToolUseBlock | ToolResultBlock): boolean =>
+  block.type === "tool_result" && block.interactiveRole != null;
 
 export const ToolBlockGroup = ({
   blocks,
@@ -129,11 +124,11 @@ export const ToolBlockGroup = ({
         })}
       {canRenderInteractiveBackchannel &&
         specialBlocks.map((block) => {
-          if (isAskUserQuestionTool(block.name)) {
+          if (block.interactiveRole === "ask_user_question") {
             return <AlphaAskUserQuestionBlock key={block.id} toolBlock={block} />;
           }
 
-          if (isExitPlanModeTool(block.name)) {
+          if (block.interactiveRole === "exit_plan_mode") {
             return <AlphaExitPlanModeBlock key={block.id} toolBlock={block} />;
           }
           return null;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/buildRenderGroups.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/buildRenderGroups.ts
@@ -13,7 +13,6 @@ import {
 } from "~/common/Guards";
 import type { SubagentTreeNode } from "~/pages/workspace/utils/subagentTree.ts";
 import { SUBAGENT_TOOL_NAMES } from "~/pages/workspace/utils/subagentTree.ts";
-import { isAskUserQuestionTool, isExitPlanModeTool } from "~/pages/workspace/utils/utils.ts";
 
 export type RenderGroup =
   | { type: "text"; blocks: Array<{ text: string }> }
@@ -25,8 +24,10 @@ export type RenderGroup =
   | { type: "context_cleared"; text: string }
   | { type: "resume_response" };
 
-const isSpecialToolUse = (block: ToolUseBlock): boolean =>
-  isAskUserQuestionTool(block.name) || isExitPlanModeTool(block.name);
+// Backchannel tools (ask-user-question / exit-plan-mode) are isolated into their
+// own render group so they render as the inline question/plan panel. The harness
+// stamps `interactiveRole` server-side, so this is harness-agnostic.
+const isSpecialToolUse = (block: ToolUseBlock): boolean => block.interactiveRole != null;
 
 export const buildRenderGroups = (
   content: ReadonlyArray<BlockUnion>,

--- a/sculptor/frontend/src/pages/workspace/utils/utils.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/utils.ts
@@ -16,17 +16,9 @@ export const isDiffTool = (toolName: string): toolName is DiffTool => {
   return DIFF_TOOLS.includes(toolName as DiffTool);
 };
 
-export const isAskUserQuestionTool = (toolName: string): boolean => {
-  return toolName === "AskUserQuestion" || toolName === "mcp__sculptor__ask_user_question";
-};
-
 export const formatSubagentType = (subagentType: string | undefined): string => {
   if (!subagentType) return "Subagent";
   return subagentType.charAt(0).toUpperCase() + subagentType.slice(1) + " subagent";
-};
-
-export const isExitPlanModeTool = (toolName: string): boolean => {
-  return toolName === "ExitPlanMode" || toolName === "mcp__sculptor__exit_plan_mode";
 };
 
 export const isEnterPlanModeTool = (toolName: string): boolean => {

--- a/sculptor/pyproject.toml
+++ b/sculptor/pyproject.toml
@@ -88,6 +88,11 @@ sculptor = [
     "services/environment_service/providers/docker/imbue_addons/*",
     "services/environment_service/providers/docker/default_devcontainer/*",
     "cli/ssh_config/*",
+    # Sculptor-pinned pi extensions, loaded into pi via `-e` at launch. They are
+    # `.ts` source (pi runs them through jiti, no build step) and must ship in
+    # the wheel so PiAgent.start can resolve them in an installed build, not just
+    # a repo checkout.
+    "agents/pi_agent/extensions/*",
 ]
 # Sadly, the build system will not complain if the above are misspelled.
 

--- a/sculptor/sculptor/agents/default/claude_code_sdk/harness.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/harness.py
@@ -28,6 +28,7 @@ from sculptor.interfaces.agents.harness import Harness
 from sculptor.interfaces.agents.harness import HarnessCapabilities
 from sculptor.interfaces.environments.agent_execution_environment import AgentExecutionEnvironment
 from sculptor.services.dependency_management_service import Dependency
+from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.chat_state import ContentBlock
 from sculptor.state.chat_state import ToolUseBlock
 from sculptor.state.chat_state import UserQuestion
@@ -166,6 +167,13 @@ class ClaudeCodeHarness(Harness):
         except ValidationError:
             return False
         return True
+
+    def reconstruct_pending_ask_user_question(self, block: ToolUseBlock) -> AskUserQuestionData | None:
+        # Claude's MCP AskUserQuestion tool input already carries the
+        # `AskUserQuestionData` fields, so validate it as that shape directly.
+        if not self.is_valid_ask_user_question_input(block.name, block.input):
+            return None
+        return AskUserQuestionData.model_validate({**block.input, "tool_use_id": block.id}, strict=True)
 
     def get_plan_file_path_from_tool_use(self, block: ContentBlock) -> str | None:
         if not isinstance(block, ToolUseBlock):

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1,22 +1,26 @@
 """PiAgent — `DefaultAgentWrapper` subclass wrapping `pi --mode rpc`.
 
-The agent spawns a long-lived `pi --mode rpc --session-dir <dir>
---session-id <id> --append-system-prompt <prompt> [--skill <dir> ...]`
-subprocess and pumps user turns over JSONL stdin/stdout. The session flags
-persist the conversation as a JSONL file under a per-task dir and pin its id
-Sculptor-side, so relaunching after an agent-process restart resumes the full
-conversation (`supports_session_resume`). The `--skill` flags point pi at the
-workspace's Claude-visible skill sources so its skill set matches the slash
-picker's (`supports_skills`). Pi's stdout multiplexes three channels
-(`response`, `extension_ui_request`, and the `AgentSessionEvent` union);
-the dispatcher distinguishes them by top-level `type`. Pi's tool calls
-render as rich tool blocks (`supports_tool_use_rendering=True`): the
-issuing assistant message's `toolCall` content blocks become
-`ToolUseBlock`s (name + input, shown while running) and the
-tool-execution lane's `tool_execution_end` becomes the `ToolResultBlock`
-(the result, shown when done), correlated by the shared tool-call id (see
-`tool_rendering.py` for the pi→Claude name/arg adaptation). A finished
-file-mutating tool (`edit`/`write`/`bash`) additionally triggers
+The agent spawns a long-lived `pi --mode rpc --session-dir <dir> --session-id
+<id> --no-extensions -e <pinned extension> --append-system-prompt <prompt>
+[--skill <dir> ...]` subprocess and pumps user turns over JSONL stdin/stdout.
+The session flags persist the conversation as a JSONL file under a per-task dir
+and pin its id Sculptor-side, so relaunching after an agent-process restart
+resumes the full conversation (`supports_session_resume`). The `--skill` flags
+point pi at the workspace's Claude-visible skill sources so its skill set
+matches the slash picker's (`supports_skills`). The pinned `sculptor_backchannel`
+extension (`extensions/`, `backchannel.py`), loaded with `--no-extensions -e`,
+provides ask-user-question + plan mode: its blocking dialogs arrive as
+`extension_ui_request` and are mapped onto `AskUserQuestionAgentMessage`, with
+the user's `UserQuestionAnswerMessage` routed back as the matching
+`extension_ui_response`. Pi's stdout multiplexes three channels (`response`,
+`extension_ui_request`, and the `AgentSessionEvent` union); the dispatcher
+distinguishes them by top-level `type`. Pi's tool calls render as rich tool
+blocks (`supports_tool_use_rendering=True`): the issuing assistant message's
+`toolCall` content blocks become `ToolUseBlock`s (name + input, shown while
+running) and the tool-execution lane's `tool_execution_end` becomes the
+`ToolResultBlock` (the result, shown when done), correlated by the shared
+tool-call id (see `tool_rendering.py` for the pi→Claude name/arg adaptation). A
+finished file-mutating tool (`edit`/`write`/`bash`) additionally triggers
 `on_diff_needed` so the workspace diff is regenerated — pi runs the tools
 against the workspace itself and emits no other signal that files changed.
 
@@ -36,6 +40,7 @@ from pathlib import Path
 from queue import Empty
 from queue import Queue
 from threading import Event
+from threading import Lock
 from typing import Any
 from typing import Mapping
 from typing import assert_never
@@ -48,6 +53,10 @@ from pydantic import ValidationError
 
 from sculptor.agents.default.agent_wrapper import DefaultAgentWrapper
 from sculptor.agents.default.utils import get_state_file_contents
+from sculptor.agents.pi_agent.backchannel import PI_QUESTION_HEADER
+from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
+from sculptor.agents.pi_agent.backchannel import extension_ui_response_body
+from sculptor.agents.pi_agent.backchannel import is_plan_approval
 from sculptor.agents.pi_agent.harness import PiHarness
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import ExtensionUiRequest
@@ -87,12 +96,16 @@ from sculptor.common.plugin import get_plugin_dirs
 from sculptor.foundation.common import generate_id
 from sculptor.foundation.secrets_utils import Secret
 from sculptor.foundation.thread_utils import ObservableThread
+from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
 from sculptor.interfaces.agents.agent import ClearContextUserMessage
 from sculptor.interfaces.agents.agent import InterruptProcessUserMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
 from sculptor.interfaces.agents.agent import PiAgentConfig
+from sculptor.interfaces.agents.agent import PlanModeAgentMessage
+from sculptor.interfaces.agents.agent import RequestSkippedAgentMessage
+from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
 from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
@@ -108,10 +121,14 @@ from sculptor.primitives.ids import ToolUseID
 from sculptor.services.dependency_management_service import PI_VERSION_RANGE
 from sculptor.services.dependency_management_service import parse_pi_version
 from sculptor.services.user_config.user_config import get_user_config_instance
+from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.chat_state import ContentBlockTypes
+from sculptor.state.chat_state import QuestionOption
 from sculptor.state.chat_state import TextBlock
 from sculptor.state.chat_state import ToolResultBlock
 from sculptor.state.chat_state import ToolUseBlock
+from sculptor.state.chat_state import UserQuestion
+from sculptor.state.chat_state import make_plan_approval_question
 from sculptor.state.claude_state import get_tool_invocation_string
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import Message
@@ -146,17 +163,30 @@ PI_SESSION_ID_STATE_FILE: str = "pi_session_id"
 # them (pi has no RPC equivalent) and logs each at error level — the frontend
 # gate should keep them from reaching pi, so one arriving means a gate has
 # failed. Each maps to the capability whose handler will replace its drop:
-#   UserQuestionAnswerMessage        → supports_interactive_backchannel
 #   ClearContextUserMessage          → supports_context_reset
-_DEAD_LETTER_MESSAGE_TYPES: tuple[type[Message], ...] = (
-    UserQuestionAnswerMessage,
-    ClearContextUserMessage,
-)
+_DEAD_LETTER_MESSAGE_TYPES: tuple[type[Message], ...] = (ClearContextUserMessage,)
 
 # If pi's abort-induced `agent_end` does not arrive within this grace window
 # (pi wedged or ignoring the abort), escalate to SIGTERM; the process-exit
 # fallback in `_consume_until_turn_end` then resolves the turn.
 _INTERRUPT_ESCALATION_GRACE_SECONDS: float = 5.0
+
+# The backchannel extension shipped with Sculptor (package data; see
+# pyproject.toml). Resolved next to this module so it works from an installed
+# build as well as a repo checkout, then written into the environment at launch.
+_BACKCHANNEL_EXTENSION_FILENAME: str = "sculptor_backchannel.ts"
+_EXTENSIONS_SOURCE_DIR: Path = Path(__file__).resolve().parent / "extensions"
+
+# Prepended to a turn's prompt while the agent is in plan mode. Drives the pi
+# agent to explore read-only and present its plan via the `exit_plan_mode` tool
+# for approval — the pi analogue of Claude's `is_in_plan_mode` user-instructions.
+# (Divergence, REQ-CAP-ALL-3: read-only is requested in the prompt, not enforced
+# by a tool allowlist.)
+_PLAN_MODE_PROMPT_PREFIX: str = """[PLAN MODE]
+You are in plan mode. Investigate the request using read-only tools only (read files, inspect with read-only bash, grep, find, ls) and do NOT modify any files or run state-changing commands. Produce a clear, numbered plan describing what you would do. When the plan is ready, call the `exit_plan_mode` tool to present it to the user for approval. Do not begin implementing until the user approves; if they request revisions, refine the plan and call `exit_plan_mode` again.
+
+The user's request follows:
+"""
 
 
 def _pi_version_in_range(version: str) -> bool:
@@ -300,6 +330,26 @@ class PiAgent(DefaultAgentWrapper):
     # offers), captured at launch so `_run_prompt_turn` can rewrite a picked
     # `/name` into pi's `/skill:<name>` form. Empty until `start()`.
     _discovered_skill_names: frozenset[str] = PrivateAttr(default_factory=frozenset)
+    # Absolute paths pi was launched with via `-e` (the pinned extension set);
+    # used by the fail-loud posture to tell our extension's errors from foreign.
+    _loaded_extension_paths: tuple[str, ...] = PrivateAttr(default=())
+    # Interactive-backchannel state, shared between the dispatcher thread (which
+    # sets `_pending_ui_request_id` when our extension opens a dialog) and the
+    # request-handling thread (which clears it and writes the answer in
+    # `_deliver_question_answer`). Guarded by `_backchannel_lock`.
+    _backchannel_lock: Lock = PrivateAttr(default_factory=Lock)
+    _pending_ui_request_id: str | None = PrivateAttr(default=None)
+    # Answer request ids awaiting their deferred RequestSuccess (emitted at the
+    # turn boundary so the post-answer content reaches the frontend first —
+    # mirrors Claude's `_pending_answer_request_ids`).
+    _pending_answer_request_ids: list[AgentMessageID] = PrivateAttr(default_factory=list)
+    # Tracks plan mode across turns (set from ChatInputUserMessage flags, cleared
+    # on plan approval) so the prompt carries the plan-mode preamble — the pi
+    # analogue of ClaudeProcessManager._is_in_plan_mode.
+    _is_in_plan_mode: bool = PrivateAttr(default=False)
+    # Serializes stdin writes: the prompt pump, the answer-delivery thread, and
+    # `wait()`'s abort can all write to pi's stdin.
+    _send_lock: Lock = PrivateAttr(default_factory=Lock)
 
     def start(self, secrets: Mapping[str, str | Secret]) -> None:
         # Resolve and validate the pi binary BEFORE super().start so the
@@ -353,12 +403,16 @@ class PiAgent(DefaultAgentWrapper):
         # the picker list and pi's loaded set stay in lockstep.
         skill_args = self._build_skill_launch_args()
         self._discovered_skill_names = self._discover_skill_names()
+        extension_args = self._install_pinned_extensions()
         # `--session-id` (Sculptor-pinned id, "creating it if missing") is the
         # resume lever, chosen over `--session <id>`: it never errors on an
         # absent/corrupt session (real pi 0.78.0 exits non-zero for an unknown
         # `--session`), so a lost session file degrades to a loud fresh start
         # rather than a crash loop. Pi also tolerates a truncated JSONL tail,
-        # resuming the valid prefix. See the MR for the lever rationale.
+        # resuming the valid prefix. `--no-extensions` disables pi's own
+        # extension *discovery* while the explicit `-e <path>` still loads our
+        # pinned set — together the immutability guarantee (REQ-EXT-3): only
+        # Sculptor's curated, version-pinned extension set loads.
         command = [
             binary,
             "--mode",
@@ -367,6 +421,8 @@ class PiAgent(DefaultAgentWrapper):
             str(session_dir),
             "--session-id",
             self._session_id,
+            "--no-extensions",
+            *extension_args,
             "--append-system-prompt",
             system_prompt,
             *skill_args,
@@ -430,6 +486,12 @@ class PiAgent(DefaultAgentWrapper):
                     interrupted=False,
                 )
             )
+            return True
+        if isinstance(message, UserQuestionAnswerMessage):
+            # Mid-turn answer to a backchannel dialog the agent is blocked on:
+            # delivered here on the request-handling thread (mirrors Claude's
+            # `_try_deliver_answer_to_mcp`), not queued like a new prompt.
+            self._deliver_question_answer(message)
             return True
         if isinstance(message, _DEAD_LETTER_MESSAGE_TYPES):
             # See _DEAD_LETTER_MESSAGE_TYPES. Returns False so the base class's
@@ -570,6 +632,28 @@ class PiAgent(DefaultAgentWrapper):
             skill_md.write_text(_render_synthesized_skill(name, description, body), encoding="utf-8")
         return skills_root if seen_names else None
 
+    def _install_pinned_extensions(self) -> list[str]:
+        """Materialize the pinned extension set and return its `-e <path>` args.
+
+        The extension source ships as package data next to this module
+        (`extensions/`, see pyproject.toml), so it resolves in an installed
+        build as well as a repo checkout. We write it into the per-task state
+        dir via `environment.write_file` so the pi process can read it whatever
+        the environment type (local / container / remote) — a repo-relative path
+        would not survive packaging, the trap this avoids.
+        """
+        extension_args: list[str] = []
+        loaded_paths: list[str] = []
+        state_path = self.environment.get_state_path()
+        for filename in (_BACKCHANNEL_EXTENSION_FILENAME,):
+            content = (_EXTENSIONS_SOURCE_DIR / filename).read_text(encoding="utf-8")
+            destination = state_path / filename
+            self.environment.write_file(str(destination), content)
+            extension_args.extend(["-e", str(destination)])
+            loaded_paths.append(str(destination))
+        self._loaded_extension_paths = tuple(loaded_paths)
+        return extension_args
+
     def _collect_api_key_secrets(self) -> dict[str, Secret]:
         config = get_user_config_instance()
         collected: dict[str, Secret] = {}
@@ -604,10 +688,13 @@ class PiAgent(DefaultAgentWrapper):
         if process is None:
             return
         line = json.dumps(payload, separators=(",", ":")) + "\n"
-        try:
-            process.write_stdin(line)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("PiAgent write_stdin failed: {}", e)
+        # The prompt pump, answer delivery, and wait()'s abort can all write
+        # stdin from different threads; serialize so lines never interleave.
+        with self._send_lock:
+            try:
+                process.write_stdin(line)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("PiAgent write_stdin failed: {}", e)
 
     def _request_state_blocking(self, timeout: float = 10.0) -> dict[str, Any] | None:
         """Send `get_state` and return pi's reported `RpcSessionState` data (RPC §5.1).
@@ -757,6 +844,7 @@ class PiAgent(DefaultAgentWrapper):
             self._run_prompt_turn(message)
 
     def _run_prompt_turn(self, message: ChatInputUserMessage) -> None:
+        self._update_plan_mode_from_message(message)
         with self._handle_user_message(message):
             # A fresh turn starts un-interrupted: clear interrupt state left by an
             # interrupt that raced in with no turn in flight, which would otherwise
@@ -766,15 +854,37 @@ class PiAgent(DefaultAgentWrapper):
             self._cancel_interrupt_escalation()
             prompt_id = generate_id()
             self._turn_in_flight.set()
+            turn_failed = False
             self._send_rpc(self._build_prompt_payload(prompt_id, message))
             try:
                 self._consume_until_turn_end(prompt_id)
+            except BaseException:
+                turn_failed = True
+                raise
             finally:
                 # Turn over: stand down escalation and drop interrupt-pending so a
                 # late grace-window thread can't SIGTERM the next turn's pi.
                 self._turn_in_flight.clear()
                 self._interrupt_pending.clear()
                 self._cancel_interrupt_escalation()
+                # Finalize any backchannel answer delivered mid-turn (its
+                # RequestSuccess was deferred to here so the post-answer content
+                # reached the frontend first). Runs on the failure path too, so the
+                # answer's request resolves instead of pinning the frontend
+                # "thinking" (mirrors Claude).
+                self._finalize_pending_answers(interrupted=turn_failed)
+
+    def _update_plan_mode_from_message(self, message: ChatInputUserMessage) -> None:
+        """Track plan mode across turns from the chat input's toggle flags.
+
+        Mirrors `ClaudeProcessManager` (`process_manager.py`): entering sets the
+        flag, leaving clears it; plan approval clears it later in
+        `_deliver_question_answer`.
+        """
+        if message.enter_plan_mode:
+            self._is_in_plan_mode = True
+        elif message.exit_plan_mode:
+            self._is_in_plan_mode = False
 
     def _build_prompt_payload(self, prompt_id: str, message: ChatInputUserMessage) -> dict[str, Any]:
         """Assemble the `prompt` command for one user turn, attachments included.
@@ -786,8 +896,7 @@ class PiAgent(DefaultAgentWrapper):
         """
         saved_paths = save_attachments_to_environment(self.environment, message.files)
         image_paths, path_attachments = split_image_and_path_attachments(saved_paths)
-        rewritten_text = _rewrite_skill_invocation(message.text, self._discovered_skill_names)
-        prompt_text = build_attachment_instructions(path_attachments) + rewritten_text
+        prompt_text = build_attachment_instructions(path_attachments) + self._build_prompt_text(message)
         payload: dict[str, Any] = {"type": "prompt", "id": prompt_id, "message": prompt_text}
         if image_paths:
             # No per-model image-capability gating here yet, only the
@@ -797,11 +906,35 @@ class PiAgent(DefaultAgentWrapper):
             payload["images"] = [build_image_block(path, self._read_attachment_bytes(path)) for path in image_paths]
         return payload
 
+    def _build_prompt_text(self, message: ChatInputUserMessage) -> str:
+        """The user text with the skill-invocation rewrite, plus the plan-mode
+        preamble while in plan mode."""
+        text = _rewrite_skill_invocation(message.text, self._discovered_skill_names)
+        if self._is_in_plan_mode:
+            return f"{_PLAN_MODE_PROMPT_PREFIX}{text}"
+        return text
+
     def _read_attachment_bytes(self, path: str) -> bytes:
         """Read a saved attachment's bytes from the environment copy."""
         content = self.environment.read_file(path, mode="rb")
         assert isinstance(content, bytes), "binary read must return bytes"
         return content
+
+    def _finalize_pending_answers(self, interrupted: bool) -> None:
+        """Emit the deferred RequestSuccess for answers delivered this turn.
+
+        Deferred from `_deliver_question_answer` to the turn boundary so the
+        post-answer content reaches the frontend's in-progress message before it
+        is finalized — mirrors Claude's `_process_single_message` finally block.
+        """
+        with self._backchannel_lock:
+            pending = self._pending_answer_request_ids
+            self._pending_answer_request_ids = []
+            self._pending_ui_request_id = None
+        for request_id in pending:
+            self._output_messages.put(
+                RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=request_id, interrupted=interrupted)
+            )
 
     def _consume_until_turn_end(self, prompt_id: str = "") -> None:
         """Drive pi's stdout until the current agent run terminates.
@@ -809,9 +942,10 @@ class PiAgent(DefaultAgentWrapper):
         Top-level dispatch routes on `event["type"]` into three lanes:
         `response` (command-ACK; correlate by `id`; `success: false` on
         the outstanding `prompt` raises `PiCrashError`),
-        `extension_ui_request` (logged and discarded; pi-basic loads no
-        extensions), and everything else (the `AgentSessionEvent` union,
-        dispatched per-`type`).
+        `extension_ui_request` (the backchannel extension's blocking dialogs →
+        AskUserQuestion; the turn stays open until the answer is posted back),
+        and everything else (the `AgentSessionEvent` union, dispatched
+        per-`type`).
         """
         process = self._process
         assert process is not None
@@ -876,8 +1010,8 @@ class PiAgent(DefaultAgentWrapper):
         """Dispatch one parsed RPC message. Returns True when the turn ends.
 
         A single `match` over the typed union makes the three lanes explicit:
-        `response` (correlated by `id`), `extension_ui_request` (discarded —
-        no extensions are loaded), and the session-event union. `agent_end`
+        `response` (correlated by `id`), `extension_ui_request` (the backchannel
+        extension's dialogs → AskUserQuestion), and the session-event union. `agent_end`
         is the only turn boundary; `message_end` fires once per assistant
         message (several times per run in tool loops) and so cannot terminate
         the turn. The `tool_execution_*` lane renders tool calls:
@@ -892,7 +1026,7 @@ class PiAgent(DefaultAgentWrapper):
                 self._handle_response_event(parsed, state)
                 return False
             case ExtensionUiRequest():
-                logger.debug("PiAgent ignoring extension_ui_request (no extensions loaded): {}", parsed)
+                self._handle_extension_ui_request(parsed)
                 return False
             case ParsedAgentStart():
                 # Streaming begins; nothing to emit until text_delta arrives.
@@ -1271,11 +1405,97 @@ class PiAgent(DefaultAgentWrapper):
         self._output_messages.put(AutoCompactingDoneAgentMessage(message_id=AgentMessageID()))
 
     def _handle_extension_error(self, parsed: ParsedExtensionError) -> None:
-        # Non-terminal: extensions are not loaded in pi-basic but pi could
-        # still surface one from its own bundled defaults.
+        """Fail loud on an error from our pinned extension; log foreign ones.
+
+        A thrown extension surfaces as a non-terminal `extension_error`
+        (RPC §5.2/§8). An error from the extension Sculptor loaded (`-e <path>`)
+        fails the turn visibly via `PiCrashError` rather than continuing with a
+        silently broken backchannel. An error from any other extension path
+        stays log-only.
+        """
+        if parsed.extension_path in self._loaded_extension_paths:
+            text = parsed.error or "the Sculptor backchannel extension raised an error"
+            raise PiCrashError(text, exit_code=None, metadata=None)
         logger.info(
-            "PiAgent extension_error: extension={} event={} error={}",
+            "PiAgent extension_error from foreign extension: extension={} event={} error={}",
             parsed.extension_path,
             parsed.event,
             parsed.error,
         )
+
+    def _handle_extension_ui_request(self, parsed: ExtensionUiRequest) -> None:
+        """Map a backchannel dialog onto an AskUserQuestion and hold the turn.
+
+        Our extension only opens blocking `select` (multiple-choice / plan
+        approval) and `input` (free-form) dialogs. Each becomes an
+        `AskUserQuestionAgentMessage`, and the request id is recorded so
+        `_deliver_question_answer` can post the matching `extension_ui_response`.
+        pi blocks until then (we never set a `timeout`), so the consume loop just
+        keeps draining stdout — the turn is not over. Fire-and-forget methods
+        (`notify`/`setStatus`/…) need no response and are ignored.
+        """
+        if parsed.method not in ("select", "input"):
+            logger.debug("PiAgent ignoring non-dialog extension_ui_request method: {}", parsed.method)
+            return
+        question_data = self._build_question_data(parsed)
+        with self._backchannel_lock:
+            self._pending_ui_request_id = parsed.id
+        self._output_messages.put(
+            AskUserQuestionAgentMessage(message_id=AgentMessageID(), question_data=question_data)
+        )
+
+    def _build_question_data(self, parsed: ExtensionUiRequest) -> AskUserQuestionData:
+        """Build the AskUserQuestion payload from a backchannel dialog request.
+
+        The `exit_plan_mode` tool's `select` uses the plan-approval sentinel
+        title, which maps to the canonical Sculptor plan-approval question (so
+        the frontend shows "Waiting for plan approval" and the gated methods
+        agree). Any other dialog is a regular question: `select` (options) →
+        multiple choice, `input` (no options) → free-form. `other_label` lets the
+        user type a free-form answer too; pi returns the typed value verbatim.
+        """
+        if parsed.method == "select" and parsed.title == PLAN_APPROVAL_DIALOG_TITLE:
+            return make_plan_approval_question(tool_use_id=parsed.id)
+        options = [QuestionOption(label=option, description="") for option in (parsed.options or [])]
+        return AskUserQuestionData(
+            questions=[
+                UserQuestion(
+                    question=parsed.title or "",
+                    header=PI_QUESTION_HEADER,
+                    options=options,
+                    multi_select=False,
+                    other_label="Other",
+                )
+            ],
+            tool_use_id=parsed.id,
+        )
+
+    def _deliver_question_answer(self, message: UserQuestionAnswerMessage) -> None:
+        """Post the user's answer back to the dialog pi is blocked on.
+
+        Runs on the request-handling thread while the dispatcher thread drains
+        stdout. Emits the answer's own `RequestStarted` immediately and defers
+        its `RequestSuccess` to the turn boundary (`_finalize_pending_answers`),
+        mirroring Claude's `_try_deliver_answer_to_mcp`. A plan approval also
+        clears plan mode and emits `PlanModeAgentMessage(False)`. An answer with
+        no pending dialog is stale (the frontend gate should prevent it): emit a
+        terminal `RequestSkipped` so the request resolves, and drop it.
+        """
+        with self._backchannel_lock:
+            request_id = self._pending_ui_request_id
+            if request_id is None:
+                logger.info(
+                    "PiAgent received question answer with no pending dialog (stale); skipping. tool_use_id={}",
+                    message.tool_use_id,
+                )
+                self._output_messages.put(RequestSkippedAgentMessage(request_id=message.message_id))
+                return
+            self._pending_ui_request_id = None
+            self._pending_answer_request_ids.append(message.message_id)
+        if self._is_in_plan_mode and is_plan_approval(message):
+            self._is_in_plan_mode = False
+            self._output_messages.put(PlanModeAgentMessage(message_id=AgentMessageID(), is_in_plan_mode=False))
+        self._output_messages.put(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=message.message_id)
+        )
+        self._send_rpc({"type": "extension_ui_response", "id": request_id, **extension_ui_response_body(message)})

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -53,8 +53,8 @@ from pydantic import ValidationError
 
 from sculptor.agents.default.agent_wrapper import DefaultAgentWrapper
 from sculptor.agents.default.utils import get_state_file_contents
-from sculptor.agents.pi_agent.backchannel import PI_QUESTION_HEADER
 from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
+from sculptor.agents.pi_agent.backchannel import build_ask_user_question_data
 from sculptor.agents.pi_agent.backchannel import extension_ui_response_body
 from sculptor.agents.pi_agent.backchannel import is_plan_approval
 from sculptor.agents.pi_agent.harness import PiHarness
@@ -123,11 +123,9 @@ from sculptor.services.dependency_management_service import parse_pi_version
 from sculptor.services.user_config.user_config import get_user_config_instance
 from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.chat_state import ContentBlockTypes
-from sculptor.state.chat_state import QuestionOption
 from sculptor.state.chat_state import TextBlock
 from sculptor.state.chat_state import ToolResultBlock
 from sculptor.state.chat_state import ToolUseBlock
-from sculptor.state.chat_state import UserQuestion
 from sculptor.state.chat_state import make_plan_approval_question
 from sculptor.state.claude_state import get_tool_invocation_string
 from sculptor.state.messages import ChatInputUserMessage
@@ -1456,19 +1454,7 @@ class PiAgent(DefaultAgentWrapper):
         """
         if parsed.method == "select" and parsed.title == PLAN_APPROVAL_DIALOG_TITLE:
             return make_plan_approval_question(tool_use_id=parsed.id)
-        options = [QuestionOption(label=option, description="") for option in (parsed.options or [])]
-        return AskUserQuestionData(
-            questions=[
-                UserQuestion(
-                    question=parsed.title or "",
-                    header=PI_QUESTION_HEADER,
-                    options=options,
-                    multi_select=False,
-                    other_label="Other",
-                )
-            ],
-            tool_use_id=parsed.id,
-        )
+        return build_ask_user_question_data(parsed.title or "", parsed.options or [], parsed.id)
 
     def _deliver_question_answer(self, message: UserQuestionAnswerMessage) -> None:
         """Post the user's answer back to the dialog pi is blocked on.

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -337,6 +337,14 @@ class PiAgent(DefaultAgentWrapper):
     # `_deliver_question_answer`). Guarded by `_backchannel_lock`.
     _backchannel_lock: Lock = PrivateAttr(default_factory=Lock)
     _pending_ui_request_id: str | None = PrivateAttr(default=None)
+    # Tool-call id of the backchannel tool whose dialog is currently open. Pi
+    # assigns the tool call and the extension's `ui_request` separate ids; this
+    # is the tool-call id — the one carried by the rendered ToolUseBlock /
+    # ToolResultBlock — used as the question's `tool_use_id` so the frontend
+    # correlates the answered question with its tool block (Claude's single-id
+    # model). Set and read on the dispatcher thread only. `_pending_ui_request_id`
+    # keeps the separate ui_request id for the `extension_ui_response` round-trip.
+    _pending_backchannel_tool_call_id: str | None = PrivateAttr(default=None)
     # Answer request ids awaiting their deferred RequestSuccess (emitted at the
     # turn boundary so the post-answer content reaches the frontend first —
     # mirrors Claude's `_pending_answer_request_ids`).
@@ -1183,6 +1191,12 @@ class PiAgent(DefaultAgentWrapper):
                     claude_input=dict(block.input),
                     assistant_message_id=state.assistant_message_id,
                 )
+                # Remember the backchannel tool call so the dialog it opens next
+                # adopts its id as the question's tool_use_id (see
+                # `_build_question_data`). Dialogs are sequential, so the most
+                # recent backchannel call is the one whose dialog is opening.
+                if self.harness.classify_tool_ui_role(block.name) is not None:
+                    self._pending_backchannel_tool_call_id = str(block.id)
         if content:
             self._output_messages.put(
                 ResponseBlockAgentMessage(
@@ -1452,9 +1466,15 @@ class PiAgent(DefaultAgentWrapper):
         multiple choice, `input` (no options) → free-form. `other_label` lets the
         user type a free-form answer too; pi returns the typed value verbatim.
         """
+        # The question's tool_use_id is the originating tool call's id (not the
+        # ui_request id) so the frontend correlates the answered question with the
+        # rendered ToolUseBlock / ToolResultBlock. Fall back to the ui_request id
+        # only if no backchannel tool call was seen (unexpected — the tool issues
+        # the dialog).
+        tool_use_id = self._pending_backchannel_tool_call_id or parsed.id
         if parsed.method == "select" and parsed.title == PLAN_APPROVAL_DIALOG_TITLE:
-            return make_plan_approval_question(tool_use_id=parsed.id)
-        return build_ask_user_question_data(parsed.title or "", parsed.options or [], parsed.id)
+            return make_plan_approval_question(tool_use_id=tool_use_id)
+        return build_ask_user_question_data(parsed.title or "", parsed.options or [], tool_use_id)
 
     def _deliver_question_answer(self, message: UserQuestionAnswerMessage) -> None:
         """Post the user's answer back to the dialog pi is blocked on.

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -3,8 +3,8 @@
 The tests stub the pi subprocess with a `MagicMock` `RunningProcess` so
 the full RPC pump can be exercised without a real binary. Coverage
 mirrors pi's three-channel envelope: command-ACK `response`
-events, `extension_ui_request` discards, and the `AgentSessionEvent`
-session-stream.
+events, the `extension_ui_request` backchannel lane (ask-user-question +
+plan-mode dialogs), and the `AgentSessionEvent` session-stream.
 """
 
 from __future__ import annotations
@@ -27,18 +27,25 @@ from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_ID_STATE_FILE
 from sculptor.agents.pi_agent.agent_wrapper import PiAgent
 from sculptor.agents.pi_agent.agent_wrapper import _render_synthesized_skill
 from sculptor.agents.pi_agent.agent_wrapper import _rewrite_skill_invocation
+from sculptor.agents.pi_agent.backchannel import DISMISSED_ANSWER_VALUE
+from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
+from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_HEADER
 from sculptor.agents.pi_agent.harness import PI_HARNESS
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import ParsedUnknownEvent
 from sculptor.agents.pi_agent.output_processor import extract_tool_call_blocks
 from sculptor.agents.pi_agent.output_processor import parse_rpc_message
 from sculptor.foundation.async_monkey_patches_test import expect_exact_logged_errors
+from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
 from sculptor.interfaces.agents.agent import ClearContextUserMessage
 from sculptor.interfaces.agents.agent import InterruptProcessUserMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
 from sculptor.interfaces.agents.agent import PiAgentConfig
+from sculptor.interfaces.agents.agent import PlanModeAgentMessage
+from sculptor.interfaces.agents.agent import RequestSkippedAgentMessage
+from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
 from sculptor.interfaces.agents.agent import StopAgentUserMessage
@@ -54,6 +61,7 @@ from sculptor.state.chat_state import GenericToolContent
 from sculptor.state.chat_state import TextBlock
 from sculptor.state.chat_state import ToolResultBlock
 from sculptor.state.chat_state import ToolUseBlock
+from sculptor.state.chat_state import make_plan_approval_question
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import Message
 from sculptor.state.messages import ResponseBlockAgentMessage
@@ -981,25 +989,100 @@ def test_errored_file_change_tool_execution_end_does_not_refresh_diff() -> None:
     on_diff_needed.assert_not_called()
 
 
-def test_extension_ui_request_is_discarded() -> None:
-    agent = _make_agent()
-    agent._process = _make_process(
-        [
-            _event({"type": "extension_ui_request", "id": "ui-1", "method": "select", "options": []}),
-            _event({"type": "agent_end", "messages": [], "willRetry": False}),
-        ]
-    )
-    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
-
-
-def test_extension_error_is_logged_and_non_terminal() -> None:
+def test_extension_ui_select_request_emits_ask_user_question() -> None:
+    """A backchannel `select` dialog becomes an AskUserQuestion and holds the turn."""
     agent = _make_agent()
     agent._process = _make_process(
         [
             _event(
                 {
+                    "type": "extension_ui_request",
+                    "id": "ui-1",
+                    "method": "select",
+                    "title": "Tea or coffee?",
+                    "options": ["tea", "coffee"],
+                }
+            ),
+            _event({"type": "agent_end", "messages": [], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    emitted = _drain(agent._output_messages)
+    questions = [m for m in emitted if isinstance(m, AskUserQuestionAgentMessage)]
+    assert len(questions) == 1
+    data = questions[0].question_data
+    assert data.tool_use_id == "ui-1"
+    assert len(data.questions) == 1
+    assert data.questions[0].question == "Tea or coffee?"
+    assert [opt.label for opt in data.questions[0].options] == ["tea", "coffee"]
+
+
+def test_extension_ui_input_request_emits_free_form_question() -> None:
+    """An `input` dialog (no options) becomes a free-form AskUserQuestion."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "extension_ui_request", "id": "ui-2", "method": "input", "title": "Your name?"}),
+            _event({"type": "agent_end", "messages": [], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    questions = [m for m in _drain(agent._output_messages) if isinstance(m, AskUserQuestionAgentMessage)]
+    assert len(questions) == 1
+    assert questions[0].question_data.questions[0].question == "Your name?"
+    assert questions[0].question_data.questions[0].options == []
+
+
+def test_plan_approval_select_request_emits_plan_approval_question() -> None:
+    """The plan-approval sentinel title maps to the canonical plan-approval question."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event(
+                {
+                    "type": "extension_ui_request",
+                    "id": "plan-1",
+                    "method": "select",
+                    "title": PLAN_APPROVAL_DIALOG_TITLE,
+                    "options": ["Approve plan"],
+                }
+            ),
+            _event({"type": "agent_end", "messages": [], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+    questions = [m for m in _drain(agent._output_messages) if isinstance(m, AskUserQuestionAgentMessage)]
+    assert len(questions) == 1
+    # Same canonical question Claude's ExitPlanMode synthesizes — header drives
+    # the frontend's "Waiting for plan approval".
+    assert questions[0].question_data.questions[0].header == PLAN_APPROVAL_HEADER
+
+
+def test_extension_ui_fire_and_forget_method_is_ignored() -> None:
+    """Non-dialog methods (notify/setStatus/…) need no response and emit nothing."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "extension_ui_request", "id": "n-1", "method": "notify", "message": "hi"}),
+            _event({"type": "agent_end", "messages": [], "willRetry": False}),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+    assert not _drain(agent._output_messages)
+
+
+def test_extension_error_from_foreign_extension_is_logged_and_non_terminal() -> None:
+    agent = _make_agent()
+    # No extension whose path matches _loaded_extension_paths (empty) → foreign.
+    agent._process = _make_process(
+        [
+            _event(
+                {
                     "type": "extension_error",
-                    "extensionPath": "/ext",
+                    "extensionPath": "/some/foreign/ext",
                     "event": "some-callback",
                     "error": "ext threw",
                 }
@@ -1009,6 +1092,167 @@ def test_extension_error_is_logged_and_non_terminal() -> None:
     )
     # Must not raise; must reach agent_end.
     agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+
+def test_extension_error_from_our_extension_fails_loud() -> None:
+    """Fail-loud posture: an error from the pinned backchannel extension fails the turn."""
+    agent = _make_agent()
+    agent._loaded_extension_paths = ("/state/sculptor_backchannel.ts",)
+    agent._process = _make_process(
+        [
+            _event(
+                {
+                    "type": "extension_error",
+                    "extensionPath": "/state/sculptor_backchannel.ts",
+                    "event": "tool_execute",
+                    "error": "backchannel boom",
+                }
+            ),
+        ]
+    )
+    with pytest.raises(PiCrashError, match="backchannel boom"):
+        agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+
+# --- Backchannel answer delivery & plan mode -------------------------------
+
+
+def _answer(
+    answers: dict[str, str],
+    tool_use_id: str,
+    question_data: AskUserQuestionData | None = None,
+) -> UserQuestionAnswerMessage:
+    return UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers=answers,
+        question_data=question_data or AskUserQuestionData(questions=[], tool_use_id=tool_use_id),
+        tool_use_id=tool_use_id,
+    )
+
+
+def _written_payloads(process: MagicMock) -> list[dict[str, Any]]:
+    return [json.loads(call.args[0].rstrip("\n")) for call in process.write_stdin.call_args_list]
+
+
+def test_push_message_handles_question_answer_returns_true() -> None:
+    """A question answer is handled by the backchannel, not dead-lettered."""
+    agent = _make_agent()
+    agent._process = MagicMock()
+    with expect_exact_logged_errors([]):
+        assert agent._push_message(_answer({"q": "a"}, "t1")) is True
+
+
+def test_deliver_answer_writes_extension_ui_response_and_starts_request() -> None:
+    agent = _make_agent()
+    process = MagicMock()
+    agent._process = process
+    agent._pending_ui_request_id = "ui-1"
+    answer = _answer({"Tea or coffee?": "coffee"}, "ui-1")
+    agent._deliver_question_answer(answer)
+
+    # The answer's own request is started immediately; its success is deferred.
+    started = [m for m in _drain(agent._output_messages) if isinstance(m, RequestStartedAgentMessage)]
+    assert [m.request_id for m in started] == [answer.message_id]
+    assert agent._pending_answer_request_ids == [answer.message_id]
+    assert agent._pending_ui_request_id is None
+    # The matching extension_ui_response carries the selected value.
+    assert _written_payloads(process) == [{"type": "extension_ui_response", "id": "ui-1", "value": "coffee"}]
+
+
+def test_deliver_answer_with_no_pending_dialog_skips() -> None:
+    agent = _make_agent()
+    process = MagicMock()
+    agent._process = process
+    answer = _answer({"q": "a"}, "stale")
+    agent._deliver_question_answer(answer)
+
+    skipped = [m for m in _drain(agent._output_messages) if isinstance(m, RequestSkippedAgentMessage)]
+    assert [m.request_id for m in skipped] == [answer.message_id]
+    assert process.write_stdin.call_count == 0
+
+
+def test_deliver_dismissed_answer_sends_cancellation() -> None:
+    agent = _make_agent()
+    process = MagicMock()
+    agent._process = process
+    agent._pending_ui_request_id = "ui-9"
+    agent._deliver_question_answer(_answer({"Pick one": DISMISSED_ANSWER_VALUE}, "ui-9"))
+    assert _written_payloads(process) == [{"type": "extension_ui_response", "id": "ui-9", "cancelled": True}]
+
+
+def test_deliver_plan_approval_clears_plan_mode() -> None:
+    agent = _make_agent()
+    process = MagicMock()
+    agent._process = process
+    agent._is_in_plan_mode = True
+    agent._pending_ui_request_id = "plan-1"
+    question_data = make_plan_approval_question(tool_use_id="plan-1")
+    answer = _answer({question_data.questions[0].question: "Approve plan"}, "plan-1", question_data=question_data)
+    agent._deliver_question_answer(answer)
+
+    emitted = _drain(agent._output_messages)
+    plan_msgs = [m for m in emitted if isinstance(m, PlanModeAgentMessage)]
+    assert len(plan_msgs) == 1 and plan_msgs[0].is_in_plan_mode is False
+    assert agent._is_in_plan_mode is False
+    assert _written_payloads(process) == [{"type": "extension_ui_response", "id": "plan-1", "value": "Approve plan"}]
+
+
+def test_deliver_plan_revision_keeps_plan_mode() -> None:
+    """A revision (free-form, not the approve label) does not exit plan mode."""
+    agent = _make_agent()
+    process = MagicMock()
+    agent._process = process
+    agent._is_in_plan_mode = True
+    agent._pending_ui_request_id = "plan-2"
+    question_data = make_plan_approval_question(tool_use_id="plan-2")
+    answer = _answer(
+        {question_data.questions[0].question: "Please add a rollback step"}, "plan-2", question_data=question_data
+    )
+    agent._deliver_question_answer(answer)
+
+    emitted = _drain(agent._output_messages)
+    assert not [m for m in emitted if isinstance(m, PlanModeAgentMessage)]
+    assert agent._is_in_plan_mode is True
+    assert _written_payloads(process) == [
+        {"type": "extension_ui_response", "id": "plan-2", "value": "Please add a rollback step"}
+    ]
+
+
+def test_finalize_pending_answers_emits_deferred_success() -> None:
+    agent = _make_agent()
+    request_id = AgentMessageID()
+    agent._pending_answer_request_ids = [request_id]
+    agent._finalize_pending_answers(interrupted=False)
+
+    successes = [m for m in _drain(agent._output_messages) if isinstance(m, RequestSuccessAgentMessage)]
+    assert [(m.request_id, m.interrupted) for m in successes] == [(request_id, False)]
+    assert agent._pending_answer_request_ids == []
+
+
+def test_finalize_pending_answers_marks_interrupted_on_failure() -> None:
+    agent = _make_agent()
+    request_id = AgentMessageID()
+    agent._pending_answer_request_ids = [request_id]
+    agent._finalize_pending_answers(interrupted=True)
+    successes = [m for m in _drain(agent._output_messages) if isinstance(m, RequestSuccessAgentMessage)]
+    assert [(m.request_id, m.interrupted) for m in successes] == [(request_id, True)]
+
+
+def test_plan_mode_tracking_and_prompt_preamble() -> None:
+    agent = _make_agent()
+    # Entering plan mode prepends the preamble to the prompt text.
+    enter = ChatInputUserMessage(text="add a feature", enter_plan_mode=True)
+    agent._update_plan_mode_from_message(enter)
+    assert agent._is_in_plan_mode is True
+    prompt = agent._build_prompt_text(enter)
+    assert prompt.endswith("add a feature")
+    assert "PLAN MODE" in prompt and "exit_plan_mode" in prompt
+
+    # Leaving plan mode drops the preamble.
+    leave = ChatInputUserMessage(text="never mind", exit_plan_mode=True)
+    agent._update_plan_mode_from_message(leave)
+    assert agent._is_in_plan_mode is False
+    assert agent._build_prompt_text(leave) == "never mind"
 
 
 def test_consume_ignores_non_json_and_unknown_event_types() -> None:
@@ -1044,12 +1288,6 @@ def test_push_message_enqueues_chat_input_returns_true() -> None:
 # dead-lettered (one logged error) and return unhandled.
 _DEAD_LETTER_MESSAGES: list[Message] = [
     ClearContextUserMessage(),
-    UserQuestionAnswerMessage(
-        message_id=AgentMessageID(),
-        answers={"q": "a"},
-        question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
-        tool_use_id="t1",
-    ),
 ]
 
 
@@ -1138,8 +1376,13 @@ def test_start_fresh_session_mints_and_persists_id_with_session_flags() -> None:
     assert command[command.index("--session-dir") + 1] == str(Path("/fake/state") / PI_SESSION_DIR_NAME)
     assert "--session-id" in command
     assert command[command.index("--session-id") + 1] == "sess-fresh-1"
-    # The minted id is persisted up front so a crash during the first turn still leaves a resumable id.
-    env.write_file.assert_called_once_with(str(Path("/fake/state") / PI_SESSION_ID_STATE_FILE), "sess-fresh-1")
+    # The pinned backchannel extension also ships: discovery off, our `-e` set on.
+    assert "--no-extensions" in command
+    assert "-e" in command
+    # The minted id is persisted up front so a crash during the first turn still leaves a
+    # resumable id (write_file is also called once to materialize the extension into the env).
+    session_id_path = str(Path("/fake/state") / PI_SESSION_ID_STATE_FILE)
+    assert any(c.args == (session_id_path, "sess-fresh-1") for c in env.write_file.call_args_list)
 
 
 def test_start_resume_reuses_persisted_id_and_verifies_without_rewriting() -> None:
@@ -1149,8 +1392,11 @@ def test_start_resume_reuses_persisted_id_and_verifies_without_rewriting() -> No
         agent.start(secrets={})
     command = _launched_command(env)
     assert command[command.index("--session-id") + 1] == "resume-7"
-    # Resume must NOT re-persist (the id is unchanged) and MUST verify the resume.
-    env.write_file.assert_not_called()
+    # Resume must NOT re-persist the session id (it is unchanged) and MUST verify the
+    # resume. write_file may still be called to materialize the pinned extension into
+    # the env — only the session-id path must be untouched.
+    session_id_path = str(Path("/fake/state") / PI_SESSION_ID_STATE_FILE)
+    assert all(c.args[0] != session_id_path for c in env.write_file.call_args_list)
     mock_verify.assert_called_once_with("resume-7")
 
 

--- a/sculptor/sculptor/agents/pi_agent/backchannel.py
+++ b/sculptor/sculptor/agents/pi_agent/backchannel.py
@@ -23,7 +23,12 @@ contract and routes the user's `UserQuestionAnswerMessage` back as the matching
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
+from sculptor.state.chat_state import AskUserQuestionData
+from sculptor.state.chat_state import QuestionOption
+from sculptor.state.chat_state import UserQuestion
 from sculptor.state.chat_state import make_plan_approval_question
 
 # Tool names registered by sculptor_backchannel.ts — MUST match the `.ts`.
@@ -54,6 +59,29 @@ DISMISSED_ANSWER_VALUE: str = "[Dismissed]"
 _CANONICAL_PLAN_QUESTION = make_plan_approval_question(tool_use_id="")
 PLAN_APPROVAL_HEADER: str = _CANONICAL_PLAN_QUESTION.questions[0].header
 PLAN_APPROVE_ANSWER: str = _CANONICAL_PLAN_QUESTION.questions[0].options[0].label
+
+
+def build_ask_user_question_data(question: str, options: Sequence[str], tool_use_id: str) -> AskUserQuestionData:
+    """Build the single-question `AskUserQuestionData` for a pi ask-user-question.
+
+    Shared by the live dispatch (from the `extension_ui_request`) and the
+    page-reload reconstruction (from the persisted `ask_user_question` tool
+    block) so both render an identical Q&A panel. Empty `options` → a free-form
+    question; non-empty → multiple choice. `other_label` always lets the user
+    type a free-form answer too.
+    """
+    return AskUserQuestionData(
+        questions=[
+            UserQuestion(
+                question=question,
+                header=PI_QUESTION_HEADER,
+                options=[QuestionOption(label=option, description="") for option in options],
+                multi_select=False,
+                other_label="Other",
+            )
+        ],
+        tool_use_id=tool_use_id,
+    )
 
 
 def is_plan_approval(message: UserQuestionAnswerMessage) -> bool:

--- a/sculptor/sculptor/agents/pi_agent/backchannel.py
+++ b/sculptor/sculptor/agents/pi_agent/backchannel.py
@@ -1,0 +1,99 @@
+"""Shared contract for the pi interactive-backchannel extension.
+
+The Sculptor backchannel extension (`extensions/sculptor_backchannel.ts`) and
+the Python harness/wrapper that drive it must agree on the tool names and the
+plan-approval dialog title. Defining them here once keeps the TypeScript
+extension, the harness's gated methods (`PiHarness`), and the dispatcher
+(`PiAgent`) in lockstep — renaming a tool means editing this module and the
+`.ts` in the same change (REQ-EXT).
+
+The extension registers two tools, each of which opens a blocking pi dialog
+(`ctx.ui.select` / `ctx.ui.input`, never with a `timeout`) and surfaces it as an
+`extension_ui_request`:
+
+- `ask_user_question` — a single multiple-choice (`select`) or free-form
+  (`input`) question.
+- `exit_plan_mode` — presents the finished plan for approval via a `select`
+  dialog whose title is the plan-approval sentinel below.
+
+Sculptor maps both onto the harness-agnostic `AskUserQuestionAgentMessage`
+contract and routes the user's `UserQuestionAnswerMessage` back as the matching
+`extension_ui_response`.
+"""
+
+from __future__ import annotations
+
+from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
+from sculptor.state.chat_state import make_plan_approval_question
+
+# Tool names registered by sculptor_backchannel.ts — MUST match the `.ts`.
+ASK_USER_QUESTION_TOOL_NAME: str = "ask_user_question"
+EXIT_PLAN_MODE_TOOL_NAME: str = "exit_plan_mode"
+
+# Sentinel title the extension's `exit_plan_mode` tool passes to
+# `ctx.ui.select`. Both backchannel dialogs ride the same
+# `extension_ui_request{method:"select"}` lane; the dispatcher tells a
+# plan-approval dialog apart from a regular ask-user-question by this exact
+# title — MUST match the `.ts`.
+PLAN_APPROVAL_DIALOG_TITLE: str = "__sculptor_plan_approval__"
+
+# The default header shown for a pi ask-user-question. pi's `ctx.ui.select` /
+# `ctx.ui.input` carry only a title and options, so — unlike Claude's AUQ — pi
+# questions have no per-question category; this stands in for one.
+PI_QUESTION_HEADER: str = "Question"
+
+# Frontend sentinel for a dismissed question / plan (the value the chat UI
+# writes when the user dismisses without answering). Mirrors the Claude path's
+# `_DISMISSED_ANSWER_VALUE` (`mcp_result_formatters.py`); when the user's answer
+# is this, the dispatcher sends `{"cancelled": true}` back to pi's blocked
+# dialog so the extension's `execute` resolves to the dismissal branch.
+DISMISSED_ANSWER_VALUE: str = "[Dismissed]"
+
+# Derived from the canonical Sculptor plan-approval question so the header and
+# approve-label can never drift from `make_plan_approval_question`.
+_CANONICAL_PLAN_QUESTION = make_plan_approval_question(tool_use_id="")
+PLAN_APPROVAL_HEADER: str = _CANONICAL_PLAN_QUESTION.questions[0].header
+PLAN_APPROVE_ANSWER: str = _CANONICAL_PLAN_QUESTION.questions[0].options[0].label
+
+
+def is_plan_approval(message: UserQuestionAnswerMessage) -> bool:
+    """True when this answer approves (rather than revises/dismisses) a plan.
+
+    Mirrors the Claude path's `is_plan_approval` (`process_manager_utils.py`):
+    the question must be the synthesized plan-approval question (header match)
+    and the user's answer must be the approve label.
+    """
+    if not any(question.header == PLAN_APPROVAL_HEADER for question in message.question_data.questions):
+        return False
+    return any(answer.strip() == PLAN_APPROVE_ANSWER for answer in message.answers.values())
+
+
+def extension_ui_response_body(message: UserQuestionAnswerMessage) -> dict[str, object]:
+    """Build the `extension_ui_response` body (sans `type`/`id`) for an answer.
+
+    The extension's dialogs are single-question `select`/`input` calls, so there
+    is exactly one answer to relay back to the blocked dialog. A dismissed answer
+    becomes a cancellation (`{"cancelled": true}`); any other answer is sent as
+    the dialog `value` (the selected option, or the free-form / "Revise" text —
+    pi returns whatever value the client posts).
+    """
+    value = _single_answer_value(message)
+    if value is None or value == DISMISSED_ANSWER_VALUE:
+        return {"cancelled": True}
+    return {"value": value}
+
+
+def _single_answer_value(message: UserQuestionAnswerMessage) -> str | None:
+    """Return the one answer string for the dialog, or None if there is none.
+
+    Prefers the answer keyed by the question text; falls back to any non-empty
+    answer (a single-question dialog has at most one).
+    """
+    for question in message.question_data.questions:
+        answer = message.answers.get(question.question)
+        if answer:
+            return answer
+    for answer in message.answers.values():
+        if answer:
+            return answer
+    return None

--- a/sculptor/sculptor/agents/pi_agent/backchannel_test.py
+++ b/sculptor/sculptor/agents/pi_agent/backchannel_test.py
@@ -1,0 +1,77 @@
+"""Tests for the pi backchannel contract helpers (`backchannel.py`)."""
+
+from __future__ import annotations
+
+from sculptor.agents.pi_agent.backchannel import DISMISSED_ANSWER_VALUE
+from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_HEADER
+from sculptor.agents.pi_agent.backchannel import PLAN_APPROVE_ANSWER
+from sculptor.agents.pi_agent.backchannel import extension_ui_response_body
+from sculptor.agents.pi_agent.backchannel import is_plan_approval
+from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
+from sculptor.primitives.ids import AgentMessageID
+from sculptor.state.chat_state import AskUserQuestionData
+from sculptor.state.chat_state import QuestionOption
+from sculptor.state.chat_state import UserQuestion
+from sculptor.state.chat_state import make_plan_approval_question
+
+
+def _answer(answers: dict[str, str], question_data: AskUserQuestionData) -> UserQuestionAnswerMessage:
+    return UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers=answers,
+        question_data=question_data,
+        tool_use_id=question_data.tool_use_id,
+    )
+
+
+def _question(text: str, *, options: list[str]) -> AskUserQuestionData:
+    return AskUserQuestionData(
+        questions=[
+            UserQuestion(
+                question=text,
+                header="Question",
+                options=[QuestionOption(label=o, description="") for o in options],
+                multi_select=False,
+                other_label="Other",
+            )
+        ],
+        tool_use_id="t1",
+    )
+
+
+def test_plan_approval_constants_track_canonical_question() -> None:
+    canonical = make_plan_approval_question(tool_use_id="x")
+    assert PLAN_APPROVAL_HEADER == canonical.questions[0].header
+    assert PLAN_APPROVE_ANSWER == canonical.questions[0].options[0].label
+
+
+def test_is_plan_approval_true_only_on_approve() -> None:
+    plan = make_plan_approval_question(tool_use_id="p1")
+    question_text = plan.questions[0].question
+    assert is_plan_approval(_answer({question_text: PLAN_APPROVE_ANSWER}, plan)) is True
+    # A revision (free-form text) is not an approval.
+    assert is_plan_approval(_answer({question_text: "add a rollback step"}, plan)) is False
+    # A non-plan question is never a plan approval, even if answered "Approve plan".
+    regular = _question("Proceed?", options=["Approve plan"])
+    assert is_plan_approval(_answer({"Proceed?": PLAN_APPROVE_ANSWER}, regular)) is False
+
+
+def test_extension_ui_response_body_for_selected_value() -> None:
+    question = _question("Tea or coffee?", options=["tea", "coffee"])
+    assert extension_ui_response_body(_answer({"Tea or coffee?": "coffee"}, question)) == {"value": "coffee"}
+
+
+def test_extension_ui_response_body_for_free_form_value() -> None:
+    question = _question("Your name?", options=[])
+    assert extension_ui_response_body(_answer({"Your name?": "Ada"}, question)) == {"value": "Ada"}
+
+
+def test_extension_ui_response_body_for_dismissal() -> None:
+    question = _question("Pick one", options=["a", "b"])
+    body = extension_ui_response_body(_answer({"Pick one": DISMISSED_ANSWER_VALUE}, question))
+    assert body == {"cancelled": True}
+
+
+def test_extension_ui_response_body_for_empty_answers_is_cancellation() -> None:
+    question = _question("Pick one", options=["a", "b"])
+    assert extension_ui_response_body(_answer({}, question)) == {"cancelled": True}

--- a/sculptor/sculptor/agents/pi_agent/extensions/sculptor_backchannel.ts
+++ b/sculptor/sculptor/agents/pi_agent/extensions/sculptor_backchannel.ts
@@ -1,0 +1,139 @@
+/**
+ * Sculptor backchannel extension.
+ *
+ * Gives a pi (`--mode rpc`) agent the two interactive-backchannel surfaces
+ * Sculptor already exposes for Claude — ask-user-question and plan mode —
+ * by registering two tools whose `execute` opens a blocking pi dialog
+ * (`ctx.ui.select` / `ctx.ui.input`). In RPC mode those dialogs surface as
+ * `extension_ui_request` events that Sculptor maps onto its harness-agnostic
+ * `AskUserQuestionAgentMessage` contract, and the user's answer is delivered
+ * back as the matching `extension_ui_response`. With no `timeout` on the
+ * dialog calls pi blocks indefinitely — exactly Sculptor's unbounded-wait
+ * question model (the user may take as long as they like to answer).
+ *
+ * Pinned with the pi binary as one immutable unit (PI_VERSION_RANGE in
+ * `dependency_management_service`). It is NOT user-visible or user-configurable
+ * and is loaded explicitly via `-e` under `--no-extensions` (no discovery).
+ * Re-validate against `examples/extensions/plan-mode` and the RPC extension-UI
+ * protocol on any pi version bump. It embeds no secrets and emits no telemetry.
+ *
+ * Wire contract shared with the Python side
+ * (`sculptor/agents/pi_agent/backchannel.py`): the two tool names and the
+ * plan-approval dialog title below MUST match the constants there. Renaming
+ * one means editing both files in the same change.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+// MUST match backchannel.py: ASK_USER_QUESTION_TOOL_NAME / EXIT_PLAN_MODE_TOOL_NAME.
+const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
+const EXIT_PLAN_MODE_TOOL_NAME = "exit_plan_mode";
+
+// Sentinel title the plan-approval dialog passes to ctx.ui.select. The
+// ask-user-question and plan-approval dialogs both ride the same
+// extension_ui_request{method:"select"} lane; Sculptor distinguishes them by
+// this title (MUST match backchannel.py: PLAN_APPROVAL_DIALOG_TITLE).
+const PLAN_APPROVAL_DIALOG_TITLE = "__sculptor_plan_approval__";
+
+// The single option offered by the plan-approval dialog. Matches the label
+// `make_plan_approval_question` puts on the canonical Sculptor plan question;
+// a freeform answer (typed via the Sculptor "Revise" affordance) comes back as
+// a value other than this and is treated as revision feedback.
+const PLAN_APPROVE_ANSWER = "Approve plan";
+
+export default function sculptorBackchannelExtension(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: ASK_USER_QUESTION_TOOL_NAME,
+		label: "Ask User Question",
+		description:
+			"Ask the user a question and wait for their answer before continuing. " +
+			"Provide `options` for a multiple-choice question, or omit them for a " +
+			"free-form text answer. Use this for blocking decisions you need the " +
+			"user to make mid-task; for rhetorical or non-blocking asides, just " +
+			"write text instead.",
+		promptSnippet: "Ask the user a blocking question and wait for their answer",
+		promptGuidelines: [
+			`Use ${ASK_USER_QUESTION_TOOL_NAME} when you need a decision from the user before you can proceed.`,
+		],
+		parameters: Type.Object({
+			question: Type.String({ description: "The question to put to the user." }),
+			options: Type.Optional(
+				Type.Array(Type.String(), {
+					description:
+						"Multiple-choice options. Omit for a free-form text answer.",
+				}),
+			),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const options = params.options ?? [];
+			const answer =
+				options.length > 0
+					? await ctx.ui.select(params.question, options)
+					: await ctx.ui.input(params.question, "");
+			if (answer === undefined) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "The user dismissed the question without answering. Stop and wait for the user to respond.",
+						},
+					],
+					details: { dismissed: true },
+				};
+			}
+			return {
+				content: [{ type: "text", text: `The user answered: ${answer}` }],
+				details: { answer },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: EXIT_PLAN_MODE_TOOL_NAME,
+		label: "Exit Plan Mode",
+		description:
+			"Call this once your plan is ready, to present it to the user for " +
+			"approval before you make any changes. Do not modify files until the " +
+			"user approves. If the user requests revisions, refine the plan and " +
+			"call this tool again.",
+		promptSnippet: "Present the finished plan for user approval before making changes",
+		promptGuidelines: [
+			`Use ${EXIT_PLAN_MODE_TOOL_NAME} when you are in plan mode and your plan is ready for the user to approve.`,
+		],
+		parameters: Type.Object({
+			plan: Type.Optional(
+				Type.String({ description: "The plan to present, for the user to approve." }),
+			),
+		}),
+		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+			const choice = await ctx.ui.select(PLAN_APPROVAL_DIALOG_TITLE, [PLAN_APPROVE_ANSWER]);
+			if (choice === undefined) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "The user dismissed the plan. Stop and wait for further instructions; do not start implementing.",
+						},
+					],
+					details: { dismissed: true },
+				};
+			}
+			if (choice === PLAN_APPROVE_ANSWER) {
+				return {
+					content: [{ type: "text", text: "The user approved the plan. Proceed with implementing it." }],
+					details: { approved: true },
+				};
+			}
+			return {
+				content: [
+					{
+						type: "text",
+						text: `The user did not approve the plan and requests revisions: ${choice}`,
+					},
+				],
+				details: { approved: false, feedback: choice },
+			};
+		},
+	});
+}

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -1,7 +1,6 @@
 """The pi harness — non-Claude implementor of `Harness`.
 
-Pi ships as a degraded harness: no AskUserQuestion, no plan mode, no
-sub-agents. It DOES render tool calls
+Pi is no longer a fully degraded harness. It renders tool calls
 (`supports_tool_use_rendering=True`): pi's tool-execution lane is adapted onto
 Sculptor's harness-agnostic tool blocks (see `agent_wrapper` / `tool_rendering`).
 Session resume IS supported — pi persists a per-task JSONL session
@@ -11,8 +10,13 @@ workspace's skill directories via `--skill` flags and follows an invoked skill
 (see `agent_wrapper._build_skill_launch_args` / `_rewrite_skill_invocation`).
 It also carries file references, image input, and file attachments (delivered
 by prompt assembly), and compacts context — `compaction_start/end` events drive
-the StatusPill "Compacting" chrome. The `capabilities()` override is the
-truthful declaration that consumers gate on.
+the StatusPill "Compacting" chrome. And it gains an interactive backchannel
+(ask-user-question + plan mode) from the Sculptor-pinned `sculptor_backchannel`
+extension (see `backchannel.py` and `extensions/sculptor_backchannel.ts`), so
+`supports_interactive_backchannel` is `True` and the gated methods recognize
+that extension's tool names. Still `False`: sub-agents, context reset, fast
+mode, and background tasks. The `capabilities()` override is the truthful
+declaration that consumers gate on.
 
 Agent construction is owned by the registry
 (`harness_registry.create_agent_for_run`), not this module, so the pi
@@ -21,6 +25,8 @@ agent module can hold a `PiHarness` reference without an import cycle.
 
 from __future__ import annotations
 
+from sculptor.agents.pi_agent.backchannel import ASK_USER_QUESTION_TOOL_NAME
+from sculptor.agents.pi_agent.backchannel import EXIT_PLAN_MODE_TOOL_NAME
 from sculptor.interfaces.agents.harness import Harness
 from sculptor.interfaces.agents.harness import HarnessCapabilities
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
@@ -62,7 +68,9 @@ class PiHarness(Harness):
 
     def capabilities(self) -> HarnessCapabilities:
         return HarnessCapabilities(
-            supports_interactive_backchannel=False,
+            # Delivered via the pinned `sculptor_backchannel` extension (AUQ +
+            # plan mode); the gated methods below recognize its tool names.
+            supports_interactive_backchannel=True,
             # Pi reads the workspace's Claude-visible skills via repeatable
             # --skill flags (agent_wrapper._build_skill_launch_args), enumerates
             # them through its own skills layer, and follows a picked skill
@@ -106,6 +114,28 @@ class PiHarness(Harness):
             # the same as Claude — true.
             supports_file_references=True,
         )
+
+    def is_ask_user_question_tool(self, tool_name: str) -> bool:
+        return tool_name == ASK_USER_QUESTION_TOOL_NAME
+
+    def is_exit_plan_mode_tool(self, tool_name: str) -> bool:
+        return tool_name == EXIT_PLAN_MODE_TOOL_NAME
+
+    def is_valid_ask_user_question_input(self, tool_name: str, tool_input: dict) -> bool:
+        # Mirrors the Claude harness: non-AUQ tools always pass; the AUQ tool's
+        # input is valid when it carries a non-empty `question` string (the
+        # backchannel extension's `ask_user_question` schema — `backchannel.py`).
+        if tool_name != ASK_USER_QUESTION_TOOL_NAME:
+            return True
+        question = tool_input.get("question")
+        return isinstance(question, str) and bool(question)
+
+    # NOTE (divergence, REQ-CAP-ALL-3): pi presents the plan inline as assistant
+    # text rather than writing a `.claude/plans/` file, so there is no plan-file
+    # path to surface — `get_plan_file_path_from_tool_use` /
+    # `extract_recent_plan_file_path` keep the base `None`, and the plan-approval
+    # question carries no click-to-reopen link. The plan/approve/exit flow itself
+    # behaves as on Claude.
 
 
 PI_HARNESS: PiHarness = PiHarness()

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -27,9 +27,12 @@ from __future__ import annotations
 
 from sculptor.agents.pi_agent.backchannel import ASK_USER_QUESTION_TOOL_NAME
 from sculptor.agents.pi_agent.backchannel import EXIT_PLAN_MODE_TOOL_NAME
+from sculptor.agents.pi_agent.backchannel import build_ask_user_question_data
 from sculptor.interfaces.agents.harness import Harness
 from sculptor.interfaces.agents.harness import HarnessCapabilities
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
+from sculptor.state.chat_state import AskUserQuestionData
+from sculptor.state.chat_state import ToolUseBlock
 
 # Pi has no MCP / AskUserQuestion / ExitPlanMode surface; the Claude
 # prompt's tool-instructions block is deliberately absent. Names Sculptor
@@ -129,6 +132,19 @@ class PiHarness(Harness):
             return True
         question = tool_input.get("question")
         return isinstance(question, str) and bool(question)
+
+    def reconstruct_pending_ask_user_question(self, block: ToolUseBlock) -> AskUserQuestionData | None:
+        # Pi's `ask_user_question` tool carries a flat `{question, options}` input
+        # (the extension's schema), not the nested `AskUserQuestionData` the base
+        # validates against, so translate it the same way live dispatch does.
+        if not self.is_valid_ask_user_question_input(block.name, block.input):
+            return None
+        options = block.input.get("options")
+        return build_ask_user_question_data(
+            block.input["question"],
+            options if isinstance(options, list) else [],
+            str(block.id),
+        )
 
     # NOTE (divergence, REQ-CAP-ALL-3): pi presents the plan inline as assistant
     # text rather than writing a `.claude/plans/` file, so there is no plan-file

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -5,6 +5,8 @@ from sculptor.agents.pi_agent.backchannel import EXIT_PLAN_MODE_TOOL_NAME
 from sculptor.agents.pi_agent.harness import PI_HARNESS
 from sculptor.interfaces.agents.harness import HarnessCapabilities
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
+from sculptor.primitives.ids import ToolUseID
+from sculptor.state.chat_state import ToolUseBlock
 
 
 def test_pi_harness_capabilities() -> None:
@@ -44,6 +46,36 @@ def test_pi_harness_validates_ask_user_question_input() -> None:
     assert PI_HARNESS.is_valid_ask_user_question_input(ASK_USER_QUESTION_TOOL_NAME, {"question": ""}) is False
     # Non-AUQ tools always pass (mirrors the Claude harness convention).
     assert PI_HARNESS.is_valid_ask_user_question_input("read", {"path": "x"}) is True
+
+
+def test_pi_harness_reconstructs_pending_question_from_flat_tool_input() -> None:
+    # Real pi persists the ask_user_question call as a tool block whose input is
+    # the extension's flat {question, options} shape — NOT AskUserQuestionData.
+    # The harness translates it back into the canonical question so a reloaded
+    # page re-pends it (the base harness would reject this shape).
+    block = ToolUseBlock(
+        id=ToolUseID("tu_auq"),
+        name=ASK_USER_QUESTION_TOOL_NAME,
+        input={"question": "Tea or coffee?", "options": ["tea", "coffee"]},
+    )
+    reconstructed = PI_HARNESS.reconstruct_pending_ask_user_question(block)
+    assert reconstructed is not None
+    assert reconstructed.tool_use_id == "tu_auq"
+    question = reconstructed.questions[0]
+    assert question.question == "Tea or coffee?"
+    assert [option.label for option in question.options] == ["tea", "coffee"]
+
+
+def test_pi_harness_reconstructs_free_form_question_without_options() -> None:
+    block = ToolUseBlock(id=ToolUseID("tu_free"), name=ASK_USER_QUESTION_TOOL_NAME, input={"question": "Your name?"})
+    reconstructed = PI_HARNESS.reconstruct_pending_ask_user_question(block)
+    assert reconstructed is not None
+    assert reconstructed.questions[0].options == []
+
+
+def test_pi_harness_skips_reconstruction_for_invalid_question_input() -> None:
+    block = ToolUseBlock(id=ToolUseID("tu_bad"), name=ASK_USER_QUESTION_TOOL_NAME, input={"not_a_question": 1})
+    assert PI_HARNESS.reconstruct_pending_ask_user_question(block) is None
 
 
 def test_pi_harness_identity() -> None:

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -48,6 +48,14 @@ def test_pi_harness_validates_ask_user_question_input() -> None:
     assert PI_HARNESS.is_valid_ask_user_question_input("read", {"path": "x"}) is True
 
 
+def test_pi_harness_classifies_tool_ui_role() -> None:
+    # The harness owns the name->role mapping; the conversion layer stamps the
+    # result onto the block so the frontend renders by role, not by tool name.
+    assert PI_HARNESS.classify_tool_ui_role(ASK_USER_QUESTION_TOOL_NAME) == "ask_user_question"
+    assert PI_HARNESS.classify_tool_ui_role(EXIT_PLAN_MODE_TOOL_NAME) == "exit_plan_mode"
+    assert PI_HARNESS.classify_tool_ui_role("read") is None
+
+
 def test_pi_harness_reconstructs_pending_question_from_flat_tool_input() -> None:
     # Real pi persists the ask_user_question call as a tool block whose input is
     # the extension's flat {question, options} shape — NOT AskUserQuestionData.

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -1,5 +1,7 @@
-"""Tests for `PiHarness`'s identity and capability set."""
+"""Tests for `PiHarness`'s identity, capability set, and gated methods."""
 
+from sculptor.agents.pi_agent.backchannel import ASK_USER_QUESTION_TOOL_NAME
+from sculptor.agents.pi_agent.backchannel import EXIT_PLAN_MODE_TOOL_NAME
 from sculptor.agents.pi_agent.harness import PI_HARNESS
 from sculptor.interfaces.agents.harness import HarnessCapabilities
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
@@ -9,7 +11,7 @@ def test_pi_harness_capabilities() -> None:
     # Pi is a degraded harness: a capability is true only where Sculptor has a
     # pi-side mechanism for it (see PiHarness.capabilities for the per-flag why).
     assert PI_HARNESS.capabilities() == HarnessCapabilities(
-        supports_interactive_backchannel=False,
+        supports_interactive_backchannel=True,
         supports_skills=True,
         supports_sub_agents=False,
         supports_image_input=True,
@@ -23,6 +25,25 @@ def test_pi_harness_capabilities() -> None:
         supports_interruption=True,
         supports_file_references=True,
     )
+
+
+def test_pi_harness_gated_methods_recognize_backchannel_tools() -> None:
+    assert PI_HARNESS.is_ask_user_question_tool(ASK_USER_QUESTION_TOOL_NAME) is True
+    assert PI_HARNESS.is_ask_user_question_tool("read") is False
+    assert PI_HARNESS.is_exit_plan_mode_tool(EXIT_PLAN_MODE_TOOL_NAME) is True
+    assert PI_HARNESS.is_exit_plan_mode_tool("write") is False
+
+
+def test_pi_harness_validates_ask_user_question_input() -> None:
+    # The AUQ tool's input is valid when it carries a non-empty question string.
+    assert (
+        PI_HARNESS.is_valid_ask_user_question_input(ASK_USER_QUESTION_TOOL_NAME, {"question": "Tea or coffee?"})
+        is True
+    )
+    assert PI_HARNESS.is_valid_ask_user_question_input(ASK_USER_QUESTION_TOOL_NAME, {}) is False
+    assert PI_HARNESS.is_valid_ask_user_question_input(ASK_USER_QUESTION_TOOL_NAME, {"question": ""}) is False
+    # Non-AUQ tools always pass (mirrors the Claude harness convention).
+    assert PI_HARNESS.is_valid_ask_user_question_input("read", {"path": "x"}) is True
 
 
 def test_pi_harness_identity() -> None:

--- a/sculptor/sculptor/agents/pi_agent/output_processor.py
+++ b/sculptor/sculptor/agents/pi_agent/output_processor.py
@@ -75,11 +75,15 @@ class ExtensionUiRequest(SerializableModel):
     # `editor`) and fire-and-forget calls (`notify`/`setStatus`/`setWidget`/
     # `setTitle`/`set_editor_text`). `timeout`, when present, means pi
     # auto-resolves a dialog with a default if the client doesn't reply, so
-    # the client need not track timeouts. Method-specific payload fields are
-    # left to `extra="allow"`; pi-basic loads no extensions, so these never
-    # appear in practice (RPC §5.3).
+    # the client need not track timeouts — the backchannel extension never sets
+    # one (Sculptor's unbounded-wait question model).
     method: str
     timeout: int | None = None
+    # Dialog payload fields the backchannel dispatcher consumes (RPC §5.3):
+    # `select`/`input`/`confirm`/`editor` carry a `title`; `select` also carries
+    # `options`. Other method-specific fields ride `extra="allow"`.
+    title: str | None = None
+    options: list[str] | None = None
 
 
 # --- Lane 3: session events (the AgentSessionEvent union, RPC §5.2) --------

--- a/sculptor/sculptor/interfaces/agents/harness.py
+++ b/sculptor/sculptor/interfaces/agents/harness.py
@@ -147,16 +147,19 @@ class Harness(BaseModel, abc.ABC):
 
     def reconstruct_pending_ask_user_question(self, block: ToolUseBlock) -> AskUserQuestionData | None:
         """Rebuild the pending question from a persisted ask-user-question tool
-        block (page-reload support), or `None` when its input is not valid.
+        block (page-reload support), or `None` when its input is not a valid
+        question.
 
-        The default reads the tool input as the `AskUserQuestionData` fields
-        directly — the shape of Claude's MCP AskUserQuestion tool. A harness
-        whose ask-user-question tool carries a different input shape overrides
-        this to translate from its own shape.
+        Only reached once `is_ask_user_question_tool(block.name)` is True — i.e.
+        for a harness that has opted into ask-user-question — so the base has no
+        universal tool-input shape to assume. A harness whose
+        `is_ask_user_question_tool` can return True MUST override this to
+        translate its own tool-input shape into `AskUserQuestionData`.
         """
-        if not self.is_valid_ask_user_question_input(block.name, block.input):
-            return None
-        return AskUserQuestionData.model_validate({**block.input, "tool_use_id": block.id}, strict=True)
+        raise NotImplementedError(
+            "a harness whose is_ask_user_question_tool can return True must override "
+            "reconstruct_pending_ask_user_question"
+        )
 
     def get_plan_file_path_from_tool_use(self, block: ContentBlock) -> str | None:
         return None

--- a/sculptor/sculptor/interfaces/agents/harness.py
+++ b/sculptor/sculptor/interfaces/agents/harness.py
@@ -47,6 +47,7 @@ from sculptor.primitives.ids import TaskID
 from sculptor.services.workspace_service.api import WorkspaceService
 from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.chat_state import ContentBlock
+from sculptor.state.chat_state import ToolInteractiveRole
 from sculptor.state.chat_state import ToolUseBlock
 
 
@@ -144,6 +145,20 @@ class Harness(BaseModel, abc.ABC):
 
     def is_valid_ask_user_question_input(self, tool_name: str, tool_input: dict) -> bool:
         return False
+
+    def classify_tool_ui_role(self, tool_name: str) -> ToolInteractiveRole | None:
+        """The interactive-backchannel role of a tool, or `None` for a regular one.
+
+        Composes the per-harness `is_ask_user_question_tool` /
+        `is_exit_plan_mode_tool` so each harness owns the name→role mapping in one
+        place; the conversion layer stamps the result onto the tool block so the
+        frontend renders by role, never by tool name.
+        """
+        if self.is_ask_user_question_tool(tool_name):
+            return "ask_user_question"
+        if self.is_exit_plan_mode_tool(tool_name):
+            return "exit_plan_mode"
+        return None
 
     def reconstruct_pending_ask_user_question(self, block: ToolUseBlock) -> AskUserQuestionData | None:
         """Rebuild the pending question from a persisted ask-user-question tool

--- a/sculptor/sculptor/interfaces/agents/harness.py
+++ b/sculptor/sculptor/interfaces/agents/harness.py
@@ -45,7 +45,9 @@ from sculptor.foundation.pydantic_serialization import SerializableModel
 from sculptor.interfaces.environments.agent_execution_environment import AgentExecutionEnvironment
 from sculptor.primitives.ids import TaskID
 from sculptor.services.workspace_service.api import WorkspaceService
+from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.chat_state import ContentBlock
+from sculptor.state.chat_state import ToolUseBlock
 
 
 class HarnessCapabilities(SerializableModel):
@@ -142,6 +144,19 @@ class Harness(BaseModel, abc.ABC):
 
     def is_valid_ask_user_question_input(self, tool_name: str, tool_input: dict) -> bool:
         return False
+
+    def reconstruct_pending_ask_user_question(self, block: ToolUseBlock) -> AskUserQuestionData | None:
+        """Rebuild the pending question from a persisted ask-user-question tool
+        block (page-reload support), or `None` when its input is not valid.
+
+        The default reads the tool input as the `AskUserQuestionData` fields
+        directly — the shape of Claude's MCP AskUserQuestion tool. A harness
+        whose ask-user-question tool carries a different input shape overrides
+        this to translate from its own shape.
+        """
+        if not self.is_valid_ask_user_question_input(block.name, block.input):
+            return None
+        return AskUserQuestionData.model_validate({**block.input, "tool_use_id": block.id}, strict=True)
 
     def get_plan_file_path_from_tool_use(self, block: ContentBlock) -> str | None:
         return None

--- a/sculptor/sculptor/state/chat_state.py
+++ b/sculptor/sculptor/state/chat_state.py
@@ -47,6 +47,12 @@ class ResumeResponseBlock(ContentBlock):
 
 ToolInput = dict[str, Any]
 
+# The interactive-backchannel role of a tool, when it is one — set server-side
+# from the task's harness (`Harness.classify_tool_ui_role`) so the frontend
+# renders ask-user-question / plan-approval tools by role instead of matching a
+# hardcoded set of tool names. `None` for a regular tool.
+ToolInteractiveRole = Literal["ask_user_question", "exit_plan_mode"]
+
 
 class ToolUseBlock(ContentBlock):
     object_type: str = "ToolUseBlock"
@@ -54,6 +60,10 @@ class ToolUseBlock(ContentBlock):
     id: ToolUseID = Field(..., description="Unique identifier for this tool use")
     name: str = Field(..., description="Name of the tool being used")
     input: ToolInput = Field(default_factory=ToolInput, description="Input parameters for the tool")
+    interactive_role: ToolInteractiveRole | None = Field(
+        default=None,
+        description="Set server-side from the harness when this tool is an interactive-backchannel surface (ask-user-question / exit-plan-mode); the frontend renders by this role rather than by tool name. None for a regular tool.",
+    )
 
 
 class ToolResultContent(SerializableModel):
@@ -113,6 +123,10 @@ class ToolResultBlock(ContentBlock):
     is_error: bool = Field(default=False, description="Whether the tool execution resulted in an error")
     duration_seconds: float | None = Field(
         default=None, description="Wall-clock duration of the tool execution in seconds"
+    )
+    interactive_role: ToolInteractiveRole | None = Field(
+        default=None,
+        description="Set server-side from the harness when the originating tool is an interactive-backchannel surface; lets the frontend suppress the result (it renders inside the question panel) by role rather than by tool name. None for a regular tool.",
     )
     description: str | None = Field(default=None, description="Human-readable description of what the tool call does")
 

--- a/sculptor/sculptor/state/chat_state.py
+++ b/sculptor/sculptor/state/chat_state.py
@@ -270,7 +270,7 @@ def make_plan_approval_question(
     return AskUserQuestionData(
         questions=[
             UserQuestion(
-                question="Claude has finished planning. How would you like to proceed?",
+                question="Planning complete. How would you like to proceed?",
                 header="Plan approval",
                 options=[
                     QuestionOption(label="Approve plan", description="Proceed with implementing the plan"),

--- a/sculptor/sculptor/state/chat_state_test.py
+++ b/sculptor/sculptor/state/chat_state_test.py
@@ -13,6 +13,13 @@ def test_make_plan_approval_question_propagates_plan_file_path() -> None:
     assert q.plan_file_path == "/abs/.claude/plans/y.md"
 
 
+def test_make_plan_approval_question_text_is_harness_neutral() -> None:
+    # The canonical plan question is shown by every harness (including pi, which
+    # is deliberately Claude-free), so it must not name a specific agent.
+    question_text = make_plan_approval_question(tool_use_id="toolu_x").questions[0].question
+    assert "Claude" not in question_text
+
+
 def test_ask_user_question_data_deserializes_without_plan_file_path() -> None:
     legacy_payload = {
         "questions": [

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -38,6 +38,13 @@ base64 `ImageContent` blocks) but never decodes them — it has no model. The
 and the prompt text so integration tests can assert image/attachment delivery
 end-to-end without a real upstream model.
 
+The `fake_pi:ui_request` directive scripts the interactive-backchannel lane:
+it emits an `extension_ui_request` (the shape the `sculptor_backchannel`
+extension's dialogs produce), blocks until the matching
+`extension_ui_response` arrives on stdin, then streams the answer back as
+assistant text — exercising the full ask-user-question / plan-approval
+round-trip without loading any real extension.
+
 CLI surface matches what ``PiAgent.start`` spawns:
 
     pi --mode rpc --session-dir <dir> --session-id <id> --append-system-prompt <prompt>
@@ -108,6 +115,13 @@ class _TurnAborted(Exception):
 # main loop emits turn events), so serialize whole lines to avoid interleaving.
 _STDOUT_LOCK = threading.Lock()
 
+# `extension_ui_response` payloads, routed here from the background stdin reader
+# so a blocked `ui_request` directive can collect its answer while the reader
+# keeps handling out-of-band `abort`. The reader is the single stdin consumer,
+# and the directive handler is registry-dispatched, so this module-level queue
+# is how the two connect.
+_UI_RESPONSE_QUEUE: "Queue[dict]" = Queue()
+
 
 @dataclass
 class _TurnBuilder:
@@ -118,12 +132,23 @@ class _TurnBuilder:
     is how integration tests assert image/attachment delivery without a model.
     """
 
+    prompt_id: str | None = None
     chunks: list[str] = field(default_factory=list)
     prompt_text: str = ""
     images: list[dict] = field(default_factory=list)
+    _ui_counter: int = 0
 
     def emit(self, text: str) -> None:
         self.chunks.append(text)
+
+    def reset(self) -> None:
+        """Drop accumulated text — used after flushing a message_end mid-turn."""
+        self.chunks = []
+
+    def next_ui_request_id(self) -> str:
+        """A fresh extension_ui_request id, unique within the turn."""
+        self._ui_counter += 1
+        return f"{self.prompt_id or 'turn'}-ui-{self._ui_counter}"
 
     @property
     def has_text(self) -> bool:
@@ -509,6 +534,64 @@ def _handle_recall(args: dict, builder: _TurnBuilder, abort_event: Event, state:
         builder.emit("RECALL:NO_PRIOR_CONTEXT")
 
 
+def _read_extension_ui_response(expected_id: str, abort_event: Event) -> dict:
+    """Collect the matching `extension_ui_response` routed from the stdin reader.
+
+    The background reader enqueues `extension_ui_response` payloads on
+    `_UI_RESPONSE_QUEUE`; a set `abort_event` (an `abort` command or stdin EOF)
+    resolves as a cancellation — mirroring how the real backchannel dialog
+    unblocks when the client answers or the turn is aborted. A payload carrying
+    `cancelled` (the client's dismissal, or the reader's EOF sentinel) is itself
+    a cancellation.
+    """
+    while not abort_event.is_set():
+        try:
+            payload = _UI_RESPONSE_QUEUE.get(timeout=0.05)
+        except Empty:
+            continue
+        if payload.get("cancelled"):
+            return payload
+        if payload.get("id") == expected_id:
+            return payload
+    return {"cancelled": True}
+
+
+def _handle_ui_request(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
+    """Emit a backchannel dialog, block for the answer, echo it into the turn.
+
+    Scripts the real extension's blocking-dialog lane without loading any
+    extension: emit `extension_ui_request {method,title,options}`, wait for the
+    matching `extension_ui_response` (routed from the stdin reader), then stream
+    the answer back as assistant text so a test can assert the agent used it. A
+    `message_end` is flushed first (mirroring pi ending the assistant message
+    that carried the tool call) so the post-answer text streams as a fresh
+    assistant message.
+
+    `state` is unused (backchannel dialogs are not session-dependent) but the
+    signature matches the shared directive-handler contract.
+
+    Args: `method` ("select"/"input"), `title`, optional `options`, optional
+    `answer_prefix` (default "ANSWER="), optional `dismissed_text`.
+    """
+    _emit_message_end(builder.full_text)
+    builder.reset()
+    request_id = builder.next_ui_request_id()
+    event: dict = {"type": "extension_ui_request", "id": request_id, "method": args.get("method", "select")}
+    if "title" in args:
+        event["title"] = args["title"]
+    if "options" in args:
+        event["options"] = args["options"]
+    _emit(event)
+    response = _read_extension_ui_response(request_id, abort_event)
+    if response.get("cancelled"):
+        answer_text = str(args.get("dismissed_text", "[dismissed]"))
+    else:
+        answer_text = str(response.get("value", ""))
+    rendered = str(args.get("answer_prefix", "ANSWER=")) + answer_text
+    _emit_text_delta(rendered, builder.full_text + rendered)
+    builder.emit(rendered)
+
+
 _COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, Event, _SessionState], None]] = {
     "emit_text": _handle_emit_text,
     "stream_text": _handle_stream_text,
@@ -518,6 +601,7 @@ _COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, Event, _SessionState]
     "recall": _handle_recall,
     "report_inputs": _handle_report_inputs,
     "compaction": _handle_compaction,
+    "ui_request": _handle_ui_request,
 }
 
 
@@ -593,7 +677,7 @@ def _run_turn(
     if error_message is not None:
         _emit_response("prompt", success=False, prompt_id=prompt_id, error=error_message)
         return
-    builder = _TurnBuilder(prompt_text=prompt_text, images=images)
+    builder = _TurnBuilder(prompt_id=prompt_id, prompt_text=prompt_text, images=images)
     _emit_response("prompt", success=True, prompt_id=prompt_id)
     _emit({"type": "agent_start"})
     _emit_user_message_end(prompt_text)
@@ -656,9 +740,15 @@ def _run_rpc_loop(system_prompt: str, session_dir: Path | None, session_id: str)
                 # NOT exit (real pi stays alive — see module docstring).
                 _emit_response("abort", success=True, prompt_id=command_id)
                 abort_event.set()
+            elif event_type == "extension_ui_response":
+                # Out-of-band: route to a blocked `ui_request` directive (see
+                # _handle_ui_request); the main loop never processes these.
+                _UI_RESPONSE_QUEUE.put(payload)
             elif event_type in ("prompt", "get_state"):
                 # In-order: queued so get_state observes preceding turns' state.
                 command_queue.put(payload)
+        # Unblock any `ui_request` still waiting when stdin closes at shutdown.
+        _UI_RESPONSE_QUEUE.put({"cancelled": True})
         stdin_closed.set()
 
     reader = threading.Thread(target=_read_stdin, name="fake_pi-stdin-reader", daemon=True)

--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -519,10 +519,9 @@ def convert_agent_messages_to_task_update(
                     recent_plan_file_path = plan_path
                 if isinstance(block, ToolUseBlock) and harness.is_ask_user_question_tool(block.name):
                     if block.id not in submitted_question_answers:
-                        if harness.is_valid_ask_user_question_input(block.name, block.input):
-                            pending_user_question = AskUserQuestionData.model_validate(
-                                {**block.input, "tool_use_id": block.id}, strict=True
-                            )
+                        reconstructed_question = harness.reconstruct_pending_ask_user_question(block)
+                        if reconstructed_question is not None:
+                            pending_user_question = reconstructed_question
                         else:
                             logger.info(
                                 "Skipping AskUserQuestion pending state from persisted ToolUseBlock with invalid input: {}",

--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -367,6 +367,7 @@ def convert_agent_messages_to_task_update(
                 msg.first_response_message_id,
                 msg.approximate_creation_time,
                 streaming.start_index,
+                harness,
                 parent_tool_use_id=msg_parent,
             )
 
@@ -871,6 +872,22 @@ def _create_empty_assistant_message(
     )
 
 
+def _stamp_interactive_role(block: ContentBlockTypes, harness: Harness) -> ContentBlockTypes:
+    """Stamp a tool block with its harness-derived interactive-backchannel role.
+
+    Applied wherever tool blocks enter the converted content — the final
+    (`_handle_response_blocks`) AND the streaming-partial (`_handle_partial_response`)
+    paths — so the frontend renders ask-user-question / plan-approval tools by
+    role rather than by tool name, whichever path delivered the block first.
+    Non-tool blocks pass through unchanged.
+    """
+    if isinstance(block, ToolUseBlock):
+        return block.model_copy(update={"interactive_role": harness.classify_tool_ui_role(block.name)})
+    if isinstance(block, ToolResultBlock):
+        return block.model_copy(update={"interactive_role": harness.classify_tool_ui_role(block.tool_name)})
+    return block
+
+
 def _handle_response_blocks(
     in_progress: ChatMessage | None,
     blocks: tuple[ContentBlockTypes, ...],
@@ -918,12 +935,14 @@ def _handle_response_blocks(
                 # For AskUserQuestion, remove any existing ToolResultBlock with matching tool_use_id.
                 # This handles the case where ToolResultBlock arrived in a previous message
                 # before ToolUseBlock (which can happen during streaming or persistence).
-                if harness.is_ask_user_question_tool(block.name) or harness.is_exit_plan_mode_tool(block.name):
+                if harness.classify_tool_ui_role(block.name) is not None:
                     content = [
                         b for b in content if not (isinstance(b, ToolResultBlock) and b.tool_use_id == block.id)
                     ]
 
-                content.append(block)
+                # Stamp the harness-derived interactive role so the frontend
+                # renders backchannel tools by role rather than by tool name.
+                content.append(_stamp_interactive_role(block, harness))
                 existing_tool_use_ids.add(block.id)
         elif isinstance(block, ToolResultBlock):
             # Defer ToolResultBlocks to second pass
@@ -931,6 +950,12 @@ def _handle_response_blocks(
 
     # Second pass: Process ToolResultBlocks now that all ToolUseBlocks are in place
     for block in tool_result_blocks:
+        # Stamp the harness-derived role so a backchannel result that survives to
+        # the frontend (its tool use lived in an earlier message) is suppressed by
+        # role rather than by tool name. Stamped inline (not via
+        # `_stamp_interactive_role`) to keep the narrow `ToolResultBlock` type
+        # `_replace_tool_use_with_result` requires.
+        block = block.model_copy(update={"interactive_role": harness.classify_tool_ui_role(block.tool_name)})
         # Try to replace matching tool use with result
         content, replaced = _replace_tool_use_with_result(content, block, harness)
 
@@ -977,6 +1002,7 @@ def _handle_partial_response(
     message_id: AgentMessageID,
     approximate_creation_time: datetime.datetime,
     streaming_start_index: int,
+    harness: Harness,
     parent_tool_use_id: str | None = None,
 ) -> ChatMessage:
     """Handle streaming partial - replace content from streaming_start_index."""
@@ -992,8 +1018,15 @@ def _handle_partial_response(
 
     # Skip ToolUseBlocks whose ID already exists in the committed content to prevent
     # duplication (e.g. if persistence ResponseBlockAgentMessage arrived before the partial).
+    # Stamp the interactive role here too: a backchannel tool's block is delivered
+    # via the partial first, and the later final ResponseBlockAgentMessage skips it
+    # as a duplicate — so without stamping on this path the live turn never gets a role.
     committed_tool_use_ids = {b.id for b in committed_content if isinstance(b, ToolUseBlock)}
-    deduplicated = tuple(b for b in content if not (isinstance(b, ToolUseBlock) and b.id in committed_tool_use_ids))
+    deduplicated = tuple(
+        _stamp_interactive_role(b, harness)
+        for b in content
+        if not (isinstance(b, ToolUseBlock) and b.id in committed_tool_use_ids)
+    )
     new_content = committed_content + deduplicated
 
     return in_progress.model_copy(update={"content": new_content})

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -1,4 +1,6 @@
 from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
+from sculptor.agents.pi_agent.backchannel import build_ask_user_question_data
+from sculptor.agents.pi_agent.harness import PI_HARNESS
 from sculptor.foundation.itertools import only
 from sculptor.foundation.serialization import SerializedException
 from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
@@ -5914,3 +5916,131 @@ def test_resumed_turn_log_shape_replays_to_a_finalized_state() -> None:
         f"the turn must finalize (no stuck Thinking pill); got {state.in_progress_user_message_id}"
     )
     assert state.in_progress_chat_message is None
+
+
+def test_pi_ask_user_question_stamps_role_and_correlates_with_answer() -> None:
+    """Real-pi AUQ rendering parity with Claude — the gap FakePi can't catch.
+
+    Pi emits the ask_user_question call as a tool block with the extension's flat
+    ``{question, options}`` input. Conversion must (1) stamp ``interactive_role``
+    from the pi harness so the frontend renders the question panel by role rather
+    than by tool name, and (2) key ``submitted_question_answers`` by the same
+    tool-call id the rendered ToolUseBlock carries, so the answered panel
+    correlates (the dispatcher unifies the question's tool_use_id onto the
+    tool-call id; FakePi never emits this tool block, so this is unit-level).
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+    tool_call_id = ToolUseID("toolu_pi_auq")
+
+    tool_use = ResponseBlockAgentMessage(
+        role="assistant",
+        assistant_message_id=AssistantMessageID("assistant-pi-auq"),
+        message_id=AgentMessageID(),
+        content=(
+            ToolUseBlock(
+                id=tool_call_id,
+                name="ask_user_question",
+                input={"question": "Tabs or spaces?", "options": ["Tabs", "Spaces"]},
+            ),
+        ),
+    )
+    state = convert_agent_messages_to_task_update(
+        [tool_use],
+        task_id=task_id,
+        harness=PI_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+    assert state.in_progress_chat_message is not None
+    use_block = state.in_progress_chat_message.content[0]
+    assert isinstance(use_block, ToolUseBlock)
+    assert use_block.interactive_role == "ask_user_question"
+
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Tabs or spaces?": "Spaces"},
+        question_data=build_ask_user_question_data("Tabs or spaces?", ["Tabs", "Spaces"], str(tool_call_id)),
+        tool_use_id=str(tool_call_id),
+    )
+    state = convert_agent_messages_to_task_update(
+        [answer],
+        task_id=task_id,
+        harness=PI_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    # The answer is keyed by the same id the rendered tool block carries, so the
+    # answered question panel finds it (this is the correlation that was broken).
+    assert str(use_block.id) in state.submitted_question_answers
+    assert state.submitted_question_answers[str(use_block.id)].answers == {"Tabs or spaces?": "Spaces"}
+
+
+def test_pi_ask_user_question_result_block_is_stamped_for_suppression() -> None:
+    """A pi AUQ tool_result that reaches the frontend (its tool use lived in an
+    earlier, already-finalized message) must carry ``interactive_role`` so the
+    frontend suppresses it — otherwise it renders as a stray second tool card."""
+    state = convert_agent_messages_to_task_update(
+        [
+            ResponseBlockAgentMessage(
+                role="assistant",
+                assistant_message_id=AssistantMessageID("assistant-pi-auq-result"),
+                message_id=AgentMessageID(),
+                content=(
+                    ToolResultBlock(
+                        tool_use_id=ToolUseID("toolu_pi_auq_orphan"),
+                        tool_name="ask_user_question",
+                        invocation_string="",
+                        content=GenericToolContent(text="The user answered: Spaces"),
+                    ),
+                ),
+            )
+        ],
+        task_id=TaskID(),
+        harness=PI_HARNESS,
+        completed_message_by_id={},
+        current_state=None,
+    )
+    assert state.in_progress_chat_message is not None
+    result_block = state.in_progress_chat_message.content[0]
+    assert isinstance(result_block, ToolResultBlock)
+    assert result_block.interactive_role == "ask_user_question"
+
+
+def test_pi_ask_user_question_role_stamped_when_delivered_via_partial_first() -> None:
+    """The live-streaming escape: the AUQ tool block arrives first in a
+    PartialResponseBlockAgentMessage (the agent re-advertises its interleaved
+    content as a partial), and the later ResponseBlockAgentMessage is skipped as
+    a duplicate. The partial path must stamp interactive_role too, or the live
+    turn renders as a generic tool card instead of the question panel.
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+    assistant_message_id = AssistantMessageID("assistant-pi-partial")
+    chat_message_id = AgentMessageID()
+    tool_call_id = ToolUseID("toolu_pi_partial")
+    auq_block = ToolUseBlock(id=tool_call_id, name="ask_user_question", input={"question": "Tabs or spaces?"})
+
+    partial = PartialResponseBlockAgentMessage(
+        assistant_message_id=assistant_message_id,
+        message_id=AgentMessageID(),
+        first_response_message_id=chat_message_id,
+        content=(auq_block,),
+    )
+    final = ResponseBlockAgentMessage(
+        role="assistant",
+        assistant_message_id=assistant_message_id,
+        message_id=chat_message_id,
+        content=(auq_block,),
+    )
+    state = convert_agent_messages_to_task_update(
+        [partial, final],
+        task_id=task_id,
+        harness=PI_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+    assert state.in_progress_chat_message is not None
+    blocks = [b for b in state.in_progress_chat_message.content if isinstance(b, ToolUseBlock)]
+    assert len(blocks) == 1, "the duplicate final block must not double-render"
+    assert blocks[0].interactive_role == "ask_user_question"

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -1706,7 +1706,7 @@ def test_answered_plan_approval_not_re_shown_after_ephemeral_replay() -> None:
     plan_question_data = make_plan_approval_question(str(tool_use_id))
     answer_msg = UserQuestionAnswerMessage(
         message_id=AgentMessageID(),
-        answers={"Claude has finished planning. How would you like to proceed?": "Approve plan"},
+        answers={"Planning complete. How would you like to proceed?": "Approve plan"},
         question_data=plan_question_data,
         tool_use_id=str(tool_use_id),
     )

--- a/sculptor/tests/integration/frontend/test_pi_backchannel.py
+++ b/sculptor/tests/integration/frontend/test_pi_backchannel.py
@@ -1,0 +1,139 @@
+"""Integration tests for the pi interactive backchannel (FakePi-driven).
+
+Exercise the full ask-user-question and plan-mode round-trips end-to-end on a
+pi workspace: FakePi's ``ui_request`` directive emits the ``extension_ui_request``
+the real ``sculptor_backchannel`` extension's dialogs produce, Sculptor maps it
+onto the Q&A panel, and the user's answer is routed back as the matching
+``extension_ui_response`` (which FakePi echoes into the turn as ``ANSWER=<value>``).
+
+Pi does not render tool blocks yet (``supports_tool_use_rendering`` is False), so
+unlike the Claude AUQ/plan suites these assert on the Q&A panel and the answer
+the agent receives, not on AUQ/ExitPlanMode tool blocks.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
+from sculptor.interfaces.agents.agent import HarnessName
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.fake_pi import install_fake_pi_binary
+from sculptor.testing.pages.task_page import PlaywrightTaskPage
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+_SELECT_QUESTION_PROMPT = (
+    'fake_pi:ui_request `{"method": "select", "title": "Tea or coffee?", "options": ["tea", "coffee"]}`'
+)
+
+# A plan-mode turn: present a plan as text, then open the plan-approval dialog
+# (the sentinel title the real extension's exit_plan_mode tool uses).
+_PLAN_PROMPT = (
+    'fake_pi:emit_text `{"text": "My plan: step 1, step 2."}` '
+    + f'fake_pi:ui_request `{{"method": "select", "title": "{PLAN_APPROVAL_DIALOG_TITLE}", "options": ["Approve plan"]}}`'
+)
+
+
+def _start_pi_workspace(sculptor_instance_: SculptorInstance, prompt: str, workspace_name: str) -> PlaywrightTaskPage:
+    install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
+    return start_task_and_wait_for_ready(
+        sculptor_page=sculptor_instance_.page,
+        workspace_name=workspace_name,
+        model_name=None,
+        harness=HarnessName.PI,
+        prompt=prompt,
+        wait_for_agent_to_finish=False,
+    )
+
+
+@user_story("to answer a question the pi agent asks mid-turn")
+def test_pi_ask_user_question_round_trip(sculptor_instance_: SculptorInstance) -> None:
+    """The pi agent asks a multiple-choice question; the user answers; the agent uses it."""
+    page = sculptor_instance_.page
+    task_page = _start_pi_workspace(sculptor_instance_, _SELECT_QUESTION_PROMPT, "Pi AUQ")
+    chat_panel = task_page.get_chat_panel()
+
+    # The Q&A panel appears with the question and options.
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel).to_be_visible(timeout=30_000)
+    expect(ask_panel.get_question_text()).to_contain_text("Tea or coffee?")
+    expect(ask_panel.get_submit_button()).to_be_disabled()
+
+    # Answer it; the chat input returns and the agent resumes.
+    ask_panel.select_option("coffee")
+    ask_panel.submit()
+    expect(ask_panel).not_to_be_visible(timeout=30_000)
+    expect(chat_panel.get_chat_input()).to_be_visible()
+
+    # The agent received the answer and used it (FakePi echoes ANSWER=<value>).
+    expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
+    expect(chat_panel.get_assistant_messages().filter(has_text="ANSWER=coffee").first).to_be_visible()
+
+
+@user_story("to give the pi agent a free-form answer via the Other affordance")
+def test_pi_ask_user_question_free_text(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    task_page = _start_pi_workspace(sculptor_instance_, _SELECT_QUESTION_PROMPT, "Pi AUQ Free Text")
+    chat_panel = task_page.get_chat_panel()
+
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel).to_be_visible(timeout=30_000)
+    ask_panel.select_option("Other")
+    ask_panel.type_other_text("herbal tea")
+    ask_panel.submit()
+
+    expect(ask_panel).not_to_be_visible(timeout=30_000)
+    expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
+    expect(chat_panel.get_assistant_messages().filter(has_text="ANSWER=herbal tea").first).to_be_visible()
+
+
+@user_story("to dismiss a question the pi agent asks")
+def test_pi_ask_user_question_dismiss(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    task_page = _start_pi_workspace(sculptor_instance_, _SELECT_QUESTION_PROMPT, "Pi AUQ Dismiss")
+    chat_panel = task_page.get_chat_panel()
+
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel).to_be_visible(timeout=30_000)
+    ask_panel.dismiss()
+
+    expect(ask_panel).not_to_be_visible(timeout=30_000)
+    expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
+    # The extension's dialog resolved to a cancellation; FakePi echoes the
+    # dismissal sentinel.
+    expect(chat_panel.get_assistant_messages().filter(has_text="ANSWER=[dismissed]").first).to_be_visible()
+
+
+@user_story("to enter plan mode on pi, review the plan, and approve it")
+def test_pi_plan_mode_enter_and_approve(sculptor_instance_: SculptorInstance) -> None:
+    """Toggle plan mode on, send a request, approve the presented plan; plan mode clears."""
+    page = sculptor_instance_.page
+    # First turn just gets the workspace to ready with the chat input visible.
+    task_page = _start_pi_workspace(sculptor_instance_, 'fake_pi:emit_text `{"text": "ready"}`', "Pi Plan Mode")
+    chat_panel = task_page.get_chat_panel()
+    expect(chat_panel.get_thinking_indicator(), "first turn to finish").not_to_be_visible()
+
+    # Turn the plan-first toggle on, then send the planning request.
+    toggle = chat_panel.get_plan_mode_toggle()
+    expect(toggle).to_be_visible()
+    toggle.click()
+    expect(toggle).to_have_attribute("data-active", "true")
+    send_chat_message(chat_panel=chat_panel, message=_PLAN_PROMPT)
+
+    # The plan-approval prompt appears (the canonical Sculptor plan question).
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel).to_be_visible(timeout=30_000)
+    expect(ask_panel.get_question_text()).to_contain_text("How would you like to proceed")
+    expect(ask_panel.get_options().filter(has_text="Approve plan").first).to_be_visible()
+
+    # Approve; plan mode clears and the agent proceeds.
+    ask_panel.select_option("Approve plan")
+    ask_panel.submit()
+    expect(ask_panel).not_to_be_visible(timeout=30_000)
+
+    toggle = chat_panel.get_plan_mode_toggle()
+    expect(toggle).to_be_visible()
+    expect(toggle).to_have_attribute("data-active", "false")
+    expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
+    expect(chat_panel.get_assistant_messages().filter(has_text="ANSWER=Approve plan").first).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_pi_basic.py
+++ b/sculptor/tests/integration/frontend/test_pi_basic.py
@@ -2,9 +2,11 @@
 
 Creates a workspace with ``harness=pi``, sends a user message, and asserts the
 FakePi assistant response renders. Spot-checks that the most prominent
-Claude-only affordances (plan-mode toggle, sub-agent pill, fast-mode toggle)
-are suppressed and the skills panel renders its empty state. Per-capability
-parity is the responsibility of test_pi_capability_gating.py.
+Claude-only affordances (sub-agent pill, fast-mode toggle) are suppressed and
+the skills panel renders its empty state. The plan-mode toggle is NOT here: pi
+now supports the interactive backchannel, so that toggle is available — its
+gating is covered by test_pi_capability_gating.py. Per-capability parity is the
+responsibility of test_pi_capability_gating.py.
 """
 
 from playwright.sync_api import expect
@@ -68,7 +70,9 @@ def test_pi_workspace_suppresses_claude_only_surfaces(
     expect(chat_panel.get_chat_input()).to_be_visible()
     expect(chat_panel.get_send_button()).to_be_visible()
 
-    expect(page.get_by_test_id(ElementIDs.PLAN_MODE_TOGGLE)).to_have_count(0)
+    # The plan-mode toggle is intentionally NOT asserted absent here: pi now
+    # supports the interactive backchannel, so the toggle renders (its gating is
+    # covered by test_pi_capability_gating.py).
     expect(page.get_by_test_id(ElementIDs.FAST_MODE_TOGGLE)).to_have_count(0)
     expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_SUBAGENT_PILL)).to_have_count(0)
 

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -1,14 +1,15 @@
 """Per-capability UI gating, parametrized over Claude and pi.
 
 Each test parametrizes the ``harness`` fixture across the two harnesses and
-asserts that a Claude-only affordance renders under Claude and is suppressed
-under pi. Tests that depend on backend interactions FakePi can't produce
-(e.g. an AskUserQuestion block, which requires the harness's interactive
-backchannel) are out of scope here — pi cannot emit them at all.
+asserts that a capability-gated affordance renders when the harness supports
+it and is suppressed when it does not. Most affordances here are still
+Claude-only under FakePi; the interactive-backchannel surfaces (plan-mode
+toggle) now render under pi too, since pi gained that capability via the
+pinned backchannel extension.
 
-The Claude branch of each test serves as the meaningful "this affordance
-renders under Claude" baseline; the pi branch is the "this affordance is
-suppressed by the harness gate" claim.
+The end-to-end backchannel flow itself (ask-user-question round-trip,
+plan-mode enter/approve) is exercised in ``test_pi_backchannel.py``; this
+file covers only the per-capability gate state.
 """
 
 import io
@@ -92,23 +93,16 @@ def _start_busy_workspace_for_harness(
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to disable the plan-mode toggle with a tooltip in harnesses without an interactive backchannel")
-def test_plan_mode_toggle_gated_on_interactive_backchannel(
+@user_story("to use the plan-mode toggle on every harness that supports the interactive backchannel")
+def test_plan_mode_toggle_enabled_on_interactive_backchannel(
     sculptor_instance_: SculptorInstance, harness: HarnessTestConfig
 ) -> None:
+    # Both Claude and pi now support the interactive backchannel (pi via the
+    # pinned backchannel extension), so the live plan-mode toggle renders and
+    # the disabled-with-tooltip placeholder never appears — for either harness.
     _create_workspace_for_harness(sculptor_instance_, harness, "Plan Mode Toggle Gate")
-    toggle = sculptor_instance_.page.get_by_test_id(ElementIDs.PLAN_MODE_TOGGLE)
-    disabled = sculptor_instance_.page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_PLAN_MODE)
-    if harness.workspace_harness == HarnessName.CLAUDE:
-        # Claude supports the interactive backchannel: the live toggle renders
-        # and the disabled placeholder never appears.
-        expect(toggle).to_be_visible()
-        expect(disabled).to_have_count(0)
-    else:
-        # Pi lacks it: the live toggle is replaced by the disabled-with-tooltip
-        # placeholder (visible, ElementID-bearing) — not hidden.
-        expect(toggle).to_have_count(0)
-        expect(disabled).to_be_visible()
+    expect(sculptor_instance_.page.get_by_test_id(ElementIDs.PLAN_MODE_TOGGLE)).to_be_visible()
+    expect(sculptor_instance_.page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_PLAN_MODE)).to_have_count(0)
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)

--- a/sculptor/tests/integration/real_pi/helpers.py
+++ b/sculptor/tests/integration/real_pi/helpers.py
@@ -100,11 +100,14 @@ def create_pi_workspace_and_send(
     prompt: str,
     *,
     workspace_name: str = "Real Pi",
+    wait_for_finish: bool = True,
 ) -> PlaywrightTaskPage:
     """Create a real-pi workspace and send the first prompt.
 
-    Waits for the agent to finish the turn before returning. Pi's tool loop
-    runs inside the pi subprocess; Sculptor's file-watching layer reflects
+    With ``wait_for_finish`` (the default) waits for the turn to complete before
+    returning. Pass ``wait_for_finish=False`` for turns that block mid-way — e.g.
+    an ask-user-question or plan-approval dialog the test must answer. Pi's tool
+    loop runs inside the pi subprocess; Sculptor's file-watching layer reflects
     workspace mutations into the diff sidebar.
     """
     task_page = start_task_and_wait_for_ready(
@@ -113,11 +116,12 @@ def create_pi_workspace_and_send(
         prompt=prefixed(prompt),
         model_name=None,
         harness=HarnessName.PI,
+        wait_for_agent_to_finish=wait_for_finish,
     )
-    chat_panel = task_page.get_chat_panel()
-    wait_for_completed_message_count(
-        chat_panel=chat_panel,
-        expected_message_count=2,
-        timeout=RESPONSE_TIMEOUT_MS,
-    )
+    if wait_for_finish:
+        wait_for_completed_message_count(
+            chat_panel=task_page.get_chat_panel(),
+            expected_message_count=2,
+            timeout=RESPONSE_TIMEOUT_MS,
+        )
     return task_page

--- a/sculptor/tests/integration/real_pi/test_ask_user_question.py
+++ b/sculptor/tests/integration/real_pi/test_ask_user_question.py
@@ -1,0 +1,81 @@
+"""Real pi integration tests: AskUserQuestion.
+
+Mirrors ``real_claude/test_ask_user_question.py`` for pi. The interactive
+backchannel is delivered by the pinned ``sculptor_backchannel`` extension (loaded
+with the real pi binary), whose ``ask_user_question`` tool opens a blocking pi
+dialog that Sculptor surfaces as the Q&A panel.
+
+Divergence (REQ-CAP-ALL-3): pi's ``ask_user_question`` tool asks one question per
+call (the ``ctx.ui.select``/``input`` dialog is single-question), so there is no
+real-pi mirror of Claude's multiple-questions-in-one-call test; the model simply
+calls the tool again for a second question.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import RESPONSE_TIMEOUT_MS
+from tests.integration.real_pi.helpers import create_pi_workspace_and_send
+from tests.integration.real_pi.helpers import real_pi
+
+
+@real_pi
+@pytest.mark.timeout(300)
+def test_ask_user_question_single(sculptor_instance_: SculptorInstance) -> None:
+    """Pi asks a single multiple-choice question; the user answers; the agent finishes."""
+    page = sculptor_instance_.page
+
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_,
+        (
+            "Before doing anything else, you MUST call the ask_user_question tool exactly once with "
+            + "question 'What is your favorite color?' and options ['Red', 'Blue', 'Green']. "
+            + "Do not do anything else until I answer."
+        ),
+        workspace_name="Real Pi AUQ",
+        wait_for_finish=False,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel._locator).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(ask_panel.get_question_text().filter(has_text="favorite color").first).to_be_visible()
+
+    ask_panel.select_option("Blue")
+    ask_panel.submit()
+
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(chat_panel.get_error_block()).to_have_count(0)
+
+
+@real_pi
+@pytest.mark.timeout(300)
+def test_ask_user_question_free_text(sculptor_instance_: SculptorInstance) -> None:
+    """Pi asks a question; the user answers via the free-form 'Other' affordance."""
+    page = sculptor_instance_.page
+
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_,
+        (
+            "You MUST call the ask_user_question tool exactly once, right now, before doing anything else, "
+            + "with question 'What should I name the file?' and options ['default.txt']. "
+            + "Wait for my answer, then reply with exactly: FREETEXT-DONE."
+        ),
+        workspace_name="Real Pi AUQ Free Text",
+        wait_for_finish=False,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel._locator).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+
+    # The "Other" affordance is rendered alongside the provided options, so we can
+    # exercise the free-text path regardless of the options the tool was called with.
+    ask_panel.select_option("Other")
+    ask_panel.type_other_text("my-custom-name.txt")
+    ask_panel.submit()
+
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(chat_panel.get_error_block()).to_have_count(0)

--- a/sculptor/tests/integration/real_pi/test_plan_mode.py
+++ b/sculptor/tests/integration/real_pi/test_plan_mode.py
@@ -1,0 +1,107 @@
+"""Real pi integration tests: plan mode.
+
+Mirrors ``real_claude/test_plan_mode.py`` for pi. Plan mode is delivered by the
+pinned ``sculptor_backchannel`` extension: Sculptor drives entry via the
+chat-input plan-first toggle (the ``enter_plan_mode`` flag + a plan-mode prompt
+preamble), the model presents a plan and calls the ``exit_plan_mode`` tool, and
+that tool's blocking dialog surfaces as the Sculptor plan-approval prompt.
+
+Divergences (REQ-CAP-ALL-3, justified in the MR):
+- Plan entry is the Sculptor chat-input toggle, not a native prompt-driven mode
+  (pi has no native plan mode); unlike Claude we click the toggle rather than
+  saying "enter plan mode".
+- No interrupt-during-plan mirror — interruption is a separate capability
+  (``supports_interruption``), still False for pi.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import RESPONSE_TIMEOUT_MS
+from tests.integration.real_pi.helpers import create_pi_workspace_and_send
+from tests.integration.real_pi.helpers import prefixed
+from tests.integration.real_pi.helpers import real_pi
+
+
+@real_pi
+@pytest.mark.timeout(300)
+def test_plan_mode_enter_and_approve(sculptor_instance_: SculptorInstance) -> None:
+    """Toggle plan mode, have pi present a plan via exit_plan_mode, approve it."""
+    page = sculptor_instance_.page
+
+    # First turn just gets the workspace ready with the chat input + toggle visible.
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_, "Reply with exactly: READY.", workspace_name="Real Pi Plan Mode"
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # Enter plan mode via the chat-input toggle, then send the planning request.
+    toggle = chat_panel.get_plan_mode_toggle()
+    expect(toggle).to_be_visible()
+    toggle.click()
+    expect(toggle).to_have_attribute("data-active", "true")
+    send_chat_message(
+        chat_panel=chat_panel,
+        message=prefixed(
+            "Present a short plan to create a hello.txt file containing 'hello world', then call the "
+            + "exit_plan_mode tool to ask me to approve it. Do not create the file until I approve."
+        ),
+    )
+
+    # The plan-approval prompt appears once pi calls exit_plan_mode.
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel._locator).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(auq_panel.get_question_text().filter(has_text="proceed").first).to_be_visible()
+
+    # Approve; plan mode clears and the agent proceeds.
+    auq_panel.select_option("Approve plan")
+    auq_panel.submit()
+
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(chat_panel.get_error_block()).to_have_count(0)
+    expect(chat_panel.get_plan_mode_toggle()).to_have_attribute("data-active", "false")
+
+
+@real_pi
+@pytest.mark.timeout(600)
+def test_plan_mode_with_revision(sculptor_instance_: SculptorInstance) -> None:
+    """Revise pi's plan via the 'Revise' affordance; pi re-plans, then we approve."""
+    page = sculptor_instance_.page
+
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_, "Reply with exactly: READY.", workspace_name="Real Pi Plan Revision"
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    toggle = chat_panel.get_plan_mode_toggle()
+    expect(toggle).to_be_visible()
+    toggle.click()
+    expect(toggle).to_have_attribute("data-active", "true")
+    send_chat_message(
+        chat_panel=chat_panel,
+        message=prefixed(
+            "Present a plan to create a file called 'original.txt' with the content 'original content', "
+            + "then call the exit_plan_mode tool to ask for approval. Do not create the file until I approve."
+        ),
+    )
+
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel._locator).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+
+    # Revise: select the free-form "Other"/"Revise" affordance and type feedback.
+    auq_panel.select_option("Other")
+    auq_panel.type_other_text("Change the filename to 'revised.txt' instead of 'original.txt'.")
+    auq_panel.submit()
+
+    # The revision panel disappears, pi re-plans, and a fresh approval prompt appears.
+    expect(auq_panel._locator).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(auq_panel._locator).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+
+    auq_panel.select_option("Approve plan")
+    auq_panel.submit()
+
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
+    expect(chat_panel.get_error_block()).to_have_count(0)


### PR DESCRIPTION
## Summary

Delivers `supports_interactive_backchannel` for the pi harness via a pinned, in-repo extension, flipping the capability flag to `True`. Both gated interactions now work end-to-end on pi, matching the Claude experience:

- **Ask-user-question** — the agent poses a structured question, the user answers in Sculptor's UI, and the answer reaches the agent mid-turn.
- **Plan mode** — entry, plan presentation, and approval/revision.

## How it works

The `sculptor_backchannel` extension registers two tools whose `execute` opens a blocking pi dialog (`ctx.ui.select` / `ctx.ui.input`, never with a timeout). In RPC mode those surface as `extension_ui_request` events; `PiAgent` maps them onto the harness-agnostic `AskUserQuestionAgentMessage` contract and routes the user's answer back as the matching `extension_ui_response`, mirroring the Claude request lifecycle (`RequestStarted` on delivery, deferred `RequestSuccess` at the turn boundary).

The extension ships as wheel package data and is loaded with `--no-extensions -e <path>`, preserving the immutability guarantee. It embeds no secrets, emits no telemetry, and is re-validated on any pinned-version bump. The harness's gated methods answer truthfully for pi's tool names, and a mid-turn error from the extension fails the turn loudly.

## Tests

- Unit coverage for the pi_agent backchannel, agent-wrapper, and harness paths.
- Fake-pi frontend integration test (`test_pi_backchannel.py`).
- Real-pi end-to-end tests for ask-user-question and plan mode (`test_ask_user_question.py`, `test_plan_mode.py`).

(Sent by Claude)
