### PR TITLE
[SCU-1376] Upgrade Offload to v0.9.8

### DIFF
--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  OFFLOAD_VERSION: "0.9.8"
   # HCP Vault address + namespace. Mirrors the values in scripts/export-vault-env.
   VAULT_ADDR: https://vault-cluster-public-vault-df29b16f.9b573ab7.z1.hashicorp.cloud:8200
   VAULT_NAMESPACE: admin
@@ -97,12 +98,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.7-${{ runner.os }}
+          key: cargo-offload-${{ env.OFFLOAD_VERSION }}-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload >/dev/null || ! offload --version | grep -q '0.9.7'; then
-            cargo install offload@0.9.7 --force
+          if ! command -v offload >/dev/null || ! offload --version | grep -qF "$OFFLOAD_VERSION"; then
+            cargo install offload@"$OFFLOAD_VERSION" --force
           fi
           offload --version
 


### PR DESCRIPTION
Upgrades to the latest version of Offload in order to reduce memory pressure during cleanup step.

Also takes advantage of this to move us to a smaller Offload CI runner.

### How you verified it
- [x] Verified with local runs
<table>
  <thead>
    <tr>
      <th>Teardown metric (<code>sandbox_cleanup</code> span)</th>
      <th>0.9.7 OLD (per-sandbox)</th>
      <th>0.9.8 NEW (batched)</th>
      <th>Improvement</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Duration</td>
      <td><strong>39.1 s</strong></td>
      <td><strong>4.1 s</strong></td>
      <td><strong>9.5&times; shorter</strong></td>
    </tr>
    <tr>
      <td>Destroy interpreters re-spawned post-test</td>
      <td>climbs to <strong>329</strong></td>
      <td>none (declines only)</td>
      <td>eliminated</td>
    </tr>
    <tr>
      <td>Peak RSS of the shutdown re-spike</td>
      <td><strong>6.65 GB</strong></td>
      <td>none</td>
      <td>eliminated</td>
    </tr>
    <tr>
      <td>Memory-time integral</td>
      <td><strong>147 GB&middot;s</strong></td>
      <td><strong>6.6 GB&middot;s</strong></td>
      <td><strong>22&times; less</strong></td>
    </tr>
    <tr>
      <td>Swap growth during teardown</td>
      <td><strong>+0.75 GB</strong></td>
      <td>+0.00 GB</td>
      <td>eliminated</td>
    </tr>
  </tbody>
</table>

- [x] Verified successful in CI with an unchanged runner
