### PR TITLE
Give the per-test integration factory a real Electron mode (SCU-1513)

### DIFF
--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -90,6 +90,7 @@ class ElectronFrontend:
         timeout_ms: int,
         custom_backend_cmd: str | None = None,
         extra_env: dict[str, str] | None = None,
+        env_unset_keys: tuple[str, ...] = (),
     ) -> None:
         self.playwright = playwright
         self.backend_port = backend_port
@@ -97,6 +98,11 @@ class ElectronFrontend:
         self.timeout_ms = timeout_ms
         self.custom_backend_cmd = custom_backend_cmd
         self.extra_env = extra_env or {}
+        # Keys to drop from the inherited ``os.environ`` before launching Electron.
+        # ``extra_env`` can only add/override, so unsetting a parent var (e.g. a
+        # SESSION_TOKEN inherited from a Sculptor-spawned terminal) requires
+        # excluding it here.
+        self.env_unset_keys = env_unset_keys
         self._electron_proc: subprocess.Popen | None = None
         self._forwarder: Forwarder | None = None
         self._user_data_dir: str | None = None
@@ -148,7 +154,8 @@ class ElectronFrontend:
             electron_env["SCULPTOR_CUSTOM_BACKEND_CMD"] = self.custom_backend_cmd
         else:
             electron_env["SCULPTOR_API_PORT"] = str(self.backend_port)
-        full_env = {**os.environ, **self.extra_env, **electron_env}
+        inherited_env = {k: v for k, v in os.environ.items() if k not in self.env_unset_keys}
+        full_env = {**inherited_env, **self.extra_env, **electron_env}
 
         frontend_dir = get_v1_frontend_path()
         lock_path = Path("/tmp/sculptor_electron_forge.lock")

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -22,8 +22,8 @@ from tenacity import stop_after_delay
 from tenacity import wait_fixed
 
 from sculptor.testing.frontend_utils import configure_page
+from sculptor.testing.frontend_utils import get_v1_frontend_path
 from sculptor.testing.port_manager import PortManager
-from sculptor.testing.server_utils import get_v1_frontend_path
 from sculptor.testing.subprocess_utils import Forwarder
 
 # electron-forge 7.10+ stopped printing its "Launched Electron app" task

--- a/sculptor/sculptor/testing/frontend_utils.py
+++ b/sculptor/sculptor/testing/frontend_utils.py
@@ -1,5 +1,20 @@
+from pathlib import Path
+
 from playwright.sync_api import Page
 from playwright.sync_api import expect
+
+from sculptor.foundation.git import get_git_repo_root
+
+
+def get_v1_frontend_path() -> Path:
+    """Returns the path to the frontend directory in v1.
+
+    Lives here (rather than in ``server_utils``) so that ``electron_frontend`` can
+    reach it without importing ``server_utils``, which lets ``server_utils`` import
+    ``ElectronFrontend`` at module scope without an import cycle.
+    """
+    return get_git_repo_root() / "sculptor" / "frontend"
+
 
 # Single source of truth for the browser viewport used by all integration tests.
 # Also applied by _reset_browser_state between tests to undo any per-test resize

--- a/sculptor/sculptor/testing/manual_test_harness.py
+++ b/sculptor/sculptor/testing/manual_test_harness.py
@@ -29,6 +29,7 @@ from sculptor.config.user_config import UserConfig
 from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.frontend_utils import configure_page
+from sculptor.testing.frontend_utils import get_v1_frontend_path
 from sculptor.testing.mock_repo import MockRepoState
 from sculptor.testing.playwright_utils import navigate_to_frontend
 from sculptor.testing.port_manager import PortManager
@@ -36,7 +37,6 @@ from sculptor.testing.repo_resources import get_test_project_state
 from sculptor.testing.server_utils import SculptorServer
 from sculptor.testing.server_utils import get_sculptor_command_backend_only
 from sculptor.testing.server_utils import get_testing_environment
-from sculptor.testing.server_utils import get_v1_frontend_path
 from sculptor.testing.server_utils import start_server_process_and_validate_readiness
 from sculptor.testing.subprocess_utils import Forwarder
 

--- a/sculptor/sculptor/testing/packaged_electron_frontend.py
+++ b/sculptor/sculptor/testing/packaged_electron_frontend.py
@@ -229,6 +229,11 @@ class PackagedElectronFactory:
         self.default_timeout_ms = default_timeout_ms
         self.extra_env = extra_env or {}
 
+    @property
+    def is_electron(self) -> bool:
+        """Spawned instances always render in the packaged Electron shell."""
+        return True
+
     @contextmanager
     def spawn_sculptor_instance(
         self,

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -735,6 +735,12 @@ def sculptor_instance_factory_(
         sculptor_folder=sculptor_folder,
         base_repo=base_repo,
         fake_bin_dir=fake_bin_dir,
+        # browser (default) keeps the Chromium ``page`` path; electron /
+        # electron-custom-command launch a real, non-packaged Electron shell per
+        # spawned instance. playwright / port_manager are only used in those modes.
+        launch_mode=launch_mode,
+        playwright=playwright,
+        port_manager=port_manager,
     )
 
     yield factory

--- a/sculptor/sculptor/testing/sculptor_instance.py
+++ b/sculptor/sculptor/testing/sculptor_instance.py
@@ -168,6 +168,11 @@ class SculptorInstance:
         return self._project_path
 
     @property
+    def is_electron(self) -> bool:
+        """Whether this instance renders in an Electron shell (vs a plain browser page)."""
+        return self._is_electron
+
+    @property
     def backend_api_url(self) -> str:
         """Base URL of the running Sculptor backend's HTTP API (for /api/... requests).
 
@@ -685,7 +690,9 @@ class SculptorInstanceFactory:
                 Only supported in packaged-electron mode.
         """
         project_path = self.base_repo.base_path if auto_project else None
-        is_electron = isinstance(self._delegate, PackagedElectronFactory)
+        # Both the raw-backend ``SculptorFactory`` (electron / electron-custom-command
+        # launch modes) and ``PackagedElectronFactory`` expose ``is_electron``.
+        is_electron = self._delegate.is_electron
         with self._delegate.spawn_sculptor_instance(
             project_path=project_path,
             wait_until_ready=wait_until_ready,
@@ -714,8 +721,16 @@ def create_sculptor_instance_factory(
     sculptor_folder: Path,
     base_repo: MockRepoState,
     fake_bin_dir: Path,
+    launch_mode: str = "browser",
+    playwright: Playwright | None = None,
+    port_manager: PortManager | None = None,
 ) -> SculptorInstanceFactory:
-    """Build a SculptorInstanceFactory from fixture-provided parameters."""
+    """Build a SculptorInstanceFactory from fixture-provided parameters.
+
+    ``launch_mode`` selects the per-spawn frontend; ``playwright`` and
+    ``port_manager`` are only consulted by the electron launch modes (and
+    asserted present there), so browser-mode callers can omit them.
+    """
     delegate = SculptorFactory(
         environment=environment,
         port=port,
@@ -723,6 +738,9 @@ def create_sculptor_instance_factory(
         default_timeout_ms=default_timeout_ms,
         request=request,
         sculptor_folder=sculptor_folder,
+        launch_mode=launch_mode,
+        playwright=playwright,
+        port_manager=port_manager,
     )
     return SculptorInstanceFactory(
         delegate=delegate,

--- a/sculptor/sculptor/testing/server_utils.py
+++ b/sculptor/sculptor/testing/server_utils.py
@@ -4,24 +4,34 @@ import os
 import selectors
 import signal
 import subprocess
+import sys
 import time
 from collections.abc import Generator
 from collections.abc import Sequence
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import attr
 import pytest
 from loguru import logger
 from playwright.sync_api import BrowserContext
 from playwright.sync_api import Page
+from playwright.sync_api import Playwright
+from pytest_playwright.pytest_playwright import ArtifactsRecorder
 
 from sculptor.foundation.git import get_git_repo_root
 from sculptor.testing.frontend_utils import configure_page
 from sculptor.testing.playwright_utils import navigate_to_frontend
+from sculptor.testing.port_manager import PortManager
 from sculptor.testing.subprocess_utils import Forwarder
 from sculptor.testing.subprocess_utils import print_colored_line
 from sculptor.utils.build import SCULPTOR_FOLDER_OVERRIDE_ENV_FLAG
+
+if TYPE_CHECKING:
+    # ``electron_frontend`` imports ``get_v1_frontend_path`` from this module, so the
+    # runtime import lives inside ``_make_electron_frontend`` to avoid an import cycle.
+    from sculptor.testing.electron_frontend import ElectronFrontend
 
 LOCAL_HOST_URL = "http://127.0.0.1"
 READY_MESSAGE_V1 = "Server is ready to accept requests!"
@@ -80,6 +90,9 @@ class SculptorFactory:
         default_timeout_ms: int,
         request: pytest.FixtureRequest,
         sculptor_folder: Path | None = None,
+        launch_mode: str = "browser",
+        playwright: "Playwright | None" = None,
+        port_manager: "PortManager | None" = None,
     ) -> None:
         self.environment = environment
         self.database_url = database_url
@@ -87,6 +100,19 @@ class SculptorFactory:
         self.default_timeout_ms = default_timeout_ms
         self.request = request
         self.sculptor_folder = sculptor_folder
+        # ``launch_mode`` selects the per-spawn frontend: "browser" (default)
+        # drives the shared pytest-playwright page; "electron" /
+        # "electron-custom-command" launch a real, non-packaged Electron shell
+        # over CDP. ``playwright`` / ``port_manager`` are only consulted by the
+        # electron paths (and asserted present there).
+        self.launch_mode = launch_mode
+        self.playwright = playwright
+        self.port_manager = port_manager
+
+    @property
+    def is_electron(self) -> bool:
+        """Whether spawned instances render in a real (non-packaged) Electron shell."""
+        return self.launch_mode in ("electron", "electron-custom-command")
 
     @contextmanager
     def spawn_sculptor_instance(
@@ -97,8 +123,12 @@ class SculptorFactory:
     ) -> Generator[tuple[SculptorServer, Page, BrowserContext, str | None], None, None]:
         """Start a backend process and yield ``(server, page, context, session_token)``.
 
-        The session_token is always None for the raw-backend path (there's no
-        Electron main process issuing its own token).
+        In ``browser`` mode the session_token is always None (there's no Electron
+        main process issuing its own token) and the frontend is the shared
+        pytest-playwright page. In ``electron`` mode the backend is started the
+        same way but the frontend is a real Electron shell launched over CDP. In
+        ``electron-custom-command`` mode Electron spawns the backend itself, so
+        that flow is delegated to ``_spawn_custom_command_electron_instance``.
 
         Args:
             project_path: If provided, the backend starts with this repo as
@@ -111,6 +141,12 @@ class SculptorFactory:
         """
         if not wait_until_ready:
             raise NotImplementedError("wait_until_ready=False is only supported in packaged-electron mode")
+
+        if self.launch_mode == "electron-custom-command":
+            with self._spawn_custom_command_electron_instance(project_path) as result:
+                yield result
+            return
+
         environment = self.environment.copy()
         command = get_sculptor_command_backend_only(project_path, port=self.port)
 
@@ -120,11 +156,36 @@ class SculptorFactory:
         forwarder.start()
         specimen_server = SculptorServer(process=server, port=self.port)
 
-        page: "Page" = self.request.getfixturevalue("page")
-        configure_page(page, timeout_ms=self.default_timeout_ms)
-        navigate_to_frontend(page=page, url=f"http://127.0.0.1:{self.port}")
+        # Acquire the frontend. Browser mode drives the shared pytest-playwright
+        # page; electron mode launches a real Electron shell over CDP pointed at
+        # the just-started backend, mirroring the shared-instance electron path
+        # in resources.py.
+        electron_frontend: "ElectronFrontend | None" = None
+        artifacts_recorder: "ArtifactsRecorder | None" = None
+        if self.launch_mode == "electron":
+            electron_frontend, page, context = self._launch_electron_frontend()
+            # Register the CDP-acquired context so ``--tracing`` captures it; the
+            # browser path gets this for free via the ``page`` fixture's context.
+            artifacts_recorder = self.request.getfixturevalue("_artifacts_recorder")
+            artifacts_recorder.on_did_create_browser_context(context)
+        else:
+            page = self.request.getfixturevalue("page")
+            configure_page(page, timeout_ms=self.default_timeout_ms)
+            navigate_to_frontend(page=page, url=f"http://127.0.0.1:{self.port}")
+            context = page.context
 
-        yield specimen_server, page, page.context, None
+        # On a test-body failure, reclaim the heavy Electron shell (Electron + Vite
+        # dev server + xvfb) before re-raising. Browser mode has nothing to do here,
+        # and the backend teardown below stays success-path-only — preserving the
+        # original behavior where a failing test leaves the raw backend for the
+        # worker/session to reap.
+        try:
+            yield specimen_server, page, context, None
+        except BaseException:
+            if electron_frontend is not None:
+                assert artifacts_recorder is not None
+                self._teardown_electron_factory_frontend(electron_frontend, artifacts_recorder, context, page)
+            raise
 
         # Snapshot any error the backend logged *during the test* before we start
         # tearing down. Killing the process group below also kills whatever child
@@ -134,7 +195,14 @@ class SculptorFactory:
         # That ERROR is an artifact of our own forced teardown, not a test
         # failure, so the pass/fail decision below must use this pre-teardown
         # snapshot rather than whatever the Forwarder records while we kill.
+        # Electron teardown happens *after* this snapshot for the same reason:
+        # tearing the shell down disconnects its websocket, which the backend may
+        # log, and that must not be misattributed to the test.
         failure_line_during_test = forwarder.first_failure_line
+
+        if electron_frontend is not None:
+            assert artifacts_recorder is not None
+            self._teardown_electron_factory_frontend(electron_frontend, artifacts_recorder, context, page)
 
         logger.info("Terminating sculptor server and its process group")
         # Kill the entire process group to clean up any child processes.
@@ -165,6 +233,118 @@ class SculptorFactory:
         # (even if the test didn't realize it failed). Teardown-induced errors are excluded via the snapshot above.
         if not specimen_server.is_unexpected_error_caused_by_test and failure_line_during_test is not None:
             raise RuntimeError(f"Sculptor server emitted a line with ERROR: {failure_line_during_test}")
+
+    def _launch_electron_frontend(self) -> "tuple[ElectronFrontend, Page, BrowserContext]":
+        """Launch a non-packaged Electron shell over CDP against the running backend.
+
+        Returns ``(frontend, page, context)``. The Electron main process is told
+        to connect to the already-started backend via ``SCULPTOR_API_PORT``; the
+        renderer is served by an Electron-managed Vite dev server.
+        """
+        electron_frontend = self._make_electron_frontend()
+        context, page = electron_frontend.__enter__()
+        return electron_frontend, page, context
+
+    def _make_electron_frontend(
+        self,
+        *,
+        custom_backend_cmd: str | None = None,
+        extra_env: dict[str, str] | None = None,
+    ) -> "ElectronFrontend":
+        """Construct an ``ElectronFrontend`` for this factory's backend port.
+
+        The import is function-local because ``electron_frontend`` imports
+        ``get_v1_frontend_path`` from this module (a module-level import cycles).
+        """
+        from sculptor.testing.electron_frontend import ElectronFrontend
+
+        assert self.playwright is not None, "electron launch mode requires a Playwright instance"
+        assert self.port_manager is not None, "electron launch mode requires a PortManager"
+        return ElectronFrontend(
+            playwright=self.playwright,
+            backend_port=self.port,
+            port_manager=self.port_manager,
+            timeout_ms=self.default_timeout_ms,
+            custom_backend_cmd=custom_backend_cmd,
+            extra_env=extra_env,
+        )
+
+    def _teardown_electron_factory_frontend(
+        self,
+        electron_frontend: "ElectronFrontend",
+        artifacts_recorder: "ArtifactsRecorder",
+        context: BrowserContext,
+        page: Page,
+    ) -> None:
+        """Stop tracing, close the CDP page/context, then kill the Electron shell.
+
+        Order matters: ``on_will_close_browser_context`` writes the trace via the
+        live CDP connection, so it must run before the Electron process (and its
+        CDP endpoint) is killed.
+        """
+        try:
+            artifacts_recorder.on_will_close_browser_context(context)
+        except Exception:
+            logger.debug("Artifacts recorder close failed during electron factory teardown")
+        for closer, what in ((page.close, "page"), (context.close, "browser context")):
+            try:
+                closer()
+            except Exception:
+                logger.debug("{} already closed during electron factory teardown", what)
+        try:
+            electron_frontend.__exit__(None, None, None)
+        except Exception:
+            logger.debug("ElectronFrontend cleanup error during electron factory teardown")
+
+    @contextmanager
+    def _spawn_custom_command_electron_instance(
+        self,
+        project_path: Path | None,
+    ) -> Generator[tuple[SculptorServer, Page, BrowserContext, str | None], None, None]:
+        """Spawn a per-test Electron instance where Electron manages the backend.
+
+        Mirrors the shared-instance custom-command path
+        (``_create_custom_command_instance`` in resources.py): instead of
+        starting the backend separately, Electron spawns it via
+        ``SCULPTOR_CUSTOM_BACKEND_CMD``, exercising the HTTP-upload code path.
+        Per-test isolation is preserved by the factory's own backend port and
+        sculptor folder. Yields ``(server, page, context, session_token)`` where
+        ``server`` wraps the Electron process (which owns the backend child).
+        """
+        # Print the URL then exec the backend, matching the shared path. Use
+        # sys.executable so the backend runs in the test virtualenv (the Electron
+        # child otherwise inherits a different PATH).
+        project_arg = f" {project_path}" if project_path is not None else ""
+        backend_exec = f"exec {sys.executable} -m sculptor.cli.main --no-open-browser --port {self.port}{project_arg}"
+        custom_backend_cmd = f"echo http://localhost:{self.port} && {backend_exec}"
+        # The testing environment (DATABASE_URL, sculptor folder, hidden keys,
+        # unset SESSION_TOKEN/CLAUDECODE, ...) reaches the backend as Electron's
+        # extra_env, since the custom command is the backend's parent.
+        extra_env = {k: str(v) for k, v in self.environment.items() if v is not None}
+        # A known session token lets Playwright's page.request calls authenticate
+        # against the backend (which requires the token in custom-command mode).
+        session_token = os.urandom(32).hex()
+        extra_env["SCULPTOR_SESSION_TOKEN"] = session_token
+
+        electron_frontend = self._make_electron_frontend(custom_backend_cmd=custom_backend_cmd, extra_env=extra_env)
+        context, page = electron_frontend.__enter__()
+        artifacts_recorder: "ArtifactsRecorder" = self.request.getfixturevalue("_artifacts_recorder")
+        artifacts_recorder.on_did_create_browser_context(context)
+        try:
+            context.add_cookies(
+                [
+                    {
+                        "name": "x-session-token",
+                        "value": session_token,
+                        "url": f"http://127.0.0.1:{self.port}",
+                    }
+                ]
+            )
+            assert electron_frontend._electron_proc is not None
+            server = SculptorServer(process=electron_frontend._electron_proc, port=self.port)
+            yield server, page, context, session_token
+        finally:
+            self._teardown_electron_factory_frontend(electron_frontend, artifacts_recorder, context, page)
 
 
 def get_v1_frontend_path() -> Path:

--- a/sculptor/sculptor/testing/server_utils.py
+++ b/sculptor/sculptor/testing/server_utils.py
@@ -10,7 +10,6 @@ from collections.abc import Generator
 from collections.abc import Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import attr
 import pytest
@@ -20,18 +19,13 @@ from playwright.sync_api import Page
 from playwright.sync_api import Playwright
 from pytest_playwright.pytest_playwright import ArtifactsRecorder
 
-from sculptor.foundation.git import get_git_repo_root
+from sculptor.testing.electron_frontend import ElectronFrontend
 from sculptor.testing.frontend_utils import configure_page
 from sculptor.testing.playwright_utils import navigate_to_frontend
 from sculptor.testing.port_manager import PortManager
 from sculptor.testing.subprocess_utils import Forwarder
 from sculptor.testing.subprocess_utils import print_colored_line
 from sculptor.utils.build import SCULPTOR_FOLDER_OVERRIDE_ENV_FLAG
-
-if TYPE_CHECKING:
-    # ``electron_frontend`` imports ``get_v1_frontend_path`` from this module, so the
-    # runtime import lives inside ``_make_electron_frontend`` to avoid an import cycle.
-    from sculptor.testing.electron_frontend import ElectronFrontend
 
 LOCAL_HOST_URL = "http://127.0.0.1"
 READY_MESSAGE_V1 = "Server is ready to accept requests!"
@@ -268,14 +262,8 @@ class SculptorFactory:
         custom_backend_cmd: str | None = None,
         extra_env: dict[str, str] | None = None,
         env_unset_keys: tuple[str, ...] = (),
-    ) -> "ElectronFrontend":
-        """Construct an ``ElectronFrontend`` for this factory's backend port.
-
-        The import is function-local because ``electron_frontend`` imports
-        ``get_v1_frontend_path`` from this module (a module-level import cycles).
-        """
-        from sculptor.testing.electron_frontend import ElectronFrontend
-
+    ) -> ElectronFrontend:
+        """Construct an ``ElectronFrontend`` for this factory's backend port."""
         assert self.playwright is not None, "electron launch mode requires a Playwright instance"
         assert self.port_manager is not None, "electron launch mode requires a PortManager"
         return ElectronFrontend(
@@ -368,11 +356,6 @@ class SculptorFactory:
             yield server, page, context, session_token
         finally:
             self._teardown_electron_factory_frontend(electron_frontend, artifacts_recorder, context, page)
-
-
-def get_v1_frontend_path() -> Path:
-    """Returns the path to the frontend directory in v1"""
-    return get_git_repo_root() / "sculptor" / "frontend"
 
 
 def get_testing_environment(

--- a/sculptor/sculptor/testing/server_utils.py
+++ b/sculptor/sculptor/testing/server_utils.py
@@ -163,11 +163,10 @@ class SculptorFactory:
         electron_frontend: "ElectronFrontend | None" = None
         artifacts_recorder: "ArtifactsRecorder | None" = None
         if self.launch_mode == "electron":
-            electron_frontend, page, context = self._launch_electron_frontend()
-            # Register the CDP-acquired context so ``--tracing`` captures it; the
-            # browser path gets this for free via the ``page`` fixture's context.
-            artifacts_recorder = self.request.getfixturevalue("_artifacts_recorder")
-            artifacts_recorder.on_did_create_browser_context(context)
+            # _launch_electron_frontend registers the context for tracing and tears
+            # the shell back down if that registration fails, so a setup error after
+            # launch can't leak the Electron + Vite process.
+            electron_frontend, page, context, artifacts_recorder = self._launch_electron_frontend()
         else:
             page = self.request.getfixturevalue("page")
             configure_page(page, timeout_ms=self.default_timeout_ms)
@@ -234,22 +233,41 @@ class SculptorFactory:
         if not specimen_server.is_unexpected_error_caused_by_test and failure_line_during_test is not None:
             raise RuntimeError(f"Sculptor server emitted a line with ERROR: {failure_line_during_test}")
 
-    def _launch_electron_frontend(self) -> "tuple[ElectronFrontend, Page, BrowserContext]":
+    def _launch_electron_frontend(
+        self,
+        *,
+        custom_backend_cmd: str | None = None,
+        extra_env: dict[str, str] | None = None,
+        env_unset_keys: tuple[str, ...] = (),
+    ) -> "tuple[ElectronFrontend, Page, BrowserContext, ArtifactsRecorder]":
         """Launch a non-packaged Electron shell over CDP against the running backend.
 
-        Returns ``(frontend, page, context)``. The Electron main process is told
-        to connect to the already-started backend via ``SCULPTOR_API_PORT``; the
-        renderer is served by an Electron-managed Vite dev server.
+        Returns ``(frontend, page, context, artifacts_recorder)``. The Electron main
+        process is told to connect to the already-started backend via
+        ``SCULPTOR_API_PORT``; the renderer is served by an Electron-managed Vite
+        dev server. The CDP-acquired context is registered with pytest-playwright's
+        artifacts recorder so ``--tracing`` captures it (the browser path gets this
+        for free via the ``page`` fixture). If registration fails after the shell is
+        up, the shell is torn down before re-raising so it can't leak.
         """
-        electron_frontend = self._make_electron_frontend()
+        electron_frontend = self._make_electron_frontend(
+            custom_backend_cmd=custom_backend_cmd, extra_env=extra_env, env_unset_keys=env_unset_keys
+        )
         context, page = electron_frontend.__enter__()
-        return electron_frontend, page, context
+        try:
+            artifacts_recorder: ArtifactsRecorder = self.request.getfixturevalue("_artifacts_recorder")
+            artifacts_recorder.on_did_create_browser_context(context)
+        except BaseException:
+            electron_frontend.__exit__(None, None, None)
+            raise
+        return electron_frontend, page, context, artifacts_recorder
 
     def _make_electron_frontend(
         self,
         *,
         custom_backend_cmd: str | None = None,
         extra_env: dict[str, str] | None = None,
+        env_unset_keys: tuple[str, ...] = (),
     ) -> "ElectronFrontend":
         """Construct an ``ElectronFrontend`` for this factory's backend port.
 
@@ -267,6 +285,7 @@ class SculptorFactory:
             timeout_ms=self.default_timeout_ms,
             custom_backend_cmd=custom_backend_cmd,
             extra_env=extra_env,
+            env_unset_keys=env_unset_keys,
         )
 
     def _teardown_electron_factory_frontend(
@@ -317,19 +336,23 @@ class SculptorFactory:
         project_arg = f" {project_path}" if project_path is not None else ""
         backend_exec = f"exec {sys.executable} -m sculptor.cli.main --no-open-browser --port {self.port}{project_arg}"
         custom_backend_cmd = f"echo http://localhost:{self.port} && {backend_exec}"
-        # The testing environment (DATABASE_URL, sculptor folder, hidden keys,
-        # unset SESSION_TOKEN/CLAUDECODE, ...) reaches the backend as Electron's
-        # extra_env, since the custom command is the backend's parent.
+        # The testing environment (DATABASE_URL, sculptor folder, hidden keys, ...)
+        # reaches the backend as Electron's extra_env, since the custom command is the
+        # backend's parent. None-valued entries (SESSION_TOKEN, CLAUDECODE, ...) are
+        # "unset" requests: dropping them from extra_env is not enough because
+        # ElectronFrontend spreads os.environ, so a parent value would survive — hence
+        # they are passed as env_unset_keys so ElectronFrontend excludes them from the
+        # child's environment, matching the raw-backend path's unset semantics.
+        env_unset_keys = tuple(key for key, value in self.environment.items() if value is None)
         extra_env = {k: str(v) for k, v in self.environment.items() if v is not None}
         # A known session token lets Playwright's page.request calls authenticate
         # against the backend (which requires the token in custom-command mode).
         session_token = os.urandom(32).hex()
         extra_env["SCULPTOR_SESSION_TOKEN"] = session_token
 
-        electron_frontend = self._make_electron_frontend(custom_backend_cmd=custom_backend_cmd, extra_env=extra_env)
-        context, page = electron_frontend.__enter__()
-        artifacts_recorder: "ArtifactsRecorder" = self.request.getfixturevalue("_artifacts_recorder")
-        artifacts_recorder.on_did_create_browser_context(context)
+        electron_frontend, page, context, artifacts_recorder = self._launch_electron_frontend(
+            custom_backend_cmd=custom_backend_cmd, extra_env=extra_env, env_unset_keys=env_unset_keys
+        )
         try:
             context.add_cookies(
                 [

--- a/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
+++ b/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
@@ -93,10 +93,16 @@ def _assert_linear_plugin_loads_and_renders(plugins: PlaywrightPluginsSettingsEl
     expect(plugins.get_source_row(LINEAR_SOURCE)).to_contain_text(LINEAR_SETTINGS_TEXT)
 
 
+@pytest.mark.browser_and_electron
 def test_bundled_linear_plugin_loads_and_renders(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
-    """In a browser, the bundled Linear plugin loads and renders its UI."""
+    """The bundled Linear plugin loads and renders its UI in both browser and Electron.
+
+    The per-test factory instance runs in both launch modes, so this single test
+    covers the plugin's load + render in a browser and inside a real,
+    non-packaged Electron shell.
+    """
     with sculptor_instance_factory_.spawn_instance() as instance:
         settings_page = navigate_to_settings_page(page=instance.page)
         plugins = settings_page.click_on_plugins()
@@ -132,13 +138,3 @@ def test_bundled_linear_plugin_workspace_widget_shows_branch_ticket(
         widget = instance.page.get_by_test_id(LINEAR_WIDGET_TESTID)
         expect(widget).to_be_visible()
         expect(widget).to_contain_text(WIDGET_TICKET_ID)
-
-
-@pytest.mark.electron
-def test_bundled_linear_plugin_loads_and_renders_in_electron(
-    sculptor_instance_: SculptorInstance,
-) -> None:
-    """In Electron, the bundled Linear plugin loads and renders its UI."""
-    settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
-    plugins = settings_page.click_on_plugins()
-    _assert_linear_plugin_loads_and_renders(plugins)

--- a/sculptor/tests/integration/frontend/test_factory_electron_smoke.py
+++ b/sculptor/tests/integration/frontend/test_factory_electron_smoke.py
@@ -1,0 +1,42 @@
+"""Smoke test for the per-test factory's real (non-packaged) Electron path.
+
+The factory fixture (``sculptor_instance_factory_``) gained an Electron launch
+mode, so a single ``@browser_and_electron`` test can run against both a plain
+Chromium page and a real Electron shell from the same per-instance-isolated
+config. This test proves ``spawn_instance()`` reaches a rendered app in
+whichever mode the run selected, and that the Electron run produces an Electron
+instance rather than silently falling back to the browser.
+"""
+
+import pytest
+
+from sculptor.constants import ElementIDs
+from sculptor.testing.playwright_utils import expect_app_not_onboarding
+from sculptor.testing.sculptor_instance import SculptorInstanceFactory
+
+# Generous headroom for a cold per-test Electron + Vite dev server start, mirroring
+# the shared-instance render budget in sculptor/testing/resources.py. Browser mode
+# renders far faster but shares the same wait.
+_RENDER_TIMEOUT_MS = 90_000
+
+
+@pytest.mark.browser_and_electron
+def test_factory_instance_renders_app(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+    sculptor_launch_mode: str,
+) -> None:
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        # The app rendered past onboarding. The backend was started with the test
+        # project (auto_project), so the root loader lands on the Add Workspace
+        # page; its Start Task button is the canonical "app is up" signal.
+        start_task_button = instance.page.get_by_test_id(ElementIDs.START_TASK_BUTTON)
+        expect_app_not_onboarding(instance.page, start_task_button, timeout=_RENDER_TIMEOUT_MS)
+
+        # Under an electron launch mode the instance must be a real Electron shell,
+        # not the browser fallback — that is the whole point of the new path.
+        if sculptor_launch_mode in ("electron", "electron-custom-command"):
+            assert instance.is_electron, (
+                f"expected a real Electron instance under launch mode {sculptor_launch_mode!r}"
+            )
+        elif sculptor_launch_mode == "browser":
+            assert not instance.is_electron

--- a/sculptor/tests/integration/frontend/test_factory_electron_smoke.py
+++ b/sculptor/tests/integration/frontend/test_factory_electron_smoke.py
@@ -26,11 +26,11 @@ def test_factory_instance_renders_app(
     sculptor_launch_mode: str,
 ) -> None:
     with sculptor_instance_factory_.spawn_instance() as instance:
-        # The app rendered past onboarding. The backend was started with the test
-        # project (auto_project), so the root loader lands on the Add Workspace
-        # page; its Start Task button is the canonical "app is up" signal.
-        start_task_button = instance.page.get_by_test_id(ElementIDs.START_TASK_BUTTON)
-        expect_app_not_onboarding(instance.page, start_task_button, timeout=_RENDER_TIMEOUT_MS)
+        # The app rendered past onboarding. The sidebar rail is the harness's
+        # universal "app rendered, not onboarding" signal (present on every in-app
+        # destination and the empty-first-run page, but not the onboarding wizard).
+        app_ready = instance.page.get_by_test_id(ElementIDs.WORKSPACE_SIDEBAR)
+        expect_app_not_onboarding(instance.page, app_ready, timeout=_RENDER_TIMEOUT_MS)
 
         # Under an electron launch mode the instance must be a real Electron shell,
         # not the browser fallback — that is the whole point of the new path.

--- a/sculptor/tests/integration/frontend/test_plugin_loader.py
+++ b/sculptor/tests/integration/frontend/test_plugin_loader.py
@@ -6,11 +6,12 @@ fetches the manifest, validates it, dynamic-imports the entry module, and runs
 its ``activate``. Each source renders a row whose ``data-status`` reflects the
 outcome and, on failure, a ``data-phase`` naming the stage that failed.
 
-The frontend plugin system is on by default, so the browser tests run on a plain
-factory instance and the Electron variant rides the shared instance (the only
-path that launches a real, non-packaged Electron today -- the factory is
-browser-only). The same loader assertions back all of them, shared through
-``_exercise_*`` helpers.
+The frontend plugin system is on by default, so every test runs on a plain
+factory instance. The loader tests that need Electron coverage are marked
+``@browser_and_electron`` and run in both browser and Electron modes from that
+one per-test instance -- the factory can launch a real, non-packaged Electron
+shell, so no separate shared-instance Electron variant is needed. The same
+loader assertions back all of them, shared through ``_exercise_*`` helpers.
 
 Plugin sources are served from a local cross-origin fixture HTTP server (the
 shape a plugin dev server takes), which lets each failure mode be reproduced
@@ -33,7 +34,6 @@ from sculptor.testing.plugin_fixture_server import PluginFixtureServer
 from sculptor.testing.plugin_fixture_server import spawn_plugin_fixture_server
 from sculptor.testing.resources import _default_sculptor_folder_populator
 from sculptor.testing.resources import custom_sculptor_folder_populator
-from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 from sculptor.web.app import _display_path
 
@@ -212,6 +212,7 @@ def _exercise_disable_and_enable(plugins: PlaywrightPluginsSettingsElement, serv
     expect(plugins.get_source_row(source)).to_have_count(0)
 
 
+@pytest.mark.browser_and_electron
 def test_plugin_source_can_be_disabled_and_re_enabled(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """A loaded source can be disabled without removal and later re-enabled."""
     with (
@@ -223,6 +224,7 @@ def test_plugin_source_can_be_disabled_and_re_enabled(sculptor_instance_factory_
         _exercise_disable_and_enable(plugins, server)
 
 
+@pytest.mark.browser_and_electron
 def test_plugin_source_error_modes(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """Every malformed-source mode settles the row into an error at its phase.
 
@@ -267,6 +269,7 @@ def test_failed_plugin_can_be_retried(sculptor_instance_factory_: SculptorInstan
         plugins.expect_loaded(source, name="Retry Me", version="0.1.0")
 
 
+@pytest.mark.browser_and_electron
 def test_valid_plugin_loads_and_can_be_removed(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """A well-formed cross-origin source loads (name/version shown) and removes cleanly."""
     with (
@@ -410,27 +413,3 @@ def test_plugins_directory_shows_real_backend_path(sculptor_instance_factory_: S
         # the hardcoded placeholder, or this test couldn't catch that regression.
         assert expected != "~/.sculptor/plugins"
         expect(plugins.get_directory_label()).to_have_text(expected)
-
-
-@pytest.mark.electron
-def test_plugin_loader_in_electron(sculptor_instance_: SculptorInstance) -> None:
-    """The same loader flow, exercised inside a real Electron shell.
-
-    Scope: this is *non-packaged* Electron -- the renderer is still served over
-    ``http://localhost`` and driven via CDP. So it covers the Electron
-    process/IPC model and a real cross-origin fetch + dynamic import from a
-    different origin, but NOT the packaged app's ``file://`` origin (where
-    ``window.location.origin`` is ``"null"`` and the same-origin/CORS rules
-    differ). That packaged ``file://`` case remains a separate, unsolved scenario.
-
-    The factory fixture can't launch a non-packaged Electron, so Electron
-    coverage rides the shared instance. The plugin system is on by default, so we
-    drive the Plugins section directly. (The error rows the run leaves behind are
-    renderer-local and harmless -- no other Electron test reads plugin sources --
-    so we don't bother removing them.)
-    """
-    settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
-    plugins = settings_page.click_on_plugins()
-    with spawn_plugin_fixture_server() as server:
-        _exercise_error_modes(plugins, server)
-        _exercise_valid_load_and_remove(plugins, server)


### PR DESCRIPTION
## What

The per-test factory fixture (`sculptor_instance_factory_`) previously always drove a plain Chromium page, so a test that needs BOTH per-instance isolated config (e.g. a folder populator that seeds an experimental flag) AND a real Electron shell could not have both.

This adds an Electron branch to `SculptorFactory.spawn_sculptor_instance` for the `electron` and `electron-custom-command` launch modes, mirroring the shared-instance path:

- start the backend exactly as in browser mode, then launch a real (non-packaged) Electron shell over CDP (reusing `ElectronFrontend`) pointed at that backend;
- register the Electron `BrowserContext` with pytest-playwright's `_artifacts_recorder` so `--tracing` captures it;
- preserve per-instance isolation (DB, sculptor folder, backend port);
- keep `browser` the default — the browser path is unchanged.

The delegate now exposes `is_electron`, which `SculptorInstanceFactory` uses instead of an `isinstance` check.

## Why

Factory-based tests can now run in both browser and Electron modes from one parametrized test off the same seeded config. The motivating case is the frontend plugin-loader tests, which need an experimental flag seeded via the factory's folder populator; a follow-up will fold the runtime-toggle Electron workaround into parametrized factory tests.

## Testing

- Added a `@browser_and_electron` factory smoke test (`test_factory_electron_smoke.py`) that spawns an instance and asserts the app renders past onboarding in whichever mode the run selected.
- `just test-integration-electron <smoke test>` → passes; a real Electron app launches and `--tracing=on` produces `trace.zip`.
- `just test-integration <smoke test>` (browser) → passes (same test, both modes).
- `just format` / `just check` green.

## Notes

- The `electron-custom-command` factory branch is implemented (mirroring the shared custom-command path) but is not exercised by the new smoke test — no factory test uses that mode yet, and the conftest gates it to `@electron_custom_command`-marked tests.
- Per-test Electron startup is heavy (Electron + Vite dev server per spawn); no pooling added — noted as a future optimization if it proves too slow.

(Sent by Claude)