### PR TITLE
Honor Most Recently Used default model for new workspaces

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -47,6 +47,7 @@ import {
   defaultEffortLevelAtom,
   isAlwaysInterruptAndSendAtom,
   isDefaultFastModeAtom,
+  lastUsedModelAtom,
   userConfigAtom,
 } from "../../../common/state/atoms/userConfig.ts";
 import { useDraftAttachedFiles } from "../../../common/state/hooks/useDraftAttachedFiles.ts";
@@ -114,6 +115,7 @@ export const ChatInput = ({
   const defaultEffortLevel = useAtomValue(defaultEffortLevelAtom);
   const userConfig = useAtomValue(userConfigAtom);
   const [storedModel, setStoredModel] = useAtom(modelAtomFamily(taskID ?? ""));
+  const setLastUsedModel = useSetAtom(lastUsedModelAtom);
   const localModel = storedModel ?? (taskModel as LlmModel) ?? LlmModel.CLAUDE_4_OPUS_200K;
   const [isPlanFirst, setIsPlanFirst] = useState<boolean>(false);
 
@@ -127,6 +129,19 @@ export const ChatInput = ({
 
   const setIsFastMode = useCallback((value: boolean) => setStoredFastMode(value), [setStoredFastMode]);
   const setEffort = useCallback((value: EffortLevel) => setStoredEffort(value), [setStoredEffort]);
+
+  // Switching the model both updates this task's preference and records the
+  // model as the user's most recently used. The MRU value is what new
+  // workspaces default to when the "Default model" setting is "Most Recently
+  // Used"; without recording it here the MRU default would never reflect the
+  // model the user is actually using and would fall back to Fable (SCU-1457).
+  const handleModelChange = useCallback(
+    (value: LlmModel) => {
+      setStoredModel(value);
+      setLastUsedModel(value);
+    },
+    [setStoredModel, setLastUsedModel],
+  );
 
   const [toast, setToast] = useState<ToastContent | null>(null);
   // Mirrored onto the send button as `data-last-send-error` so callers can
@@ -648,7 +663,7 @@ export const ChatInput = ({
               )}
               <EffortSelector effort={effort} onEffortChange={setEffort} />
               <Flex pr="1">
-                <ModelSelector model={localModel} onModelChange={(value: LlmModel) => setStoredModel(value)} />
+                <ModelSelector model={localModel} onModelChange={handleModelChange} />
               </Flex>
               <SendButton
                 onClick={handleSend}

--- a/sculptor/tests/integration/regression/test_regression_mru_default_model.py
+++ b/sculptor/tests/integration/regression/test_regression_mru_default_model.py
@@ -1,0 +1,62 @@
+"""Regression test: a new workspace should default to the most recently used model.
+
+SCU-1457: When the "Default model" setting (Settings → Agent → Default model)
+is "Most Recently Used" — the product default, where ``userConfig.defaultLlm``
+is ``None`` — a newly created workspace should default to whatever model the
+user most recently selected.
+
+The only writer of the global "last used model" had been removed along with the
+Add Workspace page's model dropdown, and model switching moved to the chat
+panel, which only persists a *per-task* model preference. As a result the MRU
+default never reflected the model the user was actually using and always fell
+through to Fable: switching a workspace's model and then creating a new
+workspace produced a Fable agent regardless of the just-used model.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.chat_panel import select_model_by_name
+from sculptor.testing.elements.task_starter import FAKE_CLAUDE_2_MODEL_NAME
+from sculptor.testing.elements.task_starter import FAKE_CLAUDE_MODEL_NAME
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+
+@user_story("to have a new workspace default to the model I most recently used")
+def test_new_workspace_defaults_to_most_recently_used_model(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """A new workspace inherits the model most recently selected in another workspace.
+
+    Steps:
+    1. Create workspace A on "Fake Claude" (the Default model setting is the
+       product-default "Most Recently Used", i.e. ``defaultLlm`` is None).
+    2. Switch workspace A's chat-panel model to "Fake Claude 2".
+    3. Create a brand-new workspace B without touching its model selector.
+    4. Verify workspace B's model selector shows "Fake Claude 2" — the most
+       recently used model — rather than the Fable fallback.
+    """
+    page = sculptor_instance_.page
+
+    # Workspace A starts on Fake Claude.
+    task_page_a = start_task_and_wait_for_ready(
+        page,
+        model_name=FAKE_CLAUDE_MODEL_NAME,
+        workspace_name="MRU Workspace A",
+    )
+    chat_panel_a = task_page_a.get_chat_panel()
+
+    # The user switches A's model to Fake Claude 2 on the chat panel. This is
+    # now the model the user most recently used.
+    select_model_by_name(chat_panel_a, FAKE_CLAUDE_2_MODEL_NAME)
+    expect(chat_panel_a.get_model_selector()).to_have_text(FAKE_CLAUDE_2_MODEL_NAME)
+
+    # A brand-new workspace, created without touching its model selector, must
+    # default to the most recently used model (Fake Claude 2) rather than Fable.
+    task_page_b = start_task_and_wait_for_ready(
+        page,
+        model_name=None,
+        workspace_name="MRU Workspace B",
+    )
+    expect(task_page_b.get_chat_panel().get_model_selector()).to_have_text(FAKE_CLAUDE_2_MODEL_NAME)


### PR DESCRIPTION
## Original bug

> **New workspaces default to Fable despite MRU setting** ([SCU-1457](https://linear.app/imbue/issue/SCU-1457/new-workspaces-default-to-fable-despite-mru-setting))
>
> For some users, new workspaces are defaulting to Fable even when **Settings → Agent → Default model** is set to **Most Recently Used**. Switching an existing workspace back to Opus does not affect subsequently created workspaces, which continue to default to Fable.
>
> Investigate why the MRU setting is not being honored.

## Hypotheses considered

1. **The MRU "last used model" is never recorded, so the default always falls back to Fable** — **REPRODUCED**. With `Default model = Most Recently Used` (`userConfig.defaultLlm = null`), `defaultModelAtom` reads `lastUsedModelAtom`, but nothing writes that atom anymore. It always falls through to the hardcoded `CLAUDE_FABLE_5`.
2. **A usage-limit auto-downgrade rewrites the user's default to Fable** — **DISCARDED**. There is no frontend code path that switches the model to Fable on usage/rate limits and persists it as the default. The "usage limits speedrun" in the report was incidental (rapidly creating workspaces); the symptom reproduces with no rate-limiting involved.
3. **The Default model setting itself is silently changed to Fable** — **DISCARDED**. The reporter confirmed the setting still reads "Most Recently Used", and `userConfig.defaultLlm` is untouched. The bug is in how the MRU value is computed, not in the stored setting.

## For each reproduced bug

### New workspaces ignore the most-recently-used model and default to Fable

**Repro steps**
1. In **Settings → Agent → Default model**, confirm the value is **Most Recently Used** (the product default; `userConfig.defaultLlm = null`).
2. Create a workspace ("MRU Before A"). Its chat-panel model selector shows **Fable**.
3. On that workspace's chat panel, open the model selector and switch the model to **Opus** (Claude 4.8 Opus).
4. Click **+** to create a brand-new workspace ("MRU Before B"). Do not touch its model selector.
5. Observe the new workspace's chat-panel model selector.

**Expected vs actual**
- Expected: the new workspace defaults to **Opus** — the model just used (Most Recently Used).
- Actual: the new workspace defaults to **Fable**, ignoring the most-recently-used model.

**Before**

Settings confirm the Default model is "Most Recently Used":

![Settings - Default model is Most Recently Used](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1457-proof/settings-mru.png)

New workspace "MRU Before B" — created right after switching another workspace to Opus — defaults to **Fable**:

![Before fix: new workspace defaults to Fable](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1457-proof/bug-mru-before.png)

**Root cause**

When the Default model setting is "Most Recently Used", `defaultModelAtom` (`sculptor/frontend/src/common/state/atoms/userConfig.ts`) resolves the model by reading `lastUsedModelAtom`, falling back to `CLAUDE_FABLE_5` when it is empty. `lastUsedModelAtom` is a `localStorage`-backed atom, but its only writer was removed in commit `106322d5e5` ("Remove model selector from New Workspace page"), which deleted the New Workspace page's model dropdown (the `handleModelChange` there called `setLastUsedModel`). Model switching subsequently moved to the chat panel (`ChatInput.tsx`), whose handler only persisted a *per-task* preference via `modelAtomFamily` (`sculptor-model-<taskId>`). Nothing wrote `lastUsedModelAtom` anymore, so the MRU default could never reflect the model the user was actually using and always fell through to Fable. This also explains why switching an existing workspace back to Opus had no effect on newly created workspaces — that switch only updated the per-task key.

**Fix**

In `ChatInput.tsx`, route the chat-panel `ModelSelector`'s `onModelChange` through a new `handleModelChange` callback that records the chosen model as the most recently used (`setLastUsedModel(value)`) in addition to updating the per-task preference (`setStoredModel(value)`). This restores the MRU write path on the surface where users now switch models, so newly created workspaces default to the model the user last selected in any workspace. The write happens only on an explicit user model change (not on mount and not on any involuntary fallback), so an automatic downgrade can never silently become the user's default.

**Test**
- Path: `sculptor/tests/integration/regression/test_regression_mru_default_model.py`
- Kind: e2e (Playwright integration test)
- Failing-test commit: `704304d258`
- Fix commit: `9df1ae5ca7`

The test sets up the MRU scenario deterministically with Fake Claude: it switches workspace A to "Fake Claude 2", creates workspace B without touching its selector, and asserts B's model selector reads "Fake Claude 2". Before the fix it read "Fable":

```
>       expect(task_page_b.get_chat_panel().get_model_selector()).to_have_text(FAKE_CLAUDE_2_MODEL_NAME)
E       AssertionError: Locator expected to have text 'Fake Claude 2'
E       Actual value: Fable
E         - unexpected value "Fable"
sculptor/tests/integration/regression/test_regression_mru_default_model.py:62: AssertionError
============================== 1 failed in 52.90s ==============================
```

After the fix, the same unmodified test passes:

```
[gw1] [100%] PASSED sculptor/tests/integration/regression/test_regression_mru_default_model.py::test_new_workspace_defaults_to_most_recently_used_model
============================== 1 passed in 22.72s ==============================
```

**After**

New workspace "MRU After C" — created after switching another workspace to Opus, with the fix applied — now defaults to **Opus**, honoring the most-recently-used model:

![After fix: new workspace defaults to Opus](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1457-proof/bug-mru-after.png)

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
