### PR TITLE
ci: grant the checks workflow the checks:write token scope

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Pin the GITHUB_TOKEN scopes this workflow needs. The
+# mikepenz/action-junit-report steps below create check runs ("backend pytest"
+# and "sculpt CLI pytest"), which requires `checks: write`. Without this block
+# the job inherits the repository's default token permission; when that default
+# is read-only the action 403s ("Resource not accessible by integration") and
+# the required checks never get reported, leaving PRs stuck on a pending status.
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   checks-and-unit-tests:
     name: checks + unit tests


### PR DESCRIPTION
## What

Add a top-level `permissions:` block to the `checks` workflow granting `contents: read` and `checks: write`.

## Why

The `checks` workflow's two `mikepenz/action-junit-report` steps create the `backend pytest` and `sculpt CLI pytest` check runs. Creating a check run requires the `GITHUB_TOKEN` to carry the `checks: write` scope. The workflow declared no `permissions:` block, so it inherited the repository's default token permissions — and when that default is read-only, the action fails with `Resource not accessible by integration` and the check runs are never reported.

Because `sculpt CLI pytest` is a required status check, a run that never reports it leaves the check sitting indefinitely as a pending "Expected" status, blocking the PR even though the workflow job itself completed green. (`backend pytest` hit the same failure but isn't currently a required check, so its absence was invisible rather than blocking.)

Pinning the scopes the workflow actually needs — `contents: read` for checkout, `checks: write` for the report steps — makes it independent of the repo-level default.

## Scope

This fixes only the workflow side. Adjusting the repository's default workflow-token permission and/or making `backend pytest` a required check are repo-settings changes handled separately.

(Sent by Claude)