### PR TITLE
Make migrations immune to triggers referencing dropped columns

### DIFF
--- a/sculptor/sculptor/database/alembic/env.py
+++ b/sculptor/sculptor/database/alembic/env.py
@@ -4,6 +4,7 @@ from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
+from sculptor.database.alembic.utils import drop_all_automanaged_triggers
 from sculptor.database.core import METADATA
 from sculptor.services.data_model_service.sql_implementation import register_all_tables
 
@@ -75,6 +76,10 @@ def run_migrations_online() -> None:
         context.configure(connection=connection, target_metadata=target_metadata)
 
         with context.begin_transaction():
+            # Invariant: no auto-managed triggers exist while migrations run, so a migration
+            # can never fail by dropping a column a trigger still references. Triggers are
+            # recreated from the current model immediately after migrations.
+            drop_all_automanaged_triggers(connection)
             context.run_migrations()
 
 

--- a/sculptor/sculptor/database/alembic/utils.py
+++ b/sculptor/sculptor/database/alembic/utils.py
@@ -8,10 +8,41 @@ from typing import Generator
 import alembic.script
 from alembic import context
 from alembic.config import Config
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
 
 from sculptor.database.alembic.json_migrations import Schemas
 
 FROZEN_SCHEMAS_PATH = Path(__file__).parent / "frozen_pydantic_schemas.json"
+
+
+def drop_all_automanaged_triggers(connection: Connection) -> None:
+    """Drop every database trigger before migrations run.
+
+    Auto-managed tables (see ``database/automanaged.py``) carry triggers whose bodies
+    reference *every* column of the table — e.g. ``<table>_before_insert`` references
+    ``NEW.<col>`` for each column. SQLite validates trigger bodies during ``ALTER TABLE``,
+    so dropping or renaming any referenced column fails while such a trigger exists. That
+    made every column-dropping migration responsible for manually dropping its triggers
+    first — a forgettable step that broke startup more than once.
+
+    We make that class of failure impossible by guaranteeing the invariant that no trigger
+    exists while migrations run. The triggers are recreated from the current model right
+    after migrations by ``initialize_db_from_connection()``. This also matches what
+    migrations already assume — e.g. one migration populates ``<table>_latest`` by hand
+    with the comment "triggers don't exist during migration", which is only true on a fresh
+    install; this makes it true on upgrades too.
+
+    Every trigger in this database is part of the auto-managed dual-table pattern, so it is
+    safe to drop them all here.
+    """
+    if connection.dialect.name != "sqlite":
+        return
+    trigger_names = [
+        row[0] for row in connection.execute(text("SELECT name FROM sqlite_master WHERE type = 'trigger'"))
+    ]
+    for name in trigger_names:
+        connection.execute(text(f'DROP TRIGGER IF EXISTS "{name}"'))
 
 
 @contextmanager
@@ -27,6 +58,9 @@ def override_run_env(context_kwargs: dict[str, Any]) -> Generator[Config, None, 
     def run_env(self) -> None:
         context.configure(**context_kwargs)
         with context.begin_transaction():
+            connection = context_kwargs.get("connection")
+            if connection is not None:
+                drop_all_automanaged_triggers(connection)
             context.run_migrations()
 
     config = Config()

--- a/sculptor/sculptor/database/automanaged.py
+++ b/sculptor/sculptor/database/automanaged.py
@@ -229,6 +229,9 @@ def _get_sqlite_triggers(
     # NOTE: The initialization code runs on every server startup, dropping and recreating these triggers.
     # This is only safe because we assume the sqlite database is not used by multiple processes at the
     # same time. Do not introduce concurrent writers without changing how trigger/DB state is managed.
+    # NOTE: These triggers reference every column, so they are also dropped before migrations run (see
+    # drop_all_automanaged_triggers in alembic/utils.py) and recreated afterwards. That invariant means a
+    # column-dropping migration never needs to drop triggers itself — do not rely on triggers mid-migration.
     drop_existing_before_insert_trigger = DDL(f"DROP TRIGGER IF EXISTS {table_name}_before_insert;")
     before_insert_trigger = DDL(
         f"""

--- a/sculptor/sculptor/services/data_model_service/sql_implementation_test.py
+++ b/sculptor/sculptor/services/data_model_service/sql_implementation_test.py
@@ -504,6 +504,97 @@ def test_triggers_work_after_migration() -> None:
             )
 
 
+def test_drop_all_automanaged_triggers_unblocks_drop_column() -> None:
+    """Encodes the exact failure mode: a trigger referencing a column blocks DROP COLUMN.
+
+    SQLite validates trigger bodies during ALTER TABLE, so dropping a column that an
+    existing trigger references fails. drop_all_automanaged_triggers removes that hazard,
+    which is what makes the whole class of migration failures impossible.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import StaticPool
+
+    from sculptor.database.alembic.utils import drop_all_automanaged_triggers
+
+    engine = create_engine(IN_MEMORY_SQLITE, poolclass=StaticPool, connect_args={"check_same_thread": False})
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE widget (id TEXT, doomed TEXT)"))
+        connection.execute(text("CREATE TABLE widget_latest (id TEXT PRIMARY KEY, doomed TEXT)"))
+        connection.execute(
+            text("""
+                CREATE TRIGGER widget_before_insert BEFORE INSERT ON widget BEGIN
+                    INSERT INTO widget_latest (id, doomed) VALUES (NEW.id, NEW.doomed)
+                    ON CONFLICT (id) DO UPDATE SET doomed = excluded.doomed;
+                END;
+            """)
+        )
+
+    # With the trigger present, dropping the referenced column fails — the exact bug.
+    with pytest.raises(OperationalError):
+        with engine.begin() as connection:
+            connection.execute(text("ALTER TABLE widget DROP COLUMN doomed"))
+
+    # After dropping triggers, the same statement succeeds and no triggers remain.
+    with engine.begin() as connection:
+        drop_all_automanaged_triggers(connection)
+        connection.execute(text("ALTER TABLE widget DROP COLUMN doomed"))
+        remaining = [row[0] for row in connection.execute(text("SELECT name FROM sqlite_master WHERE type='trigger'"))]
+    assert remaining == []
+
+
+def test_in_memory_migration_runner_drops_preexisting_triggers() -> None:
+    """The in-memory migration runner enforces the no-triggers-during-migration invariant.
+
+    Simulates a real upgrade: a database that already carries auto-managed triggers from a
+    prior startup. Running migrations through the production runner must drop them first
+    (they are recreated afterwards by initialize_db_from_connection, which the bare runner
+    does not do). Guards against the wiring being removed from override_run_env.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import StaticPool
+
+    from sculptor.database.core import _run_migrations_on_connection
+    from sculptor.services.data_model_service.sql_implementation import register_all_tables
+
+    register_all_tables()
+
+    engine = create_engine(IN_MEMORY_SQLITE, poolclass=StaticPool, connect_args={"check_same_thread": False})
+    with engine.begin() as connection:
+        # Full init: migrate to head AND create all auto-managed triggers, as a prior startup would.
+        initialize_db_from_connection(connection, IN_MEMORY_SQLITE)
+        triggers_before = connection.execute(text("SELECT count(*) FROM sqlite_master WHERE type='trigger'")).scalar()
+        assert triggers_before > 0, "expected auto-managed triggers to exist after initialization"
+
+        # Re-run migrations through the production runner (a no-op upgrade to head).
+        _run_migrations_on_connection(connection)
+        triggers_after = connection.execute(text("SELECT count(*) FROM sqlite_master WHERE type='trigger'")).scalar()
+    assert triggers_after == 0, "the migration runner must drop all triggers before running migrations"
+
+
+def test_file_migration_runner_drops_preexisting_triggers(tmp_path: Path) -> None:
+    """Same invariant for the file-database runner (the env.py path used in production)."""
+    from sculptor.database.alembic.utils import get_alembic_script_location
+    from sculptor.database.core import _run_migrations_on_database_url
+    from sculptor.database.core import initialize_db
+    from sculptor.services.data_model_service.sql_implementation import register_all_tables
+
+    register_all_tables()
+
+    url = f"sqlite:///{tmp_path / 'database.db'}"
+    engine = create_new_engine(url)
+    # Simulate a prior startup: migrate to head and create triggers.
+    initialize_db(engine)
+    with engine.connect() as connection:
+        before = connection.execute(text("SELECT count(*) FROM sqlite_master WHERE type='trigger'")).scalar()
+    assert before > 0, "expected auto-managed triggers to exist after initialization"
+
+    # Run migrations through the file-database runner (env.py).
+    _run_migrations_on_database_url(url, get_alembic_script_location())
+    with engine.connect() as connection:
+        after = connection.execute(text("SELECT count(*) FROM sqlite_master WHERE type='trigger'")).scalar()
+    assert after == 0, "the migration runner must drop all triggers before running migrations"
+
+
 def _get_migration_fixtures() -> list[MigrationTestFixture]:
     """Discover all migration test fixtures for parametrized testing."""
     return discover_test_fixtures()


### PR DESCRIPTION
## Problem

Auto-managed tables carry triggers (`<table>_before_insert`, `set_<table>_created_at`) whose bodies reference *every* column of the table. SQLite validates trigger bodies during `ALTER TABLE`, so any migration that drops a column a trigger still references fails at startup:

```
error in trigger workspace_before_insert after drop column: no such column: NEW.harness
```

Until now, every column-dropping migration had to *remember* to drop its triggers first. That convention is forgettable, and the data shows it: while the drop-on-upgrade migrations handle it, ~10 add-column migrations' **downgrade** paths still drop their column with no trigger drop — latent copies of the same bug. It has broken startup more than once.

## Fix

Replace the convention with an enforced **invariant: no auto-managed trigger exists while migrations run.**

- New `drop_all_automanaged_triggers()` helper.
- Called at the single migration chokepoint, which is present in both runner paths — `env.py` (file databases) and `override_run_env` (in-memory) — immediately before migrations execute.
- Triggers are recreated from the current model right after migrations by the existing `initialize_db_from_connection()`, so the end state is unchanged.

This makes the failure structurally impossible rather than policed: no migration — upgrade or downgrade, now or future — ever needs to drop triggers itself. It also makes the upgrade path consistent with the fresh-install path, which migrations already assume (one migration maintains a `_latest` table by hand "because triggers don't exist during migration" — only true on a fresh install until now).

The existing per-migration `DROP TRIGGER` blocks are now redundant belt-and-suspenders and are intentionally left untouched, so the standalone bugfix they belong to remains valid on its own.

## Tests

Three guard tests (all passing):
1. The exact failure mode — a trigger referencing a column blocks `DROP COLUMN`, and the helper unblocks it.
2. & 3. End-to-end: each runner path (in-memory and file) drops pre-existing triggers before migrating. Verified that test no. 2 **fails** if the wiring is removed.

`just format`, `just check`, and `just test-unit` all pass.

(Sent by Claude)