### PR TITLE
SCU-1501: Add OpenHost manifest and Dockerfile for self-hosted deployment

### DIFF
--- a/openhost.Dockerfile
+++ b/openhost.Dockerfile
@@ -1,0 +1,106 @@
+# Dockerfile for running Sculptor as an OpenHost app, built from source.
+#
+# Unlike a released-binary image, this builds the exact code on this branch: it
+# installs the backend with uv, regenerates the API client and builds the web
+# UI, then runs the backend from source — serving the bundled UI itself, with no
+# Electron shell. OpenHost builds with the repo root as the build context, from a
+# clean git clone (so gitignored artifacts like node_modules/.venv/frontend dist
+# are regenerated here, not copied in).
+#
+# All persistent state lands in the OpenHost app data dir so it survives
+# rebuilds / "update and reload".
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git curl ca-certificates xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 — for the frontend build and the API-client codegen.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# uv — Python package/venv manager; it provisions the right Python for the project.
+RUN curl -fsSL https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+# Copy into the venv instead of hardlinking the uv cache, so it stays
+# self-contained when run later under a different (rootless) UID.
+ENV UV_LINK_MODE=copy
+# Install uv's managed Python under a world-readable path (default is
+# /root/.local/share/uv/python, which the non-root runtime UID can't traverse).
+# The venv's python symlinks here, so it must stay accessible at runtime.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
+
+WORKDIR /app
+COPY . /app
+
+# Install the backend env first — the frontend's generate-api step shells out to
+# `uv run` to emit the OpenAPI schema, so the backend env must already exist.
+RUN cd /app/sculptor && uv sync
+
+# Regenerate the API client from the (just-built) backend, then build the web UI.
+RUN cd /app/sculptor/frontend && \
+    npm install --force && \
+    npm run generate-api && \
+    npm run build
+
+# --- Runtime setup ---------------------------------------------------------
+
+# Rename Ubuntu's stock 'ubuntu' user (UID 1000) to 'sculptor'; the entrypoint
+# remaps its UID to whatever rootless podman assigns at runtime. World-writable
+# /etc/passwd lets that remap happen as a non-root user. /app is made world
+# read/executable so the runtime UID can run the built venv and read the UI.
+RUN usermod -l sculptor -d /home/sculptor -m ubuntu && \
+    groupmod -n sculptor ubuntu && \
+    mkdir -p /home/sculptor && chmod 777 /home/sculptor && \
+    mkdir -p /data && chmod 777 /data && \
+    chmod 666 /etc/passwd && \
+    chmod -R a+rX /app /opt/uv-python
+
+ENV HOME=/home/sculptor
+# Serve on all interfaces so the OpenHost router can proxy to us.
+ENV SCULPTOR_BIND_HOST=0.0.0.0
+# Port the backend listens on. Keep in sync with `port` in openhost.toml.
+ENV SCULPTOR_API_PORT=5050
+# Persist DB, workspaces, downloaded agent binaries, and user config into the
+# OpenHost backed-up app data dir (the app is named "sculptor" in openhost.toml).
+ENV SCULPTOR_FOLDER=/data/app_data/sculptor
+# Persist Claude Code's OAuth credentials (written by the in-app sign-in flow).
+ENV CLAUDE_CONFIG_DIR=/data/app_data/sculptor/claude
+
+# A minimal git repo for Sculptor to open as a project on first run.
+WORKDIR /workspace
+RUN git -c user.email="sculptor@container" -c user.name="Sculptor" init && \
+    git -c user.email="sculptor@container" -c user.name="Sculptor" commit --allow-empty -m "Initial commit" && \
+    chmod -R 777 /workspace && \
+    git config --system safe.directory '*'
+
+# Minimal entrypoint: give the runtime UID a valid /etc/passwd entry (rootless
+# podman assigns an arbitrary UID), then exec the command. No binary download —
+# we run from the source built above. Written with printf to avoid heredoc
+# portability concerns across build backends.
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    'uid=$(id -u)' \
+    'if ! getent passwd "$uid" >/dev/null 2>&1; then' \
+    '  gid=$(id -g)' \
+    '  tmp=$(mktemp /tmp/passwd.XXXXXX)' \
+    '  sed "s/^sculptor:x:1000:1000:/sculptor:x:${uid}:${gid}:/" /etc/passwd > "$tmp"' \
+    '  cat "$tmp" > /etc/passwd' \
+    '  rm -f "$tmp"' \
+    'fi' \
+    'exec "$@"' \
+    > /usr/local/bin/openhost-entrypoint.sh && \
+    chmod +x /usr/local/bin/openhost-entrypoint.sh
+
+USER sculptor
+ENTRYPOINT ["/usr/local/bin/openhost-entrypoint.sh"]
+# Ensure the persistent dirs exist, then run the backend from the built venv.
+# The venv lives at the uv *workspace* root (/app/.venv), not /app/sculptor.
+# No --no-serve-static: the backend serves the web UI built above (resolved via
+# the 'sculptor' package's editable install at /app/sculptor/frontend/dist).
+CMD ["sh", "-c", "mkdir -p \"$SCULPTOR_FOLDER\" \"$CLAUDE_CONFIG_DIR\" && exec /app/.venv/bin/python -m sculptor.cli.main --no-open-browser /workspace"]

--- a/openhost.toml
+++ b/openhost.toml
@@ -1,0 +1,44 @@
+# OpenHost app manifest for running Sculptor as a self-hosted app.
+#
+# Deploy onto an OpenHost compute space from the dashboard ("Deploy New App")
+# or with the `oh` CLI:
+#
+#   oh app deploy https://github.com/imbue-ai/sculptor@<branch> --name sculptor
+#
+# The router builds `openhost.Dockerfile` (build context = repo root), runs the
+# container under rootless podman, and reverse-proxies HTTPS to it at
+# https://sculptor.<your-zone-domain>/ behind OpenHost's owner login.
+#
+# See docs/development/ in the openhost repo, or docs/src/manifest_spec.md there,
+# for the full field reference.
+
+[app]
+name = "sculptor"
+version = "0.1.0"
+description = "Sculptor — AI coding agent platform by Imbue"
+authors = ["Imbue"]
+
+[runtime.container]
+# Path to the Dockerfile, relative to the repo root. The build context is always
+# the repo root, so this Dockerfile can COPY the existing container recipe scripts.
+image = "openhost.Dockerfile"
+# Port the Sculptor backend listens on inside the container (SCULPTOR_API_PORT).
+# Kept in sync with the value set in openhost.Dockerfile.
+port = 5050
+
+[routing]
+# Backend readiness probe (unauthenticated). Used by the router to know the app is up.
+health_check = "/api/v1/health"
+
+[resources]
+# Sculptor runs Claude Code agents as local subprocesses inside this container,
+# so size it for the backend plus a few concurrent agents. Tune to taste / host.
+memory_mb = 4096
+cpu_millicores = 4000
+
+[data]
+# Persistent, backed-up directory mounted at /data/app_data/sculptor (also exposed
+# as $OPENHOST_APP_DATA_DIR). openhost.Dockerfile points SCULPTOR_FOLDER and the
+# Claude config dir here so the database, workspaces, downloaded agent binary, and
+# Claude auth all survive rebuilds / "update and reload".
+app_data = true


### PR DESCRIPTION
## What

Adds `openhost.toml` (the app manifest) and `openhost.Dockerfile` for a self-hosted OpenHost deployment.

- The image builds Sculptor **from source** (install the backend with uv, regenerate the API client, build the web UI, run from source serving the bundled UI) so a self-hosted deploy carries unreleased changes.

## Stack

- **Stacked on top of #40 (SCU-1502).** This PR targets `bryden/scu-1502-claude-auth-code` because the source-built image carries the headless paste-a-code Claude sign-in flow from that PR.
- Review/merge #40 first; this PR will retarget to `main` automatically once the base merges.

Linear: SCU-1501

(Sent by Claude)
