### PR TITLE
Serve the packaged renderer from a custom secure app:// origin

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,14 @@
 
 FROM ubuntu:24.04
 
+# xvfb + xauth provide the virtual X display the Electron integration launch
+# mode needs (the harness wraps Electron in `xvfb-run` when there's no DISPLAY).
+# Electron's other shared libs come from `playwright install --with-deps
+# chromium` in finalize-base-image.sh, which also handles Ubuntu 24.04's t64
+# package renames.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git curl ca-certificates build-essential pkg-config libssl-dev \
+        xvfb xauth \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,12 +11,16 @@ FROM ubuntu:24.04
 
 # xvfb + xauth provide the virtual X display the Electron integration launch
 # mode needs (the harness wraps Electron in `xvfb-run` when there's no DISPLAY).
-# Electron's other shared libs come from `playwright install --with-deps
-# chromium` in finalize-base-image.sh, which also handles Ubuntu 24.04's t64
-# package renames.
+# libgtk-3-0t64 + libnotify4 are the GTK GUI stack that full Electron links
+# against: `playwright install --with-deps chromium` (finalize-base-image.sh)
+# installs deps for Playwright's *headless* Chromium shell, which omits GTK — so
+# without these the Electron binary aborts at startup with "libgtk-3.so.0:
+# cannot open shared object file" and never opens its remote-debugging port.
+# (t64 is Ubuntu 24.04's 64-bit-time_t package rename; libgtk-3-0t64 pulls in
+# the pango/cairo/gdk-pixbuf/atk closure transitively.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git curl ca-certificates build-essential pkg-config libssl-dev \
-        xvfb xauth \
+        xvfb xauth libgtk-3-0t64 libnotify4 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,6 +45,11 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 # Critical for Modal snapshots — without this, some files vanish after snapshot restore.
 ENV UV_LINK_MODE=copy
 ENV NVM_DIR="/root/.nvm"
+# Put the nvm-installed node/npm on PATH for non-interactive shells. nvm only
+# wires them in per-shell, and the offload test process doesn't source nvm — so
+# without this the Electron integration harness's `npm run electron:start`
+# fails with "npm: not found" (exit 127). NODE_VERSION + NVM_DIR are set above.
+ENV PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin:${PATH}"
 
 WORKDIR /app
 

--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -171,3 +171,131 @@ jobs:
           junit-path: test-results/junit-integration.xml
           tests-outcome: ${{ steps.tests.outcome }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Runs the @electron integration subset in Electron launch mode (real Electron
+  # under xvfb, driven over CDP). These tests are skipped by the browser-mode
+  # lane above, so without this job they run in no CI lane at all. Kept as a
+  # separate job (rather than a matrix) so the browser lane stays untouched.
+  offload-electron-integration-tests:
+    name: offload electron integration tests
+    # SECURITY: same fork gate as the browser lane — never run untrusted forked
+    # code on the self-hosted offload-runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: offload-runner
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      id-token: write
+      checks: write
+    env:
+      JUST_VERBOSE: "1"
+      SCIENCE_FILESYSTEM_ROOT: /tmp/science
+      VAULT_AUTH_ROLE: sculptor_test_gh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history needed for offload's checkpoint resolution.
+          fetch-depth: 0
+
+      # Use a consistent bot identity for the git-note commits offload writes.
+      - name: Configure git identity for offload note writes
+        run: |
+          git config user.email "dev@imbue.com"
+          git config user.name "imbue-dev"
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rsync jq unzip ca-certificates
+
+      - name: Install Vault CLI
+        run: |
+          VAULT_VERSION=1.19.0
+          VAULT_SHA256=9df904271319452bbb37825cfe50726383037550cc04b7c2d0ab09e2f08f82a1
+          curl -fsSL "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o /tmp/vault.zip
+          echo "${VAULT_SHA256}  /tmp/vault.zip" | sha256sum -c -
+          sudo unzip -o /tmp/vault.zip -d /usr/local/bin
+          rm /tmp/vault.zip
+          vault --version
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Setup just
+        uses: extractions/setup-just@v2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache offload binary
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/offload
+          key: cargo-offload-${{ env.OFFLOAD_VERSION }}-${{ runner.os }}
+
+      - name: Install offload
+        run: |
+          if ! command -v offload >/dev/null || ! offload --version | grep -qF "$OFFLOAD_VERSION"; then
+            cargo install offload@"$OFFLOAD_VERSION" --force
+          fi
+          offload --version
+
+      - name: Fetch offload image-cache git notes
+        run: git fetch origin 'refs/notes/*:refs/notes/*' || true
+
+      - name: Sync Python deps
+        run: uv sync --frozen
+
+      - name: Run offload electron integration tests
+        id: tests
+        run: |
+          eval "$(./scripts/export-vault-env \
+            shared/modal/MODAL_TOKEN_ID \
+            shared/modal/MODAL_TOKEN_SECRET)"
+          ulimit -n 8192
+
+          OFFLOAD_EXIT=0
+          just test-offload-electron --ci || OFFLOAD_EXIT=$?
+
+          # Reap leaked Modal python3 workers so they don't linger on the
+          # runner host between jobs. See SCU-1376 for the underlying issue.
+          pkill -TERM -f 'python3.*modal' 2>/dev/null || true
+          sleep 3
+          pkill -KILL -f 'python3.*modal' 2>/dev/null || true
+
+          # offload exits 2 for "some tests failed"; preserve that so the
+          # rest of the pipeline still uploads artifacts and parses JUnit.
+          if [ "$OFFLOAD_EXIT" -ne 0 ] && [ "$OFFLOAD_EXIT" -ne 2 ]; then
+            exit "$OFFLOAD_EXIT"
+          fi
+
+      - name: Surface failed + flaky test names
+        if: always()
+        run: python3 scripts/ci/print_offload_failed_tests.py test-results-electron/junit-electron.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-offload-electron
+          path: test-results-electron/
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Report test results (flake-aware)
+        if: always()
+        uses: ./.github/actions/report-flaky-aware-tests
+        with:
+          check-name: offload electron integration tests
+          junit-path: test-results-electron/junit-electron.xml
+          tests-outcome: ${{ steps.tests.outcome }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -1476,6 +1476,16 @@ test-offload *args="":
     ulimit -n 8192
     offload run --trace {{args}} || [ $? -eq 2 ]
 
+# Run the @electron integration subset on Offload (Modal) in Electron launch
+# mode; see offload-electron.toml. These are skipped by the browser-mode lane.
+[group("test")]
+test-offload-electron *args="":
+    #!/bin/bash
+    set -ueo pipefail
+    {{ _require_offload }}
+    ulimit -n 8192
+    offload run -c offload-electron.toml --trace {{args}} || [ $? -eq 2 ]
+
 # Run the backend unit suite on Offload (Modal); see offload-unit.toml.
 # Alternative to `just test-unit-backend` (pytest -n 8).
 [group("test")]

--- a/offload-electron.toml
+++ b/offload-electron.toml
@@ -1,0 +1,74 @@
+# Offload runner for the Electron-launch-mode integration tests.
+# Run with: just test-offload-electron
+#
+# Companion to offload.toml (which runs the suite in the default `browser`
+# launch mode). The @electron-marked tests require a real Electron app driven
+# over CDP and are skipped in browser mode (see sculptor/conftest.py), so they
+# run in no other CI lane. This config runs exactly that subset by passing
+# `--sculptor-launch-mode=electron`; the Electron app launches under xvfb
+# (provided by the base image — see .devcontainer/Dockerfile).
+#
+# Reuses offload.toml's base image (same Dockerfile + finalize script), so no
+# separate image build beyond the shared checkpoint.
+
+[offload]
+max_parallel = 200
+# Electron is heavier than headless Chromium and its frontend launch alone can
+# take 50-60s, so give each batch more headroom than the browser lane's 900s.
+test_timeout_secs = 1200
+stream_output = true
+sandbox_project_root = "/app/sculptor"
+sandbox_repo_root = "/app"
+sandbox_init_cmd = "bash /app/scripts/finalize-base-image.sh"
+# Electron dev mode (electron-forge start) serves the renderer from the Vite
+# dev server, so it needs the generated API client + sculpt client but not a
+# production renderer bundle (no `npm run build`).
+post_patch_cmd = "export PATH=/root/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH && cd /app/sculptor/frontend && npm run generate-api && cd /app && just generate-sculpt-client"
+
+[provider]
+type = "modal"
+dockerfile = ".devcontainer/Dockerfile"
+include_cwd = false
+
+[provider.env]
+SESSION_TOKEN = ""
+PROJECT_PATH = "/tmp/repo"
+GOOGLE_API_KEY = "fake"
+
+[framework]
+type = "pytest"
+command = "uv run --project sculptor pytest"
+# --sculptor-launch-mode=electron flips the harness onto the real Electron app
+# (and, in turn, the sculptor://app protocol). -p no:xdist: offload parallelizes
+# across sandboxes, so pytest runs serially within each.
+paths = ["sculptor/tests/integration/"]
+run_args = "-p no:xdist --sculptor-launch-mode=electron"
+
+# The @electron subset. real_claude/real_pi are excluded as in the browser lane;
+# the conftest launch-mode gate additionally skips any non-electron test.
+[groups.electron]
+retry_count = 1
+filters = "-m 'electron and not real_claude and not real_pi'"
+
+[checkpoint]
+build_inputs = [
+    ".devcontainer/Dockerfile",
+    ".dockerignore",
+    ".github/workflows/offload.yml",
+    "offload-electron.toml",
+    "scripts/finalize-base-image.sh",
+    "pyproject.toml",
+    "sculptor/pyproject.toml",
+    "sculptor/frontend/package.json",
+    "uv.lock",
+]
+
+[history]
+record_history = "flag"
+
+# Separate output dir so Electron results don't clobber the browser run.
+[report]
+output_dir = "test-results-electron"
+junit = true
+junit_file = "junit-electron.xml"
+download_globs = ["test-results-electron/**"]

--- a/sculptor/frontend/src/electron/appProtocol.test.ts
+++ b/sculptor/frontend/src/electron/appProtocol.test.ts
@@ -1,0 +1,97 @@
+/** Tests for the custom app-scheme URL→file mapping and its traversal guard.
+ *
+ * These cover the pure helpers in ``appProtocol.ts`` — the part of the
+ * protocol that is testable without an Electron runtime. The live
+ * ``protocol.handle`` wiring in ``main.ts`` is only exercised in a packaged
+ * build (the Electron integration tests run in dev mode, where the renderer is
+ * served over http), so the security-critical path mapping is pinned here.
+ */
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  APP_ORIGIN,
+  APP_SCHEME,
+  getAppRendererUrl,
+  resolveRequestToFilePath,
+  shouldFallbackToIndex,
+} from "./appProtocol";
+
+const BUNDLE = path.resolve("/opt/sculptor/.vite/build/renderer");
+
+describe("getAppRendererUrl", () => {
+  it("points at index.html on the app origin", () => {
+    expect(getAppRendererUrl()).toBe(`${APP_ORIGIN}/index.html`);
+    expect(getAppRendererUrl()).toBe("sculptor://app/index.html");
+  });
+});
+
+describe("resolveRequestToFilePath", () => {
+  it("maps a normal asset path into the bundle directory", () => {
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/assets/index-abc.js")).toBe(
+      path.join(BUNDLE, "assets", "index-abc.js"),
+    );
+  });
+
+  it("defaults the root path to index.html", () => {
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/")).toBe(path.join(BUNDLE, "index.html"));
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app")).toBe(path.join(BUNDLE, "index.html"));
+  });
+
+  it("decodes percent-encoded paths", () => {
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/a%20b/c.png")).toBe(
+      path.join(BUNDLE, "a b", "c.png"),
+    );
+  });
+
+  it("ignores query strings and fragments (cache-bust tokens, hash routes)", () => {
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/assets/x.js?t=123")).toBe(
+      path.join(BUNDLE, "assets", "x.js"),
+    );
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/index.html#/settings")).toBe(
+      path.join(BUNDLE, "index.html"),
+    );
+  });
+
+  // Path traversal is contained by two layers: the scheme is registered as
+  // "standard", so the URL parser normalizes dot-segments away at the origin
+  // root, and `path.resolve` keeps anything that survives as a literal segment
+  // inside the bundle. Either way the result stays within `bundleDir` (and a
+  // nonexistent target 404s at the handler) rather than escaping to the disk.
+  it("contains dot-segment traversal within the bundle directory", () => {
+    for (const url of [
+      "sculptor://app/../../etc/passwd",
+      "sculptor://app/%2e%2e/%2e%2e/etc/passwd",
+      "sculptor://app/assets/../../../secret",
+      "sculptor://app/%252e%252e/%252e%252e/etc/passwd", // double-encoded
+    ]) {
+      const resolved = resolveRequestToFilePath(BUNDLE, url);
+      expect(resolved, url).not.toBeNull();
+      expect(resolved!.startsWith(BUNDLE + path.sep), url).toBe(true);
+    }
+  });
+
+  it("rejects other schemes and other hosts", () => {
+    expect(resolveRequestToFilePath(BUNDLE, "file:///etc/passwd")).toBeNull();
+    expect(resolveRequestToFilePath(BUNDLE, "https://app/assets/x.js")).toBeNull();
+    expect(resolveRequestToFilePath(BUNDLE, `${APP_SCHEME}://evil/assets/x.js`)).toBeNull();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(resolveRequestToFilePath(BUNDLE, "not a url")).toBeNull();
+  });
+});
+
+describe("shouldFallbackToIndex", () => {
+  it("falls back for extensionless (route-like) paths", () => {
+    expect(shouldFallbackToIndex(path.join(BUNDLE, "settings"))).toBe(true);
+    expect(shouldFallbackToIndex(path.join(BUNDLE, "workspace", "abc"))).toBe(true);
+  });
+
+  it("does not mask a genuinely missing asset", () => {
+    expect(shouldFallbackToIndex(path.join(BUNDLE, "assets", "x.js"))).toBe(false);
+    expect(shouldFallbackToIndex(path.join(BUNDLE, "favicon.ico"))).toBe(false);
+    expect(shouldFallbackToIndex(path.join(BUNDLE, "logo.svg"))).toBe(false);
+  });
+});

--- a/sculptor/frontend/src/electron/appProtocol.test.ts
+++ b/sculptor/frontend/src/electron/appProtocol.test.ts
@@ -40,9 +40,7 @@ describe("resolveRequestToFilePath", () => {
   });
 
   it("decodes percent-encoded paths", () => {
-    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/a%20b/c.png")).toBe(
-      path.join(BUNDLE, "a b", "c.png"),
-    );
+    expect(resolveRequestToFilePath(BUNDLE, "sculptor://app/a%20b/c.png")).toBe(path.join(BUNDLE, "a b", "c.png"));
   });
 
   it("ignores query strings and fragments (cache-bust tokens, hash routes)", () => {

--- a/sculptor/frontend/src/electron/appProtocol.ts
+++ b/sculptor/frontend/src/electron/appProtocol.ts
@@ -58,6 +58,7 @@ export const resolveRequestToFilePath = (bundleDir: string, requestUrl: string):
   } catch {
     return null;
   }
+
   if (parsed.protocol !== `${APP_SCHEME}:` || parsed.host !== APP_HOST) {
     return null;
   }
@@ -69,6 +70,7 @@ export const resolveRequestToFilePath = (bundleDir: string, requestUrl: string):
     // Malformed percent-encoding.
     return null;
   }
+
   if (pathname === "" || pathname === "/") {
     pathname = "/index.html";
   }

--- a/sculptor/frontend/src/electron/appProtocol.ts
+++ b/sculptor/frontend/src/electron/appProtocol.ts
@@ -1,0 +1,94 @@
+/**
+ * The custom `sculptor://app` protocol used to serve the packaged renderer.
+ *
+ * In production the renderer is loaded from a real, secure origin
+ * (`sculptor://app/index.html`) served by the Electron main process out of the
+ * built frontend bundle, instead of from `file://`. A stable origin is what
+ * makes absolute-path resolution, `fetch`, dynamic `import()`, and CSP behave
+ * like a normal web page — the prerequisite for runtime-loaded frontend
+ * plugins, which will later be served under this same origin (e.g.
+ * `sculptor://app/plugins/<id>/...` and `sculptor://app/plugin-runtime/...`).
+ *
+ * This module currently owns only host-bundle serving; the `app` host prefix
+ * is deliberately reserved so the plugin work can hang `/plugins/` and
+ * `/plugin-runtime/` paths off the same origin (no cross-origin CORS plumbing
+ * between host and plugins, and the plugin import map's absolute paths resolve
+ * against this origin).
+ *
+ * The helpers here are intentionally free of any Electron imports — they carry
+ * the URL→file mapping and the path-traversal guard so they can be unit-tested
+ * without an Electron runtime. The actual `registerSchemesAsPrivileged` /
+ * `protocol.handle` wiring lives in `main.ts`.
+ */
+import * as path from "node:path";
+
+/** The custom scheme the packaged renderer (and, later, plugins) are served from. */
+export const APP_SCHEME = "sculptor";
+
+/**
+ * The single host under the scheme. Everything is served from one origin so
+ * the (future) plugin import map and same-origin plugin loading need no CORS
+ * plumbing; the host bundle and plugins differ only by path prefix.
+ */
+export const APP_HOST = "app";
+
+/** The renderer's origin — also what the backend CORS allowlist must accept. */
+export const APP_ORIGIN = `${APP_SCHEME}://${APP_HOST}`;
+
+/** The URL the production renderer is loaded from. */
+export const getAppRendererUrl = (): string => `${APP_ORIGIN}/index.html`;
+
+/**
+ * Map a request URL on the app scheme to an absolute file path inside
+ * `bundleDir`. Returns `null` only when the request is malformed or targets
+ * another scheme or host; a valid app-host request always resolves to a path
+ * *within* `bundleDir`.
+ *
+ * Traversal is contained by two layers: the scheme is registered as
+ * "standard", so the URL parser normalizes `../` dot-segments away at the
+ * origin root, and the `path.resolve` + prefix check below is a defense-in-
+ * depth net for anything that survives decoding. The returned path is not
+ * guaranteed to exist — existence and SPA fallback are the caller's concern
+ * (see `shouldFallbackToIndex`).
+ */
+export const resolveRequestToFilePath = (bundleDir: string, requestUrl: string): string | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(requestUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== `${APP_SCHEME}:` || parsed.host !== APP_HOST) {
+    return null;
+  }
+
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(parsed.pathname);
+  } catch {
+    // Malformed percent-encoding.
+    return null;
+  }
+  if (pathname === "" || pathname === "/") {
+    pathname = "/index.html";
+  }
+
+  const root = path.resolve(bundleDir);
+  // `pathname` always starts with "/"; join it onto the root and re-resolve so
+  // any "../" segments collapse, then confirm the result is still inside root.
+  const resolved = path.resolve(root, `.${pathname}`);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    return null;
+  }
+  return resolved;
+};
+
+/**
+ * Whether a not-found request should fall back to the SPA shell
+ * (`index.html`) rather than 404. The renderer uses a hash router, so a deep
+ * link keeps its route in the URL fragment and the path is just "/"; this
+ * fallback only catches extensionless (route-like) paths and leaves a
+ * genuinely missing asset (`.js`, `.css`, an image) as a real 404 so such
+ * bugs stay visible.
+ */
+export const shouldFallbackToIndex = (filePath: string): boolean => path.extname(filePath) === "";

--- a/sculptor/frontend/src/electron/main.ts
+++ b/sculptor/frontend/src/electron/main.ts
@@ -78,6 +78,21 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
+// In production the renderer always loads from the custom sculptor://app
+// origin. In development it normally loads straight from the Vite dev server
+// over http (HMR, fast iteration), but integration tests set
+// SCULPTOR_USE_APP_SCHEME=1 to exercise the real app-scheme origin without a
+// packaged build: the handler then proxies every request to the Vite dev
+// server (injected here as its origin), so Vite still transforms and serves
+// the renderer while each request rides sculptor://app.
+const APP_SCHEME_DEV_SERVER_ORIGIN =
+  IS_DEVELOPMENT && process.env.SCULPTOR_USE_APP_SCHEME === "1"
+    ? `http://127.0.0.1:${process.env.SCULPTOR_FRONTEND_PORT || "5173"}`
+    : null;
+
+/** Whether the renderer is loaded from sculptor://app (vs. the dev server URL). */
+const shouldUseAppScheme = !IS_DEVELOPMENT || APP_SCHEME_DEV_SERVER_ORIGIN !== null;
+
 // When running from source, SCULPTOR_ICON_LABEL controls the large text at the
 // top of the dev icon (e.g. "src", "pytest") and SCULPTOR_FRONTEND_PORT is
 // shown at the bottom.  The app name in the macOS menu bar/dock is handled
@@ -867,25 +882,20 @@ const createWindow = async (): Promise<void> => {
     });
   }
 
-  const appUrl = IS_DEVELOPMENT
-    ? // The standard way to get the dev server URL is using MAIN_WINDOW_VITE_DEV_SERVER_URL,
-      // populated by Vite using its define mechanism.
-      // However, defines are substituted during compilation and reflected in the compiled JavaScript,
-      // so this creates a race condition when launching multiple dev instances at the same time,
-      // which is exactly what we do during integration tests:
-      // different instances will compete to write their respective frontend URLs to the compiled file,
-      // so other instances may load an Electron window with the wrong URL.
-      //
-      // So instead,
-      // we construct the frontend URL using SCULPTOR_FRONTEND_PORT, which is populated at runtime,
-      // so different dev instances will open their corresponding frontend URLs correctly.
-      `http://localhost:${process.env.SCULPTOR_FRONTEND_PORT || "5173"}`
-    : // In production we serve the built frontend from a custom, secure origin
-      // (sculptor://app) via the registered app protocol instead of file://. A
-      // real origin makes absolute paths, fetch, dynamic import, and CSP behave
-      // like a normal web page. The backend CORS allowlist accepts this origin
-      // (see sculptor/web/app.py).
-      getAppRendererUrl();
+  // In production (and tests that opt in via SCULPTOR_USE_APP_SCHEME) the
+  // renderer loads from the custom, secure sculptor://app origin served by the
+  // app protocol instead of file://. A real origin makes absolute paths, fetch,
+  // dynamic import, and CSP behave like a normal web page; the backend CORS
+  // allowlist accepts it (see sculptor/web/app.py). In plain development it
+  // loads straight from the Vite dev server over http.
+  //
+  // We construct the dev server URL from SCULPTOR_FRONTEND_PORT (populated at
+  // runtime) rather than MAIN_WINDOW_VITE_DEV_SERVER_URL: that Vite define is
+  // substituted at compile time, so concurrent dev instances (as in integration
+  // tests) would race to write it and could open the wrong URL.
+  const appUrl = shouldUseAppScheme
+    ? getAppRendererUrl()
+    : `http://localhost:${process.env.SCULPTOR_FRONTEND_PORT || "5173"}`;
 
   logger.info("[main] Initial URL:", appUrl);
   await window.loadURL(appUrl);
@@ -1060,6 +1070,14 @@ const createWindow = async (): Promise<void> => {
 const registerAppProtocolHandler = (): void => {
   const bundleDir = path.join(app.getAppPath(), ".vite/build/renderer");
   protocol.handle(APP_SCHEME, async (request) => {
+    if (APP_SCHEME_DEV_SERVER_ORIGIN !== null) {
+      // Test/dev: proxy to the Vite dev server, preserving path + query so its
+      // on-the-fly module transforms and asset requests resolve there. (The
+      // app's API/WebSocket traffic goes straight to the backend via absolute
+      // URLs, so it never reaches this handler.)
+      const { pathname, search } = new URL(request.url);
+      return net.fetch(`${APP_SCHEME_DEV_SERVER_ORIGIN}${pathname}${search}`);
+    }
     const resolved = resolveRequestToFilePath(bundleDir, request.url);
     if (resolved === null) {
       return new Response("Bad request", { status: 400 });

--- a/sculptor/frontend/src/electron/main.ts
+++ b/sculptor/frontend/src/electron/main.ts
@@ -3,13 +3,27 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
+import { pathToFileURL } from "node:url";
 
 import { randomBytes } from "crypto";
 import type { MenuItemConstructorOptions } from "electron";
-import { app, BrowserWindow, clipboard, dialog, globalShortcut, ipcMain, Menu, shell, webContents } from "electron";
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  globalShortcut,
+  ipcMain,
+  Menu,
+  net,
+  protocol,
+  shell,
+  webContents,
+} from "electron";
 import Store from "electron-store";
 
 import type { AnyBackendStatus, SculptorDevInfo } from "../shared/types";
+import { APP_SCHEME, getAppRendererUrl, resolveRequestToFilePath, shouldFallbackToIndex } from "./appProtocol";
 import { initAutoUpdater } from "./autoUpdater";
 import type { ZoomCommand } from "./constants";
 import {
@@ -51,6 +65,18 @@ const IS_MAC = process.platform === "darwin";
 const IS_LINUX = process.platform === "linux";
 
 /* eslint-enable @typescript-eslint/naming-convention */
+
+// Mark the custom app scheme as a standard, secure, fetch-capable origin. This
+// must run before the app's "ready" event, so it lives at module top level.
+// The handler that actually serves files is registered after the app is ready
+// (see registerAppProtocolHandler). In development the renderer is still loaded
+// over http from the Vite dev server, so this scheme goes unused there.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: APP_SCHEME,
+    privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true, stream: true },
+  },
+]);
 
 // When running from source, SCULPTOR_ICON_LABEL controls the large text at the
 // top of the dev icon (e.g. "src", "pytest") and SCULPTOR_FRONTEND_PORT is
@@ -854,8 +880,12 @@ const createWindow = async (): Promise<void> => {
       // we construct the frontend URL using SCULPTOR_FRONTEND_PORT, which is populated at runtime,
       // so different dev instances will open their corresponding frontend URLs correctly.
       `http://localhost:${process.env.SCULPTOR_FRONTEND_PORT || "5173"}`
-    : // Note: we load the built frontend from a file in production which requires us to circumvent CORS in the backend.
-      `file://${path.join(app.getAppPath(), ".vite/build/renderer/index.html")}`;
+    : // In production we serve the built frontend from a custom, secure origin
+      // (sculptor://app) via the registered app protocol instead of file://. A
+      // real origin makes absolute paths, fetch, dynamic import, and CSP behave
+      // like a normal web page. The backend CORS allowlist accepts this origin
+      // (see sculptor/web/app.py).
+      getAppRendererUrl();
 
   logger.info("[main] Initial URL:", appUrl);
   await window.loadURL(appUrl);
@@ -1019,7 +1049,36 @@ const createWindow = async (): Promise<void> => {
   });
 };
 
+/**
+ * Serve the built renderer bundle over the custom `sculptor://app` scheme.
+ * Maps each request to a file inside the bundle directory (with a path-
+ * traversal guard) and streams it back via `net.fetch`, which infers the MIME
+ * type from the extension. Extensionless misses fall back to the SPA shell.
+ * Only meaningful for packaged builds; in development the renderer is loaded
+ * from the Vite dev server and this handler is never hit.
+ */
+const registerAppProtocolHandler = (): void => {
+  const bundleDir = path.join(app.getAppPath(), ".vite/build/renderer");
+  protocol.handle(APP_SCHEME, async (request) => {
+    const resolved = resolveRequestToFilePath(bundleDir, request.url);
+    if (resolved === null) {
+      return new Response("Bad request", { status: 400 });
+    }
+    let target = resolved;
+    if (!fs.existsSync(target)) {
+      if (shouldFallbackToIndex(target)) {
+        target = path.join(bundleDir, "index.html");
+      } else {
+        return new Response("Not found", { status: 404 });
+      }
+    }
+    return net.fetch(pathToFileURL(target).toString());
+  });
+};
+
 app.whenReady().then(async () => {
+  // Register the app-scheme file handler before any window loads from it.
+  registerAppProtocolHandler();
   traceMark("electron.app_ready");
   // Create application menu
   createApplicationMenu();

--- a/sculptor/sculptor/testing/auto_update_server.py
+++ b/sculptor/sculptor/testing/auto_update_server.py
@@ -253,12 +253,12 @@ class AutoUpdateTestServer:
     def set_offline(self) -> None:
         """Make the server return 503 for all requests."""
         with self._state.lock:
-            self._state.offline = True
+            self._state.is_offline = True
 
     def set_online(self) -> None:
         """Restore normal request handling after :meth:`set_offline`."""
         with self._state.lock:
-            self._state.offline = False
+            self._state.is_offline = False
 
     def get_request_paths(self) -> list[str]:
         """Return a copy of all request paths received so far."""

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -71,6 +71,8 @@ class ElectronFrontend:
         frontend_port = self.port_manager.get_free_port()
         self._user_data_dir = tempfile.mkdtemp(prefix="sculptor_electron_")
 
+        is_headless = sys.platform == "linux" and "DISPLAY" not in os.environ and "WAYLAND_DISPLAY" not in os.environ
+
         cmd: tuple[str, ...] = (
             "npm",
             "run",
@@ -83,7 +85,15 @@ class ElectronFrontend:
         if os.getuid() == 0:
             cmd = cmd + ("--no-sandbox",)
 
-        if sys.platform == "linux" and "DISPLAY" not in os.environ and "WAYLAND_DISPLAY" not in os.environ:
+        if is_headless:
+            # Under xvfb there is no real GPU, and Chromium's GPU process then
+            # crash-loops at init (gl_context_egl "Failed to get config for
+            # surface 0" -> "Exiting GPU process due to errors during
+            # initialization"). Force software rendering so frames are produced
+            # deterministically instead of relying on that fallback recovering.
+            cmd = cmd + ("--disable-gpu",)
+
+        if is_headless:
             cmd = ("xvfb-run", "-a", "-e", "/tmp/xvfb-error.log", "-s", "-screen 0 1600x1000x16") + cmd
 
         electron_env: dict[str, str] = {

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -89,6 +89,10 @@ class ElectronFrontend:
             "SCULPTOR_FRONTEND_PORT": str(frontend_port),
             "SCULPTOR_USER_DATA_DIR": self._user_data_dir,
             "SCULPTOR_ICON_LABEL": "pytest",
+            # Load the renderer from the custom sculptor://app origin (the
+            # protocol proxies to the Vite dev server) so integration tests
+            # exercise the real packaged-app origin without a packaged build.
+            "SCULPTOR_USE_APP_SCHEME": "1",
         }
         # In custom command mode, Electron spawns the backend itself via the
         # custom command — so we do NOT set SCULPTOR_API_PORT (the command

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -191,10 +191,8 @@ class ElectronFrontend:
             exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
             post_launch = list(self._forwarder.recent_output) if self._forwarder is not None else []
             tail = "\n".join([*recent_output, *post_launch]) or "(no output captured)"
-            raise RuntimeError(
-                f"Electron launched but CDP setup on port {cdp_port} failed "
-                f"(Electron exit code {exit_code}): {exc}. Last Electron output:\n{tail}"
-            ) from exc
+            message = f"Electron launched but CDP setup on port {cdp_port} failed (exit code {exit_code}): {exc}. Last Electron output:\n{tail}"
+            raise RuntimeError(message) from exc
         logger.info("[timing] CDP connect + page acquisition: {:.2f}s", time.monotonic() - t_cdp)
 
         self._browser_context = context

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -156,10 +156,8 @@ class ElectronFrontend:
             self._kill_electron()
             exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
             tail = "\n".join(recent_output) or "(no output captured)"
-            raise RuntimeError(
-                f"Electron frontend failed to start (process exit code: {exit_code}).\n"
-                f"Last Electron output:\n{tail}"
-            )
+            message = f"Electron frontend failed to start (exit code {exit_code}). Last Electron output:\n{tail}"
+            raise RuntimeError(message)
 
         t_cdp = time.monotonic()
         try:

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -175,9 +175,26 @@ class ElectronFrontend:
             assert len(pages) == 1, f"Expected exactly one non-devtools page, got {pages}"
             page = pages[0]
             configure_page(page, timeout_ms=self.timeout_ms)
-        except Exception:
+        except Exception as exc:
+            # Electron reached its ready message (so the launch-failure path
+            # above didn't fire), but a later step failed — most often the CDP
+            # connect, where the bare PlaywrightError ("connect ECONNREFUSED")
+            # gives no hint as to why the debug port never opened. Offload
+            # streams only the failure summary, not per-sandbox logs, so without
+            # this the real reason is invisible in CI. The Forwarder has been
+            # draining stdout (stderr is merged in) since launch, so its tail
+            # holds Chromium's own startup output — including the "DevTools
+            # listening on ws://..." line that appears iff --remote-debugging-port
+            # took effect. Kill first so that tail captures everything up to exit
+            # (the deque outlives the forwarder thread).
             self._kill_electron()
-            raise
+            exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
+            post_launch = list(self._forwarder.recent_output) if self._forwarder is not None else []
+            tail = "\n".join([*recent_output, *post_launch]) or "(no output captured)"
+            raise RuntimeError(
+                f"Electron launched but CDP setup on port {cdp_port} failed "
+                f"(Electron exit code {exit_code}): {exc}. Last Electron output:\n{tail}"
+            ) from exc
         logger.info("[timing] CDP connect + page acquisition: {:.2f}s", time.monotonic() - t_cdp)
 
         self._browser_context = context

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections import deque
 from pathlib import Path
 
 from filelock import FileLock
@@ -108,6 +109,12 @@ class ElectronFrontend:
         lock_path = Path("/tmp/sculptor_electron_forge.lock")
 
         is_launched = False
+        # Keep the most recent Electron stdout/stderr (stderr is merged into
+        # stdout below) so that, if Electron never reaches its ready message, we
+        # can surface the actual crash output in the raised error. Offload only
+        # streams the failure summary, not the per-sandbox logs, so without this
+        # the real reason ("Check logs above") is invisible in CI.
+        recent_output: deque[str] = deque(maxlen=50)
         file_lock = FileLock(str(lock_path), timeout=_FORGE_LOCK_TIMEOUT_SECONDS)
         t_lock = time.monotonic()
         file_lock.acquire()
@@ -128,6 +135,7 @@ class ElectronFrontend:
             )
             assert self._electron_proc.stdout is not None
             for line in self._electron_proc.stdout:
+                recent_output.append(line.rstrip())
                 logger.info("[Electron stdout] {}", line.rstrip())
                 if ELECTRON_READY_MESSAGE in line:
                     is_launched = True
@@ -146,7 +154,12 @@ class ElectronFrontend:
 
         if not is_launched:
             self._kill_electron()
-            raise RuntimeError("Electron frontend failed to start. Check logs above.")
+            exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
+            tail = "\n".join(recent_output) or "(no output captured)"
+            raise RuntimeError(
+                f"Electron frontend failed to start (process exit code: {exit_code}).\n"
+                f"Last Electron output:\n{tail}"
+            )
 
         t_cdp = time.monotonic()
         try:

--- a/sculptor/sculptor/testing/elements/browser_panel.py
+++ b/sculptor/sculptor/testing/elements/browser_panel.py
@@ -16,7 +16,15 @@ from playwright.sync_api import expect
 from sculptor.constants import ElementIDs
 from sculptor.testing.elements.base import PlaywrightIntegrationTestElement
 
-_WEBVIEW_ATTACH_TIMEOUT_SECONDS: float = 10.0
+# Waits that depend on the <webview> guest actually attaching and committing a
+# navigation (vs. the address bar, which just mirrors the typed URL instantly).
+# Under the offload electron lane's heavy parallelism (xvfb + software
+# rendering, up to 200 sandboxes at once) the guest can take well over 10s to
+# attach and load — the fixture server is hit and returns 200, but only after
+# the old 10s budget had already expired, surfacing as a flaky "Webview
+# location did not reach ...; last value was ''". Give these a generous budget.
+_WEBVIEW_ATTACH_TIMEOUT_SECONDS: float = 30.0
+_WEBVIEW_LOAD_TIMEOUT_SECONDS: float = 30.0
 _URL_POLL_INTERVAL_SECONDS: float = 0.1
 _DEFAULT_ADDRESS_BAR_TIMEOUT_SECONDS: float = 10.0
 _PNG_MAGIC: bytes = b"\x89PNG\r\n\x1a\n"
@@ -150,7 +158,7 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
         raise AssertionError(f"Address bar did not contain {needle!r}; last value was {last_value!r}")
 
     def _wait_for_webview_location_contains(
-        self, needle: str, *, timeout_seconds: float = _DEFAULT_ADDRESS_BAR_TIMEOUT_SECONDS
+        self, needle: str, *, timeout_seconds: float = _WEBVIEW_LOAD_TIMEOUT_SECONDS
     ) -> None:
         """Wait until the webview's live ``document.location`` reflects ``needle``.
 

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -294,10 +294,16 @@ def _get_or_create_shared_instance(
     logger.info("[timing] SPA initial render: {:.2f}s", time.monotonic() - t2)
     logger.info("[timing] Total instance startup: {:.2f}s", time.monotonic() - t0)
 
+    # Capture the SPA's own origin (sculptor://app in Electron, the backend URL
+    # in browser mode) now that it has rendered, so between-test resets navigate
+    # to the renderer rather than the backend API URL.
+    frontend_url = page.url.split("#")[0].rstrip("/")
+
     # Build the instance
     instance = SculptorInstance(
         server=server,
         page=page,
+        frontend_url=frontend_url,
         repo=initial_repo,
         sculptor_folder=sculptor_folder,
         fake_bin_dir=fake_bin_dir,
@@ -443,6 +449,8 @@ def _create_packaged_instance(
     instance = SculptorInstance(
         server=server,
         page=page,
+        # base_url above was derived from page.url, so it is the SPA's origin.
+        frontend_url=base_url,
         repo=initial_repo,
         sculptor_folder=sculptor_folder,
         fake_bin_dir=fake_bin_dir,
@@ -556,6 +564,7 @@ def _create_custom_command_instance(
     instance = SculptorInstance(
         server=server,
         page=page,
+        frontend_url=page.url.split("#")[0].rstrip("/"),
         repo=initial_repo,
         sculptor_folder=sculptor_folder,
         fake_bin_dir=fake_bin_dir,

--- a/sculptor/sculptor/testing/sculptor_instance.py
+++ b/sculptor/sculptor/testing/sculptor_instance.py
@@ -147,6 +147,11 @@ class SculptorInstance:
 
     server: SculptorServer
     page: Page
+    # Origin the SPA is served from, used for navigation (e.g. resets). In
+    # browser mode this is the backend's own URL; in Electron app-scheme mode
+    # the renderer is served from sculptor://app, which is a *different* origin
+    # than the backend API — so navigation must target this, not the API URL.
+    frontend_url: str
     repo: MockRepoState
     sculptor_folder: Path
     fake_bin_dir: Path
@@ -164,8 +169,12 @@ class SculptorInstance:
         return self._project_path
 
     @property
-    def base_url(self) -> str:
-        """The base URL of the running Sculptor backend."""
+    def backend_api_url(self) -> str:
+        """Base URL of the running Sculptor backend's HTTP API (for /api/... requests).
+
+        Note this is the *backend* origin, which in Electron app-scheme mode is
+        distinct from ``frontend_url`` (the sculptor://app renderer origin).
+        """
         return self.server.url
 
     # ------------------------------------------------------------------
@@ -249,7 +258,7 @@ class SculptorInstance:
                 {
                     "name": "x-session-token",
                     "value": self._session_token,
-                    "url": self.base_url,
+                    "url": self.backend_api_url,
                 }
             ]
         )
@@ -305,7 +314,7 @@ class SculptorInstance:
         # tree, which cancels those pending timers.
         self._reset_user_config_defaults()
 
-        self.page.goto(f"{self.base_url}#/ws/new")
+        self.page.goto(f"{self.frontend_url}#/ws/new")
 
         # Wait for the Add Workspace page to render — raise if onboarding
         # shows instead (no shared-instance test should trigger onboarding).
@@ -374,7 +383,7 @@ class SculptorInstance:
         carrying the previous test's flags — back to the backend, undoing the
         reset before the test body runs.  See SCU-541 for the original failure.
         """
-        base_url = self.base_url.rstrip("/")
+        base_url = self.backend_api_url.rstrip("/")
         timeout = self._default_timeout_ms
         try:
             response = self.page.request.get(f"{base_url}/api/v1/config", timeout=timeout)
@@ -429,7 +438,7 @@ class SculptorInstance:
         an explicit timeout of ``_default_timeout_ms`` per call), guaranteeing
         the transaction is fully committed before we proceed.
         """
-        base_url = self.base_url.rstrip("/")
+        base_url = self.backend_api_url.rstrip("/")
         timeout = self._default_timeout_ms
         try:
             # /workspaces/recent returns all non-deleted workspaces (open and
@@ -674,6 +683,7 @@ class SculptorInstanceFactory:
             instance = SculptorInstance(
                 server=server,
                 page=sculptor_page,
+                frontend_url=sculptor_page.url.split("#")[0].rstrip("/"),
                 repo=self.base_repo,
                 sculptor_folder=self._delegate.sculptor_folder,
                 fake_bin_dir=self.fake_bin_dir,

--- a/sculptor/sculptor/testing/subprocess_utils.py
+++ b/sculptor/sculptor/testing/subprocess_utils.py
@@ -1,6 +1,9 @@
 import subprocess
 import threading
+from collections import deque
 from typing import Callable
+
+_DEFAULT_RECENT_OUTPUT_LINES = 50
 
 
 class Forwarder(threading.Thread):
@@ -14,12 +17,18 @@ class Forwarder(threading.Thread):
         sculptor_server: subprocess.Popen,
         prefix: str = "",
         known_harmless_func: Callable[[str], bool] | None = None,
+        recent_output_lines: int = _DEFAULT_RECENT_OUTPUT_LINES,
     ) -> None:
         super().__init__(daemon=True)
         self.prefix = prefix
         self.sculptor_server = sculptor_server
         self.first_failure_line: str | None = None
         self.known_harmless_func = known_harmless_func
+        # Retain the most recent lines so callers can surface the process's
+        # output after the fact — e.g. when the Electron app forwards fine but a
+        # later step (CDP connect) fails and the bare exception carries no clue
+        # as to what the process was doing.
+        self.recent_output: deque[str] = deque(maxlen=recent_output_lines)
         self._stop_event = threading.Event()
 
     def stop(self, timeout: float = 5.0) -> None:
@@ -34,6 +43,7 @@ class Forwarder(threading.Thread):
                 line = self.sculptor_server.stdout.readline()
                 if not line:
                     break
+                self.recent_output.append(line.rstrip())
                 # Note: the print(line) here routes to pytest junit due to an issue with how pytest hides stdout
                 #       the logger actually displays to the user
                 print_colored_line(self.prefix + line.rstrip(), known_harmless_func=self.known_harmless_func)

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -429,6 +429,7 @@ APP.add_middleware(
         f"http://127.0.0.1:{api_port}",  # Direct web backend access, this usually doesnt need cors
         *([f"http://{frontend_host}:{frontend_port}"] if frontend_host is not None else []),
         "null",  # file:// URLs report origin as "null"
+        "sculptor://app",  # packaged renderer served from the custom app protocol
     ],
     # If we are running for an integration test, we need to allow any port so that our clients can port-hop.
     allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$" if is_integration_testing else None,

--- a/sculptor/tests/integration/frontend/test_add_workspace_page.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_page.py
@@ -445,7 +445,7 @@ def test_deleting_project_also_deletes_its_workspaces(
         )
 
         workspace_id = _extract_workspace_id(page.url)
-        base_url = page.url.split("#")[0].rstrip("/")
+        base_url = sculptor_instance.backend_api_url.rstrip("/")
 
         get_response = page.request.get(f"{base_url}/api/v1/workspaces/{workspace_id}")
         assert get_response.ok, f"Expected workspace {workspace_id} to exist, got status {get_response.status}"

--- a/sculptor/tests/integration/frontend/test_ask_user_question.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question.py
@@ -1708,13 +1708,13 @@ def _run_sculpt(instance: SculptorInstance, args: list[str]) -> tuple[int, str, 
     Automatically injects --base-url and sets the SCULPT_PROJECT_ID
     environment variable so the CLI can resolve the project.
     """
-    base_url = instance.base_url.rstrip("/")
+    base_url = instance.backend_api_url.rstrip("/")
     response = instance.page.request.get(f"{base_url}/api/v1/projects/active")
     projects = response.json()
     project_id = projects[0]["objectId"] if projects else ""
 
     env = {**os.environ, "SCULPT_PROJECT_ID": project_id}
-    full_args = args + ["--base-url", instance.base_url]
+    full_args = args + ["--base-url", instance.backend_api_url]
     result = subprocess.run(
         [sys.executable, "-m", "sculpt.main"] + full_args,
         capture_output=True,

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -112,7 +112,7 @@ def _enable_babysitter(instance: SculptorInstance) -> None:
     can fire before the parent agent's first chat message is committed, so
     we set the user-config fallback explicitly here.
     """
-    base_url = instance.base_url.rstrip("/")
+    base_url = instance.backend_api_url.rstrip("/")
     response = instance.page.request.get(f"{base_url}/api/v1/config", timeout=_CONFIG_API_TIMEOUT_MS)
     assert response.ok, f"GET /api/v1/config failed: {response.status}"
     config = response.json()

--- a/sculptor/tests/integration/frontend/test_clone_local_only_branch.py
+++ b/sculptor/tests/integration/frontend/test_clone_local_only_branch.py
@@ -40,8 +40,7 @@ def _workspace_id_from_url(page: Page) -> str:
     return match.group(1)
 
 
-def _clone_code_dir_for_workspace(page: Page, workspace_id: str, timeout_ms: int = 30_000) -> Path:
-    base_url = page.url.split("#")[0].rstrip("/")
+def _clone_code_dir_for_workspace(page: Page, base_url: str, workspace_id: str, timeout_ms: int = 30_000) -> Path:
     for _ in range(timeout_ms // 200):
         response = page.request.get(f"{base_url}/api/v1/workspaces/{workspace_id}")
         assert response.ok, f"GET workspace failed: {response.status} {response.text()}"
@@ -122,7 +121,7 @@ def test_clone_from_local_only_branch_with_source_remotes_present(
     expect(task_page.get_chat_panel()).to_be_visible(timeout=60_000)
 
     workspace_id = _workspace_id_from_url(page)
-    clone_path = _clone_code_dir_for_workspace(page, workspace_id)
+    clone_path = _clone_code_dir_for_workspace(page, sculptor_instance_.backend_api_url, workspace_id)
     assert _git_branch(clone_path) == LOCAL_ONLY_BRANCH, (
         f"expected clone checked out on {LOCAL_ONLY_BRANCH!r}, got {_git_branch(clone_path)!r}"
     )

--- a/sculptor/tests/integration/frontend/test_clone_mode_branch_name.py
+++ b/sculptor/tests/integration/frontend/test_clone_mode_branch_name.py
@@ -31,8 +31,7 @@ def _workspace_id_from_url(page: Page) -> str:
     return match.group(1)
 
 
-def _clone_code_dir_for_workspace(page: Page, workspace_id: str, timeout_ms: int = 30_000) -> Path:
-    base_url = page.url.split("#")[0].rstrip("/")
+def _clone_code_dir_for_workspace(page: Page, base_url: str, workspace_id: str, timeout_ms: int = 30_000) -> Path:
     for _ in range(timeout_ms // 200):
         response = page.request.get(f"{base_url}/api/v1/workspaces/{workspace_id}")
         assert response.ok, f"GET workspace failed: {response.status} {response.text()}"
@@ -81,7 +80,7 @@ def test_clone_mode_cleared_branch_checks_out_base(sculptor_instance_: SculptorI
     add_ws_page.submit_and_wait_for_chat_panel()
 
     workspace_id = _workspace_id_from_url(page)
-    clone_path = _clone_code_dir_for_workspace(page, workspace_id)
+    clone_path = _clone_code_dir_for_workspace(page, sculptor_instance_.backend_api_url, workspace_id)
     current = _git_branch(clone_path)
     assert current in {"main", "master", "testing"}, f"unexpected base branch: {current!r}"
     assert not _branch_exists(clone_path, "test/some-work"), "clearing the branch field should not create a new branch"
@@ -105,6 +104,6 @@ def test_clone_mode_kept_branch_name_creates_new_branch(sculptor_instance_: Scul
     add_ws_page.submit_and_wait_for_chat_panel()
 
     workspace_id = _workspace_id_from_url(page)
-    clone_path = _clone_code_dir_for_workspace(page, workspace_id)
+    clone_path = _clone_code_dir_for_workspace(page, sculptor_instance_.backend_api_url, workspace_id)
     assert _git_branch(clone_path) == expected_branch
     assert _branch_exists(clone_path, expected_branch)

--- a/sculptor/tests/integration/frontend/test_diff_scope_switching.py
+++ b/sculptor/tests/integration/frontend/test_diff_scope_switching.py
@@ -148,7 +148,7 @@ def test_changes_tab_updates_on_target_branch_change(sculptor_instance_: Sculpto
 
     # Change target branch to origin/feature-refresh-test (same as HEAD)
     workspace_id = _extract_workspace_id(page.url)
-    base_url = page.url.split("#")[0].rstrip("/")
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
     response = page.request.patch(
         f"{base_url}/api/v1/workspaces/{workspace_id}",
         data={"target_branch": "origin/feature-refresh-test"},

--- a/sculptor/tests/integration/frontend/test_history_panel.py
+++ b/sculptor/tests/integration/frontend/test_history_panel.py
@@ -199,7 +199,7 @@ def test_history_panel_refreshes_on_target_branch_change(sculptor_instance_: Scu
     # Read HEAD's short hash from the commits API so we can assert the terminus
     # moves to HEAD after the target-branch change.
     workspace_id = _extract_workspace_id(page.url)
-    base_url = page.url.split("#")[0].rstrip("/")
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
     pre_patch = page.request.get(f"{base_url}/api/v1/workspaces/{workspace_id}/commits")
     assert pre_patch.ok, f"Failed to read commits: {pre_patch.status}"
     head_short_hash = pre_patch.json()["commits"][0]["hash"][:11]

--- a/sculptor/tests/integration/frontend/test_image_upload.py
+++ b/sculptor/tests/integration/frontend/test_image_upload.py
@@ -220,8 +220,11 @@ def test_images_deleted_when_task_deleted(
     for image_path in image_paths:
         assert image_path.exists(), f"Image should exist at {image_path}"
 
-    # Delete the workspace via the API
-    base_url = page.url.split("#")[0].rstrip("/")
+    # Delete the workspace via the API. Use the backend's HTTP origin, not
+    # page.url: in Electron app-scheme mode the page is served from
+    # sculptor://app, which page.request cannot fetch ("Protocol sculptor: not
+    # supported").
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
     response = page.request.get(f"{base_url}/api/v1/workspaces/recent")
     assert response.ok, f"Failed to list workspaces: {response.status}"
     workspaces = response.json().get("workspaces", [])

--- a/sculptor/tests/integration/frontend/test_sculpt_cli.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_cli.py
@@ -37,7 +37,7 @@ def _get_project_id(instance: SculptorInstance, retries: int = 3) -> str:
     Retries on transient connection errors (e.g. ECONNRESET) that can
     occur under heavy CI load.
     """
-    base_url = instance.base_url.rstrip("/")
+    base_url = instance.backend_api_url.rstrip("/")
     for attempt in range(retries):
         try:
             response = instance.page.request.get(f"{base_url}/api/v1/projects/active")
@@ -64,7 +64,7 @@ def _run_sculpt(instance: SculptorInstance, args: list[str]) -> tuple[int, str]:
         "SCULPT_PROJECT_ID": project_id,
     }
 
-    full_args = args + ["--base-url", instance.base_url, "--json"]
+    full_args = args + ["--base-url", instance.backend_api_url, "--json"]
     result = subprocess.run(
         [sys.executable, "-m", "sculpt.main"] + full_args,
         capture_output=True,
@@ -87,7 +87,7 @@ def _run_sculpt_raw(instance: SculptorInstance, args: list[str]) -> tuple[int, s
         "SCULPT_PROJECT_ID": project_id,
     }
 
-    full_args = args + ["--base-url", instance.base_url]
+    full_args = args + ["--base-url", instance.backend_api_url]
     result = subprocess.run(
         [sys.executable, "-m", "sculpt.main"] + full_args,
         capture_output=True,

--- a/sculptor/tests/integration/frontend/test_sculpt_ui_open_file.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_ui_open_file.py
@@ -48,7 +48,7 @@ def _run_sculpt_ui_open_file(
 
     Returns (exit_code, stdout, stderr).
     """
-    args = ["ui", "open-file", path, "-w", workspace_id, "--base-url", instance.base_url]
+    args = ["ui", "open-file", path, "-w", workspace_id, "--base-url", instance.backend_api_url]
     if mode is not None:
         args += ["--mode", mode]
 
@@ -153,7 +153,7 @@ def test_closed_workspace_exits_3(sculptor_instance_: SculptorInstance) -> None:
     workspace_id = _start_empty_workspace(page)
 
     # Close the workspace via the API.
-    base_url = sculptor_instance_.base_url.rstrip("/")
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
     response = request_with_retry(
         page.request.patch,
         f"{base_url}/api/v1/workspaces/{workspace_id}",

--- a/sculptor/tests/integration/frontend/test_sculpt_ui_webview.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_ui_webview.py
@@ -32,7 +32,7 @@ def _run_sculpt_ui(
     timeout_seconds: float = 30.0,
 ) -> tuple[int, str, str]:
     result = subprocess.run(
-        [sys.executable, "-m", "sculpt.main", "ui", *args, "--base-url", instance.base_url],
+        [sys.executable, "-m", "sculpt.main", "ui", *args, "--base-url", instance.backend_api_url],
         capture_output=True,
         text=True,
         timeout=timeout_seconds,
@@ -96,7 +96,7 @@ def test_navigate_closed_workspace_exits_3(sculptor_instance_: SculptorInstance)
     page = sculptor_instance_.page
     workspace_id = _start_empty_workspace(page)
 
-    base_url = sculptor_instance_.base_url.rstrip("/")
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
     response = page.request.patch(
         f"{base_url}/api/v1/workspaces/{workspace_id}",
         data={"is_open": False},

--- a/sculptor/tests/integration/frontend/test_telemetry_opt_out.py
+++ b/sculptor/tests/integration/frontend/test_telemetry_opt_out.py
@@ -26,7 +26,6 @@ Onboarding (fresh instances):
 
 from pathlib import Path
 
-from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.config.user_config import DependencyPaths
@@ -44,10 +43,10 @@ from sculptor.testing.user_stories import user_story
 _TELEMETRY_FLAG_KEYS = ("isErrorReportingEnabled", "isProductAnalyticsEnabled", "isSessionRecordingEnabled")
 
 
-def _get_user_config(page: Page) -> dict:
+def _get_user_config(instance: SculptorInstance) -> dict:
     """Fetch the persisted user config through the backend API."""
-    base_url = page.url.split("#")[0].rstrip("/")
-    response = page.request.get(f"{base_url}/api/v1/config")
+    base_url = instance.backend_api_url.rstrip("/")
+    response = instance.page.request.get(f"{base_url}/api/v1/config")
     assert response.ok, f"GET /api/v1/config failed: {response.status}"
     return response.json()
 
@@ -79,21 +78,21 @@ def test_privacy_settings_telemetry_switch(sculptor_instance_: SculptorInstance)
     privacy_section.get_opt_out_cancel_button().click()
     expect(privacy_section.get_opt_out_dialog()).not_to_be_visible()
     expect(telemetry_switch).to_have_attribute("data-state", "checked")
-    config = _get_user_config(page)
+    config = _get_user_config(sculptor_instance_)
     assert config["isErrorReportingEnabled"] is True
     assert config["isProductAnalyticsEnabled"] is True
 
     # 3. Confirming the opt-out persists all-flags-off.
     privacy_section.disable_telemetry()
     expect(telemetry_switch).to_have_attribute("data-state", "unchecked")
-    config = _get_user_config(page)
+    config = _get_user_config(sculptor_instance_)
     assert all(config[key] is False for key in _TELEMETRY_FLAG_KEYS), config
 
     # 4. Opting back in is instant — no dialog — and restores the flags.
     privacy_section.enable_telemetry()
     expect(privacy_section.get_opt_out_dialog()).not_to_be_visible()
     expect(telemetry_switch).to_have_attribute("data-state", "checked")
-    config = _get_user_config(page)
+    config = _get_user_config(sculptor_instance_)
     assert config["isErrorReportingEnabled"] is True
     assert config["isProductAnalyticsEnabled"] is True
     assert config["isSessionRecordingEnabled"] is False
@@ -103,8 +102,8 @@ def test_privacy_settings_telemetry_switch(sculptor_instance_: SculptorInstance)
 def test_put_config_rejects_telemetry_flag_changes(sculptor_instance_: SculptorInstance) -> None:
     """Verifies behavior 5: the PUT guard for the SDK-facing telemetry flags."""
     page = sculptor_instance_.page
-    base_url = page.url.split("#")[0].rstrip("/")
-    config = _get_user_config(page)
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
+    config = _get_user_config(sculptor_instance_)
 
     # Changing a telemetry flag is rejected with a pointer at the dedicated endpoint.
     response = page.request.put(
@@ -163,7 +162,7 @@ def test_onboarding_email_with_telemetry_opt_out(sculptor_instance_factory_: Scu
 
         expect(onboarding_page.get_installation_step()).to_be_visible()
 
-        config = _get_user_config(page)
+        config = _get_user_config(sculptor_instance)
         assert config["userEmail"] == "optout@user.com"
         assert config["isPrivacyPolicyConsented"] is True
         assert all(config[key] is False for key in _TELEMETRY_FLAG_KEYS), config
@@ -192,7 +191,7 @@ def test_onboarding_skip_account_setup(sculptor_instance_factory_: SculptorInsta
 
         # The config stays anonymous; consent and the default telemetry
         # choice are recorded.
-        config = _get_user_config(page)
+        config = _get_user_config(sculptor_instance)
         assert config["userEmail"] == ""
         assert config["isPrivacyPolicyConsented"] is True
         assert config["isErrorReportingEnabled"] is True

--- a/sculptor/tests/integration/frontend/test_websocket_session_token_auth.py
+++ b/sculptor/tests/integration/frontend/test_websocket_session_token_auth.py
@@ -67,7 +67,7 @@ def test_stream_websocket_requires_session_token(
     # actually enforces it (the default test environment leaves it unset).
     sculptor_instance_factory_.update_environment(SESSION_TOKEN=_SESSION_TOKEN)
     with sculptor_instance_factory_.spawn_instance() as instance:
-        base_url = instance.base_url
+        base_url = instance.backend_api_url
 
         # 1. No token: a drive-by client can't authenticate, so the handshake
         #    must be rejected with the dedicated 4401 close code.

--- a/sculptor/tests/integration/real_claude/helpers.py
+++ b/sculptor/tests/integration/real_claude/helpers.py
@@ -309,7 +309,7 @@ def get_transcript_path(
     Calls the backend diagnostics endpoint to retrieve the session JSONL path.
     Raises AssertionError if the transcript file doesn't exist.
     """
-    base_url = instance.base_url.rstrip("/")
+    base_url = instance.backend_api_url.rstrip("/")
     workspace_id = _extract_workspace_id(task_page._page.url)
     agent_id = task_page.get_task_id()
 

--- a/sculptor/tests/integration/regression/test_regression_agent_count_diagnostics.py
+++ b/sculptor/tests/integration/regression/test_regression_agent_count_diagnostics.py
@@ -67,7 +67,7 @@ def test_agent_count_matches_between_settings_and_diagnostics(
     5. Assert they match
     """
     page = sculptor_instance_.page
-    base_url = sculptor_instance_.base_url
+    base_url = sculptor_instance_.backend_api_url
 
     # Create a workspace with an agent that asks a user question.
     # This keeps the agent in RUNNING state, waiting for user input.


### PR DESCRIPTION
**Draft / exploration.** Opened to get CI coverage (the test workflow only runs on PRs). This is the focused "custom protocol" prototype that the runtime-plugin work will build on later — it deliberately contains **only** the protocol/origin change, no plugin code.

## Why

The packaged Electron app loads its renderer from `file://`, which gives the page the opaque `"null"` origin. That breaks the web primitives a normal page relies on:

- absolute path resolution points at the filesystem root, not the app bundle
- `fetch()` of local resources is blocked
- dynamic `import()` is restricted
- there's no real security context for CSP

It's also the blocker for runtime-loaded frontend plugins, which need a stable origin so their import map and same-origin loading behave predictably.

## What changed

Introduce a custom `sculptor://app` scheme, registered as **standard + secure + fetch-capable**, and serve the built renderer bundle through it via `protocol.handle` instead of `file://`:

- **`appProtocol.ts`** — the URL→file mapping and a path-traversal guard as pure, Electron-free helpers (so they're unit-testable without an Electron runtime). Traversal is contained by two layers: the standard scheme normalizes `../` at the origin root, and a `path.resolve` + prefix check is the defense-in-depth net.
- **`main.ts`** — registers the scheme before app-ready, registers the file handler on ready (with an extensionless-path SPA fallback), and points the production renderer URL at `sculptor://app/index.html`. **Development is unchanged** (still the Vite dev server over http).
- **`web/app.py`** — the backend CORS allowlist accepts the new origin.

The `app` host prefix is intentionally a single origin so later work can serve plugins and their runtime stubs under the same origin **by path** (`/plugins/<id>/...`, `/plugin-runtime/...`) with no cross-origin plumbing.

## Test coverage / gap

- `appProtocol.test.ts` covers the path mapping, traversal containment, scheme/host rejection, and SPA fallback.
- **Gap:** the existing Electron integration tests run against the dev server (http), so the live `protocol.handle` path isn't exercised end-to-end yet. A packaged-mode integration test is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeQKimzSyEDjr9RpgX8w9o)_