### PR TITLE
Fix thick horizontal scrollbar in chat panel on resize

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.module.scss
@@ -22,7 +22,15 @@
 
 .scrollContainer {
   height: 100%;
-  overflow-y: auto;
+  // The chat scrolls vertically only. Without an explicit `overflow-x`, the
+  // spec promotes the default `visible` to `auto` whenever `overflow-y` is
+  // non-visible — so any transient horizontal overflow (e.g. a wide table or
+  // long inline-code line measured before layout settles) surfaces a thick,
+  // unstyled horizontal scrollbar (the vertical `thin-scrollbar` mixin only
+  // sizes the scrollbar width, not height). Pin it hidden: tables and code
+  // blocks carry their own inner horizontal scroll containers, so nothing
+  // legitimate is clipped.
+  overflow: hidden auto;
   position: relative;
   width: 100%;
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaMarkdownBlock.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaMarkdownBlock.module.scss
@@ -4,8 +4,12 @@
   font-family: var(--default-font-family);
   font-size: var(--font-size-2);
   line-height: var(--chat-line-height);
-  overflow-wrap: break-word;
-  word-break: break-word;
+  // `anywhere` (not `break-word`) so long unbreakable tokens — file paths,
+  // env-var names, multiple inline `code` spans on one line — also collapse
+  // the min-content width. `break-word` only breaks visually and leaves
+  // min-content at the longest token, which lets the content force the chat
+  // column wider than its container (horizontal overflow).
+  overflow-wrap: anywhere;
 
   // First child should not have top margin
   > :first-child {


### PR DESCRIPTION
## Summary

Fixes a thick, unstyled horizontal scrollbar that could appear across the whole chat panel — most reliably when the chat is resized narrower (e.g. opening a file and dragging the splitter) while a message contains long, unbreakable inline-code tokens (file paths, env-var names, or several `code` spans on one line).

## Root cause

- `.scrollContainer` set only `overflow-y: auto`. Per the CSS overflow rules, a `visible` axis computes to `auto` when the other axis is non-visible, so `overflow-x` silently became `auto`. Any transient horizontal overflow — a row laid out wider than its column before layout settles during a resize — then surfaced a horizontal scrollbar, rendered at full default thickness because the shared `thin-scrollbar` mixin only sizes the vertical scrollbar's width (never the horizontal one's height).
- `.markdownBlock` used `overflow-wrap: break-word` (plus the legacy `word-break: break-word`), which breaks long tokens visually but does **not** collapse the element's min-content width — so the content could still force the column wider than its container.

## Fix

- `.scrollContainer`: pin `overflow-x: hidden` — the chat scrolls vertically only. Tables and code blocks carry their own inner horizontal scroll containers, so nothing legitimate is clipped.
- `.markdownBlock`: switch to `overflow-wrap: anywhere`, which collapses the min-content width so long tokens wrap instead of forcing horizontal overflow.

## Before / after

<img width="936" height="1014" alt="CleanShot 2026-06-12 at 18 03 38" src="https://github.com/user-attachments/assets/c6f6f676-0f8f-4852-bd63-e34f6fe10bf4" />

<img width="660" height="627" alt="CleanShot 2026-06-12 at 18 04 03" src="https://github.com/user-attachments/assets/d3f794b4-95af-4709-a293-e3f46133e67e" />

## Testing

- `just format`, `just check`, and `just test-unit` all pass.
- Reproduced and verified end-to-end in the running app: with the fix reverted, shrinking the chat via the splitter produced the thick scrollbar; with the fix applied, the same action wraps cleanly with no scrollbar.

(Sent by Claude)
