### PR TITLE
ci: run required checks on merge_group so the merge queue can merge

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ name: checks
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -2,6 +2,7 @@ name: offload
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Problem

`main` is protected by a GitHub **merge queue** ruleset that requires these status checks: `checks + unit tests`, `sculpt CLI pytest`, `backend pytest`, and `offload integration tests`.

When a PR is added to the queue, GitHub builds a temporary `gh-readonly-queue/main/...` ref and dispatches a **`merge_group`** event. The required checks must run *and pass on that ref* for the entry to merge.

But `checks.yml` and `offload.yml` only triggered on `pull_request` and `push`. With no workflow listening for `merge_group`, the required checks never reported on queued entries — so a PR could be fully green as a PR, get enqueued, and then sit in the queue until it timed out (`check_response_timeout_minutes: 60`) and was evicted, never merging.

## Fix

Add a `merge_group:` trigger to both workflows so the required checks run on the queued ref and the queue can complete merges:

- `checks.yml` → `checks + unit tests`, `backend pytest`, `sculpt CLI pytest`
- `offload.yml` → `offload integration tests`

The existing job-level conditions are merge-queue-safe: the offload job's `if` short-circuits true for non-`pull_request` events, and the `cancel-in-progress` concurrency setting stays off for `merge_group`.

## Note on landing this

There is a chicken-and-egg here: this fix cannot merge through the broken queue itself. It needs an admin to bypass the `main` ruleset and merge directly (`gh pr merge --merge --admin`). Once it lands, the queue works for everyone.

(Sent by Claude)
