### PR TITLE
docs(skills): caution against `sculpt workspace create` in handoff/stack

### DIFF
--- a/sculptor/sculptor-experimental/skills/handoff/SKILL.md
+++ b/sculptor/sculptor-experimental/skills/handoff/SKILL.md
@@ -114,6 +114,12 @@ sculpt run \
 auto-named branch cut from the current branch — the same mechanism the UI uses —
 so the committed work carries over.
 
+> **Use `sculpt run`, not `sculpt workspace create`.** `sculpt run` creates the
+> workspace, its agent, *and* the git worktree in one step. `sculpt workspace
+> create` only registers a workspace record — no agent, no checkout — so it
+> renders as a blank screen in the UI. To add an agent to an already-empty
+> workspace, run `sculpt agent create -w <ws_id> -p "..."`.
+
 Add `-m sonnet` (or another model) to override the default model.
 
 ## Step 5 — Report back

--- a/sculptor/sculptor-experimental/skills/stack/SKILL.md
+++ b/sculptor/sculptor-experimental/skills/stack/SKILL.md
@@ -71,3 +71,9 @@ sculpt run \
   --json \
   "<context-summary prompt>"
 ```
+
+> **Use `sculpt run`, not `sculpt workspace create`.** `sculpt run` creates the
+> workspace, its agent, *and* the git worktree in one step. `sculpt workspace
+> create` only registers a workspace record — no agent, no checkout — so it
+> renders as a blank screen in the UI. To add an agent to an already-empty
+> workspace, run `sculpt agent create -w <ws_id> -p "..."`.


### PR DESCRIPTION
## What

Adds a short caution to both Sculptor skills that create a new workspace:

- `sculptor/sculptor-experimental/skills/handoff/SKILL.md` (Step 4, new-workspace path)
- `sculptor/sculptor-experimental/skills/stack/SKILL.md` (after the create command block)

Each note clarifies that the skill should use `sculpt run`, not `sculpt workspace create`.

## Why

`sculpt workspace create` looks like the obvious way to make a workspace, but it only registers a workspace DB record — it provisions **no agent and no git worktree**. The result has no checkout on disk and renders as a **blank screen** in the Sculptor UI. `sculpt run` instead creates the workspace, its agent, and the git worktree in one step, which is what both skills already invoke.

The note also points to `sculpt agent create -w <ws_id> -p "..."` as the way to add a first agent to an already-empty workspace (which triggers worktree provisioning).

This was hit in real use while creating stacked workspaces, so documenting it in the skills should prevent the same dead end.

## Scope

Docs-only change to two Markdown skill files (+12 lines total). `just format` and `just check` both pass.

(Sent by Claude)