### PR TITLE
pi: support turn interruption via the abort command

### DIFF
--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -132,15 +132,22 @@ PI_SESSION_ID_STATE_FILE: str = "pi_session_id"
 # gate should keep them from reaching pi, so one arriving means a gate has
 # failed. Each maps to the capability whose handler will replace its drop:
 #   UserQuestionAnswerMessage        → supports_interactive_backchannel
-#   InterruptProcessUserMessage      → supports_interruption
 #   ClearContextUserMessage          → supports_context_reset
-# ResumeAgentResponseRunnerMessage is no longer here — `_push_message` handles it
-# (supports_session_resume).
+# ResumeAgentResponseRunnerMessage and InterruptProcessUserMessage are NOT here:
+# both are handled for real by `_push_message` — session resume
+# (supports_session_resume) and pi's `abort` command (supports_interruption; see
+# `_request_interrupt`), respectively.
 _DEAD_LETTER_MESSAGE_TYPES: tuple[type[Message], ...] = (
     UserQuestionAnswerMessage,
-    InterruptProcessUserMessage,
     ClearContextUserMessage,
 )
+
+# After `abort`, pi's interrupted `agent_end` arrives in ≈11 ms. If it does not
+# arrive within this grace window — pi is wedged or ignoring
+# the abort — escalate to SIGTERM (pi exits 143, RPC §3) and let the
+# process-exit fallback in `_consume_until_turn_end` resolve the turn. Generous
+# relative to the observed latency so a momentarily slow pi is never force-killed.
+_INTERRUPT_ESCALATION_GRACE_SECONDS: float = 5.0
 
 
 def _pi_version_in_range(version: str) -> bool:
@@ -209,6 +216,17 @@ class PiAgent(DefaultAgentWrapper):
     # The pi session id this process resumes / creates (pinned via --session-id);
     # persisted in PI_SESSION_ID_STATE_FILE so a restart reuses it.
     _session_id: str = PrivateAttr(default="")
+    # Set while a turn is actively draining pi's stdout — gates the interrupt
+    # escalation so an interrupt that races in between turns never SIGTERMs an
+    # idle (but healthy) pi.
+    _turn_in_flight: Event = PrivateAttr(default_factory=Event)
+    # Set when an interrupt has been requested and we are waiting for pi's
+    # abort-induced boundary. The dispatcher consults it so `stopReason:"aborted"`
+    # finalizes the partial response instead of raising `PiCrashError`.
+    _interrupt_pending: Event = PrivateAttr(default_factory=Event)
+    # The current escalation timer's cancel signal (one per interrupt). Set when
+    # the turn ends so the grace-window thread stands down without SIGTERM.
+    _escalation_cancel: Event | None = PrivateAttr(default=None)
 
     def start(self, secrets: Mapping[str, str | Secret]) -> None:
         # Resolve and validate the pi binary BEFORE super().start so the
@@ -313,6 +331,24 @@ class PiAgent(DefaultAgentWrapper):
                     request_id=message.for_user_message_id,
                     error=None,
                     interrupted=True,
+                )
+            )
+            return True
+        if isinstance(message, InterruptProcessUserMessage):
+            self._request_interrupt()
+            # Resolve the interrupt request itself. The frontend's POST to
+            # /interrupt blocks in `await_message_response` until a
+            # RequestComplete carries THIS message's id, and the StatusPill
+            # stays in the "stopping" state until then. The interrupted CHAT
+            # turn resolves separately when pi's abort-induced `agent_end`
+            # arrives (the base wrapper reads `_was_interrupted`); this control
+            # action is itself never "interrupted", hence interrupted=False.
+            self._output_messages.put(
+                RequestSuccessAgentMessage(
+                    message_id=AgentMessageID(),
+                    request_id=message.message_id,
+                    error=None,
+                    interrupted=False,
                 )
             )
             return True
@@ -488,16 +524,104 @@ class PiAgent(DefaultAgentWrapper):
         else:
             logger.info("PiAgent resumed pi session {} (messageCount={})", expected_session_id, message_count)
 
+    def _request_interrupt(self) -> None:
+        """Halt the in-flight pi turn via pi's `abort` command (supports_interruption).
+
+        Runs on the request-handling thread, concurrently with the
+        message-processing thread that is draining the turn. Sets the base
+        `_was_interrupted` event — the wrapper's success path reads-and-clears it
+        to surface `RequestSuccess(interrupted=True)` for the turn — and an
+        interrupt-pending flag the dispatcher consults so the abort-induced
+        `stopReason:"aborted"` finalizes the partial response instead of raising
+        `PiCrashError`. The turn keeps draining inside `_handle_user_message`;
+        pi's `agent_end` (≈11 ms after abort) ends it. No new
+        message types are needed. If that `agent_end` never arrives, the
+        escalation ladder SIGTERMs pi so the process-exit fallback in
+        `_consume_until_turn_end` still resolves the turn.
+        """
+        self._was_interrupted.set()
+        self._interrupt_pending.set()
+        self._send_rpc({"type": "abort", "id": generate_id()})
+        # Arm escalation only when a turn is actually in flight: an interrupt
+        # that raced in between turns must not force-kill a healthy idle pi.
+        if self._turn_in_flight.is_set():
+            cancel = Event()
+            self._escalation_cancel = cancel
+            self.concurrency_group.start_new_thread(
+                target=self._await_interrupt_escalation,
+                args=(cancel,),
+            )
+
+    def _await_interrupt_escalation(self, cancel: Event) -> None:
+        """Wait out the grace window, then SIGTERM pi if the turn hasn't ended."""
+        if cancel.wait(timeout=_INTERRUPT_ESCALATION_GRACE_SECONDS):
+            return
+        self._escalate_interrupt()
+
+    def _escalate_interrupt(self) -> None:
+        """SIGTERM pi when the abort produced no `agent_end` within the grace window.
+
+        Pi exits 143; `_consume_until_turn_end`'s `process.is_finished()` exit
+        path then resolves the turn. A no-op if the turn already ended after the
+        abort (`_interrupt_pending` cleared) or the process is already gone.
+        """
+        if not self._interrupt_pending.is_set():
+            return
+        process = self._process
+        if process is None or process.is_finished():
+            return
+        logger.info(
+            "PiAgent abort grace window ({}s) expired without agent_end; escalating to SIGTERM",
+            _INTERRUPT_ESCALATION_GRACE_SECONDS,
+        )
+        process.terminate()
+
+    def _cancel_interrupt_escalation(self) -> None:
+        cancel = self._escalation_cancel
+        if cancel is not None:
+            cancel.set()
+
+    def _is_abort_expected(self) -> bool:
+        """Whether a `stopReason:"aborted"` message is the expected interrupted boundary.
+
+        True when we asked pi to stop — an interrupt is pending, or we are
+        shutting down (`wait()` sends `abort` then closes stdin). Otherwise an
+        `aborted` message is an unexpected pi failure and must raise
+        `PiCrashError` (see `_handle_message_end` / `_handle_agent_end`).
+        """
+        return self._interrupt_pending.is_set() or self._shutdown_event.is_set()
+
     def _process_message_queue(self) -> None:
         while not self._shutdown_event.is_set():
             try:
                 message = self._input_agent_messages.get(timeout=0.5)
             except queue.Empty:
                 continue
-            with self._handle_user_message(message):
-                prompt_id = generate_id()
-                self._send_rpc({"type": "prompt", "id": prompt_id, "message": message.text})
+            self._run_prompt_turn(message)
+
+    def _run_prompt_turn(self, message: ChatInputUserMessage) -> None:
+        with self._handle_user_message(message):
+            # A fresh turn starts un-interrupted. Clearing here defuses an
+            # interrupt that raced in with no turn in flight (mirrors Claude's
+            # _process_single_message race note, process_manager.py:575-583):
+            # such an interrupt leaves `_was_interrupted` set, which would
+            # otherwise mis-mark THIS turn as interrupted. This is a turn-start
+            # reset, NOT a clear-on-success — the base wrapper still owns the
+            # read-and-clear of `_was_interrupted` on the success path.
+            self._was_interrupted.clear()
+            self._interrupt_pending.clear()
+            self._cancel_interrupt_escalation()
+            prompt_id = generate_id()
+            self._turn_in_flight.set()
+            self._send_rpc({"type": "prompt", "id": prompt_id, "message": message.text})
+            try:
                 self._consume_until_turn_end(prompt_id)
+            finally:
+                # Turn over: stand down escalation and drop interrupt-pending so a
+                # late grace-window thread can't SIGTERM the next turn's pi.
+                self._turn_in_flight.clear()
+                self._interrupt_pending.clear()
+                self._cancel_interrupt_escalation()
 
     def _consume_until_turn_end(self, prompt_id: str = "") -> None:
         """Drive pi's stdout until the current agent run terminates.
@@ -689,7 +813,10 @@ class PiAgent(DefaultAgentWrapper):
         advertised, so the UI collapses partials into a stable final block.
         The accumulator is then reset for the next message; the tool-call
         registry persists (the lane's result events arrive after this reset).
-        A terminal-error `stopReason` raises `PiCrashError`. Non-assistant
+        A terminal-error `stopReason` raises `PiCrashError`;
+        `stopReason:"aborted"` does too UNLESS an abort is expected (an
+        interrupt is pending, or shutdown) — then it is the interrupted
+        boundary and the partial content is finalized normally. Non-assistant
         `message_end`s (notably the role="user" prompt echo pi emits at
         agent-run start) are dropped.
         """
@@ -703,9 +830,13 @@ class PiAgent(DefaultAgentWrapper):
         if parsed.message.role != "assistant":
             logger.debug("PiAgent dropping non-assistant message_end (role={})", parsed.message.role)
             return
-        if parsed.message.stop_reason in ("error", "aborted"):
+        stop_reason = parsed.message.stop_reason
+        if stop_reason == "error" or (stop_reason == "aborted" and not self._is_abort_expected()):
             text = extract_assistant_text(parsed.message) or state.accumulated_text or "pi message ended in error"
             raise PiCrashError(text, exit_code=None, metadata=None)
+        # An expected-abort message falls through to here (the guard above did
+        # not raise) and finalizes whatever interleaved content it carries —
+        # `stopReason:"aborted"` retains the partial text/tool blocks.
         content = self._build_interleaved_content(parsed.message, state)
         has_tool_blocks = any(isinstance(block, ToolUseBlock) for block in content)
         if has_tool_blocks:
@@ -886,14 +1017,23 @@ class PiAgent(DefaultAgentWrapper):
         accumulated text is finalized here using the partials' IDs so
         the UI still settles on a stable block. A terminal `stopReason`
         on any assistant message in the final transcript raises
-        `PiCrashError`. `willRetry: true` means pi will start another
-        agent run, typically after a transient failure — the current
-        turn still ends so the caller can drain the next pump.
+        `PiCrashError` — EXCEPT `stopReason:"aborted"` when an abort is
+        expected (interrupt pending, or shutdown), which is the interrupted
+        boundary and finalizes the partial text instead.
+        `willRetry: true` means pi will start another agent run, typically
+        after a transient failure — the current turn still ends so the caller
+        can drain the next pump.
         """
+        abort_expected = self._is_abort_expected()
         for message in parsed.messages:
-            if message.role == "assistant" and message.stop_reason in ("error", "aborted"):
-                text = extract_assistant_text(message) or state.accumulated_text or "pi agent ended in error"
-                raise PiCrashError(text, exit_code=None, metadata=None)
+            if message.role != "assistant" or message.stop_reason not in ("error", "aborted"):
+                continue
+            if message.stop_reason == "aborted" and abort_expected:
+                # Expected interrupted boundary — fall through to finalize the
+                # accumulated partial text rather than raise.
+                continue
+            text = extract_assistant_text(message) or state.accumulated_text or "pi agent ended in error"
+            raise PiCrashError(text, exit_code=None, metadata=None)
         if state.accumulated_text:
             self._output_messages.put(
                 ResponseBlockAgentMessage(

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -133,20 +133,14 @@ PI_SESSION_ID_STATE_FILE: str = "pi_session_id"
 # failed. Each maps to the capability whose handler will replace its drop:
 #   UserQuestionAnswerMessage        → supports_interactive_backchannel
 #   ClearContextUserMessage          → supports_context_reset
-# ResumeAgentResponseRunnerMessage and InterruptProcessUserMessage are NOT here:
-# both are handled for real by `_push_message` — session resume
-# (supports_session_resume) and pi's `abort` command (supports_interruption; see
-# `_request_interrupt`), respectively.
 _DEAD_LETTER_MESSAGE_TYPES: tuple[type[Message], ...] = (
     UserQuestionAnswerMessage,
     ClearContextUserMessage,
 )
 
-# After `abort`, pi's interrupted `agent_end` arrives in ≈11 ms. If it does not
-# arrive within this grace window — pi is wedged or ignoring
-# the abort — escalate to SIGTERM (pi exits 143, RPC §3) and let the
-# process-exit fallback in `_consume_until_turn_end` resolve the turn. Generous
-# relative to the observed latency so a momentarily slow pi is never force-killed.
+# If pi's abort-induced `agent_end` does not arrive within this grace window
+# (pi wedged or ignoring the abort), escalate to SIGTERM; the process-exit
+# fallback in `_consume_until_turn_end` then resolves the turn.
 _INTERRUPT_ESCALATION_GRACE_SECONDS: float = 5.0
 
 
@@ -336,13 +330,12 @@ class PiAgent(DefaultAgentWrapper):
             return True
         if isinstance(message, InterruptProcessUserMessage):
             self._request_interrupt()
-            # Resolve the interrupt request itself. The frontend's POST to
+            # Resolve the interrupt request itself: the frontend's POST to
             # /interrupt blocks in `await_message_response` until a
-            # RequestComplete carries THIS message's id, and the StatusPill
-            # stays in the "stopping" state until then. The interrupted CHAT
-            # turn resolves separately when pi's abort-induced `agent_end`
-            # arrives (the base wrapper reads `_was_interrupted`); this control
-            # action is itself never "interrupted", hence interrupted=False.
+            # RequestComplete carries this message's id, and the StatusPill
+            # stays "stopping" until then. The interrupted chat turn resolves
+            # separately when pi's abort-induced `agent_end` arrives; this
+            # control action is itself never interrupted, hence interrupted=False.
             self._output_messages.put(
                 RequestSuccessAgentMessage(
                     message_id=AgentMessageID(),
@@ -528,16 +521,14 @@ class PiAgent(DefaultAgentWrapper):
         """Halt the in-flight pi turn via pi's `abort` command (supports_interruption).
 
         Runs on the request-handling thread, concurrently with the
-        message-processing thread that is draining the turn. Sets the base
-        `_was_interrupted` event — the wrapper's success path reads-and-clears it
-        to surface `RequestSuccess(interrupted=True)` for the turn — and an
-        interrupt-pending flag the dispatcher consults so the abort-induced
-        `stopReason:"aborted"` finalizes the partial response instead of raising
-        `PiCrashError`. The turn keeps draining inside `_handle_user_message`;
-        pi's `agent_end` (≈11 ms after abort) ends it. No new
-        message types are needed. If that `agent_end` never arrives, the
-        escalation ladder SIGTERMs pi so the process-exit fallback in
-        `_consume_until_turn_end` still resolves the turn.
+        message-processing thread draining the turn. Sets the base
+        `_was_interrupted` event (the wrapper's success path reads-and-clears it
+        to surface `RequestSuccess(interrupted=True)`) and an interrupt-pending
+        flag the dispatcher consults so the abort-induced `stopReason:"aborted"`
+        finalizes the partial response instead of raising `PiCrashError`. The
+        turn keeps draining inside `_handle_user_message` until pi's `agent_end`;
+        if that never arrives, the escalation ladder SIGTERMs pi so the
+        process-exit fallback in `_consume_until_turn_end` still resolves the turn.
         """
         self._was_interrupted.set()
         self._interrupt_pending.set()
@@ -561,9 +552,9 @@ class PiAgent(DefaultAgentWrapper):
     def _escalate_interrupt(self) -> None:
         """SIGTERM pi when the abort produced no `agent_end` within the grace window.
 
-        Pi exits 143; `_consume_until_turn_end`'s `process.is_finished()` exit
-        path then resolves the turn. A no-op if the turn already ended after the
-        abort (`_interrupt_pending` cleared) or the process is already gone.
+        `_consume_until_turn_end`'s `process.is_finished()` exit path then resolves
+        the turn. A no-op if the turn already ended after the abort
+        (`_interrupt_pending` cleared) or the process is already gone.
         """
         if not self._interrupt_pending.is_set():
             return
@@ -601,13 +592,9 @@ class PiAgent(DefaultAgentWrapper):
 
     def _run_prompt_turn(self, message: ChatInputUserMessage) -> None:
         with self._handle_user_message(message):
-            # A fresh turn starts un-interrupted. Clearing here defuses an
-            # interrupt that raced in with no turn in flight (mirrors Claude's
-            # _process_single_message race note, process_manager.py:575-583):
-            # such an interrupt leaves `_was_interrupted` set, which would
-            # otherwise mis-mark THIS turn as interrupted. This is a turn-start
-            # reset, NOT a clear-on-success — the base wrapper still owns the
-            # read-and-clear of `_was_interrupted` on the success path.
+            # A fresh turn starts un-interrupted: clear interrupt state left by an
+            # interrupt that raced in with no turn in flight, which would otherwise
+            # mis-mark this turn as interrupted.
             self._was_interrupted.clear()
             self._interrupt_pending.clear()
             self._cancel_interrupt_escalation()
@@ -834,9 +821,6 @@ class PiAgent(DefaultAgentWrapper):
         if stop_reason == "error" or (stop_reason == "aborted" and not self._is_abort_expected()):
             text = extract_assistant_text(parsed.message) or state.accumulated_text or "pi message ended in error"
             raise PiCrashError(text, exit_code=None, metadata=None)
-        # An expected-abort message falls through to here (the guard above did
-        # not raise) and finalizes whatever interleaved content it carries —
-        # `stopReason:"aborted"` retains the partial text/tool blocks.
         content = self._build_interleaved_content(parsed.message, state)
         has_tool_blocks = any(isinstance(block, ToolUseBlock) for block in content)
         if has_tool_blocks:
@@ -1029,8 +1013,7 @@ class PiAgent(DefaultAgentWrapper):
             if message.role != "assistant" or message.stop_reason not in ("error", "aborted"):
                 continue
             if message.stop_reason == "aborted" and abort_expected:
-                # Expected interrupted boundary — fall through to finalize the
-                # accumulated partial text rather than raise.
+                # Expected interrupted boundary: finalize the partial below, don't raise.
                 continue
             text = extract_assistant_text(message) or state.accumulated_text or "pi agent ended in error"
             raise PiCrashError(text, exit_code=None, metadata=None)

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -10,6 +10,8 @@ session-stream.
 from __future__ import annotations
 
 import json
+import threading
+import time
 from pathlib import Path
 from queue import Queue
 from typing import Any
@@ -395,6 +397,246 @@ def test_agent_end_with_aborted_message_raises_pi_crash_error() -> None:
     )
     with pytest.raises(PiCrashError):
         agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+
+# --- Interruption (supports_interruption) ----------------------------------
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
+    """Poll ``predicate`` until true; used to synchronize the two-thread interrupt
+    path deterministically (no fixed sleeps)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+def _abort_was_written(process: MagicMock) -> bool:
+    for call in process.write_stdin.call_args_list:
+        try:
+            payload = json.loads(call.args[0].rstrip("\n"))
+        except (json.JSONDecodeError, IndexError):
+            continue
+        if isinstance(payload, dict) and payload.get("type") == "abort":
+            return True
+    return False
+
+
+def test_push_message_interrupt_is_handled_and_sends_abort() -> None:
+    """InterruptProcessUserMessage is handled (returns True), writes `abort` to stdin,
+    and resolves its own request so the frontend's /interrupt POST returns."""
+    agent = _make_agent()
+    process = MagicMock()
+    agent._process = process
+    interrupt = InterruptProcessUserMessage()
+    handled = agent._push_message(interrupt)
+    assert handled is True
+    assert agent._was_interrupted.is_set()
+    assert agent._interrupt_pending.is_set()
+    assert _abort_was_written(process)
+    # The interrupt request itself must be completed (request_id == the interrupt
+    # message id) — `await_message_response` blocks the /interrupt POST until then,
+    # leaving the StatusPill stuck in "stopping".
+    emitted = _drain(agent._output_messages)
+    completions = [
+        m for m in emitted if isinstance(m, RequestSuccessAgentMessage) and m.request_id == interrupt.message_id
+    ]
+    assert len(completions) == 1
+    # This control action is not itself an interrupted generation turn.
+    assert completions[0].interrupted is False
+
+
+def test_interrupt_mid_turn_resolves_interrupted_and_finalizes_partial() -> None:
+    """Interrupt during a turn: abort is written, the aborted boundary finalizes
+    the partial text without raising, and the turn resolves interrupted=True."""
+    agent = _make_agent()
+    out_queue: Queue[tuple[str, bool]] = Queue()
+    out_queue.put((_event({"type": "agent_start"}), True))
+    out_queue.put((_event(_text_delta_update("partial", "partial")), True))
+    process = MagicMock()
+    process.get_queue.return_value = out_queue
+    process.is_finished.return_value = False
+    agent._process = process
+
+    # Drive the turn on a worker thread and interrupt from this (request-handling)
+    # thread once the partial has streamed — the real two-thread interrupt path.
+    worker = threading.Thread(target=agent._run_prompt_turn, args=(ChatInputUserMessage(text="long task"),))
+    worker.start()
+    try:
+        _wait_until(lambda: agent._output_messages.qsize() >= 2)
+        agent._request_interrupt()
+        # pi's abort-induced boundary: an assistant message with stopReason aborted.
+        out_queue.put(
+            (
+                _event(
+                    {
+                        "type": "agent_end",
+                        "messages": [_assistant_msg("partial", stop_reason="aborted")],
+                        "willRetry": False,
+                    }
+                ),
+                True,
+            )
+        )
+        worker.join(timeout=5.0)
+    finally:
+        if worker.is_alive():
+            agent._shutdown_event.set()
+            worker.join(timeout=5.0)
+    assert not worker.is_alive(), "interrupted turn did not resolve"
+
+    assert _abort_was_written(process)
+    emitted = _drain(agent._output_messages)
+    successes = [m for m in emitted if isinstance(m, RequestSuccessAgentMessage)]
+    assert len(successes) == 1
+    assert successes[0].interrupted is True
+    finals = [m for m in emitted if isinstance(m, ResponseBlockAgentMessage)]
+    assert len(finals) == 1
+    assert finals[0].content == (TextBlock(text="partial"),)
+
+
+def test_interrupt_with_no_turn_in_flight_does_not_poison_next_turn() -> None:
+    """A stale interrupt (no turn in flight) must not mark the NEXT turn interrupted."""
+    agent = _make_agent()
+    # An interrupt that raced in with no turn in flight leaves both flags set.
+    agent._was_interrupted.set()
+    agent._interrupt_pending.set()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event(_text_delta_update("hello", "hello")),
+            _event({"type": "agent_end", "messages": [_assistant_msg("hello")], "willRetry": False}),
+        ]
+    )
+    agent._run_prompt_turn(ChatInputUserMessage(text="fresh turn"))
+    emitted = _drain(agent._output_messages)
+    successes = [m for m in emitted if isinstance(m, RequestSuccessAgentMessage)]
+    assert len(successes) == 1
+    assert successes[0].interrupted is False
+
+
+def test_aborted_agent_end_with_interrupt_pending_finalizes_without_crash() -> None:
+    """`stopReason:"aborted"` on agent_end is the expected boundary when interrupt-pending — finalize, don't raise."""
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event(_text_delta_update("partial", "partial")),
+            _event(
+                {
+                    "type": "agent_end",
+                    "messages": [_assistant_msg("partial", stop_reason="aborted")],
+                    "willRetry": False,
+                }
+            ),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+    finals = [m for m in _drain(agent._output_messages) if isinstance(m, ResponseBlockAgentMessage)]
+    assert len(finals) == 1
+    assert finals[0].content == (TextBlock(text="partial"),)
+
+
+def test_aborted_message_end_with_interrupt_pending_finalizes_without_crash() -> None:
+    """`stopReason:"aborted"` on message_end finalizes the partial when interrupt-pending."""
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event(_text_delta_update("partial", "partial")),
+            _event({"type": "message_end", "message": _assistant_msg("partial", stop_reason="aborted")}),
+            _event(
+                {
+                    "type": "agent_end",
+                    "messages": [_assistant_msg("partial", stop_reason="aborted")],
+                    "willRetry": False,
+                }
+            ),
+        ]
+    )
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+    finals = [m for m in _drain(agent._output_messages) if isinstance(m, ResponseBlockAgentMessage)]
+    # message_end finalizes the partial and resets the accumulator, so agent_end
+    # does not double-emit.
+    assert len(finals) == 1
+    assert finals[0].content == (TextBlock(text="partial"),)
+
+
+def test_aborted_message_end_without_interrupt_pending_raises_pi_crash_error() -> None:
+    """Without an interrupt pending, `stopReason:"aborted"` is an unexpected failure — it crashes."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event({"type": "message_end", "message": _assistant_msg("oops", stop_reason="aborted")}),
+        ]
+    )
+    with pytest.raises(PiCrashError):
+        agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+
+def test_escalate_interrupt_terminates_process_when_pending_and_running() -> None:
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    process = MagicMock()
+    process.is_finished.return_value = False
+    agent._process = process
+    agent._escalate_interrupt()
+    process.terminate.assert_called_once()
+
+
+def test_escalate_interrupt_is_noop_when_interrupt_already_resolved() -> None:
+    agent = _make_agent()
+    # interrupt-pending cleared → the turn already ended after the abort.
+    process = MagicMock()
+    process.is_finished.return_value = False
+    agent._process = process
+    agent._escalate_interrupt()
+    process.terminate.assert_not_called()
+
+
+def test_escalate_interrupt_is_noop_when_process_already_finished() -> None:
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    process = MagicMock()
+    process.is_finished.return_value = True
+    agent._process = process
+    agent._escalate_interrupt()
+    process.terminate.assert_not_called()
+
+
+def test_await_interrupt_escalation_cancelled_within_grace_does_not_terminate() -> None:
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    process = MagicMock()
+    process.is_finished.return_value = False
+    agent._process = process
+    cancel = threading.Event()
+    cancel.set()  # the turn ended within the grace window
+    agent._await_interrupt_escalation(cancel)
+    process.terminate.assert_not_called()
+
+
+def test_escalation_terminate_lets_turn_resolve_via_process_exit() -> None:
+    """No agent_end → SIGTERM → the process-exit fallback resolves the turn."""
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    out_queue: Queue[tuple[str, bool]] = Queue()
+    process = MagicMock()
+    process.get_queue.return_value = out_queue
+    finished = {"value": False}
+    process.is_finished.side_effect = lambda: finished["value"]
+    process.terminate.side_effect = lambda: finished.__setitem__("value", True)
+    agent._process = process
+
+    agent._escalate_interrupt()
+    process.terminate.assert_called_once()
+    # The dispatcher's `process.is_finished() and queue empty` fallback returns.
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
 
 
 def test_auto_retry_end_failure_raises_pi_crash_error() -> None:
@@ -798,11 +1040,11 @@ def test_push_message_enqueues_chat_input_returns_true() -> None:
 
 # The capability-correlated control messages pi cannot handle; each must be
 # dead-lettered (one logged error) and return unhandled.
-# ResumeAgentResponseRunnerMessage is NOT here — it is now handled (see
-# test_push_message_resume_resolves_in_flight_request).
+# ResumeAgentResponseRunnerMessage and InterruptProcessUserMessage are NOT here —
+# both are handled now (session resume, and pi's `abort` command via
+# supports_interruption; see the resume and interrupt tests below).
 _DEAD_LETTER_MESSAGES: list[Message] = [
     ClearContextUserMessage(),
-    InterruptProcessUserMessage(),
     UserQuestionAnswerMessage(
         message_id=AgentMessageID(),
         answers={"q": "a"},

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -399,9 +399,6 @@ def test_agent_end_with_aborted_message_raises_pi_crash_error() -> None:
         agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
 
 
-# --- Interruption (supports_interruption) ----------------------------------
-
-
 def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
     """Poll ``predicate`` until true; used to synchronize the two-thread interrupt
     path deterministically (no fixed sleeps)."""

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -1040,9 +1040,6 @@ def test_push_message_enqueues_chat_input_returns_true() -> None:
 
 # The capability-correlated control messages pi cannot handle; each must be
 # dead-lettered (one logged error) and return unhandled.
-# ResumeAgentResponseRunnerMessage and InterruptProcessUserMessage are NOT here —
-# both are handled now (session resume, and pi's `abort` command via
-# supports_interruption; see the resume and interrupt tests below).
 _DEAD_LETTER_MESSAGES: list[Message] = [
     ClearContextUserMessage(),
     UserQuestionAnswerMessage(

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -76,9 +76,10 @@ class PiHarness(Harness):
             # tool calls render with name, input, in-progress state, and result.
             supports_tool_use_rendering=True,
             supports_file_attachments=False,
-            # Pi drops InterruptProcessUserMessage (see agent_wrapper._push_message),
-            # so the user-facing Stop button cannot halt a pi turn — false.
-            supports_interruption=False,
+            # Pi handles InterruptProcessUserMessage via its `abort` command (see
+            # agent_wrapper._request_interrupt), so the user-facing Stop button
+            # halts a pi turn promptly and the session stays usable — true.
+            supports_interruption=True,
             # Pi resolves @-mention path references via its own file-reading loop,
             # the same as Claude — true.
             supports_file_references=True,

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -6,13 +6,8 @@ from sculptor.interfaces.environments.agent_execution_environment import Depende
 
 
 def test_pi_harness_capabilities() -> None:
-    # Pi is degraded, but four capabilities are true: file references (pi
-    # resolves @-mention paths through its own file-reading loop the same way
-    # Claude does), tool-use rendering (pi's tool-execution lane is adapted onto
-    # Sculptor's ToolUseBlock / ToolResultBlock contract), session resume (pi
-    # persists a per-task JSONL session that a relaunched process resumes — see
-    # agent_wrapper.PiAgent), and interruption (pi's `abort` command halts a
-    # turn — see agent_wrapper._request_interrupt).
+    # Pi is a degraded harness: a capability is true only where Sculptor has a
+    # pi-side mechanism for it (see PiHarness.capabilities for the per-flag why).
     assert PI_HARNESS.capabilities() == HarnessCapabilities(
         supports_interactive_backchannel=False,
         supports_skills=False,

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -6,12 +6,13 @@ from sculptor.interfaces.environments.agent_execution_environment import Depende
 
 
 def test_pi_harness_capabilities() -> None:
-    # Pi is degraded, but three capabilities are true: file references (pi
+    # Pi is degraded, but four capabilities are true: file references (pi
     # resolves @-mention paths through its own file-reading loop the same way
     # Claude does), tool-use rendering (pi's tool-execution lane is adapted onto
-    # Sculptor's ToolUseBlock / ToolResultBlock contract), and session resume
-    # (pi persists a per-task JSONL session that a relaunched process resumes —
-    # see agent_wrapper.PiAgent).
+    # Sculptor's ToolUseBlock / ToolResultBlock contract), session resume (pi
+    # persists a per-task JSONL session that a relaunched process resumes — see
+    # agent_wrapper.PiAgent), and interruption (pi's `abort` command halts a
+    # turn — see agent_wrapper._request_interrupt).
     assert PI_HARNESS.capabilities() == HarnessCapabilities(
         supports_interactive_backchannel=False,
         supports_skills=False,
@@ -24,7 +25,7 @@ def test_pi_harness_capabilities() -> None:
         supports_session_resume=True,
         supports_tool_use_rendering=True,
         supports_file_attachments=False,
-        supports_interruption=False,
+        supports_interruption=True,
         supports_file_references=True,
     )
 

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -504,8 +504,7 @@ def _run_turn(
         if abort_event.is_set():
             raise _TurnAborted()
     except _TurnAborted:
-        # The user message reached pi, so record the (partial) turn for resume,
-        # then stop — no happy-path end.
+        # Record the (partial) turn for resume, like a completed one.
         _emit_aborted_agent_end(builder.full_text)
         state.record_turn(prompt_text)
         return
@@ -558,7 +557,6 @@ def _run_rpc_loop(system_prompt: str, session_dir: Path | None, session_id: str)
             elif event_type in ("prompt", "get_state"):
                 # In-order: queued so get_state observes preceding turns' state.
                 command_queue.put(payload)
-            # Other command types are ignored.
         stdin_closed.set()
 
     reader = threading.Thread(target=_read_stdin, name="fake_pi-stdin-reader", daemon=True)

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -20,7 +20,17 @@ surfaced).
 The preflight-failure path (`fake_pi:error`) emits a `response` with
 `success:false` and no session events, matching pi's behavior
 when the prompt is rejected before the agent starts (e.g. missing API
-key). `abort` is acknowledged with a `response` envelope too.
+key).
+
+`abort` is acknowledged with a `response` envelope and, like real pi, leaves
+the process alive for the next prompt — it does NOT exit. If a turn is in
+flight, abort preempts it and emits an `agent_end` whose assistant message
+carries `stopReason:"aborted"` plus whatever partial text the directives
+produced. To let abort interrupt a turn blocked in a
+directive (`fake_pi:sleep` / `wait_for_file`), stdin is read on a background
+thread that sets an abort flag the directive handlers poll between steps —
+kept deterministic via sentinel-file pauses, never wall-clock races. The
+process exits on stdin EOF (Sculptor closes stdin at shutdown).
 
 CLI surface matches what ``PiAgent.start`` spawns:
 
@@ -44,6 +54,7 @@ import json
 import re
 import shlex
 import sys
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -51,6 +62,9 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
+from queue import Empty
+from queue import Queue
+from threading import Event
 
 from sculptor.services.dependency_management_service import PI_VERSION_RANGE
 
@@ -65,6 +79,15 @@ _DEFAULT_RESPONSE_TEXT = "[FakePi] Task completed."
 
 class UnknownFakePiCommandError(ValueError):
     """Raised when an unknown ``fake_pi:`` directive is encountered."""
+
+
+class _TurnAborted(Exception):
+    """Raised inside a directive when an ``abort`` preempts the running turn."""
+
+
+# stdout is written from two threads (the stdin reader emits the abort ack; the
+# main loop emits turn events), so serialize whole lines to avoid interleaving.
+_STDOUT_LOCK = threading.Lock()
 
 
 @dataclass
@@ -173,8 +196,10 @@ def _extract_directives(text: str) -> list[str]:
 
 
 def _emit(event: dict) -> None:
-    sys.stdout.write(json.dumps(event, separators=(",", ":")) + "\n")
-    sys.stdout.flush()
+    line = json.dumps(event, separators=(",", ":")) + "\n"
+    with _STDOUT_LOCK:
+        sys.stdout.write(line)
+        sys.stdout.flush()
 
 
 def _assistant_message(text: str, stop_reason: str = "stop") -> dict:
@@ -238,20 +263,39 @@ def _emit_agent_end(text: str) -> None:
     )
 
 
-def _handle_emit_text(args: dict, builder: _TurnBuilder, state: _SessionState) -> None:
+def _emit_aborted_agent_end(text: str) -> None:
+    """Emit the interrupted-turn boundary: an `agent_end` whose assistant message
+    carries `stopReason:"aborted"` plus the partial text streamed so far.
+
+    Real pi keeps partial content blocks on the aborted message and fires
+    `agent_end` with `willRetry:false`. PiAgent treats this as the interrupted
+    boundary (no `PiCrashError`) while an interrupt is pending.
+    """
+    _emit(
+        {
+            "type": "agent_end",
+            "messages": [_assistant_message(text, stop_reason="aborted")],
+            "willRetry": False,
+        }
+    )
+
+
+def _handle_emit_text(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     text = args.get("text", "")
     accumulated = builder.full_text + text
     _emit_text_delta(text, accumulated)
     builder.emit(text)
 
 
-def _handle_stream_text(args: dict, builder: _TurnBuilder, state: _SessionState) -> None:
+def _handle_stream_text(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     text: str = args.get("text", "")
     chunk_size: int = int(args.get("chunk_size", 8))
     delay_seconds: float = float(args.get("delay_seconds", 0.0))
     if chunk_size <= 0:
         chunk_size = max(1, len(text))
     for offset in range(0, len(text), chunk_size):
+        if abort_event.is_set():
+            raise _TurnAborted()
         chunk = text[offset : offset + chunk_size]
         accumulated = builder.full_text + chunk
         _emit_text_delta(chunk, accumulated)
@@ -260,7 +304,7 @@ def _handle_stream_text(args: dict, builder: _TurnBuilder, state: _SessionState)
             time.sleep(delay_seconds)
 
 
-def _handle_tool_call(args: dict, builder: _TurnBuilder, state: _SessionState) -> None:
+def _handle_tool_call(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     """Emit one tool call: close the current assistant message with a toolCall
     block, then stream the tool-execution lane (start → updates → end).
 
@@ -329,23 +373,31 @@ def _handle_tool_call(args: dict, builder: _TurnBuilder, state: _SessionState) -
     )
 
 
-def _handle_sleep(args: dict, builder: _TurnBuilder, state: _SessionState) -> None:
+def _handle_sleep(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     seconds = float(args.get("seconds", 0))
-    if seconds > 0:
-        time.sleep(seconds)
+    if seconds <= 0:
+        return
+    # Poll in small steps so an abort can preempt the sleep.
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if abort_event.is_set():
+            raise _TurnAborted()
+        time.sleep(0.05)
 
 
-def _handle_wait_for_file(args: dict, builder: _TurnBuilder, state: _SessionState) -> None:
+def _handle_wait_for_file(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     timeout_seconds = float(args.get("timeout_seconds", 120))
     sentinel = Path(args["path"])
     deadline = time.monotonic() + timeout_seconds
     while not sentinel.exists():
+        if abort_event.is_set():
+            raise _TurnAborted()
         if time.monotonic() >= deadline:
             raise RuntimeError(f"fake_pi:wait_for_file timed out after {timeout_seconds}s waiting for {sentinel}")
         time.sleep(0.05)
 
 
-def _handle_recall(args: dict, builder: _TurnBuilder, state: _SessionState) -> None:
+def _handle_recall(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     """Emit the user messages remembered from BEFORE this turn.
 
     Recall succeeds only if the prior session was reloaded from disk by
@@ -360,7 +412,7 @@ def _handle_recall(args: dict, builder: _TurnBuilder, state: _SessionState) -> N
         builder.emit("RECALL:NO_PRIOR_CONTEXT")
 
 
-_COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, _SessionState], None]] = {
+_COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, Event, _SessionState], None]] = {
     "emit_text": _handle_emit_text,
     "stream_text": _handle_stream_text,
     "tool_call": _handle_tool_call,
@@ -370,13 +422,17 @@ _COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, _SessionState], None]
 }
 
 
-def _dispatch_directives(directives: Iterable[str], builder: _TurnBuilder, state: _SessionState) -> None:
+def _dispatch_directives(
+    directives: Iterable[str], builder: _TurnBuilder, abort_event: Event, state: _SessionState
+) -> None:
     for directive in directives:
+        if abort_event.is_set():
+            raise _TurnAborted()
         name, args = _parse_directive(directive)
         handler = _COMMAND_REGISTRY.get(name)
         if handler is None:
             raise UnknownFakePiCommandError(f"unknown command '{name}'")
-        handler(args, builder, state)
+        handler(args, builder, abort_event, state)
 
 
 def _find_error_directive(directives: Iterable[str]) -> str | None:
@@ -409,6 +465,7 @@ def _run_turn(
     prompt_text: str,
     turn_directives: list[str],
     system_directives: list[str],
+    abort_event: Event,
     state: _SessionState,
 ) -> None:
     """Emit the wire sequence for one user turn.
@@ -426,7 +483,10 @@ def _run_turn(
 
     The turn is recorded into ``state`` AFTER emission, so a `recall`
     directive in this turn sees only prior turns, and so a preflight error
-    records nothing.
+    records nothing. If ``abort_event`` is set while the turn is running, the
+    turn is preempted and emits the interrupted boundary (`agent_end` with
+    `stopReason:"aborted"` plus the partial text streamed so far) in place of
+    the happy-path end.
     """
     directives = turn_directives or system_directives
     error_message = _find_error_directive(directives)
@@ -437,7 +497,18 @@ def _run_turn(
     _emit_response("prompt", success=True, prompt_id=prompt_id)
     _emit({"type": "agent_start"})
     _emit_user_message_end(prompt_text)
-    _dispatch_directives(directives, builder, state)
+    try:
+        _dispatch_directives(directives, builder, abort_event, state)
+        # An abort that lands after the last directive (or during a non-blocking
+        # one) is caught here before the happy-path end is emitted.
+        if abort_event.is_set():
+            raise _TurnAborted()
+    except _TurnAborted:
+        # The user message reached pi, so record the (partial) turn for resume,
+        # then stop — no happy-path end.
+        _emit_aborted_agent_end(builder.full_text)
+        state.record_turn(prompt_text)
+        return
     if not builder.has_text:
         _emit_text_delta(_DEFAULT_RESPONSE_TEXT, _DEFAULT_RESPONSE_TEXT)
         builder.emit(_DEFAULT_RESPONSE_TEXT)
@@ -448,38 +519,75 @@ def _run_turn(
 
 
 def _run_rpc_loop(system_prompt: str, session_dir: Path | None, session_id: str) -> int:
+    """Drive the RPC loop, reading stdin on a background thread.
+
+    Only `abort` is handled out-of-band by the reader thread (it acks the abort
+    and sets ``abort_event``, which the directive handlers poll, so it can
+    preempt a turn blocked in a directive). `prompt` and `get_state` are queued
+    and handled IN ORDER by the main loop, so `get_state` reflects the message
+    count of every preceding turn (PiAgent reads it to verify a resume). Real pi
+    stays alive after abort, so the loop keeps going; the process exits on stdin
+    EOF (Sculptor closes stdin at shutdown).
+    """
     system_directives = _extract_directives(system_prompt)
     # Load (or initialize) the session once at startup; a relaunch with the same
     # dir + id reloads the prior transcript so `recall` / get_state see it.
     state = _SessionState.load(session_dir, session_id)
-    for raw_line in sys.stdin:
-        line = raw_line.strip()
-        if not line:
-            continue
+    command_queue: Queue[dict] = Queue()
+    abort_event = Event()
+    stdin_closed = Event()
+
+    def _read_stdin() -> None:
+        for raw_line in sys.stdin:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            event_type = payload.get("type")
+            command_id = payload.get("id") if isinstance(payload.get("id"), str) else None
+            if event_type == "abort":
+                # Out-of-band: ack and signal any in-flight turn to wind down; do
+                # NOT exit (real pi stays alive — see module docstring).
+                _emit_response("abort", success=True, prompt_id=command_id)
+                abort_event.set()
+            elif event_type in ("prompt", "get_state"):
+                # In-order: queued so get_state observes preceding turns' state.
+                command_queue.put(payload)
+            # Other command types are ignored.
+        stdin_closed.set()
+
+    reader = threading.Thread(target=_read_stdin, name="fake_pi-stdin-reader", daemon=True)
+    reader.start()
+
+    exit_code = 0
+    while True:
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
+            payload = command_queue.get(timeout=0.05)
+        except Empty:
+            if stdin_closed.is_set() and command_queue.empty():
+                break
             continue
-        if not isinstance(payload, dict):
+        command_id = payload.get("id") if isinstance(payload.get("id"), str) else None
+        if payload.get("type") == "get_state":
+            _emit_state(command_id, state)
             continue
-        event_type = payload.get("type")
-        prompt_id = payload.get("id") if isinstance(payload.get("id"), str) else None
-        if event_type == "get_state":
-            _emit_state(prompt_id, state)
-            continue
-        if event_type == "abort":
-            _emit_response("abort", success=True, prompt_id=prompt_id)
-            return 0
-        if event_type != "prompt":
-            continue
+        # A fresh turn clears any abort that raced in between turns (mirrors
+        # PiAgent clearing interrupt-pending when it sends the next prompt).
+        abort_event.clear()
         message_text = payload.get("message", "") or ""
         turn_directives = _extract_directives(message_text)
         try:
-            _run_turn(prompt_id, message_text, turn_directives, system_directives, state)
+            _run_turn(command_id, message_text, turn_directives, system_directives, abort_event, state)
         except UnknownFakePiCommandError as e:
-            _emit_response("prompt", success=False, prompt_id=prompt_id, error=str(e))
-            return 1
-    return 0
+            _emit_response("prompt", success=False, prompt_id=command_id, error=str(e))
+            exit_code = 1
+            break
+    return exit_code
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/sculptor/sculptor/testing/fake_pi_test.py
+++ b/sculptor/sculptor/testing/fake_pi_test.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -262,7 +264,9 @@ def test_fake_pi_rpc_per_turn_directives_take_precedence_over_system_prompt() ->
     assert update.assistant_message_event.get("delta") == "from-turn"
 
 
-def test_fake_pi_rpc_abort_emits_response_and_exits_cleanly() -> None:
+def test_fake_pi_rpc_abort_with_no_turn_acks_and_exits_on_eof() -> None:
+    """An abort with no turn in flight is acked; the process then exits on stdin
+    EOF (it does NOT terminate on the abort itself — real pi stays alive)."""
     result = _run_fake_pi(
         ["--mode", "rpc", "--no-session", "--append-system-prompt", ""],
         stdin_input=json.dumps({"type": "abort", "id": "a1"}) + "\n",
@@ -275,6 +279,65 @@ def test_fake_pi_rpc_abort_emits_response_and_exits_cleanly() -> None:
     assert response.command == "abort"
     assert response.success is True
     assert response.id == "a1"
+
+
+def _read_until(stream: object, predicate: Callable[[dict], bool], timeout: float = 10.0) -> dict:
+    """Read JSONL lines from a live fake_pi stdout until ``predicate`` matches.
+
+    Blocking ``readline`` keeps this deterministic: each event is consumed in
+    order, with no fixed sleeps.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = stream.readline()  # type: ignore[attr-defined]
+        if not line:
+            raise AssertionError("fake_pi closed stdout before the predicate matched")
+        stripped = line.strip()
+        if not stripped:
+            continue
+        event = json.loads(stripped)
+        if predicate(event):
+            return event
+    raise AssertionError("timed out waiting for predicate")
+
+
+def test_fake_pi_rpc_abort_preempts_blocked_turn_and_process_stays_alive(tmp_path: Path) -> None:
+    """An abort sent while a turn is blocked in a directive preempts it (emitting
+    the `stopReason:"aborted"` boundary) and the process serves the next prompt.
+
+    Driven over a live stdin pipe so the abort lands AFTER the turn is in flight
+    (deterministic — no racing the reader against the turn-start abort reset).
+    """
+    never = tmp_path / "never-created"
+    blocking = f'fake_pi:wait_for_file `{{"path": "{never}"}}`'
+    follow_up = 'fake_pi:emit_text `{"text": "after-abort"}`'
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", _FAKE_PI_MODULE, "--mode", "rpc", "--no-session", "--append-system-prompt", ""],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdin is not None and proc.stdout is not None
+    try:
+        # Start the turn that blocks on a sentinel file that never appears.
+        proc.stdin.write(_send_prompt(blocking, prompt_id="p1"))
+        proc.stdin.flush()
+        _read_until(proc.stdout, lambda e: e.get("type") == "agent_start")
+        # Interrupt: the blocked wait_for_file must bail with the aborted boundary.
+        proc.stdin.write(json.dumps({"type": "abort", "id": "a1"}) + "\n")
+        proc.stdin.flush()
+        aborted_end = _read_until(proc.stdout, lambda e: e.get("type") == "agent_end")
+        assert aborted_end["messages"][0]["stopReason"] == "aborted"
+        # The same process serves a follow-up prompt — it did NOT exit on abort.
+        proc.stdin.write(_send_prompt(follow_up, prompt_id="p2"))
+        proc.stdin.flush()
+        done_end = _read_until(proc.stdout, lambda e: e.get("type") == "agent_end")
+        assert done_end["messages"][0]["content"][0]["text"] == "after-abort"
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=10.0)
+    assert proc.returncode == 0
 
 
 def test_fake_pi_rpc_unknown_directive_emits_failure_response_and_exits_nonzero() -> None:

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -209,11 +209,10 @@ def test_skills_panel_empty_under_pi(sculptor_instance_: SculptorInstance, harne
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to stop an in-flight turn from the Stop button in every harness, now including pi")
+@user_story("to stop an in-flight turn from the Stop button in every harness, including pi")
 def test_stop_button_gated_on_interruption(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
-    """While the agent is busy, BOTH Claude and pi now show the live Stop button
-    (the disabled-with-tooltip placeholder is absent for both), and pressing it
-    ends the in-flight turn — pi gained interruption via its `abort` command."""
+    """While the agent is busy, both Claude and pi show the live Stop button (no
+    disabled-with-tooltip placeholder), and pressing it ends the in-flight turn."""
     page = sculptor_instance_.page
     release_path = Path(tempfile.gettempdir()) / f"pi_cap_stop_{uuid.uuid4().hex}"
     try:
@@ -235,13 +234,12 @@ def test_stop_button_gated_on_interruption(sculptor_instance_: SculptorInstance,
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to interrupt-and-send a queued message in every harness, now including pi")
+@user_story("to interrupt-and-send a queued message in every harness, including pi")
 def test_queued_interrupt_gated_on_interruption(
     sculptor_instance_: SculptorInstance, harness: HarnessTestConfig
 ) -> None:
     """A message queued while the agent is busy shows an interrupt-and-send
-    button — now live for BOTH Claude and pi (the disabled-with-tooltip
-    placeholder is absent for both)."""
+    button — live for both Claude and pi (no disabled-with-tooltip placeholder)."""
     page = sculptor_instance_.page
     # Queuing only happens with always-interrupt-and-send OFF; disable it
     # defensively in case a sibling test left it on the shared instance.
@@ -259,8 +257,8 @@ def test_queued_interrupt_gated_on_interruption(
         # Queue a second message while the agent is blocked on the sentinel.
         send_chat_message(chat_panel=chat_panel, message="queued while running")
         expect(chat_panel.get_queued_message_bar()).to_have_count(1)
-        # pi now supports interruption: the live interrupt-and-send button
-        # renders for both harnesses; the gated-off placeholder for neither.
+        # The live interrupt-and-send button renders for both harnesses; the
+        # gated-off placeholder for neither.
         expect(page.get_by_test_id(ElementIDs.QUEUED_MESSAGE_SEND_BUTTON)).to_be_visible()
         expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_QUEUED_INTERRUPT)).to_have_count(0)
     finally:

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -209,37 +209,39 @@ def test_skills_panel_empty_under_pi(sculptor_instance_: SculptorInstance, harne
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to disable the Stop button with a tooltip in harnesses that cannot interrupt a turn")
+@user_story("to stop an in-flight turn from the Stop button in every harness, now including pi")
 def test_stop_button_gated_on_interruption(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
-    """While the agent is busy: Claude shows the live Stop button; pi shows the
-    disabled-with-tooltip placeholder (the Stop control is never hidden)."""
+    """While the agent is busy, BOTH Claude and pi now show the live Stop button
+    (the disabled-with-tooltip placeholder is absent for both), and pressing it
+    ends the in-flight turn — pi gained interruption via its `abort` command."""
     page = sculptor_instance_.page
     release_path = Path(tempfile.gettempdir()) / f"pi_cap_stop_{uuid.uuid4().hex}"
     try:
-        _start_busy_workspace_for_harness(sculptor_instance_, harness, "Stop Button Gate", release_path)
+        task_page = _start_busy_workspace_for_harness(sculptor_instance_, harness, "Stop Button Gate", release_path)
+        chat_panel = task_page.get_chat_panel()
         # The pill is only up while the agent is in a cancellable (busy) state.
         expect(page.get_by_test_id(ElementIDs.STATUS_PILL)).to_be_visible(timeout=15000)
-        if harness.workspace_harness == HarnessName.CLAUDE:
-            expect(page.get_by_test_id(ElementIDs.STATUS_PILL_STOP)).to_be_visible()
-            expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_STOP)).to_have_count(0)
-        else:
-            # The disabled-with-tooltip placeholder replaces the live Stop
-            # button (the placeholder's button is asserted disabled by the
-            # CapabilityGate unit test).
-            expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_STOP)).to_be_visible()
-            expect(page.get_by_test_id(ElementIDs.STATUS_PILL_STOP)).to_have_count(0)
+        # The real Stop button renders for both harnesses; the gated-off
+        # placeholder appears for neither.
+        expect(page.get_by_test_id(ElementIDs.STATUS_PILL_STOP)).to_be_visible()
+        expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_STOP)).to_have_count(0)
+        # Pressing Stop ends the in-flight turn.
+        chat_panel.get_stop_button().click()
+        expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=15000)
     finally:
-        # Let the blocked turn finish so the shared instance tears down cleanly.
+        # Harmless if the turn already ended via Stop; releases the blocked turn
+        # if a Stop assertion failed before the click.
         release_path.touch()
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to disable the queued-message interrupt-and-send button in harnesses that cannot interrupt")
+@user_story("to interrupt-and-send a queued message in every harness, now including pi")
 def test_queued_interrupt_gated_on_interruption(
     sculptor_instance_: SculptorInstance, harness: HarnessTestConfig
 ) -> None:
     """A message queued while the agent is busy shows an interrupt-and-send
-    button — live for Claude, disabled-with-tooltip for pi."""
+    button — now live for BOTH Claude and pi (the disabled-with-tooltip
+    placeholder is absent for both)."""
     page = sculptor_instance_.page
     # Queuing only happens with always-interrupt-and-send OFF; disable it
     # defensively in case a sibling test left it on the shared instance.
@@ -257,15 +259,10 @@ def test_queued_interrupt_gated_on_interruption(
         # Queue a second message while the agent is blocked on the sentinel.
         send_chat_message(chat_panel=chat_panel, message="queued while running")
         expect(chat_panel.get_queued_message_bar()).to_have_count(1)
-        if harness.workspace_harness == HarnessName.CLAUDE:
-            expect(page.get_by_test_id(ElementIDs.QUEUED_MESSAGE_SEND_BUTTON)).to_be_visible()
-            expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_QUEUED_INTERRUPT)).to_have_count(0)
-        else:
-            # The disabled-with-tooltip placeholder replaces the live
-            # interrupt-and-send button (disabled state covered by the
-            # CapabilityGate unit test).
-            expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_QUEUED_INTERRUPT)).to_be_visible()
-            expect(page.get_by_test_id(ElementIDs.QUEUED_MESSAGE_SEND_BUTTON)).to_have_count(0)
+        # pi now supports interruption: the live interrupt-and-send button
+        # renders for both harnesses; the gated-off placeholder for neither.
+        expect(page.get_by_test_id(ElementIDs.QUEUED_MESSAGE_SEND_BUTTON)).to_be_visible()
+        expect(page.get_by_test_id(ElementIDs.CAPABILITY_DISABLED_QUEUED_INTERRUPT)).to_have_count(0)
     finally:
         release_path.touch()
 

--- a/sculptor/tests/integration/frontend/test_pi_interrupt.py
+++ b/sculptor/tests/integration/frontend/test_pi_interrupt.py
@@ -1,0 +1,61 @@
+"""Interrupt-and-continue for the pi harness (supports_interruption).
+
+Mirrors the core of ``test_interrupt_and_continue.py`` against FakePi: a turn
+that streams some text and then blocks on a sentinel file is interrupted via
+the Stop button, the chat resolves as ``Stopped``, and a follow-up turn
+completes on the same long-lived pi process. The sentinel-file pause is a
+deterministic busy window (no wall-clock racing).
+"""
+
+import tempfile
+import uuid
+from pathlib import Path
+
+from playwright.sync_api import expect
+
+from sculptor.interfaces.agents.agent import HarnessName
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.fake_pi import install_fake_pi_binary
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+
+@user_story("to stop a running pi turn and then continue with a follow-up message")
+def test_pi_interrupt_during_turn_then_continue(sculptor_instance_: SculptorInstance) -> None:
+    install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
+    page = sculptor_instance_.page
+    release_path = Path(tempfile.gettempdir()) / f"pi_interrupt_{uuid.uuid4().hex}"
+    try:
+        # Stream some text, then block on a sentinel file: a deterministic busy
+        # window in which the Stop button is live (no wall-clock dependence).
+        prompt = f'fake_pi:stream_text `{{"text": "Working on it..."}}` fake_pi:wait_for_file `{{"path": "{release_path}"}}`'
+        task_page = start_task_and_wait_for_ready(
+            sculptor_page=page,
+            workspace_name="Pi Interrupt",
+            model_name=None,
+            harness=HarnessName.PI,
+            prompt=prompt,
+            wait_for_agent_to_finish=False,
+        )
+        chat_panel = task_page.get_chat_panel()
+
+        # Wait for the turn to be busy, then Stop it.
+        expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=15000)
+        stop_button = chat_panel.get_stop_button()
+        expect(stop_button).to_be_visible()
+        stop_button.click()
+
+        # The interrupted turn resolves: the Stopped marker shows and the agent
+        # is no longer busy.
+        expect(chat_panel.get_messages().last).to_contain_text("Stopped", timeout=15000)
+        expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=15000)
+
+        # A follow-up turn completes on the same pi process.
+        send_chat_message(chat_panel=chat_panel, message='fake_pi:emit_text `{"text": "Follow-up done."}`')
+        expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=30000)
+        expect(chat_panel.get_messages().last).to_contain_text("Follow-up done.")
+    finally:
+        # Harmless if the turn already ended via Stop; releases a still-blocked
+        # turn if a pre-Stop assertion failed.
+        release_path.touch()

--- a/sculptor/tests/integration/frontend/test_pi_interrupt.py
+++ b/sculptor/tests/integration/frontend/test_pi_interrupt.py
@@ -40,14 +40,11 @@ def test_pi_interrupt_during_turn_then_continue(sculptor_instance_: SculptorInst
         )
         chat_panel = task_page.get_chat_panel()
 
-        # Wait for the turn to be busy, then Stop it.
         expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=15000)
         stop_button = chat_panel.get_stop_button()
         expect(stop_button).to_be_visible()
         stop_button.click()
 
-        # The interrupted turn resolves: the Stopped marker shows and the agent
-        # is no longer busy.
         expect(chat_panel.get_messages().last).to_contain_text("Stopped", timeout=15000)
         expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=15000)
 

--- a/sculptor/tests/integration/real_pi/helpers.py
+++ b/sculptor/tests/integration/real_pi/helpers.py
@@ -7,8 +7,12 @@ upstream model. Helpers keep the per-test surface small.
 from __future__ import annotations
 
 import pytest
+from playwright.sync_api import expect
 
+from sculptor.constants import ElementIDs
 from sculptor.interfaces.agents.agent import HarnessName
+from sculptor.testing.elements.chat_panel import PlaywrightChatPanelElement
+from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -24,6 +28,9 @@ real_pi = pytest.mark.real_pi
 # Single-turn responses against real pi can take a while (cold-start + model
 # latency). Default to a roomy timeout so the suite isn't fighting noise.
 RESPONSE_TIMEOUT_MS = 180_000
+# Waiting for streaming text to first appear, and for an interrupt to settle.
+STREAMING_WAIT_TIMEOUT_MS = 60_000
+INTERRUPT_TIMEOUT_MS = 30_000
 
 # Prefix every prompt so real pi recognises this as an automated test. Reads as
 # a user instruction without conflicting with any pi system-prompt directive.
@@ -32,6 +39,60 @@ _TEST_PREFIX = "[SCULPTOR-UI-TEST] This is an automated integration test of Scul
 
 def prefixed(prompt: str) -> str:
     return _TEST_PREFIX + prompt
+
+
+def send_no_wait(chat_panel: PlaywrightChatPanelElement, prompt: str) -> None:
+    """Send a prompt without waiting for completion (for interrupt tests)."""
+    send_chat_message(chat_panel=chat_panel, message=prefixed(prompt))
+
+
+def wait_for_streaming_text(
+    chat_panel: PlaywrightChatPanelElement,
+    sentinel: str,
+    timeout_ms: int = STREAMING_WAIT_TIMEOUT_MS,
+) -> None:
+    """Wait until ``sentinel`` appears in an assistant message (even mid-stream).
+
+    Filters to assistant messages so the user's own prompt (which may quote the
+    sentinel) doesn't match before the agent has actually started streaming.
+    """
+    expect(chat_panel.get_assistant_messages().last).to_contain_text(sentinel, timeout=timeout_ms)
+
+
+def interrupt_agent(chat_panel: PlaywrightChatPanelElement) -> None:
+    """Click Stop and wait for the interrupt to complete.
+
+    The Stop button unmounts (or goes aria-disabled) once the pill stops being
+    cancellable, so wait for that before asserting the thinking indicator is
+    gone — mirrors the real_claude helper.
+    """
+    stop_button = chat_panel.get_stop_button()
+    expect(stop_button).to_be_visible(timeout=10_000)
+    stop_button.click()
+    chat_panel._page.wait_for_function(
+        """(statusStopId) => {
+            const els = document.querySelectorAll(`[data-testid="${statusStopId}"]`);
+            if (els.length === 0) return true;
+            return Array.from(els).every((el) => el.hasAttribute('disabled') || el.getAttribute('aria-disabled') === 'true');
+        }""",
+        arg=ElementIDs.STATUS_PILL_STOP,
+        timeout=INTERRUPT_TIMEOUT_MS,
+    )
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=INTERRUPT_TIMEOUT_MS)
+
+
+def assert_interrupted(chat_panel: PlaywrightChatPanelElement) -> None:
+    """Assert the 'Stopped' marker is visible on the interrupted assistant message."""
+    expect(chat_panel.get_assistant_messages().last).to_contain_text("Stopped", timeout=INTERRUPT_TIMEOUT_MS)
+
+
+def assert_last_assistant_message_contains(chat_panel: PlaywrightChatPanelElement, text: str) -> None:
+    """Assert the last ASSISTANT message contains ``text`` (auto-waits for the reply)."""
+    expect(chat_panel.get_assistant_messages().last).to_contain_text(text, timeout=RESPONSE_TIMEOUT_MS)
+
+
+def assert_no_errors(chat_panel: PlaywrightChatPanelElement) -> None:
+    expect(chat_panel.get_error_block()).to_have_count(0)
 
 
 def create_pi_workspace_and_send(

--- a/sculptor/tests/integration/real_pi/test_interrupts.py
+++ b/sculptor/tests/integration/real_pi/test_interrupts.py
@@ -5,13 +5,13 @@ Mirrors the stop case of ``real_claude/test_interrupts.py`` against a real
 button, the chat resolves as Stopped, and a follow-up turn completes on the
 same pi process.
 
-Divergence from the Claude suite (REQ-TEST-1): pi runs ``--no-session`` and
-has no session resume (``supports_session_resume=False``), so there is no
-transcript file to inspect and the Claude suite's transcript/"no amnesia"
-assertions do not apply here. The force-kill escalation ladder (no
-``agent_end`` within the grace window → SIGTERM) is a pathological-pi path
-covered deterministically by the unit tests (``agent_wrapper_test.py``) and the
-fake_pi integration test, not exercised against a real model here.
+Divergence from the Claude suite: pi runs ``--no-session`` and has no session
+resume (``supports_session_resume=False``), so there is no transcript file to
+inspect and the Claude suite's transcript/"no amnesia" assertions do not apply
+here. The force-kill escalation ladder (no ``agent_end`` within the grace
+window → SIGTERM) is a pathological-pi path covered deterministically by the
+unit tests (``agent_wrapper_test.py``) and the fake_pi integration test, not
+exercised against a real model here.
 """
 
 import pytest

--- a/sculptor/tests/integration/real_pi/test_interrupts.py
+++ b/sculptor/tests/integration/real_pi/test_interrupts.py
@@ -1,0 +1,55 @@
+"""Real pi integration test: interrupt scenarios.
+
+Mirrors the stop case of ``real_claude/test_interrupts.py`` against a real
+``pi --mode rpc`` subprocess: a long generation is interrupted via the Stop
+button, the chat resolves as Stopped, and a follow-up turn completes on the
+same pi process.
+
+Divergence from the Claude suite (REQ-TEST-1): pi runs ``--no-session`` and
+has no session resume (``supports_session_resume=False``), so there is no
+transcript file to inspect and the Claude suite's transcript/"no amnesia"
+assertions do not apply here. The force-kill escalation ladder (no
+``agent_end`` within the grace window → SIGTERM) is a pathological-pi path
+covered deterministically by the unit tests (``agent_wrapper_test.py``) and the
+fake_pi integration test, not exercised against a real model here.
+"""
+
+import pytest
+
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import assert_interrupted
+from tests.integration.real_pi.helpers import assert_last_assistant_message_contains
+from tests.integration.real_pi.helpers import assert_no_errors
+from tests.integration.real_pi.helpers import create_pi_workspace_and_send
+from tests.integration.real_pi.helpers import interrupt_agent
+from tests.integration.real_pi.helpers import real_pi
+from tests.integration.real_pi.helpers import send_no_wait
+from tests.integration.real_pi.helpers import wait_for_streaming_text
+
+
+@real_pi
+@pytest.mark.timeout(300)
+def test_pi_interrupt_during_streaming_then_continue(sculptor_instance_: SculptorInstance) -> None:
+    """Graceful stop of a long generation, then a follow-up turn on the same agent."""
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_,
+        "Reply with exactly the text PI-READY-71245. Do not add any other text.",
+    )
+    chat_panel = task_page.get_chat_panel()
+    assert_last_assistant_message_contains(chat_panel, "PI-READY-71245")
+
+    # Start a long generation (gives time to interrupt mid-stream).
+    send_no_wait(
+        chat_panel,
+        "Write a very long, detailed essay about the history of computing. It must be at least 2000 words. Start your essay with exactly: PI-ESSAY-BEGINS:",
+    )
+    wait_for_streaming_text(chat_panel, "PI-ESSAY-BEGINS")
+
+    interrupt_agent(chat_panel)
+    assert_interrupted(chat_panel)
+    assert_no_errors(chat_panel)
+
+    # The same pi process serves a follow-up turn after the interrupt.
+    send_no_wait(chat_panel, "Reply with exactly the text PI-RECOVERED-OK-30518. Do not add any other text.")
+    assert_last_assistant_message_contains(chat_panel, "PI-RECOVERED-OK-30518")
+    assert_no_errors(chat_panel)


### PR DESCRIPTION
## What & why

The pi harness could not stop an in-flight turn: the Stop button rendered as a disabled-with-tooltip placeholder, and interrupt requests were dropped. This makes the pi harness support turn interruption (`supports_interruption=True`) by wiring the Stop affordance end-to-end through pi's `abort` command.

Stopping ends a pi turn promptly, the partial response is preserved, and the agent stays responsive for the next prompt — matching how the Claude harness behaves. Interruption is a Sculptor-side adaptation; no change to the pi binary is required.

## How

- `PiAgent._push_message` now accepts the interrupt message: it sends `{"type":"abort"}` to pi (id-correlated) and resolves the interrupt request itself, so the in-flight Stop action completes and the StatusPill leaves its "stopping" state.
- The abort-induced `agent_end` / `message_end` carrying `stopReason:"aborted"` is treated as the interrupted-turn boundary — the partial content is finalized and the turn resolves `interrupted=True` — but only while an interrupt is pending (or during shutdown). An unexpected `aborted` still surfaces as an error, preserving crash detection.
- An interrupt that races in with no turn in flight is cleared at the next prompt, so it cannot mis-mark a fresh turn.
- Escalation ladder: if no `agent_end` arrives within a grace window after the abort, pi is SIGTERM'd and the existing process-exit path resolves the turn.
- The test double (FakePi) mirrors real pi: it acks `abort`, stays alive, and preempts an in-flight turn (emitting the aborted boundary) instead of exiting; stdin is read on a background thread so a turn blocked in a directive can be interrupted deterministically.
- The capability-gating tests are updated so the Stop button and the queued interrupt-and-send button render for both harnesses; pressing Stop ends the pi turn.

## Tests

- Unit (`agent_wrapper_test.py`, `fake_pi_test.py`): interrupt mid-turn finalizes the partial without crashing and resolves interrupted; aborted-vs-crash disambiguation both ways; a no-turn interrupt does not poison the next turn; the interrupt request is completed (so the Stop POST returns); escalation terminates and the turn resolves via the process-exit fallback; FakePi abort preempts a blocked turn and the process stays alive.
- Integration (FakePi): the flipped capability-gating tests and a new stop-then-continue test pass — Stop ends the turn, the chat resolves as `Stopped`, and a follow-up turn completes on the same process.
- Real pi: `real_pi/test_interrupts.py` passes against a real `pi --mode rpc` subprocess and a real model — graceful stop of a long generation, then a follow-up turn on the same agent. (pi runs without a persisted transcript and resume is covered separately, so the no-amnesia assertions used for the Claude suite do not apply; the force-kill escalation ladder is covered by the unit and FakePi integration tests.)

(Sent by Claude)
