### PR TITLE
Fix four backend correctness/security bugs from backend review

### DIFF
--- a/sculptor/sculptor/agents/default/agent_wrapper.py
+++ b/sculptor/sculptor/agents/default/agent_wrapper.py
@@ -114,6 +114,10 @@ class DefaultAgentWrapper(Agent):
             case StopAgentUserMessage():
                 logger.info("Stopping agent")
                 with self._handle_user_message(message):
+                    # Mark the turn as stopping so the clean-exit branch of
+                    # _handle_user_message suppresses RequestSuccessAgentMessage: an
+                    # interrupted turn must not report success.
+                    self._is_stopping = True
                     self.terminate(DEFAULT_WAIT_TIMEOUT)
                     self._exit_code = AGENT_EXIT_CODE_CLEAN_SHUTDOWN_ON_INTERRUPT
                 logger.info("Finished stopping agent")

--- a/sculptor/sculptor/agents/default/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/default/agent_wrapper_test.py
@@ -4,6 +4,7 @@ from sculptor.agents.default.agent_wrapper import DefaultAgentWrapper
 from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
+from sculptor.interfaces.agents.agent import StopAgentUserMessage
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.state.messages import LLMModel
 
@@ -19,6 +20,16 @@ class _WrapperForTest(DefaultAgentWrapper):
 
     def wait(self, timeout: float) -> int:
         return 0
+
+
+class _StoppableWrapperForTest(_WrapperForTest):
+    """``terminate`` is stubbed to a no-op so the ``StopAgentUserMessage`` path can
+    be exercised without environment/harness wiring -- the real ``terminate`` calls
+    ``self.environment.stop_terminal_manager()``, which ``model_construct`` leaves
+    unset."""
+
+    def terminate(self, force_kill_seconds: float = 5.0) -> None:
+        return None
 
 
 def _drain(queue: Queue) -> list:
@@ -72,3 +83,24 @@ def test_resume_turn_uses_for_user_message_id_as_request_id() -> None:
     assert succeeded[0].request_id == original_user_message_id, (
         f"RequestSuccess must use for_user_message_id; got {succeeded[0].request_id}"
     )
+
+
+def test_stop_message_does_not_emit_request_success() -> None:
+    """Handling a ``StopAgentUserMessage`` must NOT emit a ``RequestSuccessAgentMessage``.
+
+    Once a turn is being stopped it is being interrupted, so its per-turn bracket
+    must not report success -- otherwise the frontend sees the interrupted turn
+    "succeed". The stop handler enforces this by setting ``self._is_stopping = True``
+    so ``_handle_user_message``'s clean-exit branch suppresses the success message.
+
+    Regression test: ``_is_stopping`` was introduced (declared + read in the guard)
+    but never assigned, so the guard was always true and a ``RequestSuccessAgentMessage``
+    was emitted on every stop.
+    """
+    wrapper = _StoppableWrapperForTest.model_construct()
+
+    wrapper.push_message(StopAgentUserMessage())
+
+    emitted = _drain(wrapper._output_messages)
+    succeeded = [m for m in emitted if isinstance(m, RequestSuccessAgentMessage)]
+    assert succeeded == [], f"a stopped turn must not emit RequestSuccess; got {emitted}"

--- a/sculptor/sculptor/agents/hello_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/hello_agent/agent_wrapper.py
@@ -41,6 +41,10 @@ class HelloAgent(DefaultAgentWrapper):
             case StopAgentUserMessage():
                 with self._handle_user_message(message):
                     logger.info("Stopping agent")
+                    # Mark the turn as stopping so the clean-exit branch of
+                    # _handle_user_message suppresses RequestSuccessAgentMessage: an
+                    # interrupted turn must not report success.
+                    self._is_stopping = True
                     self._shutdown_event.set()
                     self.wait(10.0)
                     self._exit_code = AGENT_EXIT_CODE_CLEAN_SHUTDOWN_ON_INTERRUPT

--- a/sculptor/sculptor/agents/hello_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/hello_agent/agent_wrapper_test.py
@@ -1,0 +1,38 @@
+from queue import Queue
+
+from sculptor.agents.hello_agent.agent_wrapper import HelloAgent
+from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
+from sculptor.interfaces.agents.agent import StopAgentUserMessage
+
+
+class _HelloForTest(HelloAgent):
+    """``wait`` is stubbed to a no-op so the ``StopAgentUserMessage`` path can be
+    exercised without the message-processing thread / environment wiring that
+    ``model_construct`` leaves unset."""
+
+    def wait(self, timeout: float) -> int | None:
+        return 0
+
+
+def _drain(queue: Queue) -> list:
+    items = []
+    while not queue.empty():
+        items.append(queue.get())
+    return items
+
+
+def test_stop_message_does_not_emit_request_success() -> None:
+    """HelloAgent overrides ``push_message`` with its own stop handler; like the
+    base agent, a stopped turn must NOT emit a ``RequestSuccessAgentMessage``.
+
+    Regression test: the stop handler bracketed the stop in ``_handle_user_message``
+    but never set ``self._is_stopping = True``, so the inherited clean-exit guard
+    was dead and an interrupted turn reported success.
+    """
+    wrapper = _HelloForTest.model_construct()
+
+    wrapper.push_message(StopAgentUserMessage())
+
+    emitted = _drain(wrapper._output_messages)
+    succeeded = [m for m in emitted if isinstance(m, RequestSuccessAgentMessage)]
+    assert succeeded == [], f"a stopped turn must not emit RequestSuccess; got {emitted}"

--- a/sculptor/sculptor/services/task_service/concurrent_implementation.py
+++ b/sculptor/sculptor/services/task_service/concurrent_implementation.py
@@ -259,7 +259,6 @@ class ConcurrentTaskService(BaseTaskService, ABC):
             task_id = task.object_id
             if task_id not in self._runner_by_id:
                 # exceptions in here will definitely have been logged, see implementation of self._run_task
-                logger.info("Creating runner:{}", self.settings)
                 new_runner = self.create_runner(task, task_id, self.settings)
                 self._runner_by_id[task_id] = new_runner
                 new_runner.start()

--- a/sculptor/sculptor/services/task_service/errors.py
+++ b/sculptor/sculptor/services/task_service/errors.py
@@ -14,15 +14,17 @@ class InvalidTaskOperation(ExpectedError):
 
 
 class TaskError(ExpectedError):
-    def __init__(self, transaction_callback: Callable[[DataModelTransaction], Any], is_user_notified: bool) -> None:
+    def __init__(
+        self, transaction_callback: Callable[[DataModelTransaction], Any] | None, is_user_notified: bool
+    ) -> None:
         super().__init__()
         self.transaction_callback = transaction_callback
         self.is_user_notified = is_user_notified
 
 
-class UserStoppedTaskError(ExpectedError):
+class UserStoppedTaskError(TaskError):
     def __init__(self) -> None:
-        super().__init__(None, True)
+        super().__init__(transaction_callback=None, is_user_notified=True)
 
 
 class UserPausedTaskError(UserStoppedTaskError):

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -429,8 +429,8 @@ def _run_agent_in_environment(
             kill_time_start = time.monotonic()
             try:
                 agent_wrapper.terminate(_MAX_HARD_SHUTDOWN_SECONDS)
-                remaining_shutdown_time = time.monotonic() - kill_time_start
-                if remaining_shutdown_time < 0:
+                remaining_shutdown_time = _MAX_HARD_SHUTDOWN_SECONDS - (time.monotonic() - kill_time_start)
+                if remaining_shutdown_time <= 0:
                     raise UncleanTerminationAgentError("No time left to call wait() on agent wrapper")
                 exit_code = agent_wrapper.wait(remaining_shutdown_time)
             except (UncleanTerminationAgentError, WaitTimeoutAgentError) as e:


### PR DESCRIPTION
These are the genuine bug fixes extracted from a larger backend code-review
cleanup branch, split out so they can be reviewed and merged quickly,
independently of the lower-priority style/cleanup changes (which follow in a
separate PR). Each commit is fix-only — cosmetic edits that were bundled with
these fixes in the cleanup branch have been left out.

## Fixes

1. **Spurious `RequestSuccessAgentMessage` on stopped turns.** A
   stop-suppression guard read a flag that was never set, so a success message
   was emitted even when a turn was being stopped. The stop path now sets the
   flag (with regression tests for the default and hello agents).

2. **`UserStoppedTaskError` base class + constructor.** It inherited from the
   wrong base and passed positional args that were silently swallowed, so its
   intended attributes were never populated and `str()` was meaningless. Re-based
   on `TaskError` with keyword args; catch ordering and outcomes are unchanged.

3. **Hard-shutdown timeout used elapsed time instead of remaining budget.** The
   "remaining" duration was computed as time *elapsed* during `terminate()`, so
   the negative-time guard could never fire and `wait()` got ~0 — mis-reporting a
   cleanly terminating agent as hard-killed. Now computes the true remaining
   budget and guards with `<= 0`.

4. **Stop logging the settings object on runner creation.** A debug log
   serialized the full settings object — which embeds an auth token — into the
   logs on every runner creation. The line was also redundant with the adjacent
   "Starting new runner" log, so it is removed.

## Verification

- `pyre`: no type errors
- `ruff` format + lint: clean
- Targeted backend unit tests for all touched modules pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)