### PR TITLE
pi: support /clear context reset via new_session

### DIFF
--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -100,18 +100,22 @@ from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
 from sculptor.interfaces.agents.agent import ClearContextUserMessage
+from sculptor.interfaces.agents.agent import ContextClearedMessage
 from sculptor.interfaces.agents.agent import InterruptProcessUserMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
 from sculptor.interfaces.agents.agent import PiAgentConfig
 from sculptor.interfaces.agents.agent import PlanModeAgentMessage
+from sculptor.interfaces.agents.agent import RemoveQueuedMessageUserMessage
 from sculptor.interfaces.agents.agent import RequestSkippedAgentMessage
 from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
+from sculptor.interfaces.agents.agent import StopAgentUserMessage
 from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
 from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_SHUTDOWN_DUE_TO_EXCEPTION
 from sculptor.interfaces.agents.errors import AgentCrashed
 from sculptor.interfaces.agents.errors import PiBinaryNotFoundError
+from sculptor.interfaces.agents.errors import PiContextResetError
 from sculptor.interfaces.agents.errors import PiCrashError
 from sculptor.interfaces.agents.errors import PiVersionMismatchError
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
@@ -157,12 +161,14 @@ FILE_CHANGE_TOOL_NAMES: frozenset[str] = frozenset({"edit", "write", "bash"})
 PI_SESSION_DIR_NAME: str = "pi_session"
 PI_SESSION_ID_STATE_FILE: str = "pi_session_id"
 
-# Control messages for capabilities pi does not support; `_push_message` drops
-# them (pi has no RPC equivalent) and logs each at error level — the frontend
-# gate should keep them from reaching pi, so one arriving means a gate has
-# failed. Each maps to the capability whose handler will replace its drop:
-#   ClearContextUserMessage          → supports_context_reset
-_DEAD_LETTER_MESSAGE_TYPES: tuple[type[Message], ...] = (ClearContextUserMessage,)
+# Control messages that legitimately reach the end of `_push_message` without pi
+# handling them: the base class handles these after the False return (see
+# DefaultAgentWrapper.push_message). Pi recognizes them as handled-elsewhere, so
+# they are NOT dead-lettered; anything else reaching the end has no handler.
+_BASE_CLASS_HANDLED_MESSAGE_TYPES: tuple[type[Message], ...] = (
+    StopAgentUserMessage,
+    RemoveQueuedMessageUserMessage,
+)
 
 # If pi's abort-induced `agent_end` does not arrive within this grace window
 # (pi wedged or ignoring the abort), escalate to SIGTERM; the process-exit
@@ -185,6 +191,13 @@ You are in plan mode. Investigate the request using read-only tools only (read f
 
 The user's request follows:
 """
+
+# How long the context-reset handler waits for pi's `new_session` acknowledgement
+# before treating the reset as failed. Kept well under the frontend's 30s clear
+# call budget (ChatInput.tsx `wsTimeout`) so a wedged `new_session` fails loudly
+# rather than hanging the UI; the `new_session` round-trip is otherwise sub-second
+# (it is a between-turns command, not an agent run).
+_CLEAR_CONTEXT_TIMEOUT_SECONDS: float = 10.0
 
 
 def _pi_version_in_range(version: str) -> bool:
@@ -307,7 +320,9 @@ class PiAgent(DefaultAgentWrapper):
     harness: PiHarness
     config: PiAgentConfig
     git_hash: str
-    _input_agent_messages: Queue[ChatInputUserMessage] = PrivateAttr(default_factory=Queue)
+    # Carries chat turns AND between-turns context resets through one FIFO so a
+    # `/clear` runs strictly after any in-flight turn (see _process_message_queue).
+    _input_agent_messages: Queue[ChatInputUserMessage | ClearContextUserMessage] = PrivateAttr(default_factory=Queue)
     _shutdown_event: Event = PrivateAttr(default_factory=Event)
     _message_processing_thread: ObservableThread | None = PrivateAttr(default=None)
     # The pi session id this process resumes / creates (pinned via --session-id);
@@ -387,11 +402,10 @@ class PiAgent(DefaultAgentWrapper):
         # resumable id behind. The session dir is per-task (the state path already
         # is) so parallel pi workspaces never share a session.
         #
-        # NOTE for phase 04 (context reset): `new_session` starts a fresh session
-        # id within this dir. When that handler lands it MUST overwrite
-        # PI_SESSION_ID_STATE_FILE with the new id (read it back via get_state /
-        # session_info_changed) so a later resume targets the post-clear session,
-        # not this one.
+        # The context-reset path (`/clear`) sends `new_session`, which starts a
+        # fresh session id within this dir; `_handle_clear_context` overwrites
+        # PI_SESSION_ID_STATE_FILE with that new id (read back via get_state) so a
+        # later resume targets the post-clear session, not this one.
         session_dir = self.environment.get_state_path() / PI_SESSION_DIR_NAME
         persisted_session_id = get_state_file_contents(self.environment, PI_SESSION_ID_STATE_FILE)
         is_resume = persisted_session_id is not None
@@ -454,6 +468,11 @@ class PiAgent(DefaultAgentWrapper):
         if isinstance(message, ChatInputUserMessage):
             self._input_agent_messages.put(message)
             return True
+        if isinstance(message, ClearContextUserMessage):
+            # Enqueued on the same FIFO as chat turns so the reset runs strictly
+            # between turns (see _handle_clear_context); supports_context_reset.
+            self._input_agent_messages.put(message)
+            return True
         if isinstance(message, ResumeAgentResponseRunnerMessage):
             # The previous pi process died mid-turn: the in-flight chat message
             # got a RequestStarted but never a terminal RequestSuccess, so the
@@ -499,18 +518,20 @@ class PiAgent(DefaultAgentWrapper):
             # `_try_deliver_answer_to_mcp`), not queued like a new prompt.
             self._deliver_question_answer(message)
             return True
-        if isinstance(message, _DEAD_LETTER_MESSAGE_TYPES):
-            # See _DEAD_LETTER_MESSAGE_TYPES. Returns False so the base class's
-            # generic handling still runs.
+        # Belt-and-suspenders dead-letter: every control message pi supports is
+        # handled above (return True), and the base class handles the types in
+        # _BASE_CLASS_HANDLED_MESSAGE_TYPES after this False return. Anything else
+        # reaching here has no handler and the base class would drop it silently —
+        # almost certainly a frontend capability gate let through something pi
+        # cannot do. Log it loudly. We enumerate what we DO handle and reject the
+        # rest, rather than listing unsupported types ahead of time: you cannot
+        # enumerate the messages you do not yet know about.
+        if not isinstance(message, _BASE_CLASS_HANDLED_MESSAGE_TYPES):
             logger.error(
-                "PiAgent dropping unsupported control message {} for task {} — a frontend capability gate should have prevented it",
+                "PiAgent dropping unhandled control message {} for task {} — a frontend capability gate should have prevented it",
                 type(message).__name__,
                 self.task_id,
             )
-            return False
-        # StopAgentUserMessage, RemoveQueuedMessageUserMessage, and
-        # ManualSyncMergeIntoAgentAttemptedMessage are handled by the base class
-        # after this False return — handled, not dropped, so not dead-lettered.
         return False
 
     def poll(self) -> int | None:
@@ -702,19 +723,21 @@ class PiAgent(DefaultAgentWrapper):
             except Exception as e:  # noqa: BLE001
                 logger.debug("PiAgent write_stdin failed: {}", e)
 
-    def _request_state_blocking(self, timeout: float = 10.0) -> dict[str, Any] | None:
-        """Send `get_state` and return pi's reported `RpcSessionState` data (RPC §5.1).
+    def _consume_until_command_response(self, command: str, command_id: str, timeout: float) -> RpcResponse | None:
+        """Drain pi's stdout until the `response` for (command, command_id) arrives.
 
-        Reads pi's stdout queue directly, so it is ONLY safe to call before the
-        message-processing thread starts (start-time resume verification) — both
-        drain the same queue. Returns None on timeout / process exit / no
-        matching response.
+        Correlates by id (RPC §5.1), skipping any session events pi emits
+        meanwhile; returns None on timeout / process exit. Used for the
+        between-turns control commands this harness issues directly (`get_state`,
+        `new_session`). It reads the process queue, so it is ONLY safe when it is
+        the SOLE reader of that queue: before the message-processing thread starts
+        (start-time resume verification), or from within that thread between turns
+        (the context-reset handler). Never call it while a turn is streaming — the
+        turn pump (`_consume_until_turn_end`) would race it for the same queue.
         """
         process = self._process
         if process is None:
             return None
-        request_id = generate_id()
-        self._send_rpc({"type": "get_state", "id": request_id})
         out_queue = process.get_queue()
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -733,15 +756,27 @@ class PiAgent(DefaultAgentWrapper):
                 event = json.loads(stripped)
             except json.JSONDecodeError:
                 continue
-            if (
-                isinstance(event, dict)
-                and event.get("type") == "response"
-                and event.get("command") == "get_state"
-                and event.get("id") == request_id
-            ):
-                data = event.get("data")
-                return data if isinstance(data, dict) else None
+            if not isinstance(event, dict):
+                continue
+            parsed = parse_rpc_message(event)
+            if isinstance(parsed, RpcResponse) and parsed.command == command and parsed.id == command_id:
+                return parsed
         return None
+
+    def _request_state_blocking(self, timeout: float = 10.0) -> dict[str, Any] | None:
+        """Send `get_state` and return pi's reported `RpcSessionState` data (RPC §5.1).
+
+        Returns None on timeout / process exit / no matching response. Shares the
+        sole-reader safety constraint of `_consume_until_command_response`.
+        """
+        if self._process is None:
+            return None
+        request_id = generate_id()
+        self._send_rpc({"type": "get_state", "id": request_id})
+        response = self._consume_until_command_response("get_state", request_id, timeout)
+        if response is None or not isinstance(response.data, dict):
+            return None
+        return response.data
 
     def _verify_resumed_session(self, expected_session_id: str) -> None:
         """Confirm pi resumed the persisted session; log loud on any anomaly.
@@ -847,6 +882,11 @@ class PiAgent(DefaultAgentWrapper):
                 message = self._input_agent_messages.get(timeout=0.5)
             except queue.Empty:
                 continue
+            if isinstance(message, ClearContextUserMessage):
+                # Between-turns reset: this loop processes one message at a time,
+                # so reaching here means any prior turn already ended.
+                self._handle_clear_context(message)
+                continue
             self._run_prompt_turn(message)
 
     def _run_prompt_turn(self, message: ChatInputUserMessage) -> None:
@@ -941,6 +981,80 @@ class PiAgent(DefaultAgentWrapper):
             self._output_messages.put(
                 RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=request_id, interrupted=interrupted)
             )
+
+    def _handle_clear_context(self, message: ClearContextUserMessage) -> None:
+        """Reset the conversation in-process via pi's `new_session` (`/clear`).
+
+        Routed through the same `_input_agent_messages` FIFO as chat turns, so it
+        runs strictly between turns: a `/clear` that arrives mid-turn waits for the
+        in-flight turn's `agent_end` before `new_session` is sent. That is exactly
+        pi's contract — `new_session` is a between-turns command — and the queue
+        gives the ordering for free. The clear-context endpoint's
+        `await_message_response` resolves on the terminal request message
+        `_handle_user_message` emits: RequestSuccess on a clean reset, RequestFailure
+        on the error path below.
+
+        `new_session` clears history while preserving the model and thinking-level
+        selections (no process restart). On success pi mints a fresh session id;
+        because Sculptor resumes pi by id (`supports_session_resume`), the post-clear
+        id is read back and persisted (`_persist_post_clear_session_id`) — otherwise a
+        later restart would resume the PRE-clear session and silently undo the reset.
+        A `success:false` response, a `data.cancelled:true` veto (an extension's
+        `session_before_switch` declining — none are loaded today, handled
+        defensively), or no acknowledgement within `_CLEAR_CONTEXT_TIMEOUT_SECONDS`
+        is a failed reset, raised as `PiContextResetError` so the wrapper reports the
+        failure without killing the agent (the conversation is intact; the user can
+        retry).
+        """
+        with self._handle_user_message(message):
+            command_id = generate_id()
+            self._send_rpc({"type": "new_session", "id": command_id})
+            response = self._consume_until_command_response(
+                "new_session", command_id, timeout=_CLEAR_CONTEXT_TIMEOUT_SECONDS
+            )
+            if response is None:
+                raise PiContextResetError(
+                    "pi did not acknowledge new_session within the timeout", exit_code=None, metadata=None
+                )
+            if not response.success:
+                raise PiContextResetError(response.error or "pi rejected new_session", exit_code=None, metadata=None)
+            if response.data is not None and response.data.get("cancelled"):
+                raise PiContextResetError(
+                    "pi cancelled new_session (an extension vetoed the context reset)",
+                    exit_code=None,
+                    metadata=None,
+                )
+            self._persist_post_clear_session_id()
+            # UX parity with Claude's clear (process_manager._process_clear_context_message):
+            # the same ContextClearedMessage drives the "Context Cleared" chip — no
+            # bespoke pi chrome.
+            self._output_messages.put(ContextClearedMessage(message_id=AgentMessageID()))
+
+    def _persist_post_clear_session_id(self) -> None:
+        """After a successful `new_session`, persist pi's new session id.
+
+        `new_session` starts a fresh session whose id differs from the pre-clear
+        one; a later resume must target THAT id (see `start`). Read it back via
+        `get_state` and overwrite PI_SESSION_ID_STATE_FILE. If the new id cannot be
+        read (no/empty `get_state` response), log loud and keep the old id: the
+        reset still succeeded for THIS process — only a subsequent restart-resume
+        could regress to the pre-clear session, the same best-effort stance as
+        `_verify_resumed_session`.
+        """
+        state = self._request_state_blocking()
+        new_session_id = state.get("sessionId") if state is not None else None
+        if not isinstance(new_session_id, str) or not new_session_id:
+            logger.error(
+                "PiAgent could not read the post-clear pi session id (no get_state response); "
+                "a later resume may regress to the pre-clear session",
+            )
+            return
+        self._session_id = new_session_id
+        self.environment.write_file(
+            str(self.environment.get_state_path() / PI_SESSION_ID_STATE_FILE),
+            new_session_id,
+        )
+        logger.info("PiAgent persisted post-clear pi session id {}", new_session_id)
 
     def _consume_until_turn_end(self, prompt_id: str = "") -> None:
         """Drive pi's stdout until the current agent run terminates.

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -192,11 +192,9 @@ You are in plan mode. Investigate the request using read-only tools only (read f
 The user's request follows:
 """
 
-# How long the context-reset handler waits for pi's `new_session` acknowledgement
-# before treating the reset as failed. Kept well under the frontend's 30s clear
-# call budget (ChatInput.tsx `wsTimeout`) so a wedged `new_session` fails loudly
-# rather than hanging the UI; the `new_session` round-trip is otherwise sub-second
-# (it is a between-turns command, not an agent run).
+# How long the context-reset handler waits for `new_session` to be acknowledged
+# before treating the reset as failed. Under the frontend's 30s clear-call budget
+# (ChatInput.tsx `wsTimeout`) so a wedged `new_session` fails rather than hanging the UI.
 _CLEAR_CONTEXT_TIMEOUT_SECONDS: float = 10.0
 
 
@@ -518,14 +516,11 @@ class PiAgent(DefaultAgentWrapper):
             # `_try_deliver_answer_to_mcp`), not queued like a new prompt.
             self._deliver_question_answer(message)
             return True
-        # Belt-and-suspenders dead-letter: every control message pi supports is
-        # handled above (return True), and the base class handles the types in
+        # Dead-letter: every control message pi supports is handled above
+        # (return True), and the base class handles the types in
         # _BASE_CLASS_HANDLED_MESSAGE_TYPES after this False return. Anything else
-        # reaching here has no handler and the base class would drop it silently —
-        # almost certainly a frontend capability gate let through something pi
-        # cannot do. Log it loudly. We enumerate what we DO handle and reject the
-        # rest, rather than listing unsupported types ahead of time: you cannot
-        # enumerate the messages you do not yet know about.
+        # reaching here has no handler and would be dropped silently — likely a
+        # frontend capability gate let something through pi cannot do — so log it.
         if not isinstance(message, _BASE_CLASS_HANDLED_MESSAGE_TYPES):
             logger.error(
                 "PiAgent dropping unhandled control message {} for task {} — a frontend capability gate should have prevented it",
@@ -985,26 +980,21 @@ class PiAgent(DefaultAgentWrapper):
     def _handle_clear_context(self, message: ClearContextUserMessage) -> None:
         """Reset the conversation in-process via pi's `new_session` (`/clear`).
 
-        Routed through the same `_input_agent_messages` FIFO as chat turns, so it
-        runs strictly between turns: a `/clear` that arrives mid-turn waits for the
-        in-flight turn's `agent_end` before `new_session` is sent. That is exactly
-        pi's contract — `new_session` is a between-turns command — and the queue
-        gives the ordering for free. The clear-context endpoint's
+        Routed through the `_input_agent_messages` FIFO like chat turns, so it runs
+        between turns: a `/clear` arriving mid-turn waits for the in-flight turn's
+        `agent_end` before `new_session` is sent. The clear-context endpoint's
         `await_message_response` resolves on the terminal request message
-        `_handle_user_message` emits: RequestSuccess on a clean reset, RequestFailure
-        on the error path below.
+        `_handle_user_message` emits — RequestSuccess on a clean reset,
+        RequestFailure on the error path below.
 
         `new_session` clears history while preserving the model and thinking-level
-        selections (no process restart). On success pi mints a fresh session id;
-        because Sculptor resumes pi by id (`supports_session_resume`), the post-clear
-        id is read back and persisted (`_persist_post_clear_session_id`) — otherwise a
-        later restart would resume the PRE-clear session and silently undo the reset.
-        A `success:false` response, a `data.cancelled:true` veto (an extension's
-        `session_before_switch` declining — none are loaded today, handled
-        defensively), or no acknowledgement within `_CLEAR_CONTEXT_TIMEOUT_SECONDS`
-        is a failed reset, raised as `PiContextResetError` so the wrapper reports the
-        failure without killing the agent (the conversation is intact; the user can
-        retry).
+        selections (no process restart). It mints a fresh session id; since Sculptor
+        resumes pi by id (`supports_session_resume`), that id is read back and
+        persisted (`_persist_post_clear_session_id`) so a later resume targets the
+        post-clear session. A `success:false` response, a `data.cancelled:true` veto
+        (an extension's `session_before_switch`), or no acknowledgement within
+        `_CLEAR_CONTEXT_TIMEOUT_SECONDS` is a failed reset, raised as
+        `PiContextResetError` (an `AgentClientError`, so the agent keeps running).
         """
         with self._handle_user_message(message):
             command_id = generate_id()
@@ -1025,21 +1015,16 @@ class PiAgent(DefaultAgentWrapper):
                     metadata=None,
                 )
             self._persist_post_clear_session_id()
-            # UX parity with Claude's clear (process_manager._process_clear_context_message):
-            # the same ContextClearedMessage drives the "Context Cleared" chip — no
-            # bespoke pi chrome.
+            # Same ContextClearedMessage as Claude's clear — drives the "Context Cleared" chip.
             self._output_messages.put(ContextClearedMessage(message_id=AgentMessageID()))
 
     def _persist_post_clear_session_id(self) -> None:
         """After a successful `new_session`, persist pi's new session id.
 
-        `new_session` starts a fresh session whose id differs from the pre-clear
-        one; a later resume must target THAT id (see `start`). Read it back via
-        `get_state` and overwrite PI_SESSION_ID_STATE_FILE. If the new id cannot be
-        read (no/empty `get_state` response), log loud and keep the old id: the
-        reset still succeeded for THIS process — only a subsequent restart-resume
-        could regress to the pre-clear session, the same best-effort stance as
-        `_verify_resumed_session`.
+        `new_session` mints a fresh session id; a later resume must target it (see
+        `start`). Read it back via `get_state` and overwrite PI_SESSION_ID_STATE_FILE.
+        If it cannot be read (no/empty `get_state` response), log and keep the old id
+        — the reset still applied to the running process.
         """
         state = self._request_state_blocking()
         new_session_id = state.get("sessionId") if state is not None else None

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -40,10 +40,14 @@ from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
 from sculptor.interfaces.agents.agent import ClearContextUserMessage
+from sculptor.interfaces.agents.agent import ContextClearedMessage
+from sculptor.interfaces.agents.agent import EphemeralUserMessage
 from sculptor.interfaces.agents.agent import InterruptProcessUserMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
 from sculptor.interfaces.agents.agent import PiAgentConfig
 from sculptor.interfaces.agents.agent import PlanModeAgentMessage
+from sculptor.interfaces.agents.agent import RemoveQueuedMessageUserMessage
+from sculptor.interfaces.agents.agent import RequestFailureAgentMessage
 from sculptor.interfaces.agents.agent import RequestSkippedAgentMessage
 from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
@@ -63,7 +67,6 @@ from sculptor.state.chat_state import ToolResultBlock
 from sculptor.state.chat_state import ToolUseBlock
 from sculptor.state.chat_state import make_plan_approval_question
 from sculptor.state.messages import ChatInputUserMessage
-from sculptor.state.messages import Message
 from sculptor.state.messages import ResponseBlockAgentMessage
 
 _PROMPT_ID = "prompt-1"
@@ -1284,33 +1287,27 @@ def test_push_message_enqueues_chat_input_returns_true() -> None:
     assert agent._input_agent_messages.get_nowait() is chat
 
 
-# The capability-correlated control messages pi cannot handle; each must be
-# dead-lettered (one logged error) and return unhandled.
-_DEAD_LETTER_MESSAGES: list[Message] = [
-    ClearContextUserMessage(),
-]
-
-
-@pytest.mark.parametrize("message", _DEAD_LETTER_MESSAGES, ids=lambda m: type(m).__name__)
-def test_push_message_dead_letters_unsupported_control_messages(message: Message) -> None:
+def test_push_message_dead_letters_unhandled_control_messages() -> None:
+    """A control message pi has no handler for — and that the base class won't
+    handle either — is dead-lettered: logged loudly and returned unhandled. This
+    is the inverse of an allowlist of unsupported types (impossible: you cannot
+    enumerate what you do not yet know about); pi recognizes what it handles and
+    rejects the rest. EphemeralUserMessage stands in for a future unsupported
+    control surface that reaches the end of `_push_message`."""
     agent = _make_agent()
-    # The dead-letter is logged at error level; the test harness intercepts and
-    # accumulates it. `expect_exact_logged_errors` asserts exactly one error is
-    # logged whose template carries the dead-letter text (the concrete message
-    # type is interpolated into the log args, which this harness does not match
-    # on — the per-type coverage comes from the parametrization).
-    with expect_exact_logged_errors(["PiAgent dropping unsupported control message"]):
-        handled = agent._push_message(message)
-    # Returns False so base-class generic handling still runs.
+    with expect_exact_logged_errors(["PiAgent dropping unhandled control message"]):
+        handled = agent._push_message(EphemeralUserMessage(object_type="UnsupportedForTest"))
     assert handled is False
 
 
 def test_push_message_does_not_dead_letter_base_class_handled_types() -> None:
-    """StopAgentUserMessage is handled by the base class after the False return, so it must NOT log a dead-letter error here."""
+    """StopAgent and RemoveQueued are handled by the base class after the False
+    return (see DefaultAgentWrapper.push_message), so they must NOT be
+    dead-lettered here."""
     agent = _make_agent()
     with expect_exact_logged_errors([]):
-        handled = agent._push_message(StopAgentUserMessage())
-    assert handled is False
+        assert agent._push_message(StopAgentUserMessage()) is False
+        assert agent._push_message(RemoveQueuedMessageUserMessage(target_message_id=AgentMessageID())) is False
 
 
 def test_push_message_resume_resolves_in_flight_request() -> None:
@@ -1330,6 +1327,149 @@ def test_push_message_resume_resolves_in_flight_request() -> None:
     assert isinstance(emitted, RequestSuccessAgentMessage)
     assert emitted.request_id == stuck_id
     assert emitted.interrupted is True
+
+
+def test_push_message_enqueues_clear_context_returns_true() -> None:
+    """A ClearContextUserMessage goes on the same FIFO as chat turns — handled, not dead-lettered."""
+    agent = _make_agent()
+    clear = ClearContextUserMessage(message_id=AgentMessageID())
+    with expect_exact_logged_errors([]):
+        handled = agent._push_message(clear)
+    assert handled is True
+    assert agent._input_agent_messages.get_nowait() is clear
+
+
+def _clear_env() -> MagicMock:
+    """A MagicMock environment whose state path supports the post-clear session-id write."""
+    env = MagicMock(spec=AgentExecutionEnvironment)
+    env.get_state_path.return_value = Path("/fake/state")
+    return env
+
+
+def test_clear_context_sends_new_session_persists_id_and_emits_cleared() -> None:
+    """A successful /clear sends new_session, persists the post-clear session id, emits ContextCleared + RequestSuccess."""
+    env = _clear_env()
+    agent = _make_agent(env)
+    agent._session_id = "old-session"
+    process = _make_process(
+        [
+            _event(
+                {
+                    "type": "response",
+                    "command": "new_session",
+                    "success": True,
+                    "id": "cmd-new",
+                    "data": {"cancelled": False},
+                }
+            ),
+            _event(
+                {
+                    "type": "response",
+                    "command": "get_state",
+                    "success": True,
+                    "id": "cmd-state",
+                    "data": {"sessionId": "new-session", "messageCount": 0},
+                }
+            ),
+        ]
+    )
+    agent._process = process
+    # generate_id is called for the new_session command id, then the get_state request id.
+    with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-new", "cmd-state"]):
+        agent._handle_clear_context(ClearContextUserMessage(message_id=AgentMessageID()))
+
+    # new_session was written to pi's stdin, id-correlated.
+    writes = [call.args[0] for call in process.write_stdin.call_args_list]
+    assert any('"type":"new_session"' in w and '"cmd-new"' in w for w in writes)
+    # The post-clear session id replaced the persisted one so a later resume targets it.
+    assert agent._session_id == "new-session"
+    env.write_file.assert_called_once_with(str(Path("/fake/state") / PI_SESSION_ID_STATE_FILE), "new-session")
+    # Emitted: ContextCleared (UX parity) + terminal RequestSuccess, no failure.
+    emitted = _drain(agent._output_messages)
+    assert any(isinstance(m, ContextClearedMessage) for m in emitted)
+    assert any(isinstance(m, RequestSuccessAgentMessage) for m in emitted)
+    assert not any(isinstance(m, RequestFailureAgentMessage) for m in emitted)
+
+
+def test_clear_context_failure_on_success_false_reports_without_crashing() -> None:
+    """new_session success:false → RequestFailure, no ContextCleared, no id rewrite, handler does not raise."""
+    env = _clear_env()
+    agent = _make_agent(env)
+    agent._process = _make_process(
+        [_event({"type": "response", "command": "new_session", "success": False, "id": "cmd-new", "error": "boom"})]
+    )
+    with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-new"]):
+        # Must NOT raise out of the handler — the AgentClientError path reports and continues.
+        agent._handle_clear_context(ClearContextUserMessage(message_id=AgentMessageID()))
+    emitted = _drain(agent._output_messages)
+    assert any(isinstance(m, RequestFailureAgentMessage) for m in emitted)
+    assert not any(isinstance(m, ContextClearedMessage) for m in emitted)
+    env.write_file.assert_not_called()
+
+
+def test_clear_context_failure_on_cancelled_veto() -> None:
+    """new_session success:true but data.cancelled:true (an extension veto) → failed reset."""
+    env = _clear_env()
+    agent = _make_agent(env)
+    agent._process = _make_process(
+        [
+            _event(
+                {
+                    "type": "response",
+                    "command": "new_session",
+                    "success": True,
+                    "id": "cmd-new",
+                    "data": {"cancelled": True},
+                }
+            )
+        ]
+    )
+    with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-new"]):
+        agent._handle_clear_context(ClearContextUserMessage(message_id=AgentMessageID()))
+    emitted = _drain(agent._output_messages)
+    assert any(isinstance(m, RequestFailureAgentMessage) for m in emitted)
+    assert not any(isinstance(m, ContextClearedMessage) for m in emitted)
+    env.write_file.assert_not_called()
+
+
+def test_clear_context_failure_on_no_response() -> None:
+    """No new_session ack (process exited / timeout) → failed reset, no crash."""
+    env = _clear_env()
+    agent = _make_agent(env)
+    # Empty queue + is_finished True ⇒ _consume_until_command_response returns None at once.
+    agent._process = _make_process([])
+    with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-new"]):
+        agent._handle_clear_context(ClearContextUserMessage(message_id=AgentMessageID()))
+    emitted = _drain(agent._output_messages)
+    assert any(isinstance(m, RequestFailureAgentMessage) for m in emitted)
+    assert not any(isinstance(m, ContextClearedMessage) for m in emitted)
+    env.write_file.assert_not_called()
+
+
+def test_clear_context_runs_after_an_in_flight_chat_turn() -> None:
+    """FIFO ordering: a /clear queued behind a chat turn runs after the turn ends.
+
+    Both go through `_input_agent_messages`, and `_process_message_queue` handles
+    one at a time, so the turn's `_consume_until_turn_end` completes before the
+    clear's `_handle_clear_context` is dispatched.
+    """
+    agent = _make_agent()
+    agent._process = MagicMock()
+    order: list[str] = []
+    with (
+        patch.object(agent, "_consume_until_turn_end", side_effect=lambda prompt_id="": order.append("turn")),
+        patch.object(agent, "_handle_clear_context", side_effect=lambda message: order.append("clear")),
+    ):
+        agent._input_agent_messages.put(ChatInputUserMessage(text="hi"))
+        agent._input_agent_messages.put(ClearContextUserMessage(message_id=AgentMessageID()))
+        worker = threading.Thread(target=agent._process_message_queue)
+        worker.start()
+        deadline = time.monotonic() + 5.0
+        while len(order) < 2 and time.monotonic() < deadline:
+            time.sleep(0.02)
+        agent._shutdown_event.set()
+        worker.join(timeout=5.0)
+    assert order == ["turn", "clear"]
 
 
 def _make_start_env(persisted_session_id: str | None = None) -> MagicMock:

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -86,9 +86,10 @@ class PiHarness(Harness):
             # "pi can carry images", not per-model.
             supports_image_input=True,
             supports_fast_mode=False,
-            # Pi drops ClearContextUserMessage (see agent_wrapper._push_message),
-            # so the `/clear` context-reset path is unavailable — false.
-            supports_context_reset=False,
+            # Pi handles ClearContextUserMessage by sending `new_session` between
+            # turns (see agent_wrapper._handle_clear_context), which clears history
+            # in-process while preserving model / thinking level — true.
+            supports_context_reset=True,
             # Pi emits compaction_start/end (agent_wrapper maps them onto the
             # AutoCompacting* message pair → StatusPill "Compacting"), and
             # autoCompactionEnabled defaults true. The TokenPopover threshold row

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -18,7 +18,7 @@ def test_pi_harness_capabilities() -> None:
         supports_sub_agents=False,
         supports_image_input=True,
         supports_fast_mode=False,
-        supports_context_reset=False,
+        supports_context_reset=True,
         supports_compaction=True,
         supports_background_tasks=False,
         supports_session_resume=True,

--- a/sculptor/sculptor/interfaces/agents/errors.py
+++ b/sculptor/sculptor/interfaces/agents/errors.py
@@ -74,12 +74,9 @@ class PiVersionMismatchError(AgentClientError):
 class PiContextResetError(AgentClientError):
     """Raised when pi's ``new_session`` (the ``/clear`` context-reset path) fails.
 
-    A failed reset (``success:false`` response, an extension's
-    ``session_before_switch`` veto returning ``data.cancelled:true``, or no
-    response within the budget) is a recoverable client error, NOT a crash: the
-    conversation is intact and the user can retry. Being an ``AgentClientError``
-    routes it through the wrapper's report-and-continue path, so the failed
-    request surfaces while the agent keeps running.
+    An ``AgentClientError`` rather than a crash: a failed reset (``success:false``,
+    a ``data.cancelled:true`` veto, or no response within the budget) is reported
+    as a failed request while the agent keeps running.
     """
 
 

--- a/sculptor/sculptor/interfaces/agents/errors.py
+++ b/sculptor/sculptor/interfaces/agents/errors.py
@@ -71,6 +71,18 @@ class PiVersionMismatchError(AgentClientError):
         self.pinned_version = pinned_version
 
 
+class PiContextResetError(AgentClientError):
+    """Raised when pi's ``new_session`` (the ``/clear`` context-reset path) fails.
+
+    A failed reset (``success:false`` response, an extension's
+    ``session_before_switch`` veto returning ``data.cancelled:true``, or no
+    response within the budget) is a recoverable client error, NOT a crash: the
+    conversation is intact and the user can retry. Being an ``AgentClientError``
+    routes it through the wrapper's report-and-continue path, so the failed
+    request surfaces while the agent keeps running.
+    """
+
+
 class PiCrashError(AgentCrashed):
     """
     This error is raised when pi reports a structured error mid-turn or its subprocess exits unexpectedly.

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -54,8 +54,11 @@ Sessions: FakePi persists a tiny JSON session keyed by ``--session-id`` inside
 ``--session-dir`` and reloads it on relaunch, so a ``fake_pi:recall`` directive
 reproduces pre-restart content — the hook the session-resume integration test
 asserts on. ``get_state`` reports the session id + message count (this is how
-``PiAgent`` verifies a resume). Real pi persists a JSONL transcript; FakePi only
-needs enough to prove resume continuity.
+``PiAgent`` verifies a resume). A ``new_session`` command resets that state to a
+fresh id with empty history (mirroring pi's ``/clear``), so a post-reset
+``recall`` finds nothing and ``get_state`` reports the new id with messageCount
+0 — the hook the context-reset integration test asserts on. Real pi persists a
+JSONL transcript; FakePi only needs enough to prove resume + reset continuity.
 
 Wire-protocol reference: the pi RPC protocol notes (pi 0.78.0).
 """
@@ -212,6 +215,21 @@ class _SessionState:
         self.message_count += 2
         self._save()
 
+    def start_new_session(self) -> None:
+        """Mirror pi's `new_session`: a fresh session id with empty history.
+
+        The prior session file is left on disk (pi keeps it); this state now
+        points at a NEW id + file, so a following `get_state` reports the new id
+        with messageCount 0, `recall` finds no prior context, and a later resume
+        of the new id finds it empty.
+        """
+        self.session_id = uuid.uuid4().hex
+        self.message_count = 0
+        self.user_messages = []
+        if self.session_file is not None:
+            self.session_file = self.session_file.parent / f"{self.session_id}.fakepi.json"
+            self._save()
+
     def _save(self) -> None:
         if self.session_file is None:
             return
@@ -272,12 +290,16 @@ def _user_message(text: str) -> dict:
     return {"role": "user", "content": [{"type": "text", "text": text}]}
 
 
-def _emit_response(command: str, success: bool, prompt_id: str | None, error: str | None = None) -> None:
+def _emit_response(
+    command: str, success: bool, prompt_id: str | None, error: str | None = None, data: dict | None = None
+) -> None:
     payload: dict = {"type": "response", "command": command, "success": success}
     if prompt_id:
         payload["id"] = prompt_id
     if error is not None:
         payload["error"] = error
+    if data is not None:
+        payload["data"] = data
     _emit(payload)
 
 
@@ -744,8 +766,9 @@ def _run_rpc_loop(system_prompt: str, session_dir: Path | None, session_id: str)
                 # Out-of-band: route to a blocked `ui_request` directive (see
                 # _handle_ui_request); the main loop never processes these.
                 _UI_RESPONSE_QUEUE.put(payload)
-            elif event_type in ("prompt", "get_state"):
-                # In-order: queued so get_state observes preceding turns' state.
+            elif event_type in ("prompt", "get_state", "new_session"):
+                # In-order: queued so get_state / new_session observe preceding
+                # turns' state (and the reset lands strictly between turns).
                 command_queue.put(payload)
         # Unblock any `ui_request` still waiting when stdin closes at shutdown.
         _UI_RESPONSE_QUEUE.put({"cancelled": True})
@@ -765,6 +788,13 @@ def _run_rpc_loop(system_prompt: str, session_dir: Path | None, session_id: str)
         command_id = payload.get("id") if isinstance(payload.get("id"), str) else None
         if payload.get("type") == "get_state":
             _emit_state(command_id, state)
+            continue
+        if payload.get("type") == "new_session":
+            # Mirror pi's `/clear`: reset to a fresh session with empty history,
+            # then ack. `data.cancelled` is always false here (no extensions to
+            # veto the switch); PiAgent reads the new id via a following get_state.
+            state.start_new_session()
+            _emit_response("new_session", success=True, prompt_id=command_id, data={"cancelled": False})
             continue
         # A fresh turn clears any abort that raced in between turns (mirrors
         # PiAgent clearing interrupt-pending when it sends the next prompt).

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2156,6 +2156,18 @@ def clear_workspace_agent_context(
     with user_session.open_transaction(services) as transaction:
         workspace = _get_workspace_or_404(workspace_id, transaction)
         task = _validate_agent_in_workspace(agent_id, workspace, transaction, services)
+        # Defense-in-depth mirror of the frontend context-reset gate (and the
+        # plan-mode guard on the messages endpoint): a harness that cannot reset
+        # context must not be sent a ClearContextUserMessage.
+        assert isinstance(task.input_data, AgentTaskInputsV2), (
+            f"Expected AgentTaskInputsV2 for clear-context endpoint, got {type(task.input_data).__name__}"
+        )
+        harness = get_harness_for_config(task.input_data.agent_config)
+        if not harness.capabilities().supports_context_reset:
+            raise HTTPException(
+                status_code=400,
+                detail="context reset requires a harness that supports it",
+            )
 
     message_id = AgentMessageID()
     with await_message_response(message_id, task.object_id, services):

--- a/sculptor/tests/integration/frontend/test_pi_basic.py
+++ b/sculptor/tests/integration/frontend/test_pi_basic.py
@@ -48,6 +48,46 @@ def test_pi_workspace_basic_response(
     expect(chat_panel.get_assistant_messages().first).to_contain_text("FakePi")
 
 
+@user_story("to reset a pi conversation with /clear so the agent no longer recalls earlier turns")
+def test_pi_clear_resets_conversation(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """/clear under pi round-trips and genuinely restarts the conversation.
+
+    FakePi remembers prior user turns (the session-resume hook); the
+    ``fake_pi:recall`` directive surfaces them. After /clear sends ``new_session``,
+    that memory is gone — so recall finds the planted sentinel BEFORE the clear
+    and ``NO_PRIOR_CONTEXT`` AFTER it.
+    """
+    install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        workspace_name="Pi Clear",
+        model_name=None,
+        harness=HarnessName.PI,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # Turn 1: plant a sentinel (FakePi records the user turn).
+    send_chat_message(chat_panel, "SENTINEL-PINEAPPLE-4242 remember this")
+    wait_for_completed_message_count(chat_panel, expected_message_count=2)
+
+    # Turn 2: recall finds the planted sentinel — memory of prior turns works.
+    send_chat_message(chat_panel, "fake_pi:recall")
+    wait_for_completed_message_count(chat_panel, expected_message_count=4)
+    expect(chat_panel.get_assistant_messages().last).to_contain_text("SENTINEL-PINEAPPLE-4242")
+
+    # /clear via the pseudo-skill: the reset round-trips (Context Cleared summary renders).
+    send_chat_message(chat_panel, "/clear")
+    expect(chat_panel.get_context_summary_messages()).to_be_visible(timeout=60_000)
+
+    # Turn 3: after the reset, recall finds no prior context — the conversation restarted.
+    send_chat_message(chat_panel, "fake_pi:recall")
+    expect(chat_panel.get_assistant_messages().last).to_contain_text("NO_PRIOR_CONTEXT", timeout=60_000)
+
+
 @user_story("to see Claude-only affordances stay hidden in a pi workspace")
 def test_pi_workspace_suppresses_claude_only_surfaces(
     sculptor_instance_: SculptorInstance,

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -335,19 +335,16 @@ def test_queued_interrupt_gated_on_interruption(
 def test_clear_pseudo_skill_gated_on_context_reset(
     sculptor_instance_: SculptorInstance, harness: HarnessTestConfig
 ) -> None:
-    """Both Claude and pi support context reset, so typing /clear is accepted
-    (no refusal copy) and the workspace stays usable. The frontend refusal branch
-    remains for a harness that does not advertise the capability (covered by the
-    CapabilityGate unit test). The reset round-trip itself is proven by
-    test_pi_basic.test_pi_clear_resets_conversation and the real_pi/real_claude
-    clear tests — here we only assert the gate no longer refuses."""
+    """Typing /clear is accepted under both Claude and pi (no refusal copy) and the
+    workspace stays usable. This asserts only the gate; the reset round-trip is covered
+    by test_pi_basic.test_pi_clear_resets_conversation and the real_pi clear test."""
     page = sculptor_instance_.page
     task_page = _create_workspace_for_harness(sculptor_instance_, harness, "Clear Gate")
     send_chat_message(chat_panel=task_page.get_chat_panel(), message="/clear")
-    # Neither harness shows the refusal copy — both call the clear endpoint.
+    # Both harnesses support context reset: no refusal copy, the endpoint is called.
     refusal_toast = page.get_by_test_id(ElementIDs.TOAST).filter(has_text=_CAPABILITY_UNSUPPORTED_COPY)
     expect(refusal_toast).to_have_count(0)
-    # The workspace is intact — the chat input stays usable after the reset.
+    # The chat input stays usable after the reset.
     expect(page.get_by_test_id(ElementIDs.CHAT_INPUT)).to_be_visible()
 
 

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -331,24 +331,24 @@ def test_queued_interrupt_gated_on_interruption(
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to refuse /clear in harnesses without context reset, visibly, instead of silently failing")
+@user_story("to reset context with /clear under any harness that supports it, instead of being refused")
 def test_clear_pseudo_skill_gated_on_context_reset(
     sculptor_instance_: SculptorInstance, harness: HarnessTestConfig
 ) -> None:
-    """Typing /clear under pi (no context-reset) is refused frontend-side with
-    the standard copy and never calls the clear endpoint; under Claude it is
-    accepted (no refusal copy)."""
+    """Both Claude and pi support context reset, so typing /clear is accepted
+    (no refusal copy) and the workspace stays usable. The frontend refusal branch
+    remains for a harness that does not advertise the capability (covered by the
+    CapabilityGate unit test). The reset round-trip itself is proven by
+    test_pi_basic.test_pi_clear_resets_conversation and the real_pi/real_claude
+    clear tests — here we only assert the gate no longer refuses."""
     page = sculptor_instance_.page
     task_page = _create_workspace_for_harness(sculptor_instance_, harness, "Clear Gate")
     send_chat_message(chat_panel=task_page.get_chat_panel(), message="/clear")
+    # Neither harness shows the refusal copy — both call the clear endpoint.
     refusal_toast = page.get_by_test_id(ElementIDs.TOAST).filter(has_text=_CAPABILITY_UNSUPPORTED_COPY)
-    if harness.workspace_harness == HarnessName.PI:
-        expect(refusal_toast).to_be_visible()
-        # The chat input stays usable — the workspace is intact, just the reset declined.
-        expect(page.get_by_test_id(ElementIDs.CHAT_INPUT)).to_be_visible()
-    else:
-        # Claude supports context reset: no refusal copy is shown.
-        expect(refusal_toast).to_have_count(0)
+    expect(refusal_toast).to_have_count(0)
+    # The workspace is intact — the chat input stays usable after the reset.
+    expect(page.get_by_test_id(ElementIDs.CHAT_INPUT)).to_be_visible()
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)

--- a/sculptor/tests/integration/real_pi/test_clear_context.py
+++ b/sculptor/tests/integration/real_pi/test_clear_context.py
@@ -28,12 +28,7 @@ _SENTINEL = "KRYPTON-55812"
 @real_pi
 @pytest.mark.timeout(600)
 def test_real_pi_clear_resets_context(sculptor_instance_: SculptorInstance) -> None:
-    """/clear must reset the real pi session so the next turn cannot recall the codeword.
-
-    If the reset regressed (e.g. ``new_session`` not sent, or the persisted
-    session id not advanced), pi would still hold the pre-clear turn and answer
-    with the codeword instead of NO-CODE-REMEMBERED.
-    """
+    """/clear must reset the real pi session so the next turn cannot recall the codeword."""
     page = sculptor_instance_.page
 
     task_page = start_task_and_wait_for_ready(

--- a/sculptor/tests/integration/real_pi/test_clear_context.py
+++ b/sculptor/tests/integration/real_pi/test_clear_context.py
@@ -1,0 +1,71 @@
+"""Real pi integration test: /clear starts a fresh conversation.
+
+Plants a codeword on a real ``pi --mode rpc`` turn, runs the ``/clear``
+pseudo-skill (which sends ``new_session`` between turns), then asks the agent to
+recall the codeword. A correct refusal (``NO-CODE-REMEMBERED``) proves
+``new_session`` genuinely cleared the session — the agent has no record of the
+pre-clear turn. Mirrors ``real_claude/test_clear_context.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.interfaces.agents.agent import HarnessName
+from sculptor.testing.elements.base import type_trigger_char
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import RESPONSE_TIMEOUT_MS
+from tests.integration.real_pi.helpers import prefixed
+from tests.integration.real_pi.helpers import real_pi
+
+_SENTINEL = "KRYPTON-55812"
+
+
+@real_pi
+@pytest.mark.timeout(600)
+def test_real_pi_clear_resets_context(sculptor_instance_: SculptorInstance) -> None:
+    """/clear must reset the real pi session so the next turn cannot recall the codeword.
+
+    If the reset regressed (e.g. ``new_session`` not sent, or the persisted
+    session id not advanced), pi would still hold the pre-clear turn and answer
+    with the codeword instead of NO-CODE-REMEMBERED.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        workspace_name="Real Pi Clear",
+        prompt=prefixed(f"Remember this codeword: {_SENTINEL}. Reply with exactly OK and nothing else."),
+        model_name=None,
+        harness=HarnessName.PI,
+    )
+    chat_panel = task_page.get_chat_panel()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=RESPONSE_TIMEOUT_MS)
+
+    # Run the /clear pseudo-skill (sends new_session between turns). Mirrors the
+    # real_claude clear flow: type the slash trigger, pick it from the mention
+    # list, then send.
+    chat_input = chat_panel.get_chat_input()
+    type_trigger_char(chat_input, "/")
+    chat_input.press_sequentially("clear")
+    expect(chat_panel.get_mention_list()).to_be_visible(timeout=60_000)
+    page.keyboard.press("Enter")
+    chat_panel.get_send_button().click()
+    expect(chat_panel.get_context_summary_messages()).to_be_visible(timeout=60_000)
+
+    # After the reset, the agent must not recall the pre-clear codeword. Assert on
+    # the last assistant reply (long timeout) rather than an exact message count —
+    # the Context Cleared summary makes the post-clear row count ambiguous.
+    send_chat_message(
+        chat_panel=chat_panel,
+        message=prefixed(
+            "What codeword did I ask you to remember earlier? If you do not know, reply with exactly "
+            "NO-CODE-REMEMBERED. Otherwise reply in the format THE-CODE-IS: <code>."
+        ),
+    )
+    expect(chat_panel.get_assistant_messages().last).to_contain_text("NO-CODE-REMEMBERED", timeout=RESPONSE_TIMEOUT_MS)
+    expect(chat_panel.get_error_block()).to_have_count(0)


### PR DESCRIPTION
## Summary

`/clear` now genuinely resets a pi conversation. Previously pi advertised
`supports_context_reset = false` and dropped `ClearContextUserMessage`, so the
frontend refused `/clear` under pi. This change makes pi handle the reset by
sending pi's `new_session` RPC between turns, which clears the conversation
history in-process while preserving the model and thinking-level selections (no
process restart). `supports_context_reset` flips to `true`.

## What changed

- **`PiAgent`**: `ClearContextUserMessage` is routed through the agent's message
  queue and handled in `_handle_clear_context`, strictly between turns. It sends
  an id-correlated `new_session`, then reads the new pi session id via
  `get_state` and persists it. Because pi conversations are resumed by id, this
  hand-off is required: without it, a later process restart would resume the
  **pre-clear** session and silently undo the reset.
- **Failure handling**: a `success:false` response, an extension's
  `session_before_switch` veto (`data.cancelled:true`), or no acknowledgement
  within the budget is surfaced as a recoverable `PiContextResetError`, so a
  failed `/clear` reports a failed request without taking the agent down.
- **UX parity**: emits the same `ContextClearedMessage` Claude does, so the
  existing "Context Cleared" chip renders — no bespoke pi chrome.
- **Endpoint guard**: the clear-context endpoint now 400s for a harness that
  does not support context reset (defense-in-depth, mirroring the plan-mode
  guard); it passes for both Claude and pi.
- **Test harness**: the pi test double handles `new_session` by resetting its
  session state to a fresh id with empty history, so an integration recall test
  can prove the reset.

## Testing

- Deterministic gates: `just format`, `just check`, `just test-unit` — green.
- Unit coverage for the handler, the failure paths (`success:false` /
  `cancelled` / no-ack), and FIFO ordering of a clear queued behind an in-flight
  turn.
- Frontend integration (test double): the gating test now accepts `/clear`
  under pi, and a round-trip test proves a planted sentinel is recallable before
  `/clear` and gone after it.
- Real-`pi` integration: a new end-to-end test plants a codeword, runs `/clear`,
  and confirms the agent can no longer recall it.

Rebased onto the current `main` (resolving conflicts with the interruption, skills, and attachments work that landed in the interim, and the `imbue_core` → `sculptor.foundation` reorg).

### Evidence

- `just format`, `just check` (typecheck/lint/ratchets/hygiene), `just test-unit` — green.
- pi-agent unit tests — pass, covering the handler, the `success:false` / `cancelled` / no-ack failure paths, and a clear queued behind an in-flight turn.
- Frontend integration (test double) — the flipped clear gate under both Claude and pi, and a pi `/clear` round-trip that recalls a planted sentinel before the reset and not after.
- `just test-real-pi` — full suite green, including the new real-pi clear test and the session-resume test (which exercises the shared `get_state` reader this change refactors).
- The Claude `/clear` path through the new endpoint guard is verified by the Claude branch of the gating integration test. (`just test-real-claude` could not run in this environment — the harness errors at instance startup with an unrelated OnboardingWizard/project-registration setup issue, before any clear logic; not affected by this change.)

(Sent by Claude)
