### PR TITLE
Harden pi install instructions for managed provisioning

### DIFF
--- a/justfile
+++ b/justfile
@@ -841,16 +841,16 @@ install:
     just install-build-deps
     just install-backend
     just install-frontend
-    just install-pi
+    # pi is not installed here: Sculptor provisions it in MANAGED mode (the
+    # default). Run `just install-pi` only for a CUSTOM or real_pi dev setup.
 
-# Downloads the pinned, self-contained pi binary from GitHub Releases.
-# pi ships standalone per-platform binaries (no Node needed) at
-# github.com/earendil-works/pi; we install the version Sculptor's
-# PI_VERSION_RANGE pins. The binary loads sibling files (package.json, wasm,
-# theme/) relative to its real path, so we keep the whole release tree under
-# .venv/pi and symlink the binary into .venv/bin — which `uv run` puts first on
-# PATH, so the backend's `which pi` resolves to this pinned build. Auto-update /
-# managed provisioning is a deferred followup; this is the dev stopgap.
+# Installs the pinned, self-contained pi binary from GitHub Releases into
+# .venv/pi (the whole release tree — the binary loads sibling files like
+# package.json/wasm/theme relative to its real path) and symlinks it into
+# .venv/bin, which `uv run` puts first on PATH so a CUSTOM `pi` resolves to it.
+# We install the version PI_VERSION_RANGE pins. Sculptor provisions pi itself
+# in MANAGED mode (the default), so this is NOT part of `just install`/`rebuild`.
+# Opt-in dev helper: for a CUSTOM pi against .venv/bin/pi, or the real_pi suite.
 [group("install")]
 install-pi:
     #!/usr/bin/env bash
@@ -1404,12 +1404,13 @@ test-real-claude tests="sculptor/tests/integration/real_claude/" buildargs="": b
     }
     quiet_by_default test-real-claude _do_test_real_claude
 
-# Runs real pi integration tests (requires a locally installed `pi` binary at
-# the pinned version and ANTHROPIC_API_KEY). These tests hit the real upstream
-# model through real pi and are excluded from CI. Run serially by default.
+# Runs real pi integration tests (require ANTHROPIC_API_KEY). These tests hit
+# the real upstream model through real pi and are excluded from CI. The
+# `install-pi` dependency puts the pinned pi on PATH (.venv/bin/pi), which the
+# real_pi resolver requires. Run serially by default.
 # Set XDIST_WORKERS to override (e.g. XDIST_WORKERS=2 for parallel).
 [group("test")]
-test-real-pi tests="sculptor/tests/integration/real_pi/" buildargs="": build-frontend generate-sculpt-client
+test-real-pi tests="sculptor/tests/integration/real_pi/" buildargs="": install-pi build-frontend generate-sculpt-client
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "${JUST_VERBOSE:-}" != "1" ] && [ -z "${JUST_LOG_FILE:-}" ]; then

--- a/sculptor/frontend/src/pages/settings/components/PiSettingsSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiSettingsSection.tsx
@@ -80,6 +80,11 @@ export const PiSettingsSection = ({
 
   const pinnedVersion = pi?.versionRange?.recommendedVersion ?? null;
   const statusTooltip = pi?.versionRange ? `Pinned version: ${pi.versionRange.recommendedVersion}` : undefined;
+  const customInstallWarning =
+    "Not recommended — Sculptor ships pi for you. Switch Binary Source to Managed to install the " +
+    "pinned version automatically. A self-installed pi must match the pinned version" +
+    (pinnedVersion ? ` (${pinnedVersion})` : "") +
+    " exactly, or Sculptor will refuse to run it.";
 
   return (
     <SettingsSectionLayout description="Pi is an experimental second agent harness. Workspaces created with pi run pi as a subprocess and stream its responses; pi is pinned to a single version to keep the RPC schema known.">
@@ -271,12 +276,23 @@ export const PiSettingsSection = ({
       {displayMode === "CUSTOM" && (
         <SettingRow
           title="Install pi"
-          description="Sculptor does not bundle pi. Install the pinned version with one of the following commands."
+          description="Managed mode installs and version-pins pi for you. Only self-install if you have a specific reason."
         >
           <Box>
             <Flex direction="column" gap="2">
-              <Code size="2">npm install -g @earendil-works/pi-coding-agent</Code>
-              <Code size="2">curl -fsSL https://pi.dev/install.sh | sh</Code>
+              <Callout.Root color="orange">
+                <Callout.Icon>
+                  <ExclamationTriangleIcon />
+                </Callout.Icon>
+                <Callout.Text>{customInstallWarning}</Callout.Text>
+              </Callout.Root>
+              {pinnedVersion ? (
+                <Code size="2">npm install -g @earendil-works/pi-coding-agent@{pinnedVersion}</Code>
+              ) : (
+                <Text size="2" color="gray">
+                  Pinned version unavailable — use Managed mode to install pi.
+                </Text>
+              )}
             </Flex>
           </Box>
         </SettingRow>

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -980,6 +980,8 @@ def test_start_raises_pi_version_mismatch_when_out_of_range() -> None:
         agent.start(secrets={})
     assert exc_info.value.pinned_version == "0.78.0"
     assert exc_info.value.detected_version == "0.50.0"
+    # The message must point the user at the self-healing fix (managed install).
+    assert "Managed" in str(exc_info.value)
 
 
 def test_check_pi_version_reads_version_from_stderr_only_emission() -> None:

--- a/sculptor/sculptor/interfaces/agents/errors.py
+++ b/sculptor/sculptor/interfaces/agents/errors.py
@@ -61,10 +61,12 @@ class PiVersionMismatchError(AgentClientError):
     """
 
     def __init__(self, detected_version: str, pinned_version: str) -> None:
-        super().__init__(
-            f"Pi version {detected_version} is outside the pinned range (expected {pinned_version}).",
-            exit_code=None,
+        message = (
+            f"Pi version {detected_version} is outside the pinned range (expected {pinned_version}). "
+            + "Set the pi Binary Source to Managed in Settings to install the pinned version "
+            + f"automatically, or point pi at a {pinned_version} build."
         )
+        super().__init__(message, exit_code=None)
         self.detected_version = detected_version
         self.pinned_version = pinned_version
 

--- a/sculptor/sculptor/testing/elements/settings_pi.py
+++ b/sculptor/sculptor/testing/elements/settings_pi.py
@@ -57,7 +57,7 @@ class PlaywrightPiSettingsElement(PlaywrightIntegrationTestElement):
         return self.get_by_test_id(ElementIDs.PI_SETTINGS_DISABLED_BANNER)
 
     def get_install_commands_block(self) -> Locator:
-        """Get the CUSTOM-only manual npm/curl install block.
+        """Get the CUSTOM-only manual npm install block.
 
         The block carries no test id; the npm command text is the only place it
         renders, so its text identifies it (and its absence under MANAGED).

--- a/sculptor/tests/integration/frontend/test_pi_managed_install.py
+++ b/sculptor/tests/integration/frontend/test_pi_managed_install.py
@@ -98,7 +98,7 @@ def test_pi_settings_managed_shows_managed_controls_and_no_manual_install(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
     """Under MANAGED the section shows the Binary-Source selector + a managed
-    install control, hides the npm/curl manual block, and shows no auth surface."""
+    install control, hides the npm manual block, and shows no auth surface."""
     _set_pi_config(sculptor_instance_factory_, "MANAGED")
     _stage_fake_pi_managed_binary(sculptor_instance_factory_)
 
@@ -117,7 +117,7 @@ def test_pi_settings_managed_shows_managed_controls_and_no_manual_install(
         expect(pi_section.get_up_to_date()).to_contain_text("Pinned")
         expect(pi_section.get_install_button().or_(pi_section.get_up_to_date())).to_be_visible()
 
-        # The manual npm/curl block is CUSTOM-only and must be hidden here.
+        # The manual npm block is CUSTOM-only and must be hidden here.
         expect(pi_section.get_install_commands_block()).to_have_count(0)
 
         # pi authenticates via env-var injection; no sign-in surface (REQ-SVC-4).
@@ -128,7 +128,7 @@ def test_pi_settings_managed_shows_managed_controls_and_no_manual_install(
 def test_pi_settings_custom_shows_binary_path_and_manual_install(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
-    """Under CUSTOM the section shows the binary-path field and the npm/curl block."""
+    """Under CUSTOM the section shows the binary-path field and the npm block."""
     _set_pi_config(sculptor_instance_factory_, "CUSTOM")
 
     with sculptor_instance_factory_.spawn_instance() as instance:


### PR DESCRIPTION
## What & why

pi now defaults to **MANAGED** provisioning: Sculptor downloads, version-pins, verifies, and (under the multi-harness experiment) auto-installs the pinned pi build itself. Several places still instructed users and developers to self-install pi, and that guidance conflicted with managed provisioning — most visibly, the in-app instructions installed a version Sculptor would then refuse to launch. This PR reconciles the install guidance with the managed-pi reality. (Ref: SCU-1471)

## Changes

**1. Pin and de-emphasize the custom pi install instructions** — `PiSettingsSection.tsx`
The Custom-mode panel told users to run an *unpinned* `npm install -g @earendil-works/pi-coding-agent` and `curl … | sh`, both of which install pi's *latest* release. Sculptor pins pi to one exact version and refuses any other, so following these produced a pi the harness immediately rejected. Now it shows a single **version-pinned** npm command, drops the curl installer (it has no version-selection mechanism — latest only), adds a "not recommended — Sculptor ships pi for you" warning, and corrects the stale "does not bundle pi" copy.

**2. Make `install-pi` an opt-in dev helper** — `justfile`
The Managed default never consults `PATH`, yet `just install`/`rebuild` still downloaded a second pi into `.venv/bin` that the default ignores. Removed `install-pi` from the default chain, rewrote its now-false comment, and added it as a dependency of `test-real-pi` so the real_pi flow still gets the pinned pi on `PATH`.

**3. Make the pi version-mismatch error actionable** — `errors.py`
`PiVersionMismatchError` now tells the user to switch the pi Binary Source to **Managed** for an automatic pinned install (the self-healing fix), instead of only reporting the version numbers.

## Testing

- `just format` + `just check` — green
- Backend unit suite (Offload) — 1361 passed
- `just test-real-pi` — passed (exercises the new `install-pi` dependency end-to-end)

(`test-real-claude` was not run to completion in this environment — no managed Claude binary was available, which blocks the suite's onboarding gate during setup. This is unrelated to these pi-only changes; the same onboarding gate passes for real_pi, whose dependency is installed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
