### PR TITLE
Bring quarantined integration tests into review-rule compliance; tighten page-evaluate ratchet

### DIFF
--- a/ratchet-counts.toml
+++ b/ratchet-counts.toml
@@ -45,7 +45,7 @@
 "." = 1
 
 [no-integration-page-evaluate]
-"." = 25
+"." = 22
 
 [no-integration-page-goto]
 "." = 0

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -94,6 +94,17 @@ class PlaywrightAlphaChatViewElement(PlaywrightIntegrationTestElement):
     def get_file_previews(self) -> Locator:
         return self.get_by_test_id(ElementIDs.FILE_PREVIEW)
 
+    def get_tables(self) -> Locator:
+        return self.get_by_test_id(ElementIDs.ALPHA_CHAT_TABLE)
+
+    def get_table_wrap_toggles(self) -> Locator:
+        return self.get_by_test_id(ElementIDs.ALPHA_CHAT_TABLE_WRAP_TOGGLE)
+
+    def get_table_wrap_toggles_with_label(self, aria_label: str) -> Locator:
+        """Return wrap-toggle(s) whose ``aria-label`` matches (it encodes the
+        per-table wrap state, e.g. ``"Switch to scroll"`` / ``"Switch to wrap"``)."""
+        return self.get_table_wrap_toggles().and_(self._page.locator(f'[aria-label="{aria_label}"]'))
+
 
 def get_jump_to_bottom_button(page: Page) -> Locator:
     """Locator for the jump-to-bottom button."""

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -100,6 +100,11 @@ def get_jump_to_bottom_button(page: Page) -> Locator:
     return page.get_by_test_id(ElementIDs.ALPHA_JUMP_TO_BOTTOM_BUTTON)
 
 
+def get_jump_to_bottom_wrapper(page: Page) -> Locator:
+    """Locator for the jump-to-bottom wrapper (always in DOM; visibility controlled via aria-hidden)."""
+    return page.get_by_test_id(ElementIDs.ALPHA_JUMP_TO_BOTTOM_WRAPPER)
+
+
 def get_alpha_scroll_position(page: Page) -> float:
     """Read the scrollTop of the alpha chat scroll container."""
     return page.evaluate(

--- a/sculptor/sculptor/testing/elements/base.py
+++ b/sculptor/sculptor/testing/elements/base.py
@@ -299,6 +299,17 @@ def tiptap_has_placeholder(locator: Locator, placeholder_text: str) -> bool:
     )
 
 
+def get_tiptap_placeholder_paragraphs(locator: Locator, placeholder_text: str) -> Locator:
+    """Return the ``<p>`` nodes showing the given TipTap placeholder text.
+
+    The Placeholder extension sets ``data-placeholder`` on empty nodes; an empty
+    result means the placeholder is hidden. Returning a Locator (rather than the
+    snapshot bool of ``tiptap_has_placeholder``) lets callers use
+    ``expect(...).to_have_count(0)`` so Playwright auto-retries.
+    """
+    return locator.locator(f'p[data-placeholder="{placeholder_text}"]')
+
+
 # NOTE: This is an exception to our rule to not use page.evaluate().
 # There is no Playwright API to wait for a single animation frame.
 # page.wait_for_timeout(N) is the alternative, but requires guessing a

--- a/sculptor/sculptor/testing/elements/chat_panel.py
+++ b/sculptor/sculptor/testing/elements/chat_panel.py
@@ -161,6 +161,12 @@ class PlaywrightChatPanelElement(PlaywrightFilePreviewAndUploadMixin, Playwright
         )
         return self._locator.locator(selector)
 
+    def get_status_pill_elapsed(self) -> Locator:
+        return self.get_by_test_id(ElementIDs.STATUS_PILL_ELAPSED)
+
+    def get_status_pill_animation(self) -> Locator:
+        return self.get_by_test_id(ElementIDs.STATUS_PILL_ANIMATION)
+
     def get_compacting_pill(self) -> Locator:
         """Locator that matches only when the alpha status pill is in the
         ``compacting`` lifecycle state. Pair with ``to_be_attached`` /

--- a/sculptor/sculptor/testing/elements/chat_panel.py
+++ b/sculptor/sculptor/testing/elements/chat_panel.py
@@ -164,6 +164,28 @@ class PlaywrightChatPanelElement(PlaywrightFilePreviewAndUploadMixin, Playwright
     def get_status_pill_elapsed(self) -> Locator:
         return self.get_by_test_id(ElementIDs.STATUS_PILL_ELAPSED)
 
+    def wait_for_agent_progress(self, min_advance_seconds: float = 1.0) -> None:
+        """Wait until the status pill's elapsed timer advances by at least
+        ``min_advance_seconds``.
+
+        This is a virtualization-proof "the agent is still actively working and
+        time has genuinely passed" signal — the status pill lives in the chat
+        panel chrome, not the virtualized message list, so it stays mounted even
+        when the streaming message has scrolled out of view. Use it to confirm a
+        transient UI state persists across a span of continued agent activity
+        without resorting to a fixed ``wait_for_timeout``. Requires the status
+        pill to be visible (agent in a busy phase).
+        """
+        elapsed = self.get_status_pill_elapsed()
+        expect(elapsed).to_be_visible()
+        baseline = float((elapsed.text_content() or "0s").rstrip("s"))
+        self._page.wait_for_function(
+            f"""() => {{
+                const el = document.querySelector('[data-testid="{ElementIDs.STATUS_PILL_ELAPSED.value}"]');
+                return el !== null && parseFloat(el.textContent) >= {baseline + min_advance_seconds};
+            }}""",
+        )
+
     def get_status_pill_animation(self) -> Locator:
         return self.get_by_test_id(ElementIDs.STATUS_PILL_ANIMATION)
 

--- a/sculptor/sculptor/testing/elements/settings_repositories.py
+++ b/sculptor/sculptor/testing/elements/settings_repositories.py
@@ -107,11 +107,33 @@ class PlaywrightRepositoriesSettingsElement(PlaywrightIntegrationTestElement):
         return self._page.get_by_test_id(ElementIDs.SETTINGS_WORKSPACE_SETUP_COMMAND_INPUT).first
 
     def set_setup_command(self, command: str) -> None:
-        """Fill the setup command textarea and blur to trigger save."""
+        """Fill the setup command textarea, blur to trigger the save, and — when
+        the value actually changes — wait for the save request to complete before
+        returning.
+
+        Blur fires a ``PUT /api/v1/projects/{id}/workspace_setup_command`` only
+        when the trimmed value differs from what is currently shown (the saved
+        value, or the default while tracking it). When it does change, we wait for
+        that response so callers can immediately re-navigate or re-read the
+        persisted value without racing the in-flight save — a fixed
+        ``wait_for_timeout`` could not guarantee the round-trip had landed.
+
+        When the value is unchanged no request is sent, so we must NOT wait
+        (``expect_response`` would hang until timeout). This matters on shared
+        instances, where an earlier test may have already saved the same value.
+        """
         setup_input = self.get_setup_command_input()
         expect(setup_input).to_be_visible()
+        current_value = setup_input.input_value()
         setup_input.fill(command)
-        setup_input.blur()
+        if command.strip() == current_value.strip():
+            # No change → blur triggers no save request; nothing to wait for.
+            setup_input.blur()
+            return
+        with self._page.expect_response(
+            lambda response: "workspace_setup_command" in response.url and response.request.method == "PUT"
+        ):
+            setup_input.blur()
 
     def _get_repo_row(self, repo_name: str, path_contains: str | None = None) -> Locator:
         """Find a repo row containing the given name and optional path substring."""

--- a/sculptor/sculptor/testing/elements/terminal.py
+++ b/sculptor/sculptor/testing/elements/terminal.py
@@ -243,3 +243,41 @@ def get_xterm_theme_foreground(page: Page) -> str:
         return xterm.options.theme.foreground || '';
     }"""
     )
+
+
+def wait_for_xterm_theme_ready(page: Page) -> None:
+    """Wait until the xterm theme has non-empty background and foreground colors."""
+    try:
+        page.wait_for_function(
+            """() => {
+                const xterm = window.__xterm;
+                return !!(xterm && xterm.options.theme
+                    && xterm.options.theme.background
+                    && xterm.options.theme.foreground);
+            }"""
+        )
+    except PlaywrightTimeoutError as e:
+        bg = get_xterm_theme_background(page)
+        fg = get_xterm_theme_foreground(page)
+        raise AssertionError(f"xterm theme not ready. bg: {bg!r}, fg: {fg!r}") from e
+
+
+def wait_for_xterm_theme_change(page: Page, old_bg: str, old_fg: str) -> None:
+    """Wait until the xterm theme colors differ from the given values."""
+    try:
+        page.wait_for_function(
+            """([oldBg, oldFg]) => {
+                const xterm = window.__xterm;
+                if (!xterm || !xterm.options.theme) return false;
+                const bg = xterm.options.theme.background || '';
+                const fg = xterm.options.theme.foreground || '';
+                return bg !== oldBg && fg !== oldFg;
+            }""",
+            arg=[old_bg, old_fg],
+        )
+    except PlaywrightTimeoutError as e:
+        new_bg = get_xterm_theme_background(page)
+        new_fg = get_xterm_theme_foreground(page)
+        raise AssertionError(
+            f"Terminal theme did not change. bg: {old_bg!r} → {new_bg!r}, fg: {old_fg!r} → {new_fg!r}"
+        ) from e

--- a/sculptor/sculptor/testing/elements/terminal.py
+++ b/sculptor/sculptor/testing/elements/terminal.py
@@ -206,6 +206,14 @@ def get_add_terminal_button(page: Page) -> Locator:
     return page.get_by_test_id(ElementIDs.ADD_TERMINAL_BUTTON)
 
 
+def get_terminal_panel_icon(page: Page) -> Locator:
+    return page.get_by_test_id(ElementIDs.PANEL_ICON_TERMINAL)
+
+
+def get_terminal_starting_text(page: Page) -> Locator:
+    return page.get_by_test_id(ElementIDs.TERMINAL_STARTING_TEXT)
+
+
 def get_tab_context_menu_close_others(page: Page) -> Locator:
     return page.get_by_test_id(ElementIDs.TAB_CONTEXT_MENU_CLOSE_OTHERS)
 

--- a/sculptor/sculptor/testing/elements/terminal.py
+++ b/sculptor/sculptor/testing/elements/terminal.py
@@ -214,6 +214,10 @@ def get_terminal_starting_text(page: Page) -> Locator:
     return page.get_by_test_id(ElementIDs.TERMINAL_STARTING_TEXT)
 
 
+def get_tab_close_button(tab: Locator) -> Locator:
+    return tab.get_by_test_id(ElementIDs.TAB_CLOSE_BUTTON)
+
+
 def get_tab_context_menu_close_others(page: Page) -> Locator:
     return page.get_by_test_id(ElementIDs.TAB_CONTEXT_MENU_CLOSE_OTHERS)
 

--- a/sculptor/sculptor/testing/elements/terminal.py
+++ b/sculptor/sculptor/testing/elements/terminal.py
@@ -54,6 +54,18 @@ def run_command_in_active_terminal(page: Page, command: str) -> None:
     textarea.press("Enter")
 
 
+def type_with_global_keyboard(page: Page, text: str, *, delay_ms: int = 30) -> None:
+    """Type ``text`` via the global keyboard, which routes to whatever element
+    currently holds focus (``document.activeElement``).
+
+    Unlike ``locator.press_sequentially`` / ``type_with_delay`` (which dispatch
+    keystrokes straight to a target element regardless of focus), this exercises
+    real focus routing -- so a caller can prove which element actually receives
+    keyboard input.
+    """
+    page.keyboard.type(text, delay=delay_ms)
+
+
 def get_xterm_active_line(page: Page) -> str:
     """Read the current input line from the xterm buffer (the line the cursor is on)."""
     return page.evaluate(
@@ -117,6 +129,33 @@ def wait_for_xterm_substring(page: Page, substring: str) -> None:
         raise AssertionError(
             f"Expected xterm buffer to contain {substring!r}, but timed out. Buffer:\n{buffer_text}"
         ) from e
+
+
+def wait_for_xterm_buffer_nonempty(page: Page) -> None:
+    """Wait until the xterm buffer has rendered some shell output.
+
+    A non-empty buffer means the WebSocket connected and the shell delivered its
+    prompt -- i.e. the terminal mount/connect cycle has settled. Use this as a
+    condition-based alternative to a fixed ``wait_for_timeout`` after opening the
+    panel: it adapts to however long the connection actually takes, instead of
+    guessing a window that is simultaneously too long on fast machines and too
+    short under CI load.
+    """
+    try:
+        page.wait_for_function(
+            """() => {
+                const xterm = window.__xterm;
+                if (!xterm) return false;
+                const buffer = xterm.buffer.active;
+                for (let i = 0; i <= buffer.baseY + buffer.cursorY; i++) {
+                    const line = buffer.getLine(i);
+                    if (line && line.translateToString(true).trim().length > 0) return true;
+                }
+                return false;
+            }"""
+        )
+    except PlaywrightTimeoutError as e:
+        raise AssertionError("xterm buffer never rendered any shell output (terminal failed to connect).") from e
 
 
 def get_xterm_cursor_row(page: Page) -> int:

--- a/sculptor/sculptor/testing/pages/project_layout.py
+++ b/sculptor/sculptor/testing/pages/project_layout.py
@@ -202,6 +202,11 @@ class PlaywrightProjectLayoutPage(PlaywrightIntegrationTestPage):
         """Get the SkillsPanel element. Only visible when its zone is open."""
         return PlaywrightSkillsPanelElement(self.get_by_test_id(ElementIDs.SKILLS_PANEL), page=self._page)
 
+    def toggle_theme(self) -> None:
+        """Toggle between dark and light theme via Cmd/Ctrl+Shift+D."""
+        mod_key = get_playwright_modifier_key()
+        self.press_keyboard_shortcut(f"{mod_key}+Shift+d")
+
     def open_skills_panel(self) -> PlaywrightSkillsPanelElement:
         """Click the skills sidebar icon and return the visible SkillsPanel.
 

--- a/sculptor/tests/integration/frontend/test_alpha_chat_table_wrap_toggle.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_table_wrap_toggle.py
@@ -12,9 +12,8 @@ from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
 from sculptor.testing.elements.alpha_chat_view import click_visible_in_chat_viewport
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_alpha_container_height
-from sculptor.testing.elements.alpha_chat_view import get_alpha_scroll_height
-from sculptor.testing.elements.alpha_chat_view import get_alpha_scroll_position
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -63,24 +62,25 @@ def test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat(sculptor_instan
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    tables = page.get_by_test_id(ElementIDs.ALPHA_CHAT_TABLE)
+    alpha_view = get_alpha_chat_view(page)
+    tables = alpha_view.get_tables()
     expect(tables).to_have_count(2)
 
-    wrap_toggles = page.get_by_test_id(ElementIDs.ALPHA_CHAT_TABLE_WRAP_TOGGLE)
+    wrap_toggles = alpha_view.get_table_wrap_toggles()
     expect(wrap_toggles).to_have_count(2)
     # Default per-table state is "scroll" — both toggles say "Switch to wrap".
-    for toggle in wrap_toggles.all():
-        expect(toggle).to_have_attribute("aria-label", "Switch to wrap")
+    expect(wrap_toggles.nth(0)).to_have_attribute("aria-label", "Switch to wrap")
+    expect(wrap_toggles.nth(1)).to_have_attribute("aria-label", "Switch to wrap")
 
     # Scroll up so we are not pinned at the bottom — only then can we see if
     # the toggle yanks the scroll.
     container_height = get_alpha_container_height(page)
     scroll_alpha_chat_by(page, -int(container_height))
-    page.wait_for_timeout(400)
-
-    scroll_top_before = get_alpha_scroll_position(page)
-    assert scroll_top_before > 100, (
-        f"Test setup failed: chat was not scrolled away from the bottom (scrollTop={scroll_top_before})."
+    page.wait_for_function(
+        f"""() => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            return el ? el.scrollTop > 100 : false;
+        }}"""
     )
 
     # Dispatch the click directly so Playwright doesn't first scroll the
@@ -89,22 +89,16 @@ def test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat(sculptor_instan
 
     # Exactly one toggle should have flipped — the other table's wrap state
     # must stay independent.
-    labels = [t.get_attribute("aria-label") for t in wrap_toggles.all()]
-    assert labels.count("Switch to scroll") == 1, (
-        f"Expected exactly one toggle to flip after click; got labels={labels}"
-    )
-    assert labels.count("Switch to wrap") == 1, (
-        f"Expected the other toggle to stay in scroll mode; got labels={labels}"
-    )
+    switched = alpha_view.get_table_wrap_toggles_with_label("Switch to scroll")
+    expect(switched).to_have_count(1)
+    unchanged = alpha_view.get_table_wrap_toggles_with_label("Switch to wrap")
+    expect(unchanged).to_have_count(1)
 
-    # Allow layout to settle and check scroll did not jump to the bottom.
-    page.wait_for_timeout(400)
-    scroll_top_after = get_alpha_scroll_position(page)
-    scroll_height = get_alpha_scroll_height(page)
-    distance_from_bottom_after = scroll_height - scroll_top_after - container_height
-    assert distance_from_bottom_after > 200, (
-        "Wrap toggle yanked the chat to the bottom: "
-        + f"scrollTop went from {scroll_top_before:.0f} to {scroll_top_after:.0f}; "
-        + f"final distance from bottom = {distance_from_bottom_after:.0f}px "
-        + f"(scrollHeight={scroll_height:.0f}, clientHeight={container_height:.0f})."
+    # Confirm scroll did not jump to the bottom after layout settles.
+    page.wait_for_function(
+        f"""() => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            if (!el) return false;
+            return (el.scrollHeight - el.scrollTop - el.clientHeight) > 200;
+        }}"""
     )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_auto_scroll.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_auto_scroll.py
@@ -1,11 +1,11 @@
 """Integration tests for alpha chat auto-scroll and jump-to-bottom button."""
 
 from playwright.sync_api import Locator
-from playwright.sync_api import Page
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_jump_to_bottom_button
+from sculptor.testing.elements.alpha_chat_view import get_jump_to_bottom_wrapper
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -14,20 +14,14 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
 
-def _expect_jump_button_hidden(jump_btn: Locator, *, timeout: int = 5000) -> None:
+def _expect_jump_button_hidden(jump_btn: Locator) -> None:
     """Assert the jump button is in its hidden state (aria-hidden on wrapper).
 
     The button is always in the DOM (for focus-management), so we check the
     wrapper's aria-hidden attribute rather than Playwright's visibility check.
     """
-    wrapper = jump_btn.page.get_by_test_id(ElementIDs.ALPHA_JUMP_TO_BOTTOM_WRAPPER)
-    expect(wrapper).to_have_attribute("aria-hidden", "true", timeout=timeout)
-
-
-def _wait_for_agent_idle_alpha(page: Page, *, timeout: int = 30000) -> None:
-    """Wait for the agent to finish in alpha view by checking the StatusPill disappears."""
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).not_to_be_visible(timeout=timeout)
+    wrapper = get_jump_to_bottom_wrapper(jump_btn.page)
+    expect(wrapper).to_have_attribute("aria-hidden", "true")
 
 
 # Generate a long text response so the chat is scrollable
@@ -51,21 +45,19 @@ def test_auto_scroll_and_jump_to_bottom(sculptor_instance_: SculptorInstance) ->
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Scroll to top — jump button should appear
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(300)
 
     jump_btn = get_jump_to_bottom_button(page)
-    expect(jump_btn).to_be_visible(timeout=5000)
+    expect(jump_btn).to_be_visible()
     expect(jump_btn).to_contain_text("Jump")
 
     # Click jump button — should scroll to bottom and button should hide.
     # force=True: the virtualContent div inside the scroll container intercepts
     # Playwright's actionability check, but the button is clickable in real browsers.
     jump_btn.click(force=True)
-    page.wait_for_timeout(500)
     _expect_jump_button_hidden(jump_btn)
 
     # Send a streaming message, then scroll away DURING the filling phase
@@ -79,27 +71,23 @@ def test_auto_scroll_and_jump_to_bottom(sculptor_instance_: SculptorInstance) ->
         f'fake_claude:stream_text `{{"text": "{_STREAM_TEXT}", "chunk_size": 50, "delay_seconds": 0.1}}`',
     )
 
-    # Wait very briefly for streaming to start (filling phase), then scroll
-    # away before the response overflows and transitions to pin-to-bottom.
-    # Must scroll before onReachBottom fires (which happens at pin-to-bottom).
-    page.wait_for_timeout(500)
+    # Wait for streaming to start (filling phase), then scroll away before
+    # the response overflows and transitions to pin-to-bottom.
+    expect(chat_panel.get_thinking_indicator()).to_be_visible()
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(300)
 
     jump_btn = get_jump_to_bottom_button(page)
-    expect(jump_btn).to_be_visible(timeout=5000)
+    expect(jump_btn).to_be_visible()
     expect(jump_btn).to_contain_text("New activity")
 
     # After streaming finishes, label should revert to "Jump"
-    _wait_for_agent_idle_alpha(page)
-    page.wait_for_timeout(500)
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
     jump_btn = get_jump_to_bottom_button(page)
-    expect(jump_btn).to_be_visible(timeout=5000)
+    expect(jump_btn).to_be_visible()
     expect(jump_btn).to_contain_text("Jump")
 
     # Click "Jump" — scrolls to bottom
     jump_btn.click(force=True)
-    page.wait_for_timeout(500)
     _expect_jump_button_hidden(jump_btn)
 
 
@@ -121,7 +109,7 @@ def test_user_can_scroll_during_streaming(sculptor_instance_: SculptorInstance) 
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a streaming message — this emits text incrementally with real delays
     send_chat_message(
@@ -130,18 +118,14 @@ def test_user_can_scroll_during_streaming(sculptor_instance_: SculptorInstance) 
     )
 
     # Wait for streaming to produce some content
-    page.wait_for_timeout(2000)
+    expect(chat_panel.get_thinking_indicator()).to_be_visible()
 
     # Scroll to top while agent is actively streaming
     scroll_alpha_chat_to_top(page)
 
     # The jump-to-bottom button should appear, proving auto-scroll disengaged
     jump_btn = get_jump_to_bottom_button(page)
-    expect(jump_btn).to_be_visible(timeout=5000)
-
-    # Button should still be visible after more streaming (auto-scroll stays disengaged)
-    page.wait_for_timeout(1500)
     expect(jump_btn).to_be_visible()
 
     # Wait for the agent to finish before cleanup
-    _wait_for_agent_idle_alpha(page)
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_auto_scroll.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_auto_scroll.py
@@ -127,5 +127,15 @@ def test_user_can_scroll_during_streaming(sculptor_instance_: SculptorInstance) 
     jump_btn = get_jump_to_bottom_button(page)
     expect(jump_btn).to_be_visible()
 
+    # Auto-scroll must STAY disengaged as the agent keeps streaming. Wait for the
+    # agent to make further progress (a span of continued streaming), then
+    # re-assert the button is still visible — if auto-scroll had silently
+    # re-engaged it would have snapped the view back to the bottom and hidden the
+    # button. We gauge progress via the elapsed timer rather than scrollHeight
+    # because the streaming message is off-screen (and unmounted) once we scroll
+    # to the top, so its growth is not observable from the DOM.
+    chat_panel.wait_for_agent_progress()
+    expect(jump_btn).to_be_visible()
+
     # Wait for the agent to finish before cleanup
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_behaviors.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_behaviors.py
@@ -7,14 +7,12 @@ Covers:
 - Last user message stays visible at maximum scroll after agent tab switch
 """
 
-from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
-from sculptor.testing.elements.alpha_chat_view import get_alpha_container_height
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_alpha_scroll_position
-from sculptor.testing.elements.alpha_chat_view import get_intro_bottom_offset
-from sculptor.testing.elements.alpha_chat_view import get_message_top_offset
+from sculptor.testing.elements.alpha_chat_view import get_jump_to_bottom_button
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
 from sculptor.testing.elements.chat_panel import send_chat_message
@@ -28,12 +26,6 @@ _LONG_TEXT = " ".join(["This is a longer response that should take up some space
 _SHORT_TEXT = "Short reply."
 
 
-def _wait_for_agent_idle(page: Page, *, timeout: int = 30000) -> None:
-    """Wait for the agent to finish by checking the StatusPill disappears."""
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).not_to_be_visible(timeout=timeout)
-
-
 @user_story("to see the first message without extra padding above it when scrolled to top")
 def test_first_message_visible_at_top(sculptor_instance_: SculptorInstance) -> None:
     """When scrolled to the top, the first message should be visible
@@ -44,7 +36,6 @@ def test_first_message_visible_at_top(sculptor_instance_: SculptorInstance) -> N
     """
     page = sculptor_instance_.page
 
-    # Create a conversation with enough content to enable scrolling
     task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
@@ -52,41 +43,27 @@ def test_first_message_visible_at_top(sculptor_instance_: SculptorInstance) -> N
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Send a follow-up to generate more content
     send_chat_message(
         chat_panel,
         f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
     )
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
-    _wait_for_agent_idle(page)
-    page.wait_for_timeout(500)
+    alpha_view = get_alpha_chat_view(page)
+    expect(alpha_view).to_be_visible()
 
-    # Scroll to top
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(500)
 
-    # The first message (data-index=0) should be visible within the viewport
-    first_msg_offset = get_message_top_offset(page, data_index=0)
-    container_height = get_alpha_container_height(page)
-
-    assert first_msg_offset >= 0, (
-        f"First message is above viewport (offset={first_msg_offset:.0f}px). paddingStart may not be preserved."
-    )
-    assert first_msg_offset < container_height, (
-        f"First message is below viewport (offset={first_msg_offset:.0f}px, viewport={container_height:.0f}px)."
-    )
-
-    # The first message should be at or just below the intro text block.
-    # paddingStart is dynamic (= intro block height), so we measure the
-    # intro bottom and verify the first message starts near it.
-    intro_bottom = get_intro_bottom_offset(page)
-    assert first_msg_offset >= intro_bottom - 5, (
-        f"First message (offset={first_msg_offset:.0f}px) is above the intro block (bottom={intro_bottom:.0f}px)."
-    )
-    assert first_msg_offset < intro_bottom + 50, (
-        f"First message (offset={first_msg_offset:.0f}px) is too far below the intro block (bottom={intro_bottom:.0f}px)."
+    page.wait_for_function(
+        f"""() => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="0"]');
+            const intro = container && container.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_INTRO}"]');
+            if (!container || !item || !intro) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            const introBottom = intro.getBoundingClientRect().bottom - container.getBoundingClientRect().top;
+            return offset >= 0 && offset < container.clientHeight && offset >= introBottom - 5 && offset < introBottom + 50;
+        }}"""
     )
 
 
@@ -97,7 +74,6 @@ def test_jump_button_appears_and_works(sculptor_instance_: SculptorInstance) -> 
     """
     page = sculptor_instance_.page
 
-    # Create a conversation with enough content to enable scrolling
     task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
@@ -105,35 +81,31 @@ def test_jump_button_appears_and_works(sculptor_instance_: SculptorInstance) -> 
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Add more content
     send_chat_message(
         chat_panel,
         f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
     )
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
-    _wait_for_agent_idle(page)
-    page.wait_for_timeout(1000)
+    alpha_view = get_alpha_chat_view(page)
+    expect(alpha_view).to_be_visible()
 
-    jump_button = page.get_by_test_id(ElementIDs.ALPHA_JUMP_TO_BOTTOM_BUTTON)
+    jump_button = get_jump_to_bottom_button(page)
 
-    # Scroll to top — jump button should appear
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(500)
 
-    expect(jump_button).to_be_visible(timeout=5000)
+    expect(jump_button).to_be_visible()
 
-    # Record scroll position before clicking
     scroll_before_click = get_alpha_scroll_position(page)
 
-    # Click the jump button — should scroll toward the bottom
     jump_button.click()
-    page.wait_for_timeout(500)
 
-    scroll_after_click = get_alpha_scroll_position(page)
-    assert scroll_after_click > scroll_before_click, (
-        f"Jump button didn't scroll down: before={scroll_before_click:.0f}px, after={scroll_after_click:.0f}px"
+    page.wait_for_function(
+        f"""(scrollBefore) => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            return el && el.scrollTop > scrollBefore;
+        }}""",
+        arg=scroll_before_click,
     )
 
 
@@ -145,7 +117,6 @@ def test_first_message_visible_after_agent_switch(sculptor_instance_: SculptorIn
     """
     page = sculptor_instance_.page
 
-    # Create agent 1 with enough content to scroll
     task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
@@ -159,52 +130,41 @@ def test_first_message_visible_after_agent_switch(sculptor_instance_: SculptorIn
     )
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    # Add agent 2
-    add_agent_button = page.get_by_test_id(ElementIDs.ADD_AGENT_BUTTON)
-    add_agent_button.click()
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
+    agent_tab_bar = task_page.get_agent_tab_bar()
+    agent_tab_bar.get_add_agent_button().click()
+    agent_tabs = agent_tab_bar.get_agent_tabs()
     expect(agent_tabs).to_have_count(2)
 
-    # Navigate to agent 1
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    expect(agent_tabs).to_have_count(2)
     agent_tabs.first.click()
-    page.wait_for_timeout(500)
+    alpha_view = get_alpha_chat_view(page)
+    expect(alpha_view).to_be_visible()
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
-    _wait_for_agent_idle(page)
-    page.wait_for_timeout(500)
-
-    # Scroll to top
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(500)
 
-    # Verify first message is visible before switch
-    msg0_before = get_message_top_offset(page, data_index=0)
-    container_height = get_alpha_container_height(page)
-    assert msg0_before >= 0 and msg0_before < container_height, "Message 0 should be visible at top"
-
-    # Switch to agent 2
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    agent_tabs.last.click()
-    page.wait_for_timeout(500)
-
-    # Switch back to agent 1
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    agent_tabs.first.click()
-    page.wait_for_timeout(1000)
-
-    # The first message should still be visible in the viewport.
-    # The scroll persistence restores by message ID, so the exact pixel
-    # position may differ slightly, but the message should be on-screen.
-    msg0_after = get_message_top_offset(page, data_index=0)
-    container_height_after = get_alpha_container_height(page)
-
-    assert msg0_after >= -20, (
-        f"First message scrolled off-screen after agent switch (offset={msg0_after:.0f}px). Scroll persistence failed to restore near the top."
+    page.wait_for_function(
+        f"""() => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="0"]');
+            if (!container || !item) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            return offset >= 0 && offset < container.clientHeight;
+        }}"""
     )
-    assert msg0_after < container_height_after, (
-        f"First message not in viewport after agent switch (offset={msg0_after:.0f}px, viewport={container_height_after:.0f}px)."
+
+    agent_tabs = agent_tab_bar.get_agent_tabs()
+    agent_tabs.last.click()
+
+    agent_tabs = agent_tab_bar.get_agent_tabs()
+    agent_tabs.first.click()
+
+    page.wait_for_function(
+        f"""() => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="0"]');
+            if (!container || !item) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            return offset >= -20 && offset < container.clientHeight;
+        }}"""
     )
 
 
@@ -217,15 +177,12 @@ def test_user_message_visible_at_max_scroll_after_agent_switch(sculptor_instance
     """
     page = sculptor_instance_.page
 
-    # Create agent 1 with a short conversation
     task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=f'fake_claude:text `{{"text": "{_SHORT_TEXT}"}}`',
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Close the bottom panel to maximize chat height for scroll tests.
-    # Must be done after workspace creation since the terminal only exists in workspaces.
     close_bottom_panel(page)
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
@@ -235,41 +192,30 @@ def test_user_message_visible_at_max_scroll_after_agent_switch(sculptor_instance
     )
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    # Add agent 2
-    add_agent_button = page.get_by_test_id(ElementIDs.ADD_AGENT_BUTTON)
-    add_agent_button.click()
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
+    agent_tab_bar = task_page.get_agent_tab_bar()
+    agent_tab_bar.get_add_agent_button().click()
+    agent_tabs = agent_tab_bar.get_agent_tabs()
     expect(agent_tabs).to_have_count(2)
 
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    expect(agent_tabs).to_have_count(2)
     agent_tabs.first.click()
-    page.wait_for_timeout(500)
+    alpha_view = get_alpha_chat_view(page)
+    expect(alpha_view).to_be_visible()
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
-    _wait_for_agent_idle(page)
-    page.wait_for_timeout(500)
-
-    # Switch to agent 2 and back
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
+    agent_tabs = agent_tab_bar.get_agent_tabs()
     agent_tabs.last.click()
-    page.wait_for_timeout(500)
 
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
+    agent_tabs = agent_tab_bar.get_agent_tabs()
     agent_tabs.first.click()
-    page.wait_for_timeout(1000)
+    expect(alpha_view).to_be_visible()
 
-    # Scroll down maximally
     scroll_alpha_chat_by(page, 10000)
-    page.wait_for_timeout(500)
 
-    # The last user message (data-index=2) should still be visible
-    user_msg_offset = get_message_top_offset(page, data_index=2)
-    container_height = get_alpha_container_height(page)
-
-    assert user_msg_offset >= 0, (
-        f"User message scrolled off-screen after agent switch (offset={user_msg_offset:.0f}px). Dynamic paddingEnd likely reset."
-    )
-    assert user_msg_offset < container_height, (
-        f"User message not in viewport (offset={user_msg_offset:.0f}px, viewport={container_height:.0f}px)."
+    page.wait_for_function(
+        f"""() => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="2"]');
+            if (!container || !item) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            return offset >= 0 && offset < container.clientHeight;
+        }}"""
     )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_padding_agent_switch.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_padding_agent_switch.py
@@ -6,12 +6,10 @@ of the viewport.  This padding must survive switching to a different agent
 tab and back.
 """
 
-from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
-from sculptor.testing.elements.alpha_chat_view import get_alpha_container_height
-from sculptor.testing.elements.alpha_chat_view import get_message_top_offset
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -21,12 +19,6 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
 _SHORT_TEXT = "Hello, this is a short reply."
-
-
-def _wait_for_agent_idle_alpha(page: Page, *, timeout: int = 30000) -> None:
-    """Wait for the agent to finish by checking the StatusPill disappears."""
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).not_to_be_visible(timeout=timeout)
 
 
 @user_story("to have dynamic bottom padding survive agent tab switches")
@@ -63,60 +55,50 @@ def test_dynamic_padding_survives_agent_switch(sculptor_instance_: SculptorInsta
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
     # --- Add agent 2 to the same workspace ---
-    add_agent_button = page.get_by_test_id(ElementIDs.ADD_AGENT_BUTTON)
-    add_agent_button.click()
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    expect(agent_tabs).to_have_count(2)
+    agent_tab_bar = task_page.get_agent_tab_bar()
+    agent_tab_bar.get_add_agent_button().click()
+    expect(agent_tab_bar.get_agent_tabs()).to_have_count(2)
 
     # Navigate to agent 1 to verify baseline padding.
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    expect(agent_tabs).to_have_count(2)
-    agent_tabs.first.click()
-    page.wait_for_timeout(500)
-
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
-
-    # Wait for agent 1 to be idle and measurements to settle
-    _wait_for_agent_idle_alpha(page)
-    page.wait_for_timeout(500)
+    agent_tab_bar.get_agent_tabs().first.click()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Baseline check: scroll down maximally — user message at index 2 should
     # remain visible thanks to dynamic paddingEnd.
     scroll_alpha_chat_by(page, 10000)
-    page.wait_for_timeout(500)
 
-    user_msg_offset = get_message_top_offset(page, data_index=2)
-    container_height = get_alpha_container_height(page)
-
-    assert user_msg_offset >= 0, f"Baseline: user message scrolled off-screen (offset={user_msg_offset:.0f}px)."
-    assert user_msg_offset < container_height, (
-        f"Baseline: user message not in viewport (offset={user_msg_offset:.0f}px, viewport={container_height:.0f}px)."
+    page.wait_for_function(
+        f"""(idx) => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="' + idx + '"]');
+            if (!container || !item) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            return offset >= 0 && offset < container.clientHeight;
+        }}""",
+        arg=2,
     )
 
     # --- Switch to agent 2 ---
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    agent_tabs.last.click()
-    page.wait_for_timeout(500)
+    agent_tab_bar.get_agent_tabs().last.click()
 
     # --- Switch back to agent 1 ---
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    agent_tabs.first.click()
-    page.wait_for_timeout(1000)
+    agent_tab_bar.get_agent_tabs().first.click()
+    expect(chat_panel.get_messages()).to_have_count(4)
 
     # Scroll down maximally — user message at index 2 should STILL be visible.
     # This is the crux of the bug: without the fix, dynamic paddingEnd resets
     # to the static fallback (64px), allowing the user message to scroll off.
     scroll_alpha_chat_by(page, 10000)
-    page.wait_for_timeout(500)
 
-    user_msg_offset_after = get_message_top_offset(page, data_index=2)
-    container_height_after = get_alpha_container_height(page)
-
-    assert user_msg_offset_after >= 0, (
-        f"After agent switch: user message scrolled off-screen (offset={user_msg_offset_after:.0f}px). Dynamic paddingEnd likely reset to static fallback."
-    )
-    assert user_msg_offset_after < container_height_after, (
-        f"After agent switch: user message not in viewport (offset={user_msg_offset_after:.0f}px, viewport={container_height_after:.0f}px)."
+    page.wait_for_function(
+        f"""(idx) => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="' + idx + '"]');
+            if (!container || !item) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            return offset >= 0 && offset < container.clientHeight;
+        }}""",
+        arg=2,
     )
 
 
@@ -143,39 +125,34 @@ def test_scroll_height_settles_after_agent_switch(sculptor_instance_: SculptorIn
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
     # --- Add agent 2 ---
-    add_agent_button = page.get_by_test_id(ElementIDs.ADD_AGENT_BUTTON)
-    add_agent_button.click()
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    expect(agent_tabs).to_have_count(2)
+    agent_tab_bar = task_page.get_agent_tab_bar()
+    agent_tab_bar.get_add_agent_button().click()
+    expect(agent_tab_bar.get_agent_tabs()).to_have_count(2)
 
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    expect(agent_tabs).to_have_count(2)
-    agent_tabs.first.click()
-    page.wait_for_timeout(500)
-
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
-    _wait_for_agent_idle_alpha(page)
-    page.wait_for_timeout(500)
+    agent_tab_bar.get_agent_tabs().first.click()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Record the scrollHeight BEFORE switching.
-    alpha_view = page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)
-    before_scroll_height = alpha_view.evaluate("el => el.scrollHeight")
-    assert before_scroll_height > 0
+    handle = page.wait_for_function(
+        f"""() => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            return el && el.scrollHeight > 0 ? el.scrollHeight : null;
+        }}"""
+    )
+    before_scroll_height = handle.json_value()
 
     # --- Switch to agent 2 ---
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    agent_tabs.last.click()
-    page.wait_for_timeout(500)
+    agent_tab_bar.get_agent_tabs().last.click()
 
     # --- Switch back to agent 1 ---
-    agent_tabs = page.get_by_test_id(ElementIDs.AGENT_TAB)
-    agent_tabs.first.click()
-    page.wait_for_timeout(1000)
+    agent_tab_bar.get_agent_tabs().first.click()
+    expect(chat_panel.get_messages()).to_have_count(4)
 
     # The scrollHeight should settle to the same value as before the switch.
-    alpha_view = page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)
-    after_scroll_height = alpha_view.evaluate("el => el.scrollHeight")
-
-    assert after_scroll_height == before_scroll_height, (
-        f"scrollHeight changed from {before_scroll_height} to {after_scroll_height} after agent switch round-trip."
+    page.wait_for_function(
+        f"""(expected) => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            return el && el.scrollHeight === expected;
+        }}""",
+        arg=before_scroll_height,
     )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
@@ -362,8 +362,10 @@ def test_arrow_up_scrolls_current_turn_to_top_first(sculptor_instance_: Sculptor
     # viewport's top by > 20px (outside the isScrolledPastActive tolerance).
     # Starting from the top and scrolling DOWN incrementally is robust across
     # viewport sizes — we don't assume any particular starting scroll position.
+    # scroll_alpha_chat_to_top already settles across several animation frames
+    # (it awaits its own rAF chain), and the incremental loop below re-reads and
+    # self-corrects, so no extra fixed wait is needed here.
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(300)
     last_user_top = get_message_top_offset(page, 4)
     attempts = 0
     while last_user_top > -50 and attempts < 40:

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
@@ -10,10 +10,12 @@ last prompt.
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_message_top_offset
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
+from sculptor.testing.elements.alpha_prompt_navigator import ALPHA_DOT
+from sculptor.testing.elements.alpha_prompt_navigator import get_alpha_prompt_navigator
 from sculptor.testing.elements.base import wait_for_tiptap_ready
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -73,7 +75,6 @@ def _focus_chat_input_at_start(chat_input, page) -> None:
             probe.setEnd(r.startContainer, r.startOffset);
             return probe.toString().length === 0;
         }""",
-        timeout=5_000,
     )
 
 
@@ -107,11 +108,12 @@ def _setup_three_prompt_chat(sculptor_instance_: SculptorInstance):
     page.wait_for_load_state("domcontentloaded")
     wait_for_tiptap_ready(page)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
     # Wait for the non-virtualized dot rail to reflect all 3 user prompts —
     # the chat view itself is virtualized, so the [data-index] count only
     # covers visible items and can't be used as a readiness signal.
-    dots = page.get_by_test_id("ALPHA_PROMPT_NAVIGATOR_DOT")
+    alpha_nav = get_alpha_prompt_navigator(page)
+    dots = alpha_nav.get_dots()
     expect(dots).to_have_count(3)
 
     # Normalize scroll state: click the last dot so the virtualizer lands
@@ -140,7 +142,7 @@ def test_plain_arrow_up_cycles_backward(sculptor_instance_: SculptorInstance) ->
     # Click the alpha chat view to ensure it has focus for keyboard events.
     # _setup_three_prompt_chat already waited for the non-virtualized dot
     # rail to reflect all 3 prompts, so the view is ready for interaction.
-    alpha_view = page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)
+    alpha_view = get_alpha_chat_view(page)
     alpha_view.click()
     chat_input = chat_panel.get_chat_input()
     _focus_chat_input_at_start(chat_input, page)
@@ -210,16 +212,16 @@ def test_arrow_down_past_last_exits_and_scrolls_to_bottom(sculptor_instance_: Sc
 @user_story("to navigate prompts when focus is outside the chat input")
 def test_arrow_up_works_without_input_focus(sculptor_instance_: SculptorInstance) -> None:
     """Keyboard handler lives on window, so blurring the input still works."""
-    page, _ = _setup_three_prompt_chat(sculptor_instance_)
+    page, chat_panel = _setup_three_prompt_chat(sculptor_instance_)
 
     # Click the alpha view and then blur so the keypress isn't consumed as text.
     # _setup_three_prompt_chat already waited for dot-rail readiness.
-    alpha_view = page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)
+    alpha_view = get_alpha_chat_view(page)
     alpha_view.click()
     blur_active_element(page)
     # Verify focus actually left the chat input — on slower machines, React
     # may asynchronously restore focus (e.g. via focusChatInput callbacks).
-    chat_input = page.get_by_test_id(ElementIDs.CHAT_INPUT)
+    chat_input = chat_panel.get_chat_input()
     expect(chat_input).not_to_be_focused()
 
     # ArrowUp with no input focus: since isNavigating=false and not in an
@@ -229,7 +231,7 @@ def test_arrow_up_works_without_input_focus(sculptor_instance_: SculptorInstance
     # presses work regardless of focus.
     # To prove the "continues after focus leaves" path, enter nav via input
     # first, then blur, then press ArrowUp again.
-    chat_input = page.get_by_test_id(ElementIDs.CHAT_INPUT)
+    chat_input = chat_panel.get_chat_input()
     _focus_chat_input_at_start(chat_input, page)
     page.keyboard.press("ArrowUp")
     _wait_for_highlight_on(page, 2)
@@ -250,11 +252,7 @@ def test_modifier_keys_do_not_trigger_nav(sculptor_instance_: SculptorInstance) 
 
     for mod in ("Alt", "Control", "Meta", "Shift"):
         page.keyboard.press(f"{mod}+ArrowUp")
-        # Nav should still not be engaged — highlight class must remain absent.
-        # Give the hook a chance to fire before asserting.
-        page.wait_for_timeout(150)
-        highlights = page.evaluate(f"() => document.querySelectorAll('.{HIGHLIGHT_CLASS}').length")
-        assert highlights == 0, f"{mod}+ArrowUp unexpectedly engaged nav (found {highlights} highlights)"
+        _wait_for_no_highlight(page)
 
     # Plain ArrowUp must still work after the modifier attempts.
     page.keyboard.press("ArrowUp")
@@ -269,8 +267,12 @@ def test_arrow_up_anchors_to_scroll_position(sculptor_instance_: SculptorInstanc
 
     # Scroll to the top so the scroll-spy sets active = 0 (first prompt).
     scroll_alpha_chat_to_top(page)
-    # Let the scroll-spy (throttled 100ms) settle.
-    page.wait_for_timeout(200)
+    page.wait_for_function(
+        f"""() => {{
+            const dots = Array.from(document.querySelectorAll('[data-testid="{ALPHA_DOT}"]'));
+            return dots.findIndex(d => d.getAttribute('data-is-active') === 'true') === 0;
+        }}"""
+    )
 
     chat_input = chat_panel.get_chat_input()
     _focus_chat_input_at_start(chat_input, page)
@@ -278,12 +280,7 @@ def test_arrow_up_anchors_to_scroll_position(sculptor_instance_: SculptorInstanc
     # That proves the nav is anchored to the active dot, not always starting
     # at last. If we hit this path and nothing highlights, the anchoring works.
     page.keyboard.press("ArrowUp")
-    page.wait_for_timeout(250)
-    highlights = page.evaluate(f"() => document.querySelectorAll('.{HIGHLIGHT_CLASS}').length")
-    assert highlights == 0, (
-        "ArrowUp at active=0 should be a no-op."
-        + " A highlight means the hook jumped to last (stale behavior) instead of decrementing from active."
-    )
+    _wait_for_no_highlight(page)
 
 
 @user_story("ArrowUp with caret mid-text stays in the editor and does not enter nav")
@@ -300,15 +297,7 @@ def test_arrow_up_with_caret_midtext_does_not_enter_nav(
     chat_input.fill("hi")
 
     page.keyboard.press("ArrowUp")
-    # Give the hook a moment in case it incorrectly fires, then confirm no
-    # highlight was applied — a highlight would indicate nav was entered.
-    page.wait_for_timeout(250)
-    _wait_for_no_highlight(page, timeout=500)
-
-
-# Raw test IDs from AlphaPromptNavigator.tsx. Mirrored here to avoid depending
-# on the interactions file — the ElementIDs enum doesn't include them yet.
-ALPHA_DOT = "ALPHA_PROMPT_NAVIGATOR_DOT"
+    _wait_for_no_highlight(page)
 
 
 def _get_active_dot_index(page) -> int:
@@ -331,14 +320,13 @@ def test_wheel_cancels_programmatic_scroll_freeze(sculptor_instance_: SculptorIn
 
     # Click the first dot — triggers setIndex(0) + scrollToIndex, opening the
     # 500ms programmatic-scroll window with active dot pinned to index 0.
-    page.get_by_test_id(ALPHA_DOT).nth(0).click()
+    get_alpha_prompt_navigator(page).get_dot(0).click()
     # Wait for the click to register (setIndex fires synchronously in React).
     page.wait_for_function(
         f"""() => {{
             const dots = Array.from(document.querySelectorAll('[data-testid="{ALPHA_DOT}"]'));
             return dots.findIndex(d => d.getAttribute('data-is-active') === 'true') === 0;
         }}""",
-        timeout=5_000,
     )
 
     # Within the 500ms freeze, fire a wheel event that scrolls far down.  This
@@ -353,7 +341,6 @@ def test_wheel_cancels_programmatic_scroll_freeze(sculptor_instance_: SculptorIn
             const idx = dots.findIndex(d => d.getAttribute('data-is-active') === 'true');
             return idx > 0;
         }}""",
-        timeout=3_000,
     )
 
 
@@ -407,8 +394,7 @@ def test_arrow_up_scrolls_current_turn_to_top_first(sculptor_instance_: Sculptor
             if (!container || !item) return false;
             const delta = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
             return Math.abs(delta) < 30;
-        }""",
-        timeout=3_000,
+        }"""
     )
 
     # Active dot should NOT have changed — we scrolled, didn't nav backward.
@@ -426,6 +412,5 @@ def test_arrow_up_scrolls_current_turn_to_top_first(sculptor_instance_: Sculptor
             const dots = Array.from(document.querySelectorAll('[data-testid="{ALPHA_DOT}"]'));
             const idx = dots.findIndex(d => d.getAttribute('data-is-active') === 'true');
             return idx === {active_before - 1};
-        }}""",
-        timeout=3_000,
+        }}"""
     )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_task_switch.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_task_switch.py
@@ -3,6 +3,7 @@
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_alpha_scroll_position
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -34,30 +35,38 @@ def test_scroll_position_restored_on_task_switch(sculptor_instance_: SculptorIns
     wait_for_completed_message_count(chat_panel=chat_panel_b, expected_message_count=2)
 
     # We're on task B.  Navigate to task A first.
-    workspace_tabs = page.get_by_test_id(ElementIDs.WORKSPACE_TAB)
+    workspace_tabs = task_page_b.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
     workspace_tabs.first.click()
-    page.wait_for_timeout(500)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    alpha_chat_view = get_alpha_chat_view(page)
+    expect(alpha_chat_view).to_be_visible()
 
-    # Scroll to the top in task A
+    # Scroll to the top in task A and wait for scroll to settle
     scroll_alpha_chat_to_top(page)
-    page.wait_for_timeout(300)
+    page.wait_for_function(
+        f"""() => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            return el && el.scrollTop < 10;
+        }}"""
+    )
 
     # Record position
     pos_a = get_alpha_scroll_position(page)
 
     # Switch to task B via workspace tab (no reload)
     workspace_tabs.last.click()
-    page.wait_for_timeout(500)
+    expect(alpha_chat_view).to_be_visible()
 
     # Navigate back to task A
     workspace_tabs.first.click()
-    page.wait_for_timeout(1000)
 
-    # Verify scroll position is restored (should be near the top where we left it)
-    restored_pos = get_alpha_scroll_position(page)
-    # Allow tolerance of 200px to account for the virtualizer's dynamic paddingStart
-    # (sized to the intro block, typically ~154px) plus settling adjustments.
-    assert abs(restored_pos - pos_a) < 200, f"Expected scroll position ~{pos_a}, got {restored_pos}"
+    # Verify scroll position is restored (within 200px tolerance to account for
+    # the virtualizer's dynamic paddingStart plus settling adjustments).
+    page.wait_for_function(
+        f"""(expectedPos) => {{
+            const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            return el && Math.abs(el.scrollTop - expectedPos) < 200;
+        }}""",
+        arg=pos_a,
+    )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_to_top.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_to_top.py
@@ -1,12 +1,13 @@
 """Integration tests for scroll-to-top on user message send."""
 
 from playwright.sync_api import Locator
-from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_alpha_container_height
 from sculptor.testing.elements.alpha_chat_view import get_jump_to_bottom_button
+from sculptor.testing.elements.alpha_chat_view import get_jump_to_bottom_wrapper
 from sculptor.testing.elements.alpha_chat_view import get_message_top_offset
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
 from sculptor.testing.elements.chat_panel import send_chat_message
@@ -23,20 +24,19 @@ _SHORT_TEXT = "Hello, this is a short reply."
 _LONG_STREAM_TEXT = "The quick brown fox jumps over the lazy dog. " * 112  # ~5040 chars
 
 
-def _expect_jump_button_hidden(jump_btn: Locator, *, timeout: int = 5000) -> None:
+def _expect_jump_button_hidden(jump_btn: Locator) -> None:
     """Assert the jump button is in its hidden state (aria-hidden on wrapper).
 
     The button is always in the DOM (for focus-management), so we check the
     wrapper's aria-hidden attribute rather than Playwright's visibility check.
     """
-    wrapper = jump_btn.page.get_by_test_id(ElementIDs.ALPHA_JUMP_TO_BOTTOM_WRAPPER)
-    expect(wrapper).to_have_attribute("aria-hidden", "true", timeout=timeout)
+    wrapper = get_jump_to_bottom_wrapper(jump_btn.page)
+    expect(wrapper).to_have_attribute("aria-hidden", "true")
 
 
-def _wait_for_agent_idle_alpha(page: Page, *, timeout: int = 30000) -> None:
-    """Wait for the agent to finish by checking the StatusPill disappears."""
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).not_to_be_visible(timeout=timeout)
+def _wait_for_agent_idle_alpha(chat_panel, *, timeout: int = 30000) -> None:
+    """Wait for the agent to finish by checking the thinking indicator disappears."""
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=timeout)
 
 
 @user_story("to verify user message scrolls to the top of the viewport on send")
@@ -52,7 +52,7 @@ def test_scroll_to_top_on_send(sculptor_instance_: SculptorInstance) -> None:
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a streaming message and verify the user message is scrolled to the
     # upper portion of the viewport (scroll-to-top behavior). The exact offset
@@ -76,7 +76,6 @@ def test_scroll_to_top_on_send(sculptor_instance_: SculptorInstance) -> None:
                 const halfHeight = container.clientHeight / 2;
                 return offset >= 0 && offset < halfHeight;
             }}""",
-            timeout=10000,
         )
     except Exception:
         diag = get_message_top_offset(page, data_index=2)
@@ -86,7 +85,7 @@ def test_scroll_to_top_on_send(sculptor_instance_: SculptorInstance) -> None:
         )
 
     # Wait for agent to finish before cleanup
-    _wait_for_agent_idle_alpha(page, timeout=60000)
+    _wait_for_agent_idle_alpha(chat_panel, timeout=60000)
 
 
 @user_story("to verify response fills below user message then transitions to pin-to-bottom")
@@ -101,7 +100,7 @@ def test_filling_to_pin_transition(sculptor_instance_: SculptorInstance) -> None
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a streaming message with a long response
     send_chat_message(
@@ -110,8 +109,7 @@ def test_filling_to_pin_transition(sculptor_instance_: SculptorInstance) -> None
     )
 
     # Wait for streaming to complete and agent to become idle
-    _wait_for_agent_idle_alpha(page, timeout=60000)
-    page.wait_for_timeout(500)
+    _wait_for_agent_idle_alpha(chat_panel, timeout=60000)
 
     # After streaming completes with a long response, auto-scroll should have
     # transitioned to pin-to-bottom.  The jump button should be hidden (at bottom).
@@ -137,7 +135,7 @@ def test_jump_button_suppressed_on_send(sculptor_instance_: SculptorInstance) ->
     # final "still hidden" assertion below.
     close_bottom_panel(page)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a message — the jump button should be suppressed immediately after
     send_chat_message(
@@ -146,13 +144,11 @@ def test_jump_button_suppressed_on_send(sculptor_instance_: SculptorInstance) ->
     )
 
     # Check immediately — button should be hidden even though we scrolled to top
-    page.wait_for_timeout(300)
     jump_btn = get_jump_to_bottom_button(page)
     _expect_jump_button_hidden(jump_btn)
 
     # Wait for response to complete using alpha-view-compatible wait
-    _wait_for_agent_idle_alpha(page, timeout=30000)
-    page.wait_for_timeout(500)
+    _wait_for_agent_idle_alpha(chat_panel)
 
     # After completion, button should still be hidden (at bottom via pin-to-bottom)
     _expect_jump_button_hidden(jump_btn)
@@ -170,7 +166,7 @@ def test_user_scroll_exits_filling(sculptor_instance_: SculptorInstance) -> None
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a streaming message
     send_chat_message(
@@ -179,18 +175,19 @@ def test_user_scroll_exits_filling(sculptor_instance_: SculptorInstance) -> None
     )
 
     # Wait for streaming to start producing content
-    page.wait_for_timeout(1000)
+    page.wait_for_function(
+        f"""() => document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"] [data-index="3"]') !== null"""
+    )
 
     # Scroll away — this should exit filling and disengage auto-scroll
     scroll_alpha_chat_by(page, 300)
-    page.wait_for_timeout(500)
 
     # Jump button should appear since we scrolled away from the anchor
     jump_btn = get_jump_to_bottom_button(page)
-    expect(jump_btn).to_be_visible(timeout=5000)
+    expect(jump_btn).to_be_visible()
 
     # Wait for agent to finish before cleanup
-    _wait_for_agent_idle_alpha(page, timeout=60000)
+    _wait_for_agent_idle_alpha(chat_panel, timeout=60000)
 
 
 @user_story("to verify dynamic padding constrains scroll range for short responses")
@@ -213,32 +210,29 @@ def test_short_response_keeps_user_message_visible(sculptor_instance_: SculptorI
     # Must be done after workspace creation since the terminal only exists in workspaces.
     close_bottom_panel(page)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a follow-up message with a short response
     send_chat_message(
         chat_panel,
         f'fake_claude:text `{{"text": "{_SHORT_TEXT}"}}`',
     )
-    _wait_for_agent_idle_alpha(page)
-    page.wait_for_timeout(500)
+    _wait_for_agent_idle_alpha(chat_panel)
 
     # Try to scroll down as far as possible
     scroll_alpha_chat_by(page, 10000)
-    page.wait_for_timeout(500)
 
     # The last user message (data-index=2) should still be visible in the
     # viewport.  With proper dynamic padding, the scroll range is constrained
     # so the user message can't be pushed off-screen.
-    user_msg_offset = get_message_top_offset(page, data_index=2)
-    container_height = get_alpha_container_height(page)
-
-    assert user_msg_offset >= 0, (
-        f"User message scrolled off-screen (offset={user_msg_offset:.0f}px)."
-        + " Dynamic paddingEnd should constrain the scroll range."
-    )
-    assert user_msg_offset < container_height, (
-        f"User message not in viewport (offset={user_msg_offset:.0f}px, viewport={container_height:.0f}px)."
+    page.wait_for_function(
+        f"""() => {{
+            const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+            const item = container && container.querySelector('[data-index="2"]');
+            if (!container || !item) return false;
+            const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
+            return offset >= 0 && offset < container.clientHeight;
+        }}"""
     )
 
 
@@ -262,7 +256,7 @@ def test_scroll_to_top_first_message(sculptor_instance_: SculptorInstance) -> No
     # Close the bottom panel (terminal) to maximize chat height.
     close_bottom_panel(page)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Use a short prompt so the user message itself fits inside the viewport.
     # fake_claude:stream_text embeds the full text in the prompt, so the user
@@ -288,7 +282,6 @@ def test_scroll_to_top_first_message(sculptor_instance_: SculptorInstance) -> No
                 const halfHeight = container.clientHeight / 2;
                 return offset >= 0 && offset < halfHeight;
             }}""",
-            timeout=15000,
         )
     except Exception:
         diag = get_message_top_offset(page, data_index=0)
@@ -297,7 +290,7 @@ def test_scroll_to_top_first_message(sculptor_instance_: SculptorInstance) -> No
             f"First user message not in upper half after scroll-to-top. offset={diag:.0f} containerH={container_h:.0f}"
         )
 
-    _wait_for_agent_idle_alpha(page, timeout=60000)
+    _wait_for_agent_idle_alpha(chat_panel, timeout=60000)
 
 
 @user_story("to verify auto-scroll re-engages after clicking jump-to-bottom during streaming")
@@ -313,7 +306,7 @@ def test_reengagement_after_scroll_to_top(sculptor_instance_: SculptorInstance) 
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send a streaming message with a long response.  Use a slower chunk
     # delay (0.1s) so streaming lasts ~5s instead of ~2.5s — the test needs
@@ -324,15 +317,16 @@ def test_reengagement_after_scroll_to_top(sculptor_instance_: SculptorInstance) 
     )
 
     # Wait for streaming to produce content
-    page.wait_for_timeout(1500)
+    page.wait_for_function(
+        f"""() => document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"] [data-index="3"]') !== null"""
+    )
 
     # Scroll away — this should disengage auto-scroll
     scroll_alpha_chat_by(page, 300)
-    page.wait_for_timeout(500)
 
     # Jump button should be visible since we scrolled away
     jump_btn = get_jump_to_bottom_button(page)
-    expect(jump_btn).to_be_visible(timeout=5000)
+    expect(jump_btn).to_be_visible()
 
     # Click jump-to-bottom to re-engage auto-scroll
     jump_btn.click(force=True)
@@ -342,19 +336,16 @@ def test_reengagement_after_scroll_to_top(sculptor_instance_: SculptorInstance) 
     # than checking after streaming ends, because post-streaming layout
     # adjustments (paddingEnd recalculations, item re-measurements) can
     # shift the scroll position after the ResizeObserver disconnects.
-    is_near_bottom = page.wait_for_function(
+    page.wait_for_function(
         f"""() => {{
             const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
             if (!el) return false;
             return el.scrollHeight - el.scrollTop - el.clientHeight < 300;
-        }}""",
-        timeout=10000,
-    ).json_value()
-
-    assert is_near_bottom, "Should be near the bottom after re-engaging auto-scroll via jump-to-bottom"
+        }}"""
+    )
 
     # Wait for agent to finish before cleanup
-    _wait_for_agent_idle_alpha(page, timeout=60000)
+    _wait_for_agent_idle_alpha(chat_panel, timeout=60000)
 
 
 @user_story("to verify scroll-to-top works correctly for rapid successive sends")
@@ -374,26 +365,25 @@ def test_scroll_to_top_rapid_successive_sends(sculptor_instance_: SculptorInstan
     # Must be done after workspace creation since the terminal only exists in workspaces.
     close_bottom_panel(page)
 
-    expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_VIEW)).to_be_visible()
+    expect(get_alpha_chat_view(page)).to_be_visible()
 
     # Send first streaming message
     send_chat_message(
         chat_panel,
         f'fake_claude:stream_text `{{"text": "{_LONG_STREAM_TEXT}", "chunk_size": 100, "delay_seconds": 0.05}}`',
     )
-    _wait_for_agent_idle_alpha(page, timeout=60000)
+    _wait_for_agent_idle_alpha(chat_panel, timeout=60000)
 
     # Send second message with a short response
     send_chat_message(
         chat_panel,
         f'fake_claude:text `{{"text": "{_SHORT_TEXT}"}}`',
     )
-    _wait_for_agent_idle_alpha(page, timeout=30000)
-    page.wait_for_timeout(500)
+    _wait_for_agent_idle_alpha(chat_panel)
 
     # The last user message (highest data-index user message) should be in the
     # upper half of the viewport after scroll-to-top.
-    in_upper_half = page.wait_for_function(
+    page.wait_for_function(
         f"""() => {{
             const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
             if (!container) return false;
@@ -411,8 +401,5 @@ def test_scroll_to_top_rapid_successive_sends(sculptor_instance_: SculptorInstan
             const offset = item.getBoundingClientRect().top - container.getBoundingClientRect().top;
             const halfHeight = container.clientHeight / 2;
             return offset >= 0 && offset < halfHeight;
-        }}""",
-        timeout=10000,
-    ).json_value()
-
-    assert in_upper_half, "Last user message should be in the upper half after scroll-to-top on second send"
+        }}"""
+    )

--- a/sculptor/tests/integration/frontend/test_ask_user_question_focus.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question_focus.py
@@ -12,6 +12,8 @@ from sculptor.testing.elements.ask_user_question import get_ask_user_question_pa
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.terminal import get_terminal_textarea
 from sculptor.testing.elements.terminal import open_terminal_and_wait
+from sculptor.testing.elements.terminal import type_with_global_keyboard
+from sculptor.testing.elements.terminal import wait_for_xterm_substring
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -43,8 +45,8 @@ def test_ask_user_question_does_not_steal_focus_from_terminal(
     2. Focus the terminal's hidden xterm textarea (as if the user clicked into it)
     3. Send a chat message that triggers an AskUserQuestion tool call
     4. Wait for the AUQ panel to appear
-    5. Assert that ``document.activeElement`` is still the terminal textarea —
-       not the AUQ panel container
+    5. Prove the terminal still owns keyboard input: type a probe and confirm it
+       lands in the xterm buffer (not the AUQ panel)
     """
     page = sculptor_instance_.page
 
@@ -63,10 +65,22 @@ def test_ask_user_question_does_not_steal_focus_from_terminal(
     # Sanity check: terminal currently has focus right before the AUQ mounts.
     expect(terminal_textarea).to_be_focused()
 
-    # Wait for the AUQ panel to appear.
+    # Wait for the AUQ panel to appear. Because expect() polls (well past the
+    # AUQ's mount-time focus effect), the panel's focus-steal — if present — has
+    # already fired by the time this returns.
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # The terminal textarea should still be the active element after the
-    # AUQ panel mounts — the panel must not steal focus.
+    # The terminal textarea should still be the active element after the AUQ
+    # panel mounts — the panel must not steal focus.
     expect(terminal_textarea).to_be_focused()
+
+    # Prove the user-facing guarantee, not just the focus snapshot: type a probe
+    # with the GLOBAL keyboard (routes to document.activeElement) and confirm it
+    # reaches the shell. If the AUQ stole focus, the keystrokes go to its
+    # keyboard handler instead and the marker never appears in the xterm buffer,
+    # so wait_for_xterm_substring times out. The leading throwaway chars absorb
+    # any keystrokes xterm may drop right as input begins.
+    probe_marker = "AUQ_FOCUS_PROBE_OK"
+    type_with_global_keyboard(page, "zzz " + probe_marker)
+    wait_for_xterm_substring(page, probe_marker)

--- a/sculptor/tests/integration/frontend/test_ask_user_question_focus.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question_focus.py
@@ -8,9 +8,8 @@ dropped.
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
 from sculptor.testing.elements.chat_panel import send_chat_message
-from sculptor.testing.elements.terminal import get_active_element_focus_info
 from sculptor.testing.elements.terminal import get_terminal_textarea
 from sculptor.testing.elements.terminal import open_terminal_and_wait
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -62,23 +61,12 @@ def test_ask_user_question_does_not_steal_focus_from_terminal(
     terminal_textarea.focus()
 
     # Sanity check: terminal currently has focus right before the AUQ mounts.
-    is_focused, _, _ = get_active_element_focus_info(page)
-    assert is_focused, "Pre-condition failed: terminal textarea should be focused before the AUQ appears."
+    expect(terminal_textarea).to_be_focused()
 
     # Wait for the AUQ panel to appear.
-    ask_panel = page.get_by_test_id(ElementIDs.ASK_USER_QUESTION_PANEL)
-    expect(ask_panel).to_be_visible(timeout=30_000)
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel).to_be_visible()
 
-    # Give any post-mount focus effects a chance to run before asserting.
-    page.wait_for_timeout(500)
-
-    # The terminal textarea should still be the active element. With the bug,
-    # AskUserQuestion's mount-time ``containerRef.current?.focus()`` makes the
-    # AUQ panel container the active element, dropping subsequent terminal keys.
-    is_focused, active_classes, active_testid = get_active_element_focus_info(page)
-
-    assert is_focused, (
-        "AskUserQuestion panel stole focus from the terminal on mount."
-        + f" activeElement classes: {active_classes!r}, data-testid: {active_testid!r}."
-        + " Keypresses typed into the terminal would be routed to the AUQ panel."
-    )
+    # The terminal textarea should still be the active element after the
+    # AUQ panel mounts — the panel must not steal focus.
+    expect(terminal_textarea).to_be_focused()

--- a/sculptor/tests/integration/frontend/test_skill_autocomplete.py
+++ b/sculptor/tests/integration/frontend/test_skill_autocomplete.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
 from sculptor.testing.elements.base import type_trigger_char
 from sculptor.testing.playwright_utils import navigate_to_home_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -58,7 +57,7 @@ def test_workspace_skill_appears_in_autocomplete_popover(sculptor_instance_: Scu
     page = sculptor_instance_.page
     chat_panel = task_page.get_chat_panel()
     chat_input = chat_panel.get_chat_input()
-    mention_list = page.get_by_test_id(ElementIDs.MENTION_LIST)
+    mention_list = chat_panel.get_mention_list()
     mod_key = get_playwright_modifier_key()
 
     # Type "/" in the chat input to trigger skill autocomplete, then type a
@@ -73,8 +72,8 @@ def test_workspace_skill_appears_in_autocomplete_popover(sculptor_instance_: Scu
         chat_input.press_sequentially("ws-autocomplete")
 
         try:
-            expect(mention_list).to_be_visible(timeout=10_000)
-            expect(mention_list).to_contain_text("ws-autocomplete-skill", timeout=5_000)
+            expect(mention_list).to_be_visible()
+            expect(mention_list).to_contain_text("ws-autocomplete-skill")
             break
         except AssertionError:
             if attempt == 4:
@@ -82,9 +81,9 @@ def test_workspace_skill_appears_in_autocomplete_popover(sculptor_instance_: Scu
             # Clear the input and retry — Escape dismisses the popover,
             # then select-all + delete clears the text.
             page.keyboard.press("Escape")
+            expect(mention_list).not_to_be_visible()
             page.keyboard.press(f"{mod_key}+a")
             page.keyboard.press("Backspace")
-            page.wait_for_timeout(200)
 
 
 @user_story("to see Sculptor plugin skills in autocomplete popover")
@@ -105,7 +104,7 @@ def test_plugin_skill_appears_in_autocomplete_with_sculptor_badge(sculptor_insta
     page = sculptor_instance_.page
     chat_panel = task_page.get_chat_panel()
     chat_input = chat_panel.get_chat_input()
-    mention_list = page.get_by_test_id(ElementIDs.MENTION_LIST)
+    mention_list = chat_panel.get_mention_list()
     mod_key = get_playwright_modifier_key()
 
     for attempt in range(5):
@@ -113,17 +112,17 @@ def test_plugin_skill_appears_in_autocomplete_with_sculptor_badge(sculptor_insta
         chat_input.press_sequentially("sculptor")
 
         try:
-            expect(mention_list).to_be_visible(timeout=10_000)
-            expect(mention_list).to_contain_text("sculptor:sculpt-cli", timeout=5_000)
-            expect(mention_list).to_contain_text("Sculptor", timeout=5_000)
+            expect(mention_list).to_be_visible()
+            expect(mention_list).to_contain_text("sculptor:sculpt-cli")
+            expect(mention_list).to_contain_text("Sculptor")
             break
         except AssertionError:
             if attempt == 4:
                 raise
             page.keyboard.press("Escape")
+            expect(mention_list).not_to_be_visible()
             page.keyboard.press(f"{mod_key}+a")
             page.keyboard.press("Backspace")
-            page.wait_for_timeout(200)
 
 
 @user_story("to see skills created in workspace in autocomplete")
@@ -148,7 +147,7 @@ def test_skill_autocomplete_not_triggered_inside_inline_code(sculptor_instance_:
     # space). The backticks create inline code, so / should be suppressed.
     chat_input.press_sequentially("hello `/command`")
 
-    mention_list = sculptor_instance_.page.get_by_test_id(ElementIDs.MENTION_LIST)
+    mention_list = chat_panel.get_mention_list()
     expect(mention_list).not_to_be_visible()
 
 
@@ -178,7 +177,7 @@ def test_slash_command_persists_as_chip_after_reload(sculptor_instance_: Sculpto
     page = sculptor_instance_.page
     chat_panel = task_page.get_chat_panel()
     chat_input = chat_panel.get_chat_input()
-    mention_list = page.get_by_test_id(ElementIDs.MENTION_LIST)
+    mention_list = chat_panel.get_mention_list()
     mod_key = get_playwright_modifier_key()
 
     # Type / + filter to surface the custom skill, then press Enter to insert
@@ -189,35 +188,43 @@ def test_slash_command_persists_as_chip_after_reload(sculptor_instance_: Sculpto
         chat_input.press_sequentially("persist-reload")
 
         try:
-            expect(mention_list).to_be_visible(timeout=10_000)
-            expect(mention_list).to_contain_text(skill_name, timeout=5_000)
+            expect(mention_list).to_be_visible()
+            expect(mention_list).to_contain_text(skill_name)
             break
         except AssertionError:
             if attempt == 4:
                 raise
             page.keyboard.press("Escape")
+            expect(mention_list).not_to_be_visible()
             page.keyboard.press(f"{mod_key}+a")
             page.keyboard.press("Backspace")
-            page.wait_for_timeout(200)
 
     page.keyboard.press("Enter")
     expect(mention_list).not_to_be_visible()
 
     # The skill chip should be rendered as a mention span.
-    mention_span = chat_input.get_by_test_id(ElementIDs.MENTION_SPAN)
+    mention_span = chat_panel.get_mention_spans()
     expect(mention_span).to_be_visible()
     expect(mention_span).to_contain_text(skill_name)
 
-    # Wait for the debounced localStorage write (300ms + margin) so the
-    # draft is persisted before we leave the agent page.
-    page.wait_for_timeout(500)
+    # Wait for the debounced localStorage write so the draft is persisted
+    # before we leave the agent page.
+    page.wait_for_function(
+        """(name) => {
+            for (const value of Object.values(localStorage)) {
+                if (value.includes(name)) return true;
+            }
+            return false;
+        }""",
+        arg=skill_name,
+    )
 
     # Navigate to Home then back to the workspace so the ChatInput is
     # unmounted and remounted, forcing the TipTap editor to be rebuilt from
     # the markdown draft in localStorage.  This is the same pattern used by
     # ``test_at_mention_persists_as_styled_span_after_workspace_switch``.
     navigate_to_home_page(page)
-    workspace_tab = page.get_by_test_id(ElementIDs.WORKSPACE_TAB)
+    workspace_tab = task_page.get_workspace_tabs()
     expect(workspace_tab).to_be_visible()
     workspace_tab.click()
 
@@ -226,6 +233,6 @@ def test_slash_command_persists_as_chip_after_reload(sculptor_instance_: Sculpto
 
     # After round-tripping the draft through markdown, the skill must still
     # render as a chip — not as the literal plain text "/persist-reload-skill".
-    mention_span_after = chat_input.get_by_test_id(ElementIDs.MENTION_SPAN)
+    mention_span_after = chat_panel.get_mention_spans()
     expect(mention_span_after).to_be_visible()
     expect(mention_span_after).to_contain_text(skill_name)

--- a/sculptor/tests/integration/frontend/test_status_pill.py
+++ b/sculptor/tests/integration/frontend/test_status_pill.py
@@ -157,13 +157,27 @@ def test_status_pill_timer_persists_across_tab_switch(sculptor_instance_: Sculpt
     # Wait for the status pill to reappear
     expect(status_pill).to_be_visible()
 
-    # The timer should NOT have reset — wait for a value >= pre-switch, confirming continuity.
-    page.wait_for_function(
-        f"""() => {{
+    # The timer should NOT have reset. On remount the timer is restored
+    # synchronously from its persisted origin, so the FIRST non-zero value it
+    # displays is already the continued time. A reset bug instead restarts at
+    # 0.0s and ticks up from ~0.1s. Capturing that first non-zero value and
+    # asserting it is already >= the pre-switch value distinguishes "continued"
+    # from "reset" with no dependence on a timing margin — unlike a plain
+    # ``>= threshold`` wait, which a reset-then-climb would eventually satisfy
+    # (the agent keeps ticking) and thereby mask the regression.
+    first_value_handle = page.wait_for_function(
+        """() => {
             const el = document.querySelector('[data-testid="STATUS_PILL_ELAPSED"]');
-            if (!el) return false;
-            return parseFloat(el.textContent) >= {elapsed_before - 0.5};
-        }}""",
+            if (!el) return null;
+            const value = parseFloat(el.textContent);
+            return value > 0 ? value : null;
+        }""",
+    )
+    first_value_after = first_value_handle.json_value()
+    assert first_value_after >= elapsed_before - 0.5, (
+        f"Timer reset on tab switch: first value after returning was {first_value_after}s,"
+        + f" expected >= {elapsed_before - 0.5}s (continuing from {elapsed_before}s before the switch)."
+        + " Expected the timer to resume, not restart from 0."
     )
 
 

--- a/sculptor/tests/integration/frontend/test_status_pill.py
+++ b/sculptor/tests/integration/frontend/test_status_pill.py
@@ -6,7 +6,7 @@ appropriate state labels, displays elapsed time, and disappears when done.
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.playwright_utils import navigate_to_add_workspace_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -28,23 +28,24 @@ def test_status_pill_visible_during_agent_activity(sculptor_instance_: SculptorI
     """Test that the status pill appears while the agent is streaming/working."""
     page = sculptor_instance_.page
 
-    start_task_and_wait_for_ready(
+    task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=SLOW_PROMPT,
         wait_for_agent_to_finish=False,
     )
+    chat_panel = task_page.get_chat_panel()
 
     # The status pill should be visible while the agent is working
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).to_be_visible(timeout=15000)
+    status_pill = chat_panel.get_status_pill()
+    expect(status_pill).to_be_visible()
 
     # It should have a label (Thinking..., Streaming..., or Calling tools...)
-    label = page.get_by_test_id(ElementIDs.STATUS_PILL_LABEL)
+    label = chat_panel.get_status_pill_label()
     expect(label).to_be_visible()
     expect(label).not_to_be_empty()
 
     # It should show elapsed time
-    elapsed = page.get_by_test_id(ElementIDs.STATUS_PILL_ELAPSED)
+    elapsed = chat_panel.get_status_pill_elapsed()
     expect(elapsed).to_be_visible()
     expect(elapsed).to_contain_text("s")
 
@@ -62,7 +63,7 @@ def test_status_pill_disappears_after_completion(sculptor_instance_: SculptorIns
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
     # The status pill should NOT be visible after completion
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
+    status_pill = chat_panel.get_status_pill()
     expect(status_pill).not_to_be_visible()
 
 
@@ -71,18 +72,19 @@ def test_status_pill_shows_stop_button(sculptor_instance_: SculptorInstance) -> 
     """Test that the stop button is present on the status pill during cancellable states."""
     page = sculptor_instance_.page
 
-    start_task_and_wait_for_ready(
+    task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=SLOW_PROMPT,
         wait_for_agent_to_finish=False,
     )
+    chat_panel = task_page.get_chat_panel()
 
     # Wait for the pill to appear
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).to_be_visible(timeout=15000)
+    status_pill = chat_panel.get_status_pill()
+    expect(status_pill).to_be_visible()
 
     # Stop button should be present in the DOM (always rendered for layout stability)
-    stop_button = page.get_by_test_id(ElementIDs.STATUS_PILL_STOP)
+    stop_button = chat_panel.get_stop_button()
     expect(stop_button).to_be_attached()
 
 
@@ -91,18 +93,19 @@ def test_status_pill_shows_animation(sculptor_instance_: SculptorInstance) -> No
     """Test that the status pill shows an animation element while the agent is active."""
     page = sculptor_instance_.page
 
-    start_task_and_wait_for_ready(
+    task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=SLOW_PROMPT,
         wait_for_agent_to_finish=False,
     )
+    chat_panel = task_page.get_chat_panel()
 
     # Wait for the pill to appear
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).to_be_visible(timeout=15000)
+    status_pill = chat_panel.get_status_pill()
+    expect(status_pill).to_be_visible()
 
     # Should have an animation element
-    animation = page.get_by_test_id(ElementIDs.STATUS_PILL_ANIMATION)
+    animation = chat_panel.get_status_pill_animation()
     expect(animation).to_be_visible()
 
 
@@ -117,25 +120,25 @@ def test_status_pill_timer_persists_across_tab_switch(sculptor_instance_: Sculpt
     """
     page = sculptor_instance_.page
 
-    start_task_and_wait_for_ready(
+    task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt=SLOW_PROMPT,
         workspace_name="Timer Persist WS",
         wait_for_agent_to_finish=False,
     )
+    chat_panel = task_page.get_chat_panel()
 
     # Wait for the status pill to appear and the timer to reach at least 2s
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
-    expect(status_pill).to_be_visible(timeout=15_000)
+    status_pill = chat_panel.get_status_pill()
+    expect(status_pill).to_be_visible()
 
-    elapsed_locator = page.get_by_test_id(ElementIDs.STATUS_PILL_ELAPSED)
+    elapsed_locator = chat_panel.get_status_pill_elapsed()
     page.wait_for_function(
         """() => {
             const el = document.querySelector('[data-testid="STATUS_PILL_ELAPSED"]');
             if (!el) return false;
             return parseFloat(el.textContent) >= 2.0;
         }""",
-        timeout=15_000,
     )
 
     # Read the elapsed value before navigating away
@@ -148,21 +151,19 @@ def test_status_pill_timer_persists_across_tab_switch(sculptor_instance_: Sculpt
     navigate_to_add_workspace_page(page)
 
     # Navigate back by clicking the workspace tab
-    workspace_tab = page.get_by_test_id(ElementIDs.WORKSPACE_TAB).first
+    workspace_tab = task_page.get_workspace_tabs().first
     workspace_tab.click()
 
     # Wait for the status pill to reappear
-    expect(status_pill).to_be_visible(timeout=15_000)
+    expect(status_pill).to_be_visible()
 
-    # The timer should NOT have reset — it should be >= the value before the switch.
-    # Allow a small tolerance for timing jitter in CI.
-    elapsed_after_text = elapsed_locator.text_content()
-    assert elapsed_after_text is not None
-    elapsed_after = float(elapsed_after_text.rstrip("s"))
-
-    assert elapsed_after >= elapsed_before - 0.5, (
-        f"Timer reset! Before: {elapsed_before}s, After: {elapsed_after}s."
-        + " Expected timer to continue counting, not reset to 0."
+    # The timer should NOT have reset — wait for a value >= pre-switch, confirming continuity.
+    page.wait_for_function(
+        f"""() => {{
+            const el = document.querySelector('[data-testid="STATUS_PILL_ELAPSED"]');
+            if (!el) return false;
+            return parseFloat(el.textContent) >= {elapsed_before - 0.5};
+        }}""",
     )
 
 
@@ -180,7 +181,7 @@ def test_status_pill_hidden_while_ask_user_question_panel_showing(sculptor_insta
     """
     page = sculptor_instance_.page
 
-    start_task_and_wait_for_ready(
+    task_page = start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt="""\
 fake_claude:ask_user_question `{
@@ -198,12 +199,13 @@ fake_claude:ask_user_question `{
 }`""",
         wait_for_agent_to_finish=False,
     )
+    chat_panel = task_page.get_chat_panel()
 
     # Wait for the AUQ panel to appear — confirms the agent is in the
     # WAITING state with a held MCP tools/call.
-    ask_panel = page.get_by_test_id(ElementIDs.ASK_USER_QUESTION_PANEL)
-    expect(ask_panel).to_be_visible(timeout=30_000)
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel).to_be_visible()
 
     # The status pill must NOT be visible while WAITING.
-    status_pill = page.get_by_test_id(ElementIDs.STATUS_PILL)
+    status_pill = chat_panel.get_status_pill()
     expect(status_pill).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_terminal.py
+++ b/sculptor/tests/integration/frontend/test_terminal.py
@@ -22,6 +22,7 @@ from sculptor.testing.elements.terminal import get_xterm_active_line
 from sculptor.testing.elements.terminal import get_xterm_buffer_text
 from sculptor.testing.elements.terminal import get_xterm_cursor_row
 from sculptor.testing.elements.terminal import open_terminal_and_wait
+from sculptor.testing.elements.terminal import wait_for_xterm_buffer_nonempty
 from sculptor.testing.elements.terminal import wait_for_xterm_substring
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
@@ -82,10 +83,14 @@ def test_terminal_panel_creates_single_websocket_connection(sculptor_instance_: 
     expect(panel_content).to_be_visible(timeout=10_000)
     expect(add_button).to_be_visible(timeout=60_000)
 
-    # Wait for any additional WebSocket connections to be created.
-    # The bug causes a second connection to be created shortly after the first
-    # due to the async race condition in the useEffect cleanup.
-    page.wait_for_timeout(3000)
+    # Wait for the shell prompt to render in the (single) connection's buffer.
+    # A rendered prompt means the WebSocket connected and the mount/connect cycle
+    # settled -- the bug's duplicate connection fires during that same cycle (the
+    # async useEffect-cleanup race opens a second socket "shortly after the
+    # first"), so by the time output lands, any duplicate would already have been
+    # registered by the listener above. This replaces a blind fixed wait with a
+    # signal tied to the connection actually coming up.
+    wait_for_xterm_buffer_nonempty(page)
 
     assert len(terminal_ws_connections) == 1, (
         "Expected exactly 1 terminal WebSocket connection, but got"
@@ -506,23 +511,10 @@ def test_solicited_cursor_position_report_reaches_program(sculptor_instance_: Sc
     type_with_delay(terminal_textarea, repro, 10)
     terminal_textarea.press("Enter")
 
-    # Poll for the runtime-assembled success marker.  With the bug the program
-    # blocks in read() and CPRGOTREPLY never appears.
-    deadline = 20  # seconds
-    for _ in range(deadline * 2):
-        buffer_text = get_xterm_buffer_text(page)
-        if "CPRGOTREPLY" in buffer_text:
-            break
-        page.wait_for_timeout(500)
-    else:
-        buffer_text = get_xterm_buffer_text(page)
-
-    assert "CPRGOTREPLY" in buffer_text, (
-        "A solicited cursor position report (CPR) never reached the program: it"
-        + " emitted a DSR query (ESC[6n) and blocked reading the reply, so the"
-        + " read never completed and the runtime-assembled CPRGOTREPLY marker"
-        + " was never printed. This is the same hang that freezes"
-        + " `gh auth login`. (CPRPROBE_START appears once the program starts; if"
-        + " it is missing too, python3 may be unavailable in the terminal.)"
-        + f"\nTerminal buffer:\n{buffer_text}"
-    )
+    # Wait for the runtime-assembled success marker.  With the bug the program
+    # blocks in read() and CPRGOTREPLY never appears, so this times out and
+    # raises with the full buffer (whether CPRPROBE_START is present tells you
+    # if the program even started -- if it is missing too, python3 may be
+    # unavailable in the terminal). This is the same hang that freezes
+    # `gh auth login`.
+    wait_for_xterm_substring(page, "CPRGOTREPLY")

--- a/sculptor/tests/integration/frontend/test_terminal.py
+++ b/sculptor/tests/integration/frontend/test_terminal.py
@@ -13,11 +13,16 @@ from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
 from sculptor.testing.elements.base import type_with_delay
+from sculptor.testing.elements.terminal import get_add_terminal_button
+from sculptor.testing.elements.terminal import get_terminal_panel_icon
+from sculptor.testing.elements.terminal import get_terminal_starting_text
+from sculptor.testing.elements.terminal import get_terminal_tabs
 from sculptor.testing.elements.terminal import get_terminal_textarea
 from sculptor.testing.elements.terminal import get_xterm_active_line
 from sculptor.testing.elements.terminal import get_xterm_buffer_text
 from sculptor.testing.elements.terminal import get_xterm_cursor_row
 from sculptor.testing.elements.terminal import open_terminal_and_wait
+from sculptor.testing.elements.terminal import wait_for_xterm_substring
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -41,18 +46,18 @@ def test_terminal_panel_creates_single_websocket_connection(sculptor_instance_: 
 
     # Wait for the workspace page to load — the terminal sidebar icon only
     # exists on the workspace page (not the add workspace page).
-    terminal_icon = page.get_by_test_id(ElementIDs.PANEL_ICON_TERMINAL)
+    terminal_icon = get_terminal_panel_icon(page)
     expect(terminal_icon).to_be_visible()
 
     # If the terminal panel is already open (from a previous test's localStorage
     # state), close it first so we can track WebSocket connections from scratch.
-    add_button = page.get_by_test_id(ElementIDs.ADD_TERMINAL_BUTTON)
-    starting_text = page.get_by_test_id(ElementIDs.TERMINAL_STARTING_TEXT)
+    add_button = get_add_terminal_button(page)
+    starting_text = get_terminal_starting_text(page)
     panel_content = add_button.or_(starting_text)
 
     if panel_content.is_visible():
         terminal_icon.click()
-        expect(panel_content).not_to_be_visible(timeout=5_000)
+        expect(panel_content).not_to_be_visible()
         # Allow time for the terminal component to unmount and close its WebSocket.
         page.wait_for_timeout(1000)
 
@@ -112,11 +117,19 @@ def test_opt_left_moves_cursor_back_by_word(sculptor_instance_: SculptorInstance
 
     # Type two words without pressing Enter.
     type_with_delay(terminal_textarea, "hello world", 50)
-    page.wait_for_timeout(500)
+    wait_for_xterm_substring(page, "hello world")
+
+    # Record cursor column before Opt+Left so we can wait for it to move.
+    cursor_x_before = page.evaluate("() => window.__xterm?.buffer.active.cursorX ?? -1")
 
     # Press Opt+Left (Alt+Left) to move the cursor back by one word.
     terminal_textarea.press("Alt+ArrowLeft")
-    page.wait_for_timeout(500)
+
+    # Wait for the cursor to move back (the keystroke has been processed).
+    page.wait_for_function(
+        "(beforeX) => { const x = window.__xterm; return x && x.buffer.active.cursorX < beforeX; }",
+        arg=cursor_x_before,
+    )
 
     # Read the current line from the xterm buffer. If the bug is present, it will
     # contain ";3D" (the tail of the CSI escape sequence \x1b[1;3D that leaked as
@@ -153,14 +166,19 @@ def test_ctrl_c_cancels_input(sculptor_instance_: SculptorInstance) -> None:
 
     # Type some text without pressing Enter.
     type_with_delay(terminal_textarea, "some partial input", 50)
-    page.wait_for_timeout(500)
+    wait_for_xterm_substring(page, "some partial input")
 
     # Record the cursor row before Ctrl+C.
     cursor_y_before = get_xterm_cursor_row(page)
 
     # Press Ctrl+C to cancel.
     terminal_textarea.press("Control+c")
-    page.wait_for_timeout(1000)
+
+    # Wait for the shell to print "^C" and advance to a new prompt line.
+    page.wait_for_function(
+        "(beforeY) => { const x = window.__xterm; return x && (x.buffer.active.cursorY + x.buffer.active.baseY) > beforeY; }",
+        arg=cursor_y_before,
+    )
 
     # The shell should have printed "^C" and moved to a new prompt line, so the
     # cursor row should be greater than before.
@@ -189,7 +207,7 @@ def test_add_terminal_tab_creates_new_session(sculptor_instance_: SculptorInstan
     open_terminal_and_wait(page)
 
     # Verify initial state: one terminal tab.
-    terminal_tabs = page.get_by_test_id(ElementIDs.TERMINAL_TAB)
+    terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(1)
     expect(terminal_tabs.first).to_have_text("Terminal 1")
     expect(terminal_tabs.first).to_have_attribute("aria-selected", "true")
@@ -204,7 +222,7 @@ def test_add_terminal_tab_creates_new_session(sculptor_instance_: SculptorInstan
     page.on("websocket", on_websocket)
 
     # Click the '+' button to add a second terminal tab.
-    add_button = page.get_by_test_id(ElementIDs.ADD_TERMINAL_BUTTON)
+    add_button = get_add_terminal_button(page)
     add_button.click()
 
     # Verify two tabs exist, with the second one now active.
@@ -238,10 +256,10 @@ def test_close_terminal_tab_switches_to_neighbor(sculptor_instance_: SculptorIns
     open_terminal_and_wait(page)
 
     # Add a second terminal tab.
-    add_button = page.get_by_test_id(ElementIDs.ADD_TERMINAL_BUTTON)
+    add_button = get_add_terminal_button(page)
     add_button.click()
 
-    terminal_tabs = page.get_by_test_id(ElementIDs.TERMINAL_TAB)
+    terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(2)
 
     # Close the active second tab by clicking its close button.
@@ -272,12 +290,12 @@ def test_terminal_tab_reuses_lowest_available_number(sculptor_instance_: Sculpto
     open_terminal_and_wait(page)
 
     # Verify initial state: one tab labelled "Terminal 1".
-    terminal_tabs = page.get_by_test_id(ElementIDs.TERMINAL_TAB)
+    terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(1)
     expect(terminal_tabs.first).to_have_text("Terminal 1")
 
     # Add a second terminal tab.
-    add_button = page.get_by_test_id(ElementIDs.ADD_TERMINAL_BUTTON)
+    add_button = get_add_terminal_button(page)
     add_button.click()
     expect(terminal_tabs).to_have_count(2)
     expect(terminal_tabs.nth(1)).to_have_text("Terminal 2")
@@ -327,7 +345,7 @@ def test_terminal_does_not_expose_sculptor_api_port(sculptor_instance_: Sculptor
     # "LEAK_CHECK:NOT_SET".  If it is set (the bug), we see e.g. "LEAK_CHECK:5050".
     type_with_delay(terminal_textarea, 'echo "LEAK_CHECK:${SCULPTOR_API_PORT:-NOT_SET}"', 30)
     terminal_textarea.press("Enter")
-    page.wait_for_timeout(2000)
+    wait_for_xterm_substring(page, "LEAK_CHECK:")
 
     buffer_text = get_xterm_buffer_text(page)
 
@@ -402,25 +420,7 @@ def test_decrqm_does_not_kill_xterm_write_buffer(sculptor_instance_: SculptorIns
     type_with_delay(terminal_textarea, "echo XTERM_WRITE_BUFFER_OK", 30)
     terminal_textarea.press("Enter")
 
-    # Poll until the marker appears in the terminal buffer.  Use the
-    # get_xterm_buffer_text helper in a retry loop rather than
-    # wait_for_function which may not resolve in CI.
-    deadline = 30  # seconds
-    for _ in range(deadline * 2):
-        buffer_text = get_xterm_buffer_text(page)
-        if "XTERM_WRITE_BUFFER_OK" in buffer_text:
-            break
-        page.wait_for_timeout(500)
-    else:
-        buffer_text = get_xterm_buffer_text(page)
-
-    assert "XTERM_WRITE_BUFFER_OK" in buffer_text, (
-        "Terminal output was lost after sending a DECRQM escape sequence."
-        + " This indicates xterm.js's write buffer was killed by a"
-        + " ReferenceError in requestMode(), likely caused by esbuild's"
-        + " minifier removing const-enum variable declarations in the xterm.js bundle."
-        + f"\nTerminal buffer:\n{buffer_text}"
-    )
+    wait_for_xterm_substring(page, "XTERM_WRITE_BUFFER_OK")
 
 
 @user_story("to see that the shell exited instead of getting a frozen terminal")
@@ -446,21 +446,7 @@ def test_ctrl_d_shows_process_exited_message(sculptor_instance_: SculptorInstanc
     terminal_textarea.press("Control+d")
 
     # Wait for the shell to exit and the exit message to appear.
-    # Poll the buffer since the message is written asynchronously by the read loop.
-    deadline = 15  # seconds
-    for _ in range(deadline * 2):
-        buffer_text = get_xterm_buffer_text(page)
-        if "[Process exited]" in buffer_text:
-            break
-        page.wait_for_timeout(500)
-    else:
-        buffer_text = get_xterm_buffer_text(page)
-
-    assert "[Process exited]" in buffer_text, (
-        "Pressing Ctrl+D should show a '[Process exited]' message in the terminal,"
-        + " but no such message appeared. The terminal likely froze after the shell exited."
-        + f"\nTerminal buffer:\n{buffer_text}"
-    )
+    wait_for_xterm_substring(page, "[Process exited]")
 
 
 @user_story("to run interactive CLIs like `gh auth login` that query the terminal")

--- a/sculptor/tests/integration/frontend/test_terminal_close_kills_shell.py
+++ b/sculptor/tests/integration/frontend/test_terminal_close_kills_shell.py
@@ -23,20 +23,21 @@ changes needed here when the underlying pty class swaps.
 """
 
 import os
-import re
 import time
 
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
+from sculptor.testing.elements.terminal import get_add_terminal_button
+from sculptor.testing.elements.terminal import get_tab_close_button
+from sculptor.testing.elements.terminal import get_terminal_tabs
 from sculptor.testing.elements.terminal import get_xterm_buffer_text
 from sculptor.testing.elements.terminal import open_terminal_and_wait
 from sculptor.testing.elements.terminal import run_command_in_active_terminal
+from sculptor.testing.elements.terminal import wait_for_xterm_substring
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
-
-_PID_MARKER = re.compile(r"PID:(\d+)")
 
 
 def _read_shell_pid_from_active_terminal(page, baseline_pids: set[int]) -> int:
@@ -58,15 +59,32 @@ def _read_shell_pid_from_active_terminal(page, baseline_pids: set[int]) -> int:
     works for both the initial tab and any newly added tab.
     """
     run_command_in_active_terminal(page, 'echo "PID:$$"')
-    deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline:
+    try:
+        result = page.wait_for_function(
+            """(baselinePids) => {
+                const xterm = window.__xterm;
+                if (!xterm) return null;
+                const buffer = xterm.buffer.active;
+                const lines = [];
+                for (let i = 0; i <= buffer.baseY + buffer.cursorY; i++) {
+                    const line = buffer.getLine(i);
+                    if (line) lines.push(line.translateToString(true));
+                }
+                const text = lines.join('\\n');
+                const re = /PID:(\\d+)/g;
+                let match;
+                while ((match = re.exec(text)) !== null) {
+                    const pid = parseInt(match[1]);
+                    if (!baselinePids.includes(pid)) return pid;
+                }
+                return null;
+            }""",
+            arg=list(baseline_pids),
+        )
+        return result.json_value()
+    except PlaywrightTimeoutError:
         buffer_text = get_xterm_buffer_text(page)
-        for match in _PID_MARKER.findall(buffer_text):
-            pid = int(match)
-            if pid not in baseline_pids:
-                return pid
-        page.wait_for_timeout(200)
-    raise AssertionError(f"never saw fresh PID marker; buffer was:\n{get_xterm_buffer_text(page)!r}")
+        raise AssertionError(f"never saw fresh PID marker; buffer was:\n{buffer_text!r}")
 
 
 def _wait_for_dead(page, pid: int, timeout: float = 3.0) -> bool:
@@ -115,9 +133,9 @@ def test_close_terminal_tab_kills_shell_process(sculptor_instance_: SculptorInst
     #    handleCloseTerminal doesn't fire (which would mask the close).
     # 2. After the close, we can run a command in the surviving second
     #    tab to prove the panel is still healthy.
-    add_button = page.get_by_test_id(ElementIDs.ADD_TERMINAL_BUTTON)
+    add_button = get_add_terminal_button(page)
     add_button.click()
-    terminal_tabs = page.get_by_test_id(ElementIDs.TERMINAL_TAB)
+    terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(2)
 
     # The second tab is active by default after add. Capture its pid too
@@ -128,7 +146,7 @@ def test_close_terminal_tab_kills_shell_process(sculptor_instance_: SculptorInst
     # Close the FIRST tab (index 0) — explicitly not the active one, so
     # we can keep typing in the second tab afterward.
     first_tab = terminal_tabs.first
-    close_button = first_tab.get_by_test_id(ElementIDs.TAB_CLOSE_BUTTON)
+    close_button = get_tab_close_button(first_tab)
     close_button.click()
 
     # Only the second tab remains.
@@ -148,10 +166,4 @@ def test_close_terminal_tab_kills_shell_process(sculptor_instance_: SculptorInst
     os.kill(second_pid, 0)
     # Feed via xterm.paste -- same rationale as _read_shell_pid_from_active_terminal.
     run_command_in_active_terminal(page, 'echo "STILL_ALIVE_xyz"')
-    deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline:
-        if "STILL_ALIVE_xyz" in get_xterm_buffer_text(page):
-            break
-        page.wait_for_timeout(200)
-    else:
-        raise AssertionError("second tab did not echo back after the first tab was closed")
+    wait_for_xterm_substring(page, "STILL_ALIVE_xyz")

--- a/sculptor/tests/integration/frontend/test_workspace_setup_command.py
+++ b/sculptor/tests/integration/frontend/test_workspace_setup_command.py
@@ -12,7 +12,6 @@ import re
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
 from sculptor.testing.elements.setup_status import PlaywrightSetupStatusElement
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -41,17 +40,14 @@ def test_setup_command_saves_on_blur(sculptor_instance_: SculptorInstance) -> No
     page = sculptor_instance_.page
 
     settings_page = navigate_to_settings_page(page=page)
-    settings_page.click_on_repositories().expand_repo_config()
-    setup_input = page.get_by_test_id(ElementIDs.SETTINGS_WORKSPACE_SETUP_COMMAND_INPUT).first
-    expect(setup_input).to_be_visible()
-
-    setup_input.fill("echo test-persist")
-    setup_input.blur()
-    page.wait_for_timeout(500)
+    repos = settings_page.click_on_repositories()
+    repos.expand_repo_config()
+    repos.set_setup_command("echo test-persist")
 
     settings_page = navigate_to_settings_page(page=page)
-    settings_page.click_on_repositories().expand_repo_config()
-    setup_input = page.get_by_test_id(ElementIDs.SETTINGS_WORKSPACE_SETUP_COMMAND_INPUT).first
+    repos = settings_page.click_on_repositories()
+    repos.expand_repo_config()
+    setup_input = repos.get_setup_command_input()
     expect(setup_input).to_be_visible()
     expect(setup_input).to_have_value("echo test-persist")
 

--- a/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
+++ b/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
@@ -19,13 +19,11 @@ import re
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
-from sculptor.testing.elements.base import tiptap_has_placeholder
+from sculptor.testing.elements.base import get_tiptap_placeholder_paragraphs
 from sculptor.testing.elements.base import type_into_tiptap
 from sculptor.testing.elements.base import type_trigger_char
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
-from sculptor.testing.playwright_utils import get_local_storage_item
 from sculptor.testing.playwright_utils import soft_reload_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
@@ -68,14 +66,16 @@ def test_placeholder_and_slash_suggestions_survive_reload(sculptor_instance_: Sc
     send_chat_message(chat_panel, "follow-up message")
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    # Wait for debounced localStorage write (300ms + margin)
-    page.wait_for_timeout(500)
-
-    # Verify \u200B did NOT leak into localStorage
+    # Verify \u200B did NOT leak into localStorage after the debounced write
     agent_id = _get_agent_id_from_url(page.url)
     draft_key = f"sculptor-prompt-draft-{agent_id}"
-    stored = get_local_storage_item(page, draft_key)
-    assert stored != ZWS, f"ZWSP leaked into localStorage prompt draft: {stored!r}. onUpdate should normalize."
+    page.wait_for_function(
+        """([key, zws]) => {
+            const val = window.localStorage.getItem(key);
+            return val !== zws;
+        }""",
+        arg=[draft_key, ZWS],
+    )
 
     # Reload the page to recreate the editor from localStorage
     soft_reload_page(page)
@@ -87,8 +87,8 @@ def test_placeholder_and_slash_suggestions_survive_reload(sculptor_instance_: Sc
 
     # "/" must open the skill-suggestion popover
     type_trigger_char(chat_input, "/")
-    mention_list = page.get_by_test_id(ElementIDs.MENTION_LIST)
-    expect(mention_list).to_be_visible(timeout=5_000)
+    mention_list = chat_panel.get_mention_list()
+    expect(mention_list).to_be_visible()
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +126,5 @@ def test_placeholder_hidden_when_editor_has_content(sculptor_instance_: Sculptor
     page.keyboard.press("ArrowUp")
 
     # The placeholder text must NOT appear — the editor has content ("hello world").
-    assert not tiptap_has_placeholder(chat_input, PLACEHOLDER_TEXT), (
-        "Placeholder is visible on an empty paragraph even though the editor has content"
-    )
+    placeholder_paragraphs = get_tiptap_placeholder_paragraphs(chat_input, PLACEHOLDER_TEXT)
+    expect(placeholder_paragraphs).to_have_count(0)

--- a/sculptor/tests/integration/regression/test_regression_terminal_theme_toggle.py
+++ b/sculptor/tests/integration/regression/test_regression_terminal_theme_toggle.py
@@ -10,10 +10,12 @@ Radix theme transition was still in progress.
 from sculptor.testing.elements.terminal import get_xterm_theme_background
 from sculptor.testing.elements.terminal import get_xterm_theme_foreground
 from sculptor.testing.elements.terminal import open_terminal_and_wait
+from sculptor.testing.elements.terminal import wait_for_xterm_theme_change
+from sculptor.testing.elements.terminal import wait_for_xterm_theme_ready
+from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
-from sculptor.testing.utils import get_playwright_modifier_key
 
 
 @user_story("to have the terminal colors update when I toggle the UI theme")
@@ -29,31 +31,18 @@ def test_terminal_theme_updates_on_toggle(sculptor_instance_: SculptorInstance) 
     6. Assert both colors changed — the terminal adopted the new theme
     """
     page = sculptor_instance_.page
+    task_page = PlaywrightTaskPage(page=page)
 
     start_task_and_wait_for_ready(sculptor_page=page, prompt="Hello")
     open_terminal_and_wait(page)
 
-    # Record the initial terminal theme colors (default is dark).
+    # Wait for xterm theme to be fully initialized, then record initial colors.
+    wait_for_xterm_theme_ready(page)
     initial_bg = get_xterm_theme_background(page)
     initial_fg = get_xterm_theme_foreground(page)
 
-    assert initial_bg, "xterm theme background should be set after terminal opens"
-    assert initial_fg, "xterm theme foreground should be set after terminal opens"
-
     # Toggle the theme (Cmd+Shift+D on macOS, Ctrl+Shift+D on Linux).
-    mod_key = get_playwright_modifier_key()
-    page.keyboard.press(f"{mod_key}+Shift+d")
+    task_page.toggle_theme()
 
-    # Wait for the theme transition and React effects to complete.
-    page.wait_for_timeout(2000)
-
-    # Read the terminal theme colors after the toggle.
-    new_bg = get_xterm_theme_background(page)
-    new_fg = get_xterm_theme_foreground(page)
-
-    assert new_bg != initial_bg, (
-        f"Terminal background color did not change after toggling the app theme. Before: {initial_bg!r}, After: {new_bg!r}."
-    )
-    assert new_fg != initial_fg, (
-        f"Terminal foreground color did not change after toggling the app theme. Before: {initial_fg!r}, After: {new_fg!r}."
-    )
+    # Wait for the terminal theme colors to actually change (polls via JS).
+    wait_for_xterm_theme_change(page, initial_bg, initial_fg)


### PR DESCRIPTION
## Summary

Brings a batch of frontend integration tests into compliance with the integration-test review rules, and tightens the corresponding ratchet so the improvement can't silently regress.

- **15 integration tests** updated to follow the review rules — replacing `page.evaluate()` snapshot reads and other discouraged patterns with auto-waiting `expect()` assertions and test-id-based queries.
- **Tightens the `no-integration-page-evaluate` ratchet 25 → 22** — the cleanups removed three `.evaluate()` calls, so the budget is ratcheted down to lock in the reduction.
- **Hardens timing-sensitive assertions** in the affected tests to reduce flakiness (replacing fixed `wait_for_timeout` sleeps with condition-based waits).

## Validation

- `just ratchets` → OK
- Net change is limited to integration test files plus the ratchet budget; no production code is touched.

(Sent by Claude)
