### PR TITLE
SCU-1397: decommission Fly linux-sculptor-builder runner (repo cleanup)

### DIFF
--- a/scripts/export-vault-env
+++ b/scripts/export-vault-env
@@ -26,14 +26,10 @@
 #   The first two are auto-injected by the runner when the calling job
 #   declares `permissions: id-token: write`.
 #
-# - On Fly:
-#   Authenticates using Fly JWT.
-#   Expects VAULT_AUTH_ROLE to be set.
-#
 # - Locally:
 #   Expects the user to be already logged in.
 #
-# On GitHub Actions and Fly, also writes the VAULT_TOKEN from
+# On GitHub Actions, also writes the VAULT_TOKEN from
 # authentication, albeit unexported, like:
 #
 #   VAULT_TOKEN=...
@@ -55,15 +51,6 @@ if test "$GITHUB_ACTIONS" = "true"; then
     "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=imbue-vault" \
     | jq -r .value)
   export VAULT_TOKEN=$(vault write -field=token auth/jwt_github_actions/login role="$VAULT_AUTH_ROLE" jwt="$github_oidc_token")
-  echo "VAULT_TOKEN=$VAULT_TOKEN"
-elif test -S /.fly/api; then
-  # Running in a Fly machine.
-  # Use the local socket to generate an OIDC token;
-  # see https://fly.io/docs/security/openid-connect/.
-  # The app should have VAULT_AUTH_ROLE set in its fly.toml.
-  VAULT_ID_TOKEN=$(curl --unix-socket /.fly/api -X POST "http://localhost/v1/tokens/oidc" --data '{"aud":"imbue-vault"}')
-  # TODO: Make this work for apps in imbue-development too.
-  export VAULT_TOKEN=$(vault write -field=token auth/jwt_fly_prod/login role="$VAULT_AUTH_ROLE" jwt="$VAULT_ID_TOKEN")
   echo "VAULT_TOKEN=$VAULT_TOKEN"
 elif test -z "$VAULT_TOKEN" && ! test -f ~/.vault-token; then
   echo >&2 'Log in Vault first.'

--- a/sculptor/sculptor/testing/elements/base.py
+++ b/sculptor/sculptor/testing/elements/base.py
@@ -115,7 +115,7 @@ def type_into_tiptap(page: Page, locator: Locator, text: str) -> None:
     # After a page reload the React fiber tree may not have the Tiptap editor
     # prop attached yet even though the DOM element is visible and clickable.
     # Poll with requestAnimationFrame (once per frame, ~16 ms) for up to 5 s
-    # before giving up.  On Fly runners after shared-instance recreation,
+    # before giving up.  On contended CI runners after shared-instance recreation,
     # the editor can take >2 s to initialize.
     locator.evaluate(
         f"""(el, text) => new Promise((resolve, reject) => {{

--- a/sculptor/sculptor/testing/playwright_conftest.py
+++ b/sculptor/sculptor/testing/playwright_conftest.py
@@ -174,7 +174,7 @@ def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str])
     already started" on every later test in that sibling — the same
     cascade we are trying to prevent. Offload runs one test per Modal
     sandbox (no xdist), so this gate keeps the fix where it matters and
-    avoids the friendly-fire on Fly's ``XDIST_WORKERS=7`` runs and on
+    avoids the friendly-fire on CI ``XDIST_WORKERS=7`` runs and on
     local-xdist runs.
     """
     if os.environ.get("PYTEST_XDIST_WORKER") or _IS_XDIST_CONTROLLER:

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -316,7 +316,7 @@ def start_task_and_wait_for_ready(
     submit_button.click()
 
     # Wait for the chat panel to appear (indicates we navigated to the agent page).
-    # On Fly runners the workspace clone + environment setup can take >30s.
+    # On contended CI runners the workspace clone + environment setup can take >30s.
     chat_panel_locator = sculptor_page.get_by_test_id(ElementIDs.CHAT_PANEL)
     expect(chat_panel_locator).to_be_visible(timeout=60_000)
 

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -53,10 +53,10 @@ from sculptor.testing.subprocess_utils import Forwarder
 from sculptor.testing.test_repo_factory import TestRepoFactory
 
 # Timeout for the initial SPA render after server startup (shared + factory instances).
-# Longer than the default 30s to allow headroom for Fly runners and cold Electron starts.
+# Longer than the default 30s to allow headroom for cold Electron starts on CI.
 # Cold Electron startup on the contended shared CI runners (the
 # ``integration_tests_electron`` job) regularly takes 50-60s — well past the
-# previous 45s ceiling — even though Fly's dedicated runners finish in 30-40s.
+# previous 45s ceiling.
 # Bumping to 90s eats one extra wall-second per failure but lets the slow path
 # pass instead of erroring in fixture setup.
 _INITIAL_RENDER_TIMEOUT_MS = 90_000

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
@@ -118,7 +118,7 @@ def _setup_three_prompt_chat(sculptor_instance_: SculptorInstance):
     # scrollTop ≈ start[lastUserMessage], then immediately exit navigation by
     # focusing the chat input.  Without this, the auto-scroll-to-bottom after
     # the 3rd response leaves scrollTop past the last prompt's start — on
-    # Fly runners that trips ``isScrolledPastActive()`` in the app's keydown
+    # slow CI runners that trips ``isScrolledPastActive()`` in the app's keydown
     # hook, so the first ArrowUp from a test becomes "scroll current turn
     # to top" instead of "decrement to previous prompt".
     dots.nth(2).click()

--- a/sculptor/tests/integration/frontend/test_alpha_streaming_cursor.py
+++ b/sculptor/tests/integration/frontend/test_alpha_streaming_cursor.py
@@ -51,7 +51,7 @@ def test_streaming_cursor_visible_during_streaming(sculptor_instance_: SculptorI
 
     # Wait for the streaming to finish and the cursor to disappear.
     # Wait directly for the cursor element to be removed.  The streaming takes
-    # ~40s on fast machines, potentially longer on slow Fly runners.
+    # ~40s on fast machines, potentially longer on slow CI runners.
     expect(cursor).to_have_count(0, timeout=120_000)
 
 

--- a/sculptor/tests/integration/frontend/test_chat_search_bar.py
+++ b/sculptor/tests/integration/frontend/test_chat_search_bar.py
@@ -89,7 +89,7 @@ def test_search_bar_does_not_flash_red_while_typing_matching_query(
 
     # Create a conversation with searchable text content.
     # Use a unique keyword to avoid a flaky match-count inflation (expected 2,
-    # got 4) seen intermittently on Fly runners.  Root cause is unclear — could
+    # got 4) seen intermittently on slow CI runners.  Root cause is unclear — could
     # be a DOM-level race in the TreeWalker search under heavier load, or a
     # transient duplicate render.  Using a rare word sidesteps the issue.
     keyword = "zephyr"

--- a/sculptor/tests/integration/frontend/test_closed_workspaces_dropdown.py
+++ b/sculptor/tests/integration/frontend/test_closed_workspaces_dropdown.py
@@ -123,7 +123,7 @@ def test_delete_workspace_from_dropdown(
 
     # Wait for the dropdown's open animation to settle before hovering.  A
     # row that's technically "visible" mid-transform has a moving hit target,
-    # and hover() retries on instability — that's been timing out on Fly.
+    # and hover() retries on instability — that's been timing out on slow CI.
     dropdown_element = layout.get_closed_workspaces_dropdown()
     expect(dropdown_element).to_be_visible()
     row = dropdown_element.get_rows()

--- a/sculptor/tests/integration/frontend/test_pr_button_errors.py
+++ b/sculptor/tests/integration/frontend/test_pr_button_errors.py
@@ -66,7 +66,7 @@ def _start_task_and_wait_for_pr_status(page: Page, prompt: str, expected_button:
     on it.
     """
     task_page = start_task_and_wait_for_ready(page, prompt)
-    # The backend poll cadence on slow CI runners (Fly / offload) plus the
+    # The backend poll cadence on slow CI runners (e.g. offload) plus the
     # clone-on-target-branch transient means the initial PR button can take
     # a non-trivial amount of time to reach its final state — give it a
     # generous budget before we conclude the status never arrived.


### PR DESCRIPTION
## What

Post-cutover cleanup for the retired Fly-hosted `linux-sculptor-builder` Linux x64 build runner (SCU-1397). The runner's job moved to GitHub-hosted `ubuntu-latest` runners; this PR removes its leftover traces in this repo.

Two commits:

1. **Drop stale "Fly runner" comment references.** Reword the now-inaccurate "Fly runner" mentions in test/testing helpers to generic "CI runner" wording. Timeouts and rationale are unchanged — comment-only.
2. **Remove the dead Fly auth branch from `scripts/export-vault-env`.** Nothing checks out this repo and runs the script on a Fly machine anymore (CI is entirely GitHub Actions), so the `/.fly/api` OIDC branch is dead. The GitHub-Actions and local auth paths are untouched.

## Notes

- The `linux-sculptor-builder/` directory, its justfile recipes, and the GitLab CI files never existed in this (public) repo's history, so there was nothing to delete there.
- The live Fly app and the Vault role / GitLab-CI references that live in the infra repo are handled separately, outside this PR.

## Verification

`just format`, `just check`, and `just test-unit` all pass.

(Sent by Claude)