### PR TITLE
pi sub-agents: nested, attributed rendering via a pinned sub-agent extension (supports_sub_agents)

### DIFF
--- a/ratchet-counts.toml
+++ b/ratchet-counts.toml
@@ -54,7 +54,7 @@
 "." = 4
 
 [no-integration-time-sleep]
-"." = 8
+"." = 9
 
 [no-integration-type-method]
 "." = 0

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1421,8 +1421,7 @@ class PiAgent(DefaultAgentWrapper):
             return
         info.partial_text = extract_text_from_tool_payload(parsed.partial_result)
         if info.is_subagent:
-            # Stream each child's nested activity as it finishes (the parent
-            # `Agent` tool block stays in-progress until its own end event).
+            # Stream each child's nested activity as it finishes.
             self._emit_subagent_children(parsed.partial_result, info, parsed.tool_call_id, include_running=False)
 
     def _handle_tool_execution_end(self, parsed: ParsedToolExecutionEnd, state: _TurnState) -> None:
@@ -1451,9 +1450,8 @@ class PiAgent(DefaultAgentWrapper):
             assistant_message_id = info.assistant_message_id
             fallback_text = info.partial_text
             if info.is_subagent:
-                # Flush any child not yet emitted (including one still "running"
-                # at an aborted/failed parent end) so no sub-agent work is lost,
-                # before the parent `Agent` result block lands.
+                # Flush any child not yet emitted (including one still running at
+                # an aborted parent end) before the parent's result block lands.
                 self._emit_subagent_children(parsed.result, info, tool_call_id, include_running=True)
         else:
             # No registration (no toolCall block and no start seen) — map the
@@ -1486,22 +1484,16 @@ class PiAgent(DefaultAgentWrapper):
     ) -> None:
         """Emit each finished child of a sub-agent call as a nested ChatMessage.
 
-        The sub-agent extension re-sends the full `{v, children}` snapshot on
-        every `tool_execution_update` (and once more at `_end`), so this parses
-        the accumulated value idempotently and emits each child exactly once,
-        tracked by `info.emitted_child_ids`. Each child becomes its own
+        The extension re-sends the full `{v, children}` snapshot on every
+        `tool_execution_update` (and at `_end`), so this parses the accumulated
+        value and emits each child exactly once (tracked by
+        `info.emitted_child_ids`). Each child becomes its own
         `ResponseBlockAgentMessage` carrying `parent_tool_use_id =
-        parent_tool_call_id`; message_conversion turns that into a separate
-        ChatMessage grouped under the parent `Agent` tool block — the same
-        `parent_tool_use_id` attribution Claude's sub-agents use, so pi reuses
-        the AlphaSubagentPill rendering unchanged.
+        parent_tool_call_id`, which message_conversion groups under the parent
+        `Agent` tool block — the same attribution Claude's sub-agents use.
 
-        While the parent runs (`include_running=False`) only children that have
-        reached a terminal status are emitted; at the parent's end
-        (`include_running=True`) every remaining child is flushed so an
-        aborted/unfinished child still surfaces as attributed work rather than
-        vanishing. The parent `Agent` ToolUseBlock stays in-progress until its
-        own result block lands, so the pill shows a running sub-agent meanwhile.
+        With `include_running=False` only terminal children are emitted; at the
+        parent's end (`include_running=True`) any remaining child is flushed too.
         """
         progress = parse_subagent_progress(result_payload)
         if progress is None:

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -24,6 +24,14 @@ finished file-mutating tool (`edit`/`write`/`bash`) additionally triggers
 `on_diff_needed` so the workspace diff is regenerated — pi runs the tools
 against the workspace itself and emits no other signal that files changed.
 
+Sub-agents (`supports_sub_agents=True`) ride the same tool-execution lane: the
+pinned `sculptor_subagent` extension's `subagent` tool (mapped to Claude's
+`Agent`) streams a structured per-child payload in its accumulated
+`partialResult`, which the adapter (`_emit_subagent_children` + `subagent.py`)
+parses into nested child `ResponseBlockAgentMessage`s carrying
+`parent_tool_use_id`, so children group under the parent exactly as Claude's
+sub-agents do.
+
 Wire-protocol reference: the pi RPC protocol notes (pi 0.78.0).
 """
 
@@ -36,6 +44,7 @@ import re
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from queue import Empty
 from queue import Queue
@@ -89,6 +98,10 @@ from sculptor.agents.pi_agent.prompt_assembly import build_attachment_instructio
 from sculptor.agents.pi_agent.prompt_assembly import build_image_block
 from sculptor.agents.pi_agent.prompt_assembly import save_attachments_to_environment
 from sculptor.agents.pi_agent.prompt_assembly import split_image_and_path_attachments
+from sculptor.agents.pi_agent.subagent import SubagentChild
+from sculptor.agents.pi_agent.subagent import build_child_content_blocks
+from sculptor.agents.pi_agent.subagent import parse_subagent_progress
+from sculptor.agents.pi_agent.tool_rendering import SUBAGENT_DISPLAY_NAME
 from sculptor.agents.pi_agent.tool_rendering import build_tool_result_content
 from sculptor.agents.pi_agent.tool_rendering import extract_text_from_tool_payload
 from sculptor.agents.pi_agent.tool_rendering import map_pi_tool_call
@@ -179,6 +192,10 @@ _INTERRUPT_ESCALATION_GRACE_SECONDS: float = 5.0
 # pyproject.toml). Resolved next to this module so it works from an installed
 # build as well as a repo checkout, then written into the environment at launch.
 _BACKCHANNEL_EXTENSION_FILENAME: str = "sculptor_backchannel.ts"
+# The sub-agent extension shipped with Sculptor (package data; see pyproject.toml).
+# Registers the `subagent` tool that spawns child `pi` processes and streams
+# structured per-child progress the adapter renders nested (see subagent.py).
+_SUBAGENT_EXTENSION_FILENAME: str = "sculptor_subagent.ts"
 _EXTENSIONS_SOURCE_DIR: Path = Path(__file__).resolve().parent / "extensions"
 
 # Prepended to a turn's prompt while the agent is in plan mode. Drives the pi
@@ -225,6 +242,13 @@ class _ToolCall:
     # Accumulated (not delta) tool output from the latest `tool_execution_update`,
     # used as the result text if `tool_execution_end` carries no result body.
     partial_text: str = ""
+    # True for the sub-agent tool (mapped to Claude's `Agent`): its lane events
+    # carry a structured per-child payload the adapter renders as nested child
+    # messages instead of a single result. See `_emit_subagent_children`.
+    is_subagent: bool = False
+    # Child ids whose nested ChatMessage has already been emitted, so the
+    # accumulated (re-sent-every-update) payload emits each child exactly once.
+    emitted_child_ids: set[str] = field(default_factory=set)
 
 
 # Matches a leading slash-command token (`/name`) and captures the remainder
@@ -667,7 +691,7 @@ class PiAgent(DefaultAgentWrapper):
         extension_args: list[str] = []
         loaded_paths: list[str] = []
         state_path = self.environment.get_state_path()
-        for filename in (_BACKCHANNEL_EXTENSION_FILENAME,):
+        for filename in (_BACKCHANNEL_EXTENSION_FILENAME, _SUBAGENT_EXTENSION_FILENAME):
             content = (_EXTENSIONS_SOURCE_DIR / filename).read_text(encoding="utf-8")
             destination = state_path / filename
             self.environment.write_file(str(destination), content)
@@ -1289,6 +1313,7 @@ class PiAgent(DefaultAgentWrapper):
                     claude_name=block.name,
                     claude_input=dict(block.input),
                     assistant_message_id=state.assistant_message_id,
+                    is_subagent=block.name == SUBAGENT_DISPLAY_NAME,
                 )
                 # Remember the backchannel tool call so the dialog it opens next
                 # adopts its id as the question's tool_use_id (see
@@ -1369,6 +1394,7 @@ class PiAgent(DefaultAgentWrapper):
             claude_name=claude_name,
             claude_input=claude_input,
             assistant_message_id=state.assistant_message_id,
+            is_subagent=claude_name == SUBAGENT_DISPLAY_NAME,
         )
         text_blocks: tuple[ContentBlockTypes, ...] = (
             (TextBlock(text=state.accumulated_text),) if state.accumulated_text else ()
@@ -1394,6 +1420,10 @@ class PiAgent(DefaultAgentWrapper):
         if info is None:
             return
         info.partial_text = extract_text_from_tool_payload(parsed.partial_result)
+        if info.is_subagent:
+            # Stream each child's nested activity as it finishes (the parent
+            # `Agent` tool block stays in-progress until its own end event).
+            self._emit_subagent_children(parsed.partial_result, info, parsed.tool_call_id, include_running=False)
 
     def _handle_tool_execution_end(self, parsed: ParsedToolExecutionEnd, state: _TurnState) -> None:
         """Finish a tool call: refresh the workspace diff, then emit its result block."""
@@ -1420,6 +1450,11 @@ class PiAgent(DefaultAgentWrapper):
             tool_input = info.claude_input
             assistant_message_id = info.assistant_message_id
             fallback_text = info.partial_text
+            if info.is_subagent:
+                # Flush any child not yet emitted (including one still "running"
+                # at an aborted/failed parent end) so no sub-agent work is lost,
+                # before the parent `Agent` result block lands.
+                self._emit_subagent_children(parsed.result, info, tool_call_id, include_running=True)
         else:
             # No registration (no toolCall block and no start seen) — map the
             # name with empty input (the end event carries no args).
@@ -1439,6 +1474,57 @@ class PiAgent(DefaultAgentWrapper):
                 role="assistant",
                 assistant_message_id=assistant_message_id,
                 content=(result_block,),
+            )
+        )
+
+    def _emit_subagent_children(
+        self,
+        result_payload: Any,
+        info: _ToolCall,
+        parent_tool_call_id: str,
+        include_running: bool,
+    ) -> None:
+        """Emit each finished child of a sub-agent call as a nested ChatMessage.
+
+        The sub-agent extension re-sends the full `{v, children}` snapshot on
+        every `tool_execution_update` (and once more at `_end`), so this parses
+        the accumulated value idempotently and emits each child exactly once,
+        tracked by `info.emitted_child_ids`. Each child becomes its own
+        `ResponseBlockAgentMessage` carrying `parent_tool_use_id =
+        parent_tool_call_id`; message_conversion turns that into a separate
+        ChatMessage grouped under the parent `Agent` tool block — the same
+        `parent_tool_use_id` attribution Claude's sub-agents use, so pi reuses
+        the AlphaSubagentPill rendering unchanged.
+
+        While the parent runs (`include_running=False`) only children that have
+        reached a terminal status are emitted; at the parent's end
+        (`include_running=True`) every remaining child is flushed so an
+        aborted/unfinished child still surfaces as attributed work rather than
+        vanishing. The parent `Agent` ToolUseBlock stays in-progress until its
+        own result block lands, so the pill shows a running sub-agent meanwhile.
+        """
+        progress = parse_subagent_progress(result_payload)
+        if progress is None:
+            return
+        for child in progress.children:
+            if child.child_id in info.emitted_child_ids:
+                continue
+            if not include_running and not child.is_terminal:
+                continue
+            info.emitted_child_ids.add(child.child_id)
+            self._emit_child_message(child, parent_tool_call_id)
+
+    def _emit_child_message(self, child: SubagentChild, parent_tool_call_id: str) -> None:
+        # A fresh message id and assistant_message_id per child so each renders
+        # as its own attributed ChatMessage; message_conversion keys the nested
+        # grouping off parent_tool_use_id, not these ids.
+        self._output_messages.put(
+            ResponseBlockAgentMessage(
+                message_id=AgentMessageID(),
+                role="assistant",
+                assistant_message_id=AssistantMessageID(generate_id()),
+                content=build_child_content_blocks(child, parent_tool_call_id),
+                parent_tool_use_id=parent_tool_call_id,
             )
         )
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -2087,3 +2087,131 @@ def test_render_synthesized_skill_escapes_frontmatter() -> None:
     assert '\nname: "my-cmd"\n' in rendered
     assert '\ndescription: "Does X: then Y"\n' in rendered
     assert rendered.endswith("Body text")
+
+
+# --- Sub-agents (structured per-child progress → nested child messages) ------
+
+
+def _subagent_child(child_id: str, status: str, events: list[dict[str, Any]], label: str = "subagent") -> dict:
+    """One child entry in the wire shape sculptor_subagent.ts emits."""
+    return {"childId": child_id, "label": label, "task": "do a thing", "status": status, "events": events}
+
+
+def _subagent_envelope(children: list[dict]) -> dict:
+    """The {content, details} result envelope carrying the structured payload."""
+    return {"content": [{"type": "text", "text": "summary"}], "details": {"v": 1, "children": children}}
+
+
+def _read_child_events() -> list[dict[str, Any]]:
+    return [
+        {"seq": 0, "kind": "tool_call", "toolCallId": "ct1", "toolName": "read", "args": {"path": "/etc/hosts"}},
+        {"seq": 1, "kind": "tool_result", "toolCallId": "ct1", "text": "127.0.0.1 localhost", "isError": False},
+        {"seq": 2, "kind": "text", "text": "It has one line."},
+    ]
+
+
+def _child_messages(emitted: list) -> list[ResponseBlockAgentMessage]:
+    return [m for m in emitted if isinstance(m, ResponseBlockAgentMessage) and m.parent_tool_use_id is not None]
+
+
+def _run_subagent_turn(updates: list[dict], end_payload: dict) -> list:
+    """Drive one sub-agent tool call (toolCall block → lane updates → end)."""
+    agent = _make_agent()
+    events = [
+        _event({"type": "agent_start"}),
+        _event(
+            {
+                "type": "message_end",
+                "message": _assistant_msg_with_content([_tool_call_block("sa1", "subagent", {"task": "investigate"})]),
+            }
+        ),
+        _event(_tool_execution_start("sa1", "subagent", {"task": "investigate"})),
+    ]
+    for payload in updates:
+        events.append(
+            _event(
+                {
+                    "type": "tool_execution_update",
+                    "toolCallId": "sa1",
+                    "toolName": "subagent",
+                    "args": {"task": "investigate"},
+                    "partialResult": payload,
+                }
+            )
+        )
+    events.append(_event(_tool_execution_end("sa1", "subagent", result=end_payload)))
+    events.append(_event({"type": "agent_end", "messages": [], "willRetry": False}))
+    agent._process = _make_process(events)
+    agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+    return _drain(agent._output_messages)
+
+
+def test_subagent_parent_renders_as_agent_block() -> None:
+    """The pi `subagent` tool maps to Claude's `Agent` so the frontend pills it."""
+    payload = _subagent_envelope([_subagent_child("c0", "done", _read_child_events())])
+    emitted = _run_subagent_turn(updates=[payload], end_payload=payload)
+    use_blocks = _tool_use_blocks(emitted)
+    assert any(b.id == "sa1" and b.name == "Agent" for b in use_blocks)
+
+
+def test_subagent_emits_nested_child_message_with_parent_attribution() -> None:
+    """A finished child becomes its own ChatMessage carrying parent_tool_use_id =
+    the parent Agent tool id, with the child's own tool call + text nested."""
+    payload = _subagent_envelope([_subagent_child("c0", "done", _read_child_events())])
+    emitted = _run_subagent_turn(updates=[payload], end_payload=payload)
+
+    children = _child_messages(emitted)
+    assert len(children) == 1
+    child_msg = children[0]
+    assert child_msg.parent_tool_use_id == "sa1"
+    # The child's own read renders nested: a Read tool block + its result + text.
+    names = [b.name for b in child_msg.content if isinstance(b, ToolUseBlock)]
+    results = [b for b in child_msg.content if isinstance(b, ToolResultBlock)]
+    texts = [b.text for b in child_msg.content if isinstance(b, TextBlock)]
+    assert names == ["Read"]
+    assert results and results[0].tool_use_id == "sa1:c0:ct1"
+    assert "It has one line." in texts
+
+
+def test_subagent_child_emitted_exactly_once_across_accumulated_updates() -> None:
+    """partialResult is accumulated and re-sent; a done child whose snapshot
+    repeats on every update (and again at end) is emitted only once."""
+    payload = _subagent_envelope([_subagent_child("c0", "done", _read_child_events())])
+    # Same done child snapshot three times (two updates + end).
+    emitted = _run_subagent_turn(updates=[payload, payload], end_payload=payload)
+    assert len(_child_messages(emitted)) == 1
+
+
+def test_subagent_streams_child_when_it_finishes_mid_run() -> None:
+    """A child that is still running in the first snapshot, then done in the
+    next, is emitted as soon as it reaches a terminal status."""
+    running = _subagent_envelope([_subagent_child("c0", "running", [])])
+    done = _subagent_envelope([_subagent_child("c0", "done", _read_child_events())])
+    emitted = _run_subagent_turn(updates=[running, done], end_payload=done)
+    children = _child_messages(emitted)
+    assert len(children) == 1
+    assert children[0].parent_tool_use_id == "sa1"
+
+
+def test_subagent_running_child_flushed_at_parent_end() -> None:
+    """A child still 'running' when the parent tool ends (e.g. aborted) is still
+    flushed as an attributed message so no sub-agent work silently vanishes."""
+    running = _subagent_envelope([_subagent_child("c0", "running", [])])
+    emitted = _run_subagent_turn(updates=[running], end_payload=running)
+    children = _child_messages(emitted)
+    assert len(children) == 1
+    assert children[0].parent_tool_use_id == "sa1"
+
+
+def test_subagent_emits_one_child_message_per_child_in_parallel() -> None:
+    """Two parallel children each become their own attributed nested message."""
+    payload = _subagent_envelope(
+        [
+            _subagent_child("c0", "done", _read_child_events(), label="subagent 1"),
+            _subagent_child("c1", "done", _read_child_events(), label="subagent 2"),
+        ]
+    )
+    emitted = _run_subagent_turn(updates=[payload], end_payload=payload)
+    children = _child_messages(emitted)
+    assert {m.parent_tool_use_id for m in children} == {"sa1"}
+    assert len(children) == 2

--- a/sculptor/sculptor/agents/pi_agent/extensions/sculptor_subagent.ts
+++ b/sculptor/sculptor/agents/pi_agent/extensions/sculptor_subagent.ts
@@ -1,0 +1,305 @@
+/**
+ * Sculptor sub-agent extension.
+ *
+ * Gives a pi (`--mode rpc`) agent the sub-agent capability Sculptor already
+ * exposes for Claude. Registers a single `subagent` tool that delegates work to
+ * child agents, each running as its own isolated `pi` process (single task, or
+ * a capped parallel batch). Adapted from pi's shipped `examples/extensions/
+ * subagent` (process spawning, concurrency limiting, and Ctrl+C/abort →
+ * child-kill propagation), but DIVERGES in what it surfaces: instead of the
+ * example's aggregated formatted text, it streams a STRUCTURED, versioned
+ * per-child lifecycle payload under the tool result's `details` so the Sculptor
+ * adapter can render each child's activity as nested, attributed blocks (a
+ * parent entry with the child's own tool calls and text grouped beneath it) —
+ * Claude-parity sub-agent rendering. A spike proved this lane carries child
+ * tool events with ids + ordering intact before this was built.
+ *
+ * `partialResult` is ACCUMULATED, not a delta, so every `onUpdate` re-sends the
+ * full `{ v, children }` snapshot; the Python adapter re-parses it idempotently
+ * (`subagent.py`) and emits each child exactly once.
+ *
+ * Pinned with the pi binary as one immutable unit (PI_VERSION_RANGE in
+ * `dependency_management_service`). It is NOT user-visible or user-configurable
+ * and is loaded explicitly via `-e` under `--no-extensions` (no discovery).
+ * Children inherit the parent process's environment — including its API key — so
+ * no secret is plumbed or embedded here, and the tool emits no telemetry. Child
+ * processes run `--no-session` so they never pollute Sculptor's managed pi
+ * session directory.
+ *
+ * Wire contract shared with the Python side
+ * (`sculptor/agents/pi_agent/subagent.py` and `tool_rendering.py`): the tool
+ * NAME and the payload VERSION + field names below MUST match the constants
+ * there. Changing one means editing both files in the same change.
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+// MUST match tool_rendering.py: SUBAGENT_TOOL_NAME.
+const SUBAGENT_TOOL_NAME = "subagent";
+// MUST match subagent.py: SUBAGENT_PAYLOAD_VERSION.
+const SUBAGENT_PAYLOAD_VERSION = 1;
+
+// Conservative caps (mirroring the shipped example) so a runaway prompt cannot
+// spawn unbounded child processes. The adapter tolerates any child count.
+const MAX_TASKS = 8;
+const MAX_CONCURRENCY = 4;
+// Per-child bounds so the accumulated payload (re-sent every update) stays
+// bounded even if a child emits huge tool output or a very long transcript.
+const MAX_EVENTS_PER_CHILD = 200;
+const MAX_EVENT_TEXT_BYTES = 8 * 1024;
+
+type ChildEventKind = "text" | "tool_call" | "tool_result";
+
+interface ChildEvent {
+	seq: number;
+	kind: ChildEventKind;
+	text?: string;
+	toolCallId?: string;
+	toolName?: string;
+	args?: Record<string, unknown>;
+	isError?: boolean;
+}
+
+interface ChildState {
+	childId: string;
+	label: string;
+	task: string;
+	status: "running" | "done" | "error";
+	stopReason?: string;
+	exitCode?: number;
+	events: ChildEvent[];
+}
+
+interface SubagentPayload {
+	v: number;
+	children: ChildState[];
+}
+
+function truncateText(text: string): string {
+	if (Buffer.byteLength(text, "utf8") <= MAX_EVENT_TEXT_BYTES) return text;
+	let cut = text.slice(0, MAX_EVENT_TEXT_BYTES);
+	while (Buffer.byteLength(cut, "utf8") > MAX_EVENT_TEXT_BYTES) cut = cut.slice(0, -1);
+	return `${cut}\n[truncated]`;
+}
+
+function resultText(result: any): string {
+	// pi tool results ride as { content: [{type:"text", text}], details } — flatten
+	// the text parts; fall back to a compact stringify so nothing is silently lost.
+	if (result && Array.isArray(result.content)) {
+		const parts = result.content
+			.filter((b: any) => b && b.type === "text" && typeof b.text === "string")
+			.map((b: any) => b.text);
+		if (parts.length > 0) return parts.join("");
+	}
+	if (typeof result === "string") return result;
+	try {
+		return JSON.stringify(result);
+	} catch {
+		return String(result);
+	}
+}
+
+// Reuse the parent's exact pi runtime/binary for children (the managed
+// standalone binary, or a dev `node cli.js`), rather than a bare PATH `pi`
+// which may be absent or a different version. Lifted from the shipped example.
+function getPiInvocation(args: string[]): { command: string; args: string[] } {
+	const currentScript = process.argv[1];
+	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
+	if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
+		return { command: process.execPath, args: [currentScript, ...args] };
+	}
+	const execName = path.basename(process.execPath).toLowerCase();
+	const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
+	if (!isGenericRuntime) {
+		return { command: process.execPath, args };
+	}
+	return { command: "pi", args };
+}
+
+async function mapWithConcurrencyLimit<TIn, TOut>(
+	items: TIn[],
+	concurrency: number,
+	fn: (item: TIn, index: number) => Promise<TOut>,
+): Promise<TOut[]> {
+	if (items.length === 0) return [];
+	const limit = Math.max(1, Math.min(concurrency, items.length));
+	const results: TOut[] = new Array(items.length);
+	let nextIndex = 0;
+	const workers = new Array(limit).fill(null).map(async () => {
+		while (true) {
+			const current = nextIndex++;
+			if (current >= items.length) return;
+			results[current] = await fn(items[current], current);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}
+
+// Run one child to completion, mutating `child` as its events arrive and
+// invoking `emit` (the accumulated snapshot) on every change.
+async function runChild(child: ChildState, signal: AbortSignal | undefined, emit: () => void): Promise<void> {
+	let seq = 0;
+	const push = (event: Omit<ChildEvent, "seq">) => {
+		if (child.events.length >= MAX_EVENTS_PER_CHILD) return;
+		child.events.push({ seq: seq++, ...event });
+		emit();
+	};
+
+	const args = ["--mode", "json", "-p", "--no-session", `Task: ${child.task}`];
+	const invocation = getPiInvocation(args);
+	let wasAborted = false;
+
+	const exitCode = await new Promise<number>((resolve) => {
+		const proc = spawn(invocation.command, invocation.args, { shell: false, stdio: ["ignore", "pipe", "pipe"] });
+		let buffer = "";
+		const processLine = (line: string) => {
+			if (!line.trim()) return;
+			let event: any;
+			try {
+				event = JSON.parse(line);
+			} catch {
+				return;
+			}
+			// Tool calls + their results come from the tool-execution lane (clean
+			// {toolCallId, toolName, args} / {result, isError}); assistant TEXT
+			// comes from message_end. The issuing message's toolCall content block
+			// is deliberately NOT captured here so a call is recorded once.
+			if (event.type === "tool_execution_start") {
+				push({
+					kind: "tool_call",
+					toolCallId: String(event.toolCallId ?? ""),
+					toolName: String(event.toolName ?? ""),
+					args: typeof event.args === "object" && event.args ? event.args : {},
+				});
+			} else if (event.type === "tool_execution_end") {
+				push({
+					kind: "tool_result",
+					toolCallId: String(event.toolCallId ?? ""),
+					toolName: String(event.toolName ?? ""),
+					text: truncateText(resultText(event.result)),
+					isError: Boolean(event.isError),
+				});
+			} else if (event.type === "message_end" && event.message?.role === "assistant") {
+				for (const part of event.message.content ?? []) {
+					if (part?.type === "text" && typeof part.text === "string" && part.text) {
+						push({ kind: "text", text: truncateText(part.text) });
+					}
+				}
+				if (event.message.stopReason) child.stopReason = String(event.message.stopReason);
+			}
+		};
+		proc.stdout.on("data", (data) => {
+			buffer += data.toString();
+			const lines = buffer.split("\n");
+			buffer = lines.pop() || "";
+			for (const line of lines) processLine(line);
+		});
+		proc.on("close", (code) => {
+			if (buffer.trim()) processLine(buffer);
+			resolve(code ?? 0);
+		});
+		proc.on("error", () => resolve(1));
+		// Parent abort (Sculptor's Stop → pi `abort` → this AbortSignal) kills the
+		// child process tree so no orphan `pi` survives the interrupt.
+		if (signal) {
+			const kill = () => {
+				wasAborted = true;
+				proc.kill("SIGTERM");
+				setTimeout(() => {
+					if (!proc.killed) proc.kill("SIGKILL");
+				}, 3000);
+			};
+			if (signal.aborted) kill();
+			else signal.addEventListener("abort", kill, { once: true });
+		}
+	});
+
+	child.exitCode = exitCode;
+	if (wasAborted || child.stopReason === "aborted") {
+		child.status = "error";
+		child.stopReason = child.stopReason || "aborted";
+	} else if (exitCode !== 0 || child.stopReason === "error") {
+		child.status = "error";
+	} else {
+		child.status = "done";
+	}
+	emit();
+}
+
+export default function sculptorSubagentExtension(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: SUBAGENT_TOOL_NAME,
+		label: "Sub-agent",
+		description:
+			"Delegate a task to a sub-agent that runs in its own isolated context and " +
+			"reports back when done. Provide a single `task`, or `tasks` (a list) to run " +
+			"several sub-agents in parallel. Use this to parallelize independent work or " +
+			"to keep a large investigation out of the main context.",
+		promptSnippet: "Delegate a task to an isolated sub-agent",
+		promptGuidelines: [
+			`Use ${SUBAGENT_TOOL_NAME} to delegate a self-contained task (or several parallel tasks) to isolated sub-agents.`,
+		],
+		parameters: Type.Object({
+			task: Type.Optional(Type.String({ description: "A single task to delegate to one sub-agent." })),
+			tasks: Type.Optional(
+				Type.Array(
+					Type.Object({
+						task: Type.String({ description: "The task for this sub-agent." }),
+						label: Type.Optional(Type.String({ description: "A short label for this sub-agent." })),
+					}),
+					{ description: "Several tasks to run as parallel sub-agents." },
+				),
+			),
+		}),
+		async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+			const requested =
+				Array.isArray(params.tasks) && params.tasks.length > 0
+					? params.tasks.map((t, i) => ({ task: t.task, label: t.label || `subagent ${i + 1}` }))
+					: typeof params.task === "string" && params.task
+						? [{ task: params.task, label: "subagent" }]
+						: [];
+
+			if (requested.length === 0) {
+				return {
+					content: [{ type: "text", text: "No task provided. Pass `task` or a non-empty `tasks` list." }],
+					details: { v: SUBAGENT_PAYLOAD_VERSION, children: [] } satisfies SubagentPayload,
+				};
+			}
+
+			const capped = requested.slice(0, MAX_TASKS);
+			const children: ChildState[] = capped.map((t, i) => ({
+				childId: `c${i}`,
+				label: t.label,
+				task: t.task,
+				status: "running",
+				events: [],
+			}));
+
+			const snapshot = (): SubagentPayload => ({ v: SUBAGENT_PAYLOAD_VERSION, children });
+			const summaryText = () => {
+				const done = children.filter((c) => c.status === "done").length;
+				const failed = children.filter((c) => c.status === "error").length;
+				const running = children.filter((c) => c.status === "running").length;
+				return `sub-agents: ${done} done, ${failed} failed, ${running} running (of ${children.length})`;
+			};
+			const emit = () => {
+				onUpdate?.({ content: [{ type: "text", text: summaryText() }], details: snapshot() });
+			};
+			emit();
+
+			await mapWithConcurrencyLimit(children, MAX_CONCURRENCY, async (child) => {
+				await runChild(child, signal, emit);
+			});
+
+			return {
+				content: [{ type: "text", text: summaryText() }],
+				details: snapshot(),
+			};
+		},
+	});
+}

--- a/sculptor/sculptor/agents/pi_agent/extensions/sculptor_subagent.ts
+++ b/sculptor/sculptor/agents/pi_agent/extensions/sculptor_subagent.ts
@@ -1,18 +1,14 @@
 /**
  * Sculptor sub-agent extension.
  *
- * Gives a pi (`--mode rpc`) agent the sub-agent capability Sculptor already
- * exposes for Claude. Registers a single `subagent` tool that delegates work to
- * child agents, each running as its own isolated `pi` process (single task, or
- * a capped parallel batch). Adapted from pi's shipped `examples/extensions/
- * subagent` (process spawning, concurrency limiting, and Ctrl+C/abort →
- * child-kill propagation), but DIVERGES in what it surfaces: instead of the
- * example's aggregated formatted text, it streams a STRUCTURED, versioned
- * per-child lifecycle payload under the tool result's `details` so the Sculptor
- * adapter can render each child's activity as nested, attributed blocks (a
- * parent entry with the child's own tool calls and text grouped beneath it) —
- * Claude-parity sub-agent rendering. A spike proved this lane carries child
- * tool events with ids + ordering intact before this was built.
+ * Gives a pi (`--mode rpc`) agent the sub-agent capability Sculptor exposes for
+ * Claude. Registers a single `subagent` tool that delegates work to child
+ * agents, each running as its own isolated `pi` process (single task, or a
+ * capped parallel batch). It streams a STRUCTURED, versioned per-child lifecycle
+ * payload under the tool result's `details` so the Sculptor adapter can render
+ * each child's activity as nested, attributed blocks (a parent entry with the
+ * child's own tool calls and text grouped beneath it) — Claude-parity sub-agent
+ * rendering.
  *
  * `partialResult` is ACCUMULATED, not a delta, so every `onUpdate` re-sends the
  * full `{ v, children }` snapshot; the Python adapter re-parses it idempotently
@@ -43,12 +39,10 @@ const SUBAGENT_TOOL_NAME = "subagent";
 // MUST match subagent.py: SUBAGENT_PAYLOAD_VERSION.
 const SUBAGENT_PAYLOAD_VERSION = 1;
 
-// Conservative caps (mirroring the shipped example) so a runaway prompt cannot
-// spawn unbounded child processes. The adapter tolerates any child count.
+// Caps so a runaway prompt cannot spawn unbounded child processes.
 const MAX_TASKS = 8;
 const MAX_CONCURRENCY = 4;
-// Per-child bounds so the accumulated payload (re-sent every update) stays
-// bounded even if a child emits huge tool output or a very long transcript.
+// Per-child bounds so the accumulated (re-sent-every-update) payload stays bounded.
 const MAX_EVENTS_PER_CHILD = 200;
 const MAX_EVENT_TEXT_BYTES = 8 * 1024;
 
@@ -87,8 +81,8 @@ function truncateText(text: string): string {
 }
 
 function resultText(result: any): string {
-	// pi tool results ride as { content: [{type:"text", text}], details } — flatten
-	// the text parts; fall back to a compact stringify so nothing is silently lost.
+	// pi tool results ride as { content: [{type:"text", text}], details }; flatten
+	// the text parts, else stringify.
 	if (result && Array.isArray(result.content)) {
 		const parts = result.content
 			.filter((b: any) => b && b.type === "text" && typeof b.text === "string")
@@ -105,7 +99,7 @@ function resultText(result: any): string {
 
 // Reuse the parent's exact pi runtime/binary for children (the managed
 // standalone binary, or a dev `node cli.js`), rather than a bare PATH `pi`
-// which may be absent or a different version. Lifted from the shipped example.
+// which may be absent or a different version.
 function getPiInvocation(args: string[]): { command: string; args: string[] } {
 	const currentScript = process.argv[1];
 	const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -14,9 +14,14 @@ the StatusPill "Compacting" chrome. And it gains an interactive backchannel
 (ask-user-question + plan mode) from the Sculptor-pinned `sculptor_backchannel`
 extension (see `backchannel.py` and `extensions/sculptor_backchannel.ts`), so
 `supports_interactive_backchannel` is `True` and the gated methods recognize
-that extension's tool names. Still `False`: sub-agents, context reset, fast
-mode, and background tasks. The `capabilities()` override is the truthful
-declaration that consumers gate on.
+that extension's tool names. Sub-agents ARE supported — the pinned
+`sculptor_subagent` extension spawns each child as its own `pi` process and
+streams structured per-child progress that the adapter renders as nested,
+attributed child messages under the parent `Agent` tool (see `subagent.py` and
+`extensions/sculptor_subagent.ts`), so `supports_sub_agents` is `True`. Still
+`False`: fast mode, and background tasks (pi-core has no background-execution
+primitive — verdict (iv) deferral). The `capabilities()` override is the
+truthful declaration that consumers gate on.
 
 Agent construction is owned by the registry
 (`harness_registry.create_agent_for_run`), not this module, so the pi
@@ -81,7 +86,14 @@ class PiHarness(Harness):
             # them through its own skills layer, and follows a picked skill
             # rewritten to /skill:<name> (agent_wrapper._rewrite_skill_invocation).
             supports_skills=True,
-            supports_sub_agents=False,
+            # Pi spawns sub-agents through the Sculptor-pinned `sculptor_subagent`
+            # extension: each child runs as its own `pi` process and the parent
+            # tool streams a STRUCTURED per-child lifecycle payload that the
+            # adapter (agent_wrapper._emit_subagent_children + subagent.py) renders
+            # as nested, attributed child messages under the parent `Agent` tool
+            # block — Claude's parent_tool_use_id grouping, so the AlphaSubagentPill
+            # renders pi's sub-agents the same way. Parent abort kills the children.
+            supports_sub_agents=True,
             # Pi carries images on the `prompt` command's `images[]` field
             # (base64 + mimeType); attached image files are delivered there by
             # prompt assembly (agent_wrapper._build_prompt_payload). Harness-level

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -10,13 +10,14 @@ from sculptor.state.chat_state import ToolUseBlock
 
 
 def test_pi_harness_capabilities() -> None:
-    # Pi is a degraded harness: a capability is true only where Sculptor has a
-    # pi-side mechanism for it (see PiHarness.capabilities for the per-flag why).
+    # A capability is true only where Sculptor has a pi-side mechanism for it
+    # (see PiHarness.capabilities for the per-flag why). Pi now carries all but
+    # fast mode and background tasks.
     assert PI_HARNESS.capabilities() == HarnessCapabilities(
         supports_chat_interface=True,
         supports_interactive_backchannel=True,
         supports_skills=True,
-        supports_sub_agents=False,
+        supports_sub_agents=True,
         supports_image_input=True,
         supports_fast_mode=False,
         supports_context_reset=True,

--- a/sculptor/sculptor/agents/pi_agent/subagent.py
+++ b/sculptor/sculptor/agents/pi_agent/subagent.py
@@ -1,0 +1,228 @@
+"""Parse the Sculptor sub-agent extension's structured per-child progress.
+
+pi-core has no sub-agent protocol surface, so Sculptor ships a pinned extension
+(`extensions/sculptor_subagent.ts`) that registers a `subagent` tool. The tool
+spawns each child as its own `pi` process and emits, over the parent tool's
+streaming result (`tool_execution_update.partialResult` / the final
+`tool_execution_end.result`), a STRUCTURED per-child lifecycle payload under the
+result envelope's `details`:
+
+    {"v": 1, "children": [
+        {"childId", "label", "task", "status": "running"|"done"|"error",
+         "stopReason"?, "exitCode"?,
+         "events": [
+             {"seq", "kind": "tool_call",   "toolCallId", "toolName", "args"},
+             {"seq", "kind": "tool_result", "toolCallId", "text", "isError"},
+             {"seq", "kind": "text",        "text"}]}]}
+
+Unlike the shipped `subagent` example (which surfaces only aggregated formatted
+text), this structured shape lets the adapter render each child's activity as
+nested, attributed blocks — a parent `Agent` tool with the child's own tool
+calls and text grouped beneath it (`parent_tool_use_id`), matching Claude's
+sub-agent rendering. The lane carrying this faithfully (ids + ordering intact,
+no coalescing loss) was proven by a spike before this was built.
+
+`partialResult` is ACCUMULATED, not a delta: each update re-sends the full
+children/events snapshot, so this module re-parses the whole value idempotently
+(it never appends). Parsing is permissive — the payload crosses a subprocess
+boundary, so a malformed value or unknown version yields `None` (the call still
+renders as a plain `Agent` tool block) and a bad event is skipped rather than
+raising.
+
+Wire contract shared with `extensions/sculptor_subagent.ts`: the version and
+field names below MUST match what that extension emits. Changing one means
+editing both in the same change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from sculptor.agents.pi_agent.tool_rendering import map_pi_tool_call
+from sculptor.primitives.ids import ToolUseID
+from sculptor.state.chat_state import ContentBlockTypes
+from sculptor.state.chat_state import GenericToolContent
+from sculptor.state.chat_state import TextBlock
+from sculptor.state.chat_state import ToolResultBlock
+from sculptor.state.chat_state import ToolUseBlock
+from sculptor.state.claude_state import get_tool_invocation_string
+
+# Payload schema version (the `v` field). The extension stamps this; a payload
+# whose `v` differs is treated as unparseable so an extension/binary version
+# skew degrades to plain rendering rather than mis-parsing. MUST match
+# `SUBAGENT_PAYLOAD_VERSION` in `extensions/sculptor_subagent.ts`.
+SUBAGENT_PAYLOAD_VERSION: int = 1
+
+# Terminal child statuses — a child in one of these has finished and its nested
+# message is safe to emit once. "running" children are emitted (with whatever
+# they have) only when the parent tool itself ends.
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "error"})
+
+
+class SubagentChildEvent(BaseModel):
+    """One ordered lifecycle event from a child pi process."""
+
+    seq: int
+    kind: str  # "tool_call" | "tool_result" | "text"
+    text: str = ""
+    tool_call_id: str = ""
+    tool_name: str = ""
+    args: dict[str, Any] = {}
+    is_error: bool = False
+
+
+class SubagentChild(BaseModel):
+    """A single child sub-agent's accumulated lifecycle snapshot."""
+
+    child_id: str
+    label: str = "subagent"
+    task: str = ""
+    status: str = "running"
+    stop_reason: str | None = None
+    exit_code: int | None = None
+    events: list[SubagentChildEvent] = []
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in _TERMINAL_STATUSES
+
+
+class SubagentProgress(BaseModel):
+    """The full, re-parseable per-update snapshot of all children."""
+
+    version: int
+    children: list[SubagentChild] = []
+
+
+def _coerce_int(value: Any) -> int | None:
+    return value if isinstance(value, bool) is False and isinstance(value, int) else None
+
+
+def _parse_event(raw: Any) -> SubagentChildEvent | None:
+    """Parse one child event defensively; return None to skip a malformed entry."""
+    if not isinstance(raw, dict):
+        return None
+    seq = raw.get("seq")
+    kind = raw.get("kind")
+    if not isinstance(seq, int) or isinstance(seq, bool) or not isinstance(kind, str):
+        return None
+    args = raw.get("args")
+    return SubagentChildEvent(
+        seq=seq,
+        kind=kind,
+        text=raw.get("text") if isinstance(raw.get("text"), str) else "",
+        tool_call_id=raw.get("toolCallId") if isinstance(raw.get("toolCallId"), str) else "",
+        tool_name=raw.get("toolName") if isinstance(raw.get("toolName"), str) else "",
+        args=args if isinstance(args, dict) else {},
+        is_error=bool(raw.get("isError", False)),
+    )
+
+
+def _parse_child(raw: Any) -> SubagentChild | None:
+    if not isinstance(raw, dict):
+        return None
+    child_id = raw.get("childId")
+    if not isinstance(child_id, str) or not child_id:
+        return None
+    raw_events = raw.get("events")
+    events: list[SubagentChildEvent] = []
+    if isinstance(raw_events, list):
+        for entry in raw_events:
+            event = _parse_event(entry)
+            if event is not None:
+                events.append(event)
+    # Stable ordering by seq so coalesced/out-of-order updates still render in
+    # the order the child produced them (the extension assigns monotonic seqs).
+    events.sort(key=lambda event: event.seq)
+    status = raw.get("status")
+    return SubagentChild(
+        child_id=child_id,
+        label=raw.get("label") if isinstance(raw.get("label"), str) and raw.get("label") else "subagent",
+        task=raw.get("task") if isinstance(raw.get("task"), str) else "",
+        status=status if isinstance(status, str) else "running",
+        stop_reason=raw.get("stopReason") if isinstance(raw.get("stopReason"), str) else None,
+        exit_code=_coerce_int(raw.get("exitCode")),
+        events=events,
+    )
+
+
+def parse_subagent_progress(payload: Any) -> SubagentProgress | None:
+    """Re-parse the full accumulated sub-agent payload from a result envelope.
+
+    `payload` is a `tool_execution_update.partialResult` or
+    `tool_execution_end.result` — the `{content, details}` envelope. The
+    structured progress lives under `details`. Returns `None` (degrade to plain
+    rendering) when the envelope carries no recognized, version-matched payload.
+    """
+    if not isinstance(payload, dict):
+        return None
+    details = payload.get("details")
+    if not isinstance(details, dict):
+        return None
+    if details.get("v") != SUBAGENT_PAYLOAD_VERSION:
+        return None
+    raw_children = details.get("children")
+    children: list[SubagentChild] = []
+    if isinstance(raw_children, list):
+        for entry in raw_children:
+            child = _parse_child(entry)
+            if child is not None:
+                children.append(child)
+    return SubagentProgress(version=SUBAGENT_PAYLOAD_VERSION, children=children)
+
+
+def build_child_content_blocks(child: SubagentChild, parent_tool_call_id: str) -> tuple[ContentBlockTypes, ...]:
+    """Render one child's events as interleaved nested blocks.
+
+    A child's own tool calls map through the same pi→Claude adapter the main
+    loop uses (`tool_rendering`), so a child `read` renders as a `Read` block
+    exactly like a top-level one; text events become `TextBlock`s. Child
+    tool-call ids are namespaced under the parent + child so they can never
+    collide with a main-loop tool id (or another child's), keeping the
+    ToolUse/ToolResult pairing unambiguous when message_conversion builds the
+    nested ChatMessage.
+    """
+    blocks: list[ContentBlockTypes] = []
+    for event in child.events:
+        if event.kind == "text":
+            if event.text:
+                blocks.append(TextBlock(text=event.text))
+        elif event.kind == "tool_call":
+            claude_name, claude_input = map_pi_tool_call(event.tool_name, event.args)
+            blocks.append(
+                ToolUseBlock(
+                    id=ToolUseID(_namespaced_id(parent_tool_call_id, child.child_id, event.tool_call_id)),
+                    name=claude_name,
+                    input=claude_input,
+                )
+            )
+        elif event.kind == "tool_result":
+            claude_name, claude_input = map_pi_tool_call(event.tool_name, event.args)
+            blocks.append(
+                ToolResultBlock(
+                    tool_use_id=ToolUseID(_namespaced_id(parent_tool_call_id, child.child_id, event.tool_call_id)),
+                    tool_name=claude_name,
+                    invocation_string=get_tool_invocation_string(claude_name, claude_input),
+                    content=GenericToolContent(text=event.text),
+                    is_error=event.is_error,
+                )
+            )
+    # A child that produced no events still surfaces as an attributed bubble so
+    # the user sees it ran (e.g. an aborted child) — its status carries the why.
+    if not blocks:
+        blocks.append(TextBlock(text=_empty_child_text(child)))
+    return tuple(blocks)
+
+
+def _namespaced_id(parent_tool_call_id: str, child_id: str, child_tool_call_id: str) -> str:
+    return f"{parent_tool_call_id}:{child_id}:{child_tool_call_id}"
+
+
+def _empty_child_text(child: SubagentChild) -> str:
+    if child.status == "error":
+        return f"Sub-agent {child.label} failed{f' ({child.stop_reason})' if child.stop_reason else ''}."
+    if child.status == "running":
+        return f"Sub-agent {child.label} did not finish."
+    return f"Sub-agent {child.label} produced no output."

--- a/sculptor/sculptor/agents/pi_agent/subagent.py
+++ b/sculptor/sculptor/agents/pi_agent/subagent.py
@@ -15,19 +15,16 @@ result envelope's `details`:
              {"seq", "kind": "tool_result", "toolCallId", "text", "isError"},
              {"seq", "kind": "text",        "text"}]}]}
 
-Unlike the shipped `subagent` example (which surfaces only aggregated formatted
-text), this structured shape lets the adapter render each child's activity as
-nested, attributed blocks — a parent `Agent` tool with the child's own tool
-calls and text grouped beneath it (`parent_tool_use_id`), matching Claude's
-sub-agent rendering. The lane carrying this faithfully (ids + ordering intact,
-no coalescing loss) was proven by a spike before this was built.
+The structured shape lets the adapter render each child's activity as nested,
+attributed blocks — a parent `Agent` tool with the child's own tool calls and
+text grouped beneath it (`parent_tool_use_id`), matching Claude's sub-agent
+rendering.
 
 `partialResult` is ACCUMULATED, not a delta: each update re-sends the full
 children/events snapshot, so this module re-parses the whole value idempotently
 (it never appends). Parsing is permissive — the payload crosses a subprocess
-boundary, so a malformed value or unknown version yields `None` (the call still
-renders as a plain `Agent` tool block) and a bad event is skipped rather than
-raising.
+boundary, so a malformed value or unknown version yields `None` (the call then
+renders as a plain `Agent` tool block) and a bad event is skipped.
 
 Wire contract shared with `extensions/sculptor_subagent.ts`: the version and
 field names below MUST match what that extension emits. Changing one means
@@ -49,15 +46,12 @@ from sculptor.state.chat_state import ToolResultBlock
 from sculptor.state.chat_state import ToolUseBlock
 from sculptor.state.claude_state import get_tool_invocation_string
 
-# Payload schema version (the `v` field). The extension stamps this; a payload
-# whose `v` differs is treated as unparseable so an extension/binary version
-# skew degrades to plain rendering rather than mis-parsing. MUST match
-# `SUBAGENT_PAYLOAD_VERSION` in `extensions/sculptor_subagent.ts`.
+# Payload schema version (the `v` field); a payload with a different `v` is
+# treated as unparseable. MUST match `SUBAGENT_PAYLOAD_VERSION` in
+# `extensions/sculptor_subagent.ts`.
 SUBAGENT_PAYLOAD_VERSION: int = 1
 
-# Terminal child statuses — a child in one of these has finished and its nested
-# message is safe to emit once. "running" children are emitted (with whatever
-# they have) only when the parent tool itself ends.
+# Child statuses that mean the child has finished.
 _TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "error"})
 
 
@@ -133,8 +127,7 @@ def _parse_child(raw: Any) -> SubagentChild | None:
             event = _parse_event(entry)
             if event is not None:
                 events.append(event)
-    # Stable ordering by seq so coalesced/out-of-order updates still render in
-    # the order the child produced them (the extension assigns monotonic seqs).
+    # Sort by seq so out-of-order events render in producer order.
     events.sort(key=lambda event: event.seq)
     status = raw.get("status")
     return SubagentChild(
@@ -209,8 +202,8 @@ def build_child_content_blocks(child: SubagentChild, parent_tool_call_id: str) -
                     is_error=event.is_error,
                 )
             )
-    # A child that produced no events still surfaces as an attributed bubble so
-    # the user sees it ran (e.g. an aborted child) — its status carries the why.
+    # A child with no events still surfaces as an attributed bubble (e.g. an
+    # aborted child).
     if not blocks:
         blocks.append(TextBlock(text=_empty_child_text(child)))
     return tuple(blocks)

--- a/sculptor/sculptor/agents/pi_agent/subagent_test.py
+++ b/sculptor/sculptor/agents/pi_agent/subagent_test.py
@@ -1,0 +1,171 @@
+"""Tests for the sub-agent structured-progress parser and nested-block builder.
+
+Fixtures follow the wire shape `extensions/sculptor_subagent.ts` emits under a
+tool result envelope's `details`: `{v, children:[{childId, label, task, status,
+events:[...]}]}`. The parser must be permissive (the payload crosses a
+subprocess boundary) and idempotent (partialResult is accumulated, re-sent
+whole on every update).
+"""
+
+from __future__ import annotations
+
+from sculptor.agents.pi_agent.subagent import SUBAGENT_PAYLOAD_VERSION
+from sculptor.agents.pi_agent.subagent import build_child_content_blocks
+from sculptor.agents.pi_agent.subagent import parse_subagent_progress
+from sculptor.state.chat_state import GenericToolContent
+from sculptor.state.chat_state import TextBlock
+from sculptor.state.chat_state import ToolResultBlock
+from sculptor.state.chat_state import ToolUseBlock
+
+
+def _envelope(details: object) -> dict:
+    """Wrap structured `details` in the {content, details} result envelope."""
+    return {"content": [{"type": "text", "text": "summary"}], "details": details}
+
+
+def _child(child_id: str = "c0", **overrides: object) -> dict:
+    base: dict = {
+        "childId": child_id,
+        "label": "subagent",
+        "task": "do a thing",
+        "status": "done",
+        "stopReason": "stop",
+        "exitCode": 0,
+        "events": [
+            {"seq": 0, "kind": "tool_call", "toolCallId": "t1", "toolName": "read", "args": {"path": "/etc/hosts"}},
+            {"seq": 1, "kind": "tool_result", "toolCallId": "t1", "text": "127.0.0.1 localhost", "isError": False},
+            {"seq": 2, "kind": "text", "text": "The file has 1 line."},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_well_formed_single_child() -> None:
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [_child()]}))
+    assert progress is not None
+    assert len(progress.children) == 1
+    child = progress.children[0]
+    assert child.child_id == "c0"
+    assert child.status == "done"
+    assert child.is_terminal is True
+    assert [event.kind for event in child.events] == ["tool_call", "tool_result", "text"]
+    assert child.events[0].tool_name == "read"
+    assert child.events[0].args == {"path": "/etc/hosts"}
+
+
+def test_parse_reorders_events_by_seq() -> None:
+    # A coalesced / out-of-order snapshot must still render in producer order.
+    scrambled = _child(
+        events=[
+            {"seq": 2, "kind": "text", "text": "done"},
+            {"seq": 0, "kind": "tool_call", "toolCallId": "t1", "toolName": "bash", "args": {"command": "ls"}},
+            {"seq": 1, "kind": "tool_result", "toolCallId": "t1", "text": "a\nb", "isError": False},
+        ]
+    )
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [scrambled]}))
+    assert progress is not None
+    assert [event.seq for event in progress.children[0].events] == [0, 1, 2]
+    assert [event.kind for event in progress.children[0].events] == ["tool_call", "tool_result", "text"]
+
+
+def test_parse_version_mismatch_returns_none() -> None:
+    # An extension/binary skew must degrade to plain rendering, never mis-parse.
+    assert parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION + 1, "children": [_child()]})) is None
+
+
+def test_parse_missing_details_returns_none() -> None:
+    assert parse_subagent_progress({"content": [{"type": "text", "text": "x"}]}) is None
+    assert parse_subagent_progress({"content": [], "details": "not-a-dict"}) is None
+    assert parse_subagent_progress(None) is None
+    assert parse_subagent_progress("bare string") is None
+
+
+def test_parse_skips_malformed_children_and_events() -> None:
+    payload = {
+        "v": SUBAGENT_PAYLOAD_VERSION,
+        "children": [
+            "not-a-dict",
+            {"label": "no id"},  # missing childId -> skipped
+            {
+                "childId": "c1",
+                "status": "running",
+                "events": [
+                    {"kind": "text", "text": "no seq"},  # missing seq -> skipped
+                    {"seq": 0, "kind": "text", "text": "kept"},
+                    "garbage",
+                ],
+            },
+        ],
+    }
+    progress = parse_subagent_progress(_envelope(payload))
+    assert progress is not None
+    assert len(progress.children) == 1
+    child = progress.children[0]
+    assert child.child_id == "c1"
+    assert child.status == "running"
+    assert child.is_terminal is False
+    assert [event.text for event in child.events] == ["kept"]
+
+
+def test_parse_truncated_events_tolerated() -> None:
+    # A child whose events array is empty (truncated mid-stream) still parses.
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [_child(events=[])]}))
+    assert progress is not None
+    assert progress.children[0].events == []
+
+
+def test_build_child_blocks_renders_nested_tool_and_text() -> None:
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [_child()]}))
+    assert progress is not None
+    use_block, result_block, text_block = build_child_content_blocks(
+        progress.children[0], parent_tool_call_id="parent-1"
+    )
+    assert isinstance(use_block, ToolUseBlock)
+    assert use_block.name == "Read"  # child tool mapped through the pi->Claude adapter
+    assert isinstance(result_block, ToolResultBlock)
+    assert isinstance(result_block.content, GenericToolContent)
+    assert result_block.content.text == "127.0.0.1 localhost"
+    assert isinstance(text_block, TextBlock)
+    assert text_block.text == "The file has 1 line."
+
+
+def test_build_child_blocks_namespaces_tool_ids() -> None:
+    # Child tool ids are namespaced under parent+child so they can never collide
+    # with a main-loop tool id, and the ToolUse/ToolResult pair stays matched.
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [_child()]}))
+    assert progress is not None
+    blocks = build_child_content_blocks(progress.children[0], parent_tool_call_id="parent-1")
+    use_block = blocks[0]
+    result_block = blocks[1]
+    assert isinstance(use_block, ToolUseBlock)
+    assert isinstance(result_block, ToolResultBlock)
+    assert str(use_block.id) == "parent-1:c0:t1"
+    assert str(result_block.tool_use_id) == str(use_block.id)
+
+
+def test_build_child_blocks_error_result_flagged() -> None:
+    child = _child(
+        events=[
+            {"seq": 0, "kind": "tool_call", "toolCallId": "t1", "toolName": "bash", "args": {"command": "false"}},
+            {"seq": 1, "kind": "tool_result", "toolCallId": "t1", "text": "boom", "isError": True},
+        ]
+    )
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [child]}))
+    assert progress is not None
+    blocks = build_child_content_blocks(progress.children[0], parent_tool_call_id="p")
+    result_block = blocks[1]
+    assert isinstance(result_block, ToolResultBlock)
+    assert result_block.is_error is True
+
+
+def test_build_child_blocks_empty_child_gets_attributed_text() -> None:
+    # A child that produced no events still surfaces as an attributed bubble.
+    child = _child(status="error", stopReason="aborted", exitCode=137, events=[])
+    progress = parse_subagent_progress(_envelope({"v": SUBAGENT_PAYLOAD_VERSION, "children": [child]}))
+    assert progress is not None
+    blocks = build_child_content_blocks(progress.children[0], parent_tool_call_id="p")
+    assert len(blocks) == 1
+    text_block = blocks[0]
+    assert isinstance(text_block, TextBlock)
+    assert "failed" in text_block.text.lower()

--- a/sculptor/sculptor/agents/pi_agent/tool_rendering.py
+++ b/sculptor/sculptor/agents/pi_agent/tool_rendering.py
@@ -47,6 +47,38 @@ _SIMPLE_NAME_MAP: dict[str, str] = {
     "bash": "Bash",
 }
 
+# The tool name pi exposes for the Sculptor-pinned sub-agent extension
+# (`extensions/sculptor_subagent.ts`); MUST match the `name` that extension
+# registers. The adapter keys on this to parse the structured per-child progress
+# (`subagent.py`); the renderer maps it onto Claude's sub-agent tool so pi's
+# nested sub-agent activity reuses Claude's AlphaSubagentPill verbatim.
+SUBAGENT_TOOL_NAME: str = "subagent"
+
+# Claude's sub-agent tool name (the post-rename of "Task"). The frontend's
+# `SUBAGENT_TOOL_NAMES` set keys the subagent pill / metadata off this; mapping
+# pi's `subagent` tool onto it groups children (attached by `parent_tool_use_id`)
+# under the parent exactly as Claude's sub-agents render.
+SUBAGENT_DISPLAY_NAME: str = "Agent"
+
+
+def _summarize_subagent_tasks(pi_args: dict[str, Any]) -> tuple[str, str]:
+    """Derive `(subagent_type, prompt)` for the Claude-shaped `Agent` input.
+
+    The pi sub-agent tool takes either a single `{task}` or a parallel
+    `{tasks: [{task, label?}]}`. The frontend's `buildSubagentMetadataMap` reads
+    `subagent_type` (the pill's label) and `prompt` (its task text) off the
+    `Agent` tool input, so map onto those: a single task keeps its text; a
+    parallel batch summarizes the count and joins the task lines.
+    """
+    tasks = pi_args.get("tasks")
+    if isinstance(tasks, list) and tasks:
+        lines: list[str] = []
+        for entry in tasks:
+            if isinstance(entry, dict):
+                lines.append(_first_str(entry, "task"))
+        return f"subagent (x{len(tasks)})", "\n".join(line for line in lines if line)
+    return "subagent", _first_str(pi_args, "task", "prompt")
+
 
 def _first_str(args: dict[str, Any], *keys: str) -> str:
     """Return the first string value present under `keys`, else ""."""
@@ -94,6 +126,14 @@ def map_pi_tool_call(pi_tool_name: str, pi_args: dict[str, Any]) -> tuple[str, d
             }
         # bash
         return claude_name, {"command": _first_str(pi_args, "command")}
+
+    if pi_tool_name == SUBAGENT_TOOL_NAME:
+        # Render the parent sub-agent call as Claude's `Agent` tool so the
+        # frontend groups its children (attached via parent_tool_use_id) under
+        # the same AlphaSubagentPill. The structured per-child progress is
+        # parsed separately by the adapter (see `subagent.py`).
+        subagent_type, prompt = _summarize_subagent_tasks(pi_args)
+        return SUBAGENT_DISPLAY_NAME, {"subagent_type": subagent_type, "prompt": prompt}
 
     if pi_tool_name == "edit":
         file_path = _first_str(pi_args, "path", "file_path")

--- a/sculptor/sculptor/agents/pi_agent/tool_rendering.py
+++ b/sculptor/sculptor/agents/pi_agent/tool_rendering.py
@@ -49,9 +49,8 @@ _SIMPLE_NAME_MAP: dict[str, str] = {
 
 # The tool name pi exposes for the Sculptor-pinned sub-agent extension
 # (`extensions/sculptor_subagent.ts`); MUST match the `name` that extension
-# registers. The adapter keys on this to parse the structured per-child progress
-# (`subagent.py`); the renderer maps it onto Claude's sub-agent tool so pi's
-# nested sub-agent activity reuses Claude's AlphaSubagentPill verbatim.
+# registers. The adapter (`subagent.py`) keys on this to parse the structured
+# per-child progress.
 SUBAGENT_TOOL_NAME: str = "subagent"
 
 # Claude's sub-agent tool name (the post-rename of "Task"). The frontend's

--- a/sculptor/sculptor/agents/pi_agent/tool_rendering_test.py
+++ b/sculptor/sculptor/agents/pi_agent/tool_rendering_test.py
@@ -77,6 +77,24 @@ def test_map_unknown_tool_passes_through_unmapped() -> None:
     assert input_ == {"foo": "bar"}
 
 
+def test_map_subagent_single_task_to_agent() -> None:
+    # The pi sub-agent tool renders as Claude's `Agent` so the frontend groups
+    # its children under the same subagent pill.
+    name, input_ = map_pi_tool_call("subagent", {"task": "find the auth code"})
+    assert name == "Agent"
+    assert input_ == {"subagent_type": "subagent", "prompt": "find the auth code"}
+
+
+def test_map_subagent_parallel_tasks_summarized() -> None:
+    name, input_ = map_pi_tool_call(
+        "subagent",
+        {"tasks": [{"task": "find models"}, {"task": "find providers"}]},
+    )
+    assert name == "Agent"
+    assert input_["subagent_type"] == "subagent (x2)"
+    assert input_["prompt"] == "find models\nfind providers"
+
+
 def test_map_is_defensive_about_missing_or_odd_args() -> None:
     # Missing keys yield empty values rather than raising.
     assert map_pi_tool_call("read", {}) == ("Read", {"file_path": ""})

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -501,6 +501,76 @@ def _handle_tool_call(args: dict, builder: _TurnBuilder, abort_event: Event, sta
     )
 
 
+def _handle_subagent(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
+    """Script a sub-agent tool call: emit a `subagent` toolCall block, then the
+    tool-execution lane with the STRUCTURED per-child payload under
+    `result.details` (the shape `sculptor_subagent.ts` emits, parsed by
+    `subagent.py`). Lets a deterministic UI test render the nested sub-agent
+    group without spawning real child `pi` processes.
+
+    Args (all optional)::
+
+        {"id": "sa1",                   # parent tool-call id
+         "children": [                  # structured child snapshots
+             {"childId": "c0", "label": "subagent", "task": "...",
+              "status": "done",
+              "events": [{"seq":0,"kind":"tool_call","toolCallId":"ct1",
+                          "toolName":"read","args":{...}},
+                         {"seq":1,"kind":"text","text":"..."}]}]}
+
+    With no `children` a single trivial done child is scripted so the simplest
+    directive still renders a nested group.
+    """
+    tool_call_id = str(args.get("id") or "sa1")
+    children = args.get("children")
+    if not isinstance(children, list) or not children:
+        children = [
+            {
+                "childId": "c0",
+                "label": "subagent",
+                "task": "investigate",
+                "status": "done",
+                "events": [{"seq": 0, "kind": "text", "text": "Sub-agent finished."}],
+            }
+        ]
+    task_arg = {"task": str(args.get("task", "investigate"))}
+    payload = {"v": 1, "children": children}
+
+    # Close the issuing assistant message with the subagent toolCall block.
+    content: list[dict] = []
+    if builder.full_text:
+        content.append({"type": "text", "text": builder.full_text})
+    content.append({"type": "toolCall", "id": tool_call_id, "name": "subagent", "arguments": task_arg})
+    _emit({"type": "message_end", "message": {"role": "assistant", "content": content, "stopReason": "toolUse"}})
+    builder.chunks.clear()
+
+    # Tool-execution lane: the accumulated structured payload rides under
+    # `partialResult.details` / `result.details`.
+    _emit({"type": "tool_execution_start", "toolCallId": tool_call_id, "toolName": "subagent", "args": task_arg})
+    update_result = _tool_text_payload("running")
+    update_result["details"] = payload
+    _emit(
+        {
+            "type": "tool_execution_update",
+            "toolCallId": tool_call_id,
+            "toolName": "subagent",
+            "args": task_arg,
+            "partialResult": update_result,
+        }
+    )
+    end_result = _tool_text_payload("sub-agents complete")
+    end_result["details"] = payload
+    _emit(
+        {
+            "type": "tool_execution_end",
+            "toolCallId": tool_call_id,
+            "toolName": "subagent",
+            "result": end_result,
+            "isError": False,
+        }
+    )
+
+
 def _handle_sleep(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     seconds = float(args.get("seconds", 0))
     if seconds <= 0:
@@ -618,6 +688,7 @@ _COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, Event, _SessionState]
     "emit_text": _handle_emit_text,
     "stream_text": _handle_stream_text,
     "tool_call": _handle_tool_call,
+    "subagent": _handle_subagent,
     "sleep": _handle_sleep,
     "wait_for_file": _handle_wait_for_file,
     "recall": _handle_recall,

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -136,7 +136,7 @@ def test_sub_agent_pill_renders_under_both_harnesses(
     """
     task_page = _create_workspace_for_harness(sculptor_instance_, harness, "Sub-Agent Render")
     chat_panel = task_page.get_chat_panel()
-    if harness.workspace_harness == HarnessName.PI:
+    if harness.first_agent_type == "pi":
         prompt = 'fake_pi:subagent `{"children": [{"childId": "c0", "label": "scout", "task": "find files", "status": "done", "events": [{"seq": 0, "kind": "text", "text": "Found 10 files."}]}]}`'
     else:
         prompt = (

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -118,14 +118,38 @@ def test_fast_mode_toggle_gated(sculptor_instance_: SculptorInstance, harness: H
 
 
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
-@user_story("to suppress the sub-agent pill render path in harnesses without sub-agent support")
-def test_sub_agent_pill_render_path_gated(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:
-    _create_workspace_for_harness(sculptor_instance_, harness, "Sub-Agent Gate")
-    # Neither fake binary emits sub-agent tool blocks by default, so the
-    # rendered count is 0 in both branches. The assertion still has value as a
-    # regression guard against the pill leaking under pi if a future change
-    # accidentally seeds metadata for it.
-    expect(sculptor_instance_.page.get_by_test_id(ElementIDs.ALPHA_CHAT_SUBAGENT_PILL)).to_have_count(0)
+@user_story("to see a sub-agent's activity render as a nested attributed pill under both harnesses")
+def test_sub_agent_pill_renders_under_both_harnesses(
+    sculptor_instance_: SculptorInstance, harness: HarnessTestConfig
+) -> None:
+    """Sub-agents are now a shared capability: a scripted sub-agent call renders
+    as the AlphaSubagentPill (the parent entry with nested, attributed child
+    activity) under Claude AND pi.
+
+    This is the two-sided assertion for `supports_sub_agents` (REQ-TEST-4): the
+    render path was previously suppressed for pi (the gate hid the pill); pi now
+    spawns sub-agents through the pinned `sculptor_subagent` extension, whose
+    structured per-child progress the adapter maps onto the same
+    `parent_tool_use_id` grouping Claude uses. Pi's `fake_pi:subagent` directive
+    scripts the structured payload; FakeClaude's `subagent` directive scripts an
+    Agent tool call. Both surface the pill.
+    """
+    task_page = _create_workspace_for_harness(sculptor_instance_, harness, "Sub-Agent Render")
+    chat_panel = task_page.get_chat_panel()
+    if harness.workspace_harness == HarnessName.PI:
+        prompt = 'fake_pi:subagent `{"children": [{"childId": "c0", "label": "scout", "task": "find files", "status": "done", "events": [{"seq": 0, "kind": "text", "text": "Found 10 files."}]}]}`'
+    else:
+        prompt = (
+            'fake_claude:subagent `{"description": "Find files", "prompt": "List files", '
+            + '"subagent_result": "Found 10 files.", "summary_text": "The sub-agent found 10 files."}`'
+        )
+    send_chat_message(chat_panel=chat_panel, message=prompt)
+
+    # The sub-agent activity renders as the pill under both harnesses (the gate
+    # no longer suppresses it for pi).
+    expect(sculptor_instance_.page.get_by_test_id(ElementIDs.ALPHA_CHAT_SUBAGENT_PILL).first).to_be_visible(
+        timeout=30000
+    )
 
 
 def _png_bytes(color: tuple[int, int, int] = (0, 0, 255)) -> bytes:

--- a/sculptor/tests/integration/real_pi/test_sub_agents.py
+++ b/sculptor/tests/integration/real_pi/test_sub_agents.py
@@ -1,0 +1,130 @@
+"""Real pi integration tests: sub-agent rendering and clean child shutdown.
+
+Drives a real ``pi --mode rpc`` subprocess that loads the pinned
+``sculptor_subagent`` extension, prompts it to delegate a trivial task to one
+child sub-agent, and asserts the child's activity renders as the nested
+AlphaSubagentPill (parent entry + attributed child activity) — the end-to-end
+``supports_sub_agents`` path: extension → structured per-child payload over the
+tool-execution lane → adapter → ``parent_tool_use_id`` grouping → pill.
+
+A second test exercises abort composition (implementation plan §10.1.2): a
+sub-agent whose child is mid-run is interrupted via Stop, and no orphan child
+``pi`` process is left behind — the nested-case extension of the no-zombie
+assertion.
+
+Divergence note (REQ-TEST-1): there is no ``real_claude`` sub-agent *rendering*
+test to mirror (Claude's sub-agent suite lives in the deterministic
+``frontend/`` tests); the closest Claude real test is
+``real_claude/test_stop_kills_foreground_subprocess.py``, whose no-orphan intent
+the abort test below mirrors for the nested pi case.
+"""
+
+from __future__ import annotations
+
+import time
+
+import psutil
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.constants import ElementIDs
+from sculptor.testing.sculptor_instance import SculptorInstance
+from tests.integration.real_pi.helpers import RESPONSE_TIMEOUT_MS
+from tests.integration.real_pi.helpers import assert_no_errors
+from tests.integration.real_pi.helpers import create_pi_workspace_and_send
+from tests.integration.real_pi.helpers import interrupt_agent
+from tests.integration.real_pi.helpers import real_pi
+from tests.integration.real_pi.helpers import send_no_wait
+
+
+def _child_pi_process_count() -> int:
+    """Count live child sub-agent processes (``pi --mode json``).
+
+    The extension spawns each child as ``pi --mode json -p --no-session``; the
+    long-lived parent agent is ``--mode rpc``, so matching ``--mode json``
+    isolates children. Used to assert children exit (clean run) and are killed
+    on abort (no orphans).
+    """
+    count = 0
+    for proc in psutil.process_iter(["cmdline"]):
+        try:
+            cmdline = proc.info["cmdline"] or []
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        joined = " ".join(cmdline)
+        if "--mode" in cmdline and "json" in cmdline and "pi" in joined:
+            count += 1
+    return count
+
+
+def _wait_for_child_pi_processes(target: int, *, at_least: bool, timeout_s: float) -> int:
+    """Poll until the child-process count reaches ``target`` (or timeout)."""
+    deadline = time.monotonic() + timeout_s
+    last = _child_pi_process_count()
+    while time.monotonic() < deadline:
+        last = _child_pi_process_count()
+        if (at_least and last >= target) or (not at_least and last <= target):
+            return last
+        time.sleep(0.5)
+    return last
+
+
+@real_pi
+@pytest.mark.timeout(600)
+def test_pi_subagent_renders_nested_group_and_completes_cleanly(sculptor_instance_: SculptorInstance) -> None:
+    """One parent, one child: the child's activity renders as the subagent pill,
+    the turn completes without error, and no child pi process is left running."""
+    baseline_children = _child_pi_process_count()
+    prompt = (
+        "Use your subagent tool to delegate exactly one task to a single sub-agent. "
+        + 'Pass this as the task: "Run the shell command: echo PI-SUBAGENT-CHILD-50231". '
+        + "Do not run the command yourself — delegate it via the subagent tool. "
+        + "After the sub-agent reports back, reply with exactly: SUBAGENT-DONE-50231."
+    )
+    task_page = create_pi_workspace_and_send(sculptor_instance_, prompt)
+    chat_panel = task_page.get_chat_panel()
+
+    # The sub-agent's activity renders as the nested pill (parent entry + child).
+    expect(sculptor_instance_.page.get_by_test_id(ElementIDs.ALPHA_CHAT_SUBAGENT_PILL).first).to_be_visible(
+        timeout=RESPONSE_TIMEOUT_MS
+    )
+    expect(chat_panel.get_assistant_messages().last).to_contain_text("SUBAGENT-DONE-50231")
+    assert_no_errors(chat_panel)
+    expect(chat_panel.get_in_progress_tool_calls()).to_have_count(0)
+
+    # No orphan child processes: the children exited when the tool finished.
+    remaining = _wait_for_child_pi_processes(baseline_children, at_least=False, timeout_s=20)
+    assert remaining <= baseline_children, (
+        f"orphan child pi processes after clean run: {remaining} > {baseline_children}"
+    )
+
+
+@real_pi
+@pytest.mark.timeout(600)
+def test_pi_subagent_abort_leaves_no_orphan_children(sculptor_instance_: SculptorInstance) -> None:
+    """Stopping a turn while a sub-agent child is mid-run kills the child — no
+    orphan ``pi`` process survives the interrupt (abort composition, §10.1.2)."""
+    baseline_children = _child_pi_process_count()
+    task_page = create_pi_workspace_and_send(
+        sculptor_instance_,
+        "Reply with exactly the text PI-READY-50232. Do not add any other text.",
+    )
+    chat_panel = task_page.get_chat_panel()
+    expect(chat_panel.get_assistant_messages().last).to_contain_text("PI-READY-50232")
+
+    # Delegate a long-running child task, then interrupt while it runs.
+    send_no_wait(
+        chat_panel,
+        "Use your subagent tool to delegate exactly one task to a single sub-agent. "
+        + 'Pass this as the task: "Run the shell command: sleep 120". '
+        + "Delegate it via the subagent tool; do not run it yourself.",
+    )
+    # Wait until the child sub-agent process is actually running.
+    appeared = _wait_for_child_pi_processes(baseline_children + 1, at_least=True, timeout_s=120)
+    assert appeared > baseline_children, "sub-agent child process never started"
+
+    interrupt_agent(chat_panel)
+
+    # The child process tree is torn down by the extension's abort handler.
+    remaining = _wait_for_child_pi_processes(baseline_children, at_least=False, timeout_s=30)
+    assert remaining <= baseline_children, f"orphan child pi processes after Stop: {remaining} > {baseline_children}"


### PR DESCRIPTION
# pi sub-agents: nested, attributed rendering via a pinned sub-agent extension (`supports_sub_agents`)

Part of the pi-capabilities cycle (phase 5 of the pi multi-harness initiative): turn
pi's capability flags `True` as genuine support lands. This tranche flips
`supports_sub_agents`.

The cycle's spec, requirements, architecture, feasibility, and per-tranche plan
live in the spec workspace and (until merged) in PR #16 on `imbue-ai/sculptor`
— `agent_docs/` is not yet on `main`, so this PR is sub-agents **code only**.

## What

pi sub-agent activity now renders grouped and attributed like Claude's — a parent
entry (the `Agent` tool block / `AlphaSubagentPill`) with each child's own tool
calls and text nested beneath it via `parent_tool_use_id`. `supports_sub_agents`
flips `True` for pi.

## How

pi-core has no sub-agent protocol surface, so this rides a Sculptor-pinned pi
extension plus a backend adapter:

- **`extensions/sculptor_subagent.ts`** (new) — registers a `subagent` tool that
  spawns each child as its own `pi --mode json -p --no-session` process (single
  task or a capped parallel batch). Adapted from pi's shipped `subagent` example
  for process management + Ctrl+C/abort → child-kill, but instead of the example's
  aggregated formatted text it emits a **structured, versioned per-child lifecycle
  payload** (`{v, children:[{childId, status, events:[tool_call|tool_result|text]}]}`)
  under the tool result's `details`.
- **`subagent.py`** (new) — defensively, idempotently re-parses that accumulated
  payload (it is re-sent whole on every `tool_execution_update`) and builds nested
  child content blocks, reusing the existing pi→Claude tool adapter so a child's
  `read` renders as a `Read` block just like a top-level one.
- **`agent_wrapper.py`** — maps the `subagent` tool onto Claude's `Agent`, and as
  each child finishes emits it as its own `ResponseBlockAgentMessage` carrying
  `parent_tool_use_id` = the parent tool id. `message_conversion` already turns
  that into a child ChatMessage grouped under the parent, so pi reuses Claude's
  `AlphaSubagentPill` unchanged. Parent abort kills the children.

### Spike-first (this was the heaviest, lowest-confidence item)

Per the plan, a timeboxed spike proved the structured-progress lane is viable
**before** building the adapter: an extension's arbitrary `details` object
survives the RPC `tool_execution_update.partialResult` / `tool_execution_end.result`
verbatim, with child tool events and ordering intact, as accumulated full
snapshots. Verdict: **viable** — no REQ-INV-6 pause needed. (Spike code was kept
out of the merge.)

## Divergences (REQ-CAP-ALL-3)

- **Child activity renders at child completion**, not token-by-token. The lane can
  stream, but `message_conversion`'s single in-progress-message model makes live
  multi-child streaming fragile; emitting each child once on completion is robust
  and yields the same nested+attributed end state. The parent pill shows a running
  sub-agent meanwhile.
- **Single + parallel** sub-agent modes are supported (children capped, mirroring
  the example: ≤8 tasks, ≤4 concurrent). Chained workflows are not in this tranche.

## REQ-EXT checklist

- [x] Extension lives in-repo and is code-reviewed like any other code.
- [x] Pinned with the pi binary as one immutable unit (loaded via `-e` under
      `--no-extensions`; ships as package data).
- [x] Not user-visible / user-configurable (no plugin-management surface).
- [x] Embeds no secrets — children inherit the parent's API-key env.
- [x] Emits no telemetry.

## Notes

- Bumps the `no-integration-time-sleep` ratchet budget by 1 (8 → 9) for the
  real-pi orphan-process poll, matching the existing Stop-kills-subprocess
  orphan-test pattern.

## Evidence bundle (REQ-PROC-6)

- **Deterministic gates (single run):** `just format` OK · `just check`
  (typecheck + ratchets + lint + hygiene) OK · `just test-unit` all sub-suites
  passed.
- **Full `just test-real-pi`:** 18 passed, 0 failed (~7 min) — no regressions,
  including the two new `real_pi/test_sub_agents.py` tests (nested render +
  abort leaves no orphan child processes).

### Acceptance checklist (REQ-CAP-SUB-AGENTS / REQ-TEST)

- [x] Spike verdict recorded first (structured progress viable); no deferral.
- [x] Nested + attributed rendering under pi matches Claude's grouping.
- [x] Abort leaves no orphan child `pi` processes (real-pi test).
- [x] `supports_sub_agents=True` + stance comments.
- [x] Flipped gate-state test (`test_sub_agent_pill_renders_under_both_harnesses`).
- [x] Unit: payload parser (well-formed / out-of-order / truncated / versioned)
      + nested-emission shape; new `real_pi/test_sub_agents.py`.

(Sent by Claude)
