### PR TITLE
Cherry-pick #42 (harness-migration fix) into 0.37.0 RC

### DIFF
--- a/sculptor/sculptor/database/alembic/version_tests/test_b3f1a9c2d6e5.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_b3f1a9c2d6e5.py
@@ -56,6 +56,24 @@ class TestMigrationB3f1a9c2d6e5(MigrationTestFixture):
                 {"ws_id": WORKSPACE_ID, "project_id": PROJECT_ID},
             )
 
+        # Reproduce production state: at runtime, initialize_db() installs an auto-managed
+        # before-insert trigger on `workspace` that references every base column, including
+        # NEW.harness (see database/automanaged.py). SQLite validates trigger bodies during
+        # ALTER TABLE, so dropping the harness column fails unless the migration drops this
+        # trigger first. The migration test harness does not install these triggers, so we
+        # recreate the relevant one here to exercise the DROP COLUMN path the way production does.
+        connection.execute(
+            sa.text("""
+                CREATE TRIGGER workspace_before_insert
+                BEFORE INSERT ON workspace
+                BEGIN
+                    INSERT INTO workspace_latest (object_id, harness)
+                    VALUES (NEW.object_id, NEW.harness)
+                    ON CONFLICT (object_id) DO UPDATE SET harness = excluded.harness;
+                END;
+            """)
+        )
+
     def verify(self, connection: sa.engine.Connection) -> None:
         for table in ("workspace", "workspace_latest"):
             columns = {

--- a/sculptor/sculptor/database/alembic/versions/b3f1a9c2d6e5_drop_harness_from_workspace.py
+++ b/sculptor/sculptor/database/alembic/versions/b3f1a9c2d6e5_drop_harness_from_workspace.py
@@ -23,6 +23,15 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    connection = op.get_bind()
+
+    # Drop triggers that reference the workspace table before dropping the column.
+    # SQLite validates trigger references during ALTER TABLE, so the trigger
+    # referencing NEW.harness would cause the DROP COLUMN to fail.
+    # The triggers are recreated by initialize_db() on next Sculptor startup.
+    connection.execute(sa.text("DROP TRIGGER IF EXISTS workspace_before_insert"))
+    connection.execute(sa.text("DROP TRIGGER IF EXISTS set_workspace_created_at"))
+
     op.drop_column("workspace", "harness")
     op.drop_column("workspace_latest", "harness")
 


### PR DESCRIPTION
Cherry-picks the fix from #42 (`060b47c`, "Fix drop-harness migration failing on databases with auto-managed triggers") onto `release/sculptor-v0.37.0` for the next RC (rc2).

Picked the single fix commit, not the merge commit. Clean pick, no conflicts. Source PR merged to `main` as merge commit `e148f0f`.

(Sent by Claude)