### PR TITLE
[SCU-218] Add cmd+shift+w shortcut to delete the active workspace

### DIFF
--- a/sculptor/frontend/src/common/keybindings/definitions.ts
+++ b/sculptor/frontend/src/common/keybindings/definitions.ts
@@ -37,6 +37,13 @@ export const KEYBINDING_DEFINITIONS: ReadonlyArray<KeybindingDefinition> = [
     defaultBinding: "Meta+W",
   },
   {
+    id: "delete_workspace",
+    name: "Delete workspace",
+    description: "Delete the current workspace and all of its agents",
+    category: "workspaces",
+    defaultBinding: "Meta+Shift+W",
+  },
+  {
     id: "next_tab",
     name: "Next tab",
     description: "Switch to the next workspace tab",

--- a/sculptor/frontend/src/common/keybindings/types.ts
+++ b/sculptor/frontend/src/common/keybindings/types.ts
@@ -8,6 +8,7 @@ export type StaticKeybindingId =
   | "new_workspace"
   | "open_workspace"
   | "close_workspace"
+  | "delete_workspace"
   | "next_tab"
   | "previous_tab"
   | "send_message"

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/workspaceActions.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/workspaceActions.ts
@@ -124,6 +124,7 @@ export const buildWorkspaceActions = (runtime: WorkspaceActionRuntime): Readonly
     paletteSubtitle: "Permanently delete this workspace",
     paletteOrder: 110,
     paletteTitleSuffix: "name",
+    paletteShortcut: "delete_workspace",
     perform: (ws): void => runtime.beginDelete(ws),
   },
 ];

--- a/sculptor/frontend/src/components/WorkspaceTabs.tsx
+++ b/sculptor/frontend/src/components/WorkspaceTabs.tsx
@@ -318,6 +318,28 @@ export const WorkspaceTabs = (): ReactElement => {
     return (): void => window.removeEventListener("keydown", handleKeyDown);
   }, [keybindingsMap, closeCurrentTab]);
 
+  // Delete workspace shortcut: open the confirmation dialog for the current
+  // workspace. Unlike close (which only removes the tab), delete permanently
+  // removes the workspace and all of its agents, so it routes through the same
+  // confirmation dialog as the right-click and Cmd+K delete actions.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (isDismissibleOverlayOpen()) return;
+      const deleteBinding = keybindingsMap.delete_workspace.binding;
+      if (deleteBinding == null || !shouldHandleKeybinding(e, deleteBinding)) return;
+      // Suppress the browser/Electron default (Cmd+Shift+W closes the window)
+      // even on non-workspace tabs where there is nothing to delete.
+      e.preventDefault();
+      if (!activeWorkspaceID) return;
+      const workspace = (workspaces ?? []).find((ws) => ws.objectId === activeWorkspaceID);
+      if (workspace == null) return;
+      setDeleteTarget({ id: workspace.objectId, name: workspace.description ?? "" });
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return (): void => window.removeEventListener("keydown", handleKeyDown);
+  }, [keybindingsMap, activeWorkspaceID, workspaces, setDeleteTarget]);
+
   // Build TabDefinition array from workspaces
   const tabs = useMemo((): Array<TabDefinition> => {
     const workspaceTabs: Array<TabDefinition> = (workspaces ?? []).map((workspace) => {

--- a/sculptor/sculptor/testing/pages/project_layout.py
+++ b/sculptor/sculptor/testing/pages/project_layout.py
@@ -95,6 +95,12 @@ class PlaywrightProjectLayoutPage(PlaywrightIntegrationTestPage):
     def get_delete_confirmation_dialog(self) -> Locator:
         return self._page.get_by_test_id(ElementIDs.DELETE_CONFIRMATION_DIALOG)
 
+    def confirm_delete(self) -> None:
+        """Click the confirm button in the delete-confirmation dialog."""
+        confirm_button = self._page.get_by_test_id(ElementIDs.DELETE_CONFIRMATION_CONFIRM)
+        expect(confirm_button).to_be_visible()
+        confirm_button.click()
+
     def get_inline_rename_input(self) -> Locator:
         return self._page.get_by_test_id(ElementIDs.INLINE_RENAME_INPUT)
 

--- a/sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py
+++ b/sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py
@@ -98,6 +98,53 @@ def test_cmd_w_closes_workspace_tab(
     expect(workspace_tabs).to_have_count(1)
 
 
+@user_story("to delete the active workspace via keyboard shortcut")
+def test_cmd_shift_w_deletes_active_workspace(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Pressing Cmd+Shift+W deletes the active workspace after confirmation.
+
+    Unlike Cmd+W (which just closes the tab), Cmd+Shift+W opens the delete
+    confirmation dialog; confirming permanently removes the workspace.
+
+    Steps:
+    1. Create two workspaces (the second is active)
+    2. Press Cmd+Shift+W
+    3. Verify the delete confirmation dialog appears
+    4. Confirm the deletion and verify the tab count drops to 1
+    5. Navigate Home and verify the deleted workspace is gone (proving it was
+       deleted, not merely closed — a closed workspace would still be listed)
+    """
+    page = sculptor_instance_.page
+    layout = PlaywrightProjectLayoutPage(page=page)
+
+    # Step 1: Create two workspaces. "Delete WS" is active after creation.
+    start_task_and_wait_for_ready(page, prompt="Task 1", workspace_name="Keep WS")
+    start_task_and_wait_for_ready(page, prompt="Task 2", workspace_name="Delete WS")
+
+    workspace_tabs = layout.get_workspace_tabs()
+    expect(workspace_tabs).to_have_count(2)
+
+    # Step 2: Press Cmd+Shift+W to delete the active workspace.
+    mod_key = get_playwright_modifier_key()
+    page.keyboard.press(f"{mod_key}+Shift+w")
+
+    # Step 3: Unlike Cmd+W, this opens the delete confirmation dialog.
+    confirm_dialog = layout.get_delete_confirmation_dialog()
+    expect(confirm_dialog).to_be_visible()
+
+    # Step 4: Confirm the deletion; the tab count drops to 1.
+    layout.confirm_delete()
+    expect(workspace_tabs).to_have_count(1)
+
+    # Step 5: The deleted workspace no longer appears on the Home page. A
+    # closed (not deleted) workspace would still be listed here.
+    navigate_to_home_page(page)
+    home_page = PlaywrightHomePage(page)
+    expect(home_page.get_workspace_rows()).to_have_count(1)
+    expect(home_page.get_workspace_rows().filter(has_text="Delete WS")).to_have_count(0)
+
+
 @user_story("to reopen a previously closed workspace from the workspace list")
 def test_reopen_closed_workspace_from_list(
     sculptor_instance_: SculptorInstance,


### PR DESCRIPTION
## Summary

Adds a keyboard shortcut — **⇧⌘W** (`Meta+Shift+W`) — to delete the currently active workspace. Pressing it opens the existing delete-confirmation dialog for the active workspace; confirming permanently deletes the workspace and all of its agents.

`⌘W` is unchanged and continues to **close** the current tab (non-destructive — the workspace still exists and can be reopened). The new shortcut targets the **delete** path and always routes through the same confirmation dialog as the right-click context menu and the `⌘K` "Delete workspace" command, so all delete entry points behave identically.

Resolves SCU-218.

## What changed

- **`keybindings/definitions.ts` / `types.ts`** — new `delete_workspace` keybinding (default `Meta+Shift+W`, category *workspaces*) and its `KeybindingId` union entry. Because it lives in the registry, it shows up automatically in the Help dialog and is rebindable in Settings → Keybindings.
- **`components/WorkspaceTabs.tsx`** — a `keydown` handler that opens the confirmation dialog for the active workspace. It is a no-op on non-workspace tabs (Home/Settings/etc.) but still calls `preventDefault` there to suppress the browser/Electron window-close default.
- **`CommandPalette/contextActions/workspaceActions.ts`** — surfaces the `⇧⌘W` hint on the command-palette / context-menu "Delete workspace" row (mirrors how "Close" carries its shortcut).
- **Tests** — a new integration test (`test_cmd_shift_w_deletes_active_workspace`) plus a `confirm_delete()` page-object helper.

## Behavior

- `⇧⌘W` on a workspace tab opens **"Delete workspace? — This will permanently delete … and all of its agents."** It does **not** delete without confirmation.
- It targets the active workspace and reuses the existing `setDeleteTarget` → `DeleteConfirmationDialog` → optimistic-delete path.

## Testing

- `just format`, `just check` (lint + types + ratchets + hygiene), and `just test-unit` all pass.
- New integration test `sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py::test_cmd_shift_w_deletes_active_workspace` passes (`1 passed`). It presses `⇧⌘W`, asserts the confirmation dialog appears, confirms, and verifies the workspace is gone from the Home list — proving it was *deleted*, not merely *closed* (a closed workspace would still be listed).
- Manually verified end-to-end via the headless-browser QA harness: created two workspaces, pressed `⇧⌘W` on the active one, confirmed the dialog named the correct workspace, deleted it, and verified it disappeared from the Home page with no "closed workspaces" pill.

(Sent by Claude)
