### PR TITLE
Add local-app and open-a-repo threat models to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,3 +40,17 @@ access.** Each task runs in its workspace — a separate copy of your
 repo — and for stronger isolation you can run agents in the experimental
 [container backend](docs/help/experimental/container_backend.md) (Docker or a
 remote).
+
+**The local app is a trust boundary.** Sculptor runs a local web server (HTTP
+and WebSockets) bound to `127.0.0.1`. A per-session token stops web pages you
+visit in a browser from reaching it. But the loopback interface itself is the
+boundary: any process on the same machine that can open a connection to that
+port can reach the API. Don't run Sculptor on a machine you share with people
+you don't trust, and don't expose its port to a network (port-forwarding, or
+binding the experimental container backend to a non-loopback address).
+
+**Opening a repository runs its code.** Setting up a workspace runs the
+project's setup command and honors repo-provided environment (e.g. a checked-in
+`.sculptor/.env`), so opening a project can execute code on your host before any
+agent starts. Only open repositories you trust — treat "open this repo" like
+"run this repo."


### PR DESCRIPTION
## Original bug

Ticket **SCU-1476** — *Add missing threat models to SECURITY.md*:

> Add a follow-up to `SECURITY.md` for two additional threat-model elements that
> are currently missing from the threat model.
>
> The local app should be described as a trust boundary: Sculptor runs a local
> HTTP/WebSocket server on `127.0.0.1`, the session token protects against web
> pages reaching it, but any local process that can connect to the loopback port
> can still reach the API.
>
> Opening a repository should also be called out as running its code: workspace
> setup runs the project's setup command and honors repo-provided environment
> such as `.sculptor/.env`, so opening a project can execute code on the host
> before any agent starts.

`SECURITY.md`'s `## Threat model` section only covered "agents act with your
access" and was missing both elements above.

## Nature of this change

This is a **documentation-only** change to `SECURITY.md` — there is no code
path or UI surface, so there is no behavioral test to write. Per
`.sculptor/testing.md`, content/rendering-only assertion tests are prohibited
and non-behavioral changes are exempt from automated tests (the same principle
as its "purely visual bugs MUST NOT have automated tests" rule); a test that
grepped `SECURITY.md` for a string would be exactly the brittle anti-pattern
that policy rejects. The appropriate evidence for a documentation change is the
diff plus verification of each claim against the code, both below.

## Verification of the documented claims

Because this is security documentation, each claim was checked against the
codebase before being written.

### Claim 1 — "The local app is a trust boundary"

**Verified TRUE.**

- The server binds to loopback by default:
  `sculptor/sculptor/config/settings.py:39` —
  `BIND_HOST: str = Field(default="127.0.0.1", ...)`, started by uvicorn at
  `sculptor/sculptor/cli/app.py:143` with the comment "We bind to 127.0.0.1 to
  avoid exposing the server to the network by default."
- A per-session token gates the API: `sculptor/sculptor/web/auth.py` defines the
  `x-session-token` header and the `SessionTokenMiddleware` that validates it on
  HTTP and WebSocket requests; the token is generated at Electron startup
  (`randomBytes(32)` in `sculptor/frontend/src/electron/main.ts`).
- The token is the only application-level gate, so any local process that can
  open the loopback port and present the token reaches the API.
- The experimental container backend can bind non-loopback:
  `container/recipes/docker/run-backend.py:132` sets
  `SCULPTOR_BIND_HOST=0.0.0.0` — which is exactly the case the new text warns
  about.

### Claim 2 — "Opening a repository runs its code"

**Verified TRUE.**

- Workspace setup runs the project's setup command:
  `sculptor/sculptor/services/workspace_service/setup_command_runner.py`
  (`SetupCommandRunner.start()`), invoked during workspace creation in
  `sculptor/sculptor/services/workspace_service/default_implementation.py`.
- It honors a checked-in `.sculptor/.env`:
  `sculptor/sculptor/services/workspace_service/environment_manager/env_file_parser.py:87-97`
  (`load_project_env_vars()` loads both `~/.sculptor/.env` and the project's
  `.sculptor/.env`), copied and loaded during environment init in
  `.../environment_manager/default_implementation.py`.
- This all runs on the host before any agent task starts — so opening a project
  can execute repo-provided code.

## Expected vs actual

- Expected: `SECURITY.md` documents the local app as a trust boundary and that
  opening a repository runs its code.
- Actual (before): the `## Threat model` section covered only "agents act with
  your access"; both elements were absent.

## Before

```markdown
## Threat model

Sculptor drives coding agents that can read and write files, run commands, and
reach the tools and git remotes you've connected. **Agents act with your
access.** Each task runs in its workspace — a separate copy of your
repo — and for stronger isolation you can run agents in the experimental
[container backend](docs/help/experimental/container_backend.md) (Docker or a
remote).
```

## After

```markdown
## Threat model

Sculptor drives coding agents that can read and write files, run commands, and
reach the tools and git remotes you've connected. **Agents act with your
access.** Each task runs in its workspace — a separate copy of your
repo — and for stronger isolation you can run agents in the experimental
[container backend](docs/help/experimental/container_backend.md) (Docker or a
remote).

**The local app is a trust boundary.** Sculptor runs a local web server (HTTP
and WebSockets) bound to `127.0.0.1`. A per-session token stops web pages you
visit in a browser from reaching it. But the loopback interface itself is the
boundary: any process on the same machine that can open a connection to that
port can reach the API. Don't run Sculptor on a machine you share with people
you don't trust, and don't expose its port to a network (port-forwarding, or
binding the experimental container backend to a non-loopback address).

**Opening a repository runs its code.** Setting up a workspace runs the
project's setup command and honors repo-provided environment (e.g. a checked-in
`.sculptor/.env`), so opening a project can execute code on your host before any
agent starts. Only open repositories you trust — treat "open this repo" like
"run this repo."
```

## Verification

- `just ratchets` — OK (the only pre-commit gate that scans a root markdown
  file; `just format`/`just check`/`just test-unit` operate on code under
  `sculptor/` and are unaffected by a docs-only change).
- Fix commit: `553f80d052`.

## Review notes

_(no outstanding review notes — the Phase A4.5 `/code-review-checklist` pass ran
and found nothing to act on.)_

(Sent by Claude)
