### PR TITLE
Fix drop-harness migration failing on databases with auto-managed triggers

### DIFF
--- a/sculptor/sculptor/database/alembic/version_tests/test_b3f1a9c2d6e5.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_b3f1a9c2d6e5.py
@@ -56,6 +56,24 @@ class TestMigrationB3f1a9c2d6e5(MigrationTestFixture):
                 {"ws_id": WORKSPACE_ID, "project_id": PROJECT_ID},
             )
 
+        # Reproduce production state: at runtime, initialize_db() installs an auto-managed
+        # before-insert trigger on `workspace` that references every base column, including
+        # NEW.harness (see database/automanaged.py). SQLite validates trigger bodies during
+        # ALTER TABLE, so dropping the harness column fails unless the migration drops this
+        # trigger first. The migration test harness does not install these triggers, so we
+        # recreate the relevant one here to exercise the DROP COLUMN path the way production does.
+        connection.execute(
+            sa.text("""
+                CREATE TRIGGER workspace_before_insert
+                BEFORE INSERT ON workspace
+                BEGIN
+                    INSERT INTO workspace_latest (object_id, harness)
+                    VALUES (NEW.object_id, NEW.harness)
+                    ON CONFLICT (object_id) DO UPDATE SET harness = excluded.harness;
+                END;
+            """)
+        )
+
     def verify(self, connection: sa.engine.Connection) -> None:
         for table in ("workspace", "workspace_latest"):
             columns = {

--- a/sculptor/sculptor/database/alembic/versions/b3f1a9c2d6e5_drop_harness_from_workspace.py
+++ b/sculptor/sculptor/database/alembic/versions/b3f1a9c2d6e5_drop_harness_from_workspace.py
@@ -23,6 +23,15 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    connection = op.get_bind()
+
+    # Drop triggers that reference the workspace table before dropping the column.
+    # SQLite validates trigger references during ALTER TABLE, so the trigger
+    # referencing NEW.harness would cause the DROP COLUMN to fail.
+    # The triggers are recreated by initialize_db() on next Sculptor startup.
+    connection.execute(sa.text("DROP TRIGGER IF EXISTS workspace_before_insert"))
+    connection.execute(sa.text("DROP TRIGGER IF EXISTS set_workspace_created_at"))
+
     op.drop_column("workspace", "harness")
     op.drop_column("workspace_latest", "harness")
 


### PR DESCRIPTION
## Problem

The migration that drops the `harness` column from the `workspace` table (`b3f1a9c2d6e5_drop_harness_from_workspace`) issued `DROP COLUMN` without first dropping the auto-managed triggers on that table. SQLite validates trigger bodies during `ALTER TABLE`, and the `workspace_before_insert` trigger references `NEW.harness`, so on any pre-existing database the migration aborted with:

```
error in trigger workspace_before_insert after drop column: no such column: NEW.harness
[SQL: ALTER TABLE workspace DROP COLUMN harness]
```

This blocked startup for anyone upgrading with existing data — migrations failed, the DB rolled back to its backup, and the app exited.

## Fix

Drop the `workspace_before_insert` and `set_workspace_created_at` triggers before dropping the column, matching the pattern already used by every other drop-column migration in the tree. The triggers are recreated by `initialize_db()` on the next startup.

## Why it wasn't caught

The migration test harness builds schema only from migrations and never installs the runtime auto-managed triggers, so there was no `NEW.harness` reference for `DROP COLUMN` to collide with — the existing fixture passed despite the bug. The fixture now installs a before-insert trigger referencing `NEW.harness`, reproducing real-world state. With that, the test **fails without the fix** (exact production error) and **passes with it**.

## Verification

- `just check`, `just format`, `just test-unit` all pass.
- Confirmed the existing sibling drop-column migrations already drop their triggers — this was an isolated regression.
- Ran the **fixed** migration against a copy of a real ~2GB / 222k-row production database that was stuck at the failing revision: migration succeeded, `harness` dropped from both `workspace` and `workspace_latest`, row counts preserved, `PRAGMA quick_check` ok, and the full `initialize_db` startup path (migrate + reinstall triggers) completed cleanly with the trigger recreated and no longer referencing `harness`.

(Sent by Claude)