### PR TITLE
Fix GitHub PR status never surfacing a failing check

### DIFF
--- a/sculptor/sculptor/web/cli_status_utils.py
+++ b/sculptor/sculptor/web/cli_status_utils.py
@@ -40,16 +40,29 @@ def classify_cli_error(stderr: str) -> CliErrorCategory:
     works for both providers.
     """
     lower = stderr.lower()
-    # Rate limits are checked first: GitHub returns them as an HTTP 403 ("API
+    # Usage errors are checked first: an unknown ``--json`` field, an unknown
+    # flag, or a malformed query makes gh/glab print a help blurb listing valid
+    # field names. That list contains tokens like "author" that would otherwise
+    # trip the auth check below and mislabel a programming error as
+    # "not authenticated". A usage error fails identically on retry and is
+    # neither an auth, network, nor rate problem, so classify it as a
+    # non-actionable transient failure rather than letting the help text decide.
+    if any(keyword in lower for keyword in ("unknown json field", "unknown flag", "available fields:")):
+        return "transient"
+    # Rate limits are checked next: GitHub returns them as an HTTP 403 ("API
     # rate limit exceeded") and the secondary-limit message mentions neither
     # "auth" nor a bare status code, so without this they'd be misclassified
     # as "no_access" (permanent, shown to the user as an access problem) when
     # they are really a temporary throttle to wait out.
     if any(keyword in lower for keyword in ("rate limit", "ratelimit", "secondary rate")):
         return "rate_limited"
-    if any(
+    # Match authentication failures without matching the literal field name
+    # "author" (gh lists it in its --json help text): a bare "auth" token, the
+    # "authentic"/"authoriz" stems (authentication, authorization, unauthorized),
+    # an explicit 401, a token problem, or a "log in" prompt.
+    if re.search(r"\bauth\b", lower) or any(
         keyword in lower
-        for keyword in ("auth", "not logged into", "not logged", "log in", "authentication", "token", "401")
+        for keyword in ("authentic", "authoriz", "not logged into", "not logged", "log in", "token", "401")
     ):
         return "not_authenticated"
     if any(keyword in lower for keyword in ("403", "forbidden", "access denied", "permission")):

--- a/sculptor/sculptor/web/cli_status_utils_test.py
+++ b/sculptor/sculptor/web/cli_status_utils_test.py
@@ -128,6 +128,31 @@ def test_classify_cli_error_empty_stderr_defaults_to_transient() -> None:
     assert classify_cli_error("") == "transient"
 
 
+# --- classify_cli_error: usage errors ---
+
+
+def test_classify_cli_error_unknown_json_field_returns_transient() -> None:
+    """gh rejects an unknown --json field and prints a field list containing
+    "author"; that must not read as not_authenticated (the bug this fixes)."""
+    stderr = 'Unknown JSON field: "reviewThreads"\nAvailable fields:\n  author\n  authorAssociation\n  state\n'
+    assert classify_cli_error(stderr) == "transient"
+
+
+def test_classify_cli_error_unknown_json_field_is_not_not_authenticated() -> None:
+    """The 'author'/'authorAssociation' help text must never classify as auth."""
+    stderr = 'Unknown JSON field: "bogus"\nAvailable fields:\n  author\n  authorAssociation\n'
+    assert classify_cli_error(stderr) != "not_authenticated"
+
+
+def test_classify_cli_error_unknown_flag_returns_transient() -> None:
+    assert classify_cli_error("unknown flag: --jsom") == "transient"
+
+
+def test_classify_cli_error_author_substring_alone_does_not_match_auth() -> None:
+    """A bare "author" token (no real auth keyword) must not match the auth check."""
+    assert classify_cli_error("returned field author for the pull request") != "not_authenticated"
+
+
 # --- classify_cli_error: priority ---
 
 

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -23,7 +23,7 @@ def fetch_pr_status(
     """Fetch PR status from GitHub for a workspace's current and target branch.
 
     Calls the gh CLI to find an open or merged PR matching the branches,
-    and if found, fetches check status, reviews, and unresolved comments.
+    and if found, surfaces check status, reviews, and unresolved comments.
 
     If no open PR matches the exact source+target pair but an open PR exists
     on the source branch targeting a different branch, the mismatch fields
@@ -55,10 +55,10 @@ def _fetch_pr_status_inner(
     """Inner implementation that raises CliStatusError on CLI failures."""
     stripped_target = strip_remote_prefix(target_branch)
 
-    # One `gh pr list` call returns every PR on this source branch regardless
-    # of state; we group by each PR's ``state`` and dispatch locally rather
-    # than issuing a separate query per state.
-    all_prs = _find_all_prs(working_dir, current_branch)
+    # One `gh api graphql` call returns every PR on this source branch (across
+    # all states) *with* its check/review/comment detail, so we group by each
+    # PR's ``state`` and dispatch locally rather than issuing a second query.
+    all_prs = _fetch_prs_with_details(working_dir, current_branch)
     open_prs = [pr for pr in all_prs if pr.get("state") == "OPEN"]
     merged_prs = [pr for pr in all_prs if pr.get("state") == "MERGED"]
     closed_prs = [pr for pr in all_prs if pr.get("state") == "CLOSED"]
@@ -67,7 +67,7 @@ def _fetch_pr_status_inner(
     # (checks, reviews, comments).
     open_match = _first_matching_target(open_prs, stripped_target)
     if open_match is not None:
-        return _build_open_pr_status(workspace_id, working_dir, open_match)
+        return _build_open_pr_status(workspace_id, open_match)
 
     # Otherwise prefer a terminal state for the exact target. Merged wins over
     # closed: GitHub PR states are disjoint (a merged PR is MERGED, never
@@ -111,8 +111,8 @@ def _fetch_pr_status_inner(
 def _first_matching_target(prs: list[dict], target_branch: str) -> dict | None:
     """Return the first PR whose base branch equals ``target_branch``, if any.
 
-    ``gh pr list`` returns PRs newest-first, so the first match is the most
-    recently created PR against that target.
+    The query orders PRs most-recently-updated first, so the first match is the
+    PR against that target the user most recently touched.
     """
     for pr in prs:
         if pr.get("baseRefName") == target_branch:
@@ -122,143 +122,159 @@ def _first_matching_target(prs: list[dict], target_branch: str) -> dict | None:
 
 def _build_open_pr_status(
     workspace_id: WorkspaceID,
-    working_dir: Path,
-    pr_data: dict,
+    pr_node: dict,
 ) -> PrStatusInfo:
-    """Build a full PrStatusInfo for an open PR (checks, reviews, comments)."""
-    pr_number = pr_data["number"]
-    details = _fetch_pr_details(working_dir, pr_number)
+    """Build a full PrStatusInfo for an open PR (checks, reviews, comments).
 
+    All detail fields already live on ``pr_node`` (the single graphql query
+    fetches them alongside the PR identity), so this does no further I/O.
+    """
     return PrStatusInfo(
         workspace_id=workspace_id,
         pr_state="open",
-        pr_iid=pr_number,
-        pr_title=pr_data.get("title"),
-        pr_web_url=pr_data.get("url"),
-        pipeline_status=_parse_check_status(details),
-        approvals=_parse_reviews(details),
-        unresolved_comments=_parse_review_comments(details),
+        pr_iid=pr_node["number"],
+        pr_title=pr_node.get("title"),
+        pr_web_url=pr_node.get("url"),
+        pipeline_status=_parse_check_status(pr_node),
+        approvals=_parse_reviews(pr_node),
+        unresolved_comments=_parse_review_comments(pr_node),
     )
 
 
-# Upper bound on PRs fetched per source branch in one `gh pr list` call. A
-# single source branch realistically has only a handful of PRs across its
-# lifetime, so one capped fetch returns every state (open/merged/closed) we
-# dispatch on without needing a per-state round trip.
-_PR_LIST_LIMIT = 30
+# Upper bound on PRs fetched per source branch in one graphql call. A single
+# source branch realistically has only a handful of PRs across its lifetime, so
+# one capped fetch (most-recently-updated first) returns every state
+# (open/merged/closed) we dispatch on. Each node also pulls check/review detail,
+# so this is deliberately small to keep the GraphQL point cost low.
+_PR_QUERY_LIMIT = 5
+
+# Single GraphQL query that replaces the old `gh pr list` + `gh pr view` pair.
+# It fetches the PR identity *and* its detail in one request, and — unlike
+# ``gh pr view --json``'s curated field subset — ``reviewThreads`` is a valid
+# field on the GraphQL ``PullRequest`` type, so unresolved-comment surfacing
+# actually works. Requesting ``statusCheckRollup { state }`` (one aggregate
+# enum) rather than every individual check context also lowers the point cost.
+# ``{owner}`` / ``{repo}`` in the field args are expanded by gh from the
+# working directory's ``origin`` remote, so no repo plumbing is needed here.
+_GRAPHQL_PR_QUERY = """
+query($owner: String!, $name: String!, $branch: String!, $limit: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(headRefName: $branch, first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        url
+        state
+        baseRefName
+        commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
+        latestReviews(first: 20) { nodes { state author { login } } }
+        reviewThreads(first: 30) {
+          nodes { isResolved comments(first: 1) { nodes { author { login } path line body } } }
+        }
+      }
+    }
+  }
+}
+"""
 
 
-def _find_all_prs(working_dir: Path, source_branch: str) -> list[dict]:
-    """Find all PRs (open, merged, or closed) for a source branch.
+def _fetch_prs_with_details(working_dir: Path, source_branch: str) -> list[dict]:
+    """Fetch all PRs (open/merged/closed) for a source branch, with detail.
 
-    ``--state=all`` returns PRs in every state; each row carries a ``state``
-    field (``OPEN`` / ``MERGED`` / ``CLOSED``) that the caller dispatches on.
-    No ``--base`` filter is applied, so the caller can also detect a PR opened
-    against a *different* target branch (the "switch target" affordance).
-    Returns up to ``_PR_LIST_LIMIT`` PRs, newest first.
+    Issues a single ``gh api graphql`` request. Each returned node carries its
+    ``state`` (``OPEN`` / ``MERGED`` / ``CLOSED``) for local dispatch, its base
+    branch (so a PR opened against a *different* target can be detected for the
+    "switch target" affordance), and the check/review/comment detail used to
+    build an open PR's full status. Returns up to ``_PR_QUERY_LIMIT`` PRs,
+    most-recently-updated first, or an empty list if the repository can't be
+    resolved.
+
+    Raises CliStatusError on any CLI failure (including rate limits, classified
+    via ``classify_cli_error``) so the poller can surface it and back off.
     """
     cmd = [
         "gh",
-        "pr",
-        "list",
-        f"--head={source_branch}",
-        "--state=all",
-        "--json",
-        "number,title,url,baseRefName,state",
-        "--limit",
-        str(_PR_LIST_LIMIT),
+        "api",
+        "graphql",
+        "-f",
+        f"query={_GRAPHQL_PR_QUERY}",
+        "-F",
+        "owner={owner}",
+        "-F",
+        "name={repo}",
+        "-f",
+        f"branch={source_branch}",
+        "-F",
+        f"limit={_PR_QUERY_LIMIT}",
     ]
     result = run_cli_with_retry(cmd, working_dir)
     if result.returncode != 0:
         raise CliStatusError(classify_cli_error(result.stderr), result.stderr)
     try:
-        prs = json.loads(result.stdout)
+        payload = json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        raise CliStatusError("transient", f"Invalid JSON from gh pr list: {result.stdout[:200]}") from e
-    return prs
+        raise CliStatusError("transient", f"Invalid JSON from gh api graphql: {result.stdout[:200]}") from e
+    repository = (payload.get("data") or {}).get("repository")
+    if repository is None:
+        return []
+    return (repository.get("pullRequests") or {}).get("nodes") or []
 
 
-def _fetch_pr_details(working_dir: Path, pr_number: int) -> dict:
-    """Fetch checks, reviews, and review threads for an open PR in one call.
+def _parse_check_status(pr_node: dict) -> Literal["running", "passed", "failed"] | None:
+    """Map a PR's aggregate status-check rollup to our three-state model.
 
-    ``gh pr view`` issues a single GraphQL request no matter how many
-    ``--json`` fields are requested, so bundling ``statusCheckRollup``,
-    ``reviews``, and ``reviewThreads`` into one invocation collapses what
-    used to be three separate GraphQL round trips into one. That detail
-    fetch is the dominant per-poll cost for a workspace with an open PR, so
-    this roughly halves the GraphQL points spent polling it.
-
-    On a non-rate-limit failure this returns an empty dict so the caller
-    still reports the open PR (just without check/review detail), matching
-    the previous best-effort behaviour. A rate-limit failure is re-raised as
-    ``CliStatusError`` so the poller can surface it and back off instead of
-    silently dropping the signal.
+    Reads ``statusCheckRollup.state`` from the PR's most recent commit. GitHub
+    already collapses every check context into one ``StatusState`` enum, so we
+    map that single value instead of scanning individual checks. Returns None
+    when the commit has no checks (the rollup is null) or reports a state we
+    don't recognize.
     """
-    result = run_cli_with_retry(
-        ["gh", "pr", "view", str(pr_number), "--json", "statusCheckRollup,reviews,reviewThreads"],
-        working_dir,
-    )
-    if result.returncode != 0:
-        category = classify_cli_error(result.stderr)
-        if category == "rate_limited":
-            raise CliStatusError(category, result.stderr)
-        logger.debug("gh pr view details failed ({}): {}", category, result.stderr)
-        return {}
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        logger.debug("Invalid JSON from gh pr view details: {}", result.stdout[:200])
-        return {}
-
-
-def _parse_check_status(details: dict) -> Literal["running", "passed", "failed"] | None:
-    checks = details.get("statusCheckRollup", [])
-    if not checks:
+    commit_nodes = (pr_node.get("commits") or {}).get("nodes") or []
+    if not commit_nodes:
         return None
-
-    has_running = False
-    has_failed = False
-    for check in checks:
-        conclusion = check.get("conclusion", "")
-        status = check.get("status", "")
-        if status in ("IN_PROGRESS", "QUEUED", "PENDING", "WAITING") or conclusion == "":
-            has_running = True
-        elif conclusion in ("FAILURE", "CANCELLED", "TIMED_OUT", "ERROR"):
-            has_failed = True
-
-    if has_failed:
+    rollup = (commit_nodes[0].get("commit") or {}).get("statusCheckRollup")
+    if rollup is None:
+        return None
+    state = rollup.get("state", "")
+    if state in ("FAILURE", "ERROR"):
         return "failed"
-    if has_running:
+    if state in ("PENDING", "EXPECTED"):
         return "running"
-    return "passed"
+    if state == "SUCCESS":
+        return "passed"
+    return None
 
 
-def _parse_reviews(details: dict) -> list[PrApproval]:
-    reviews = details.get("reviews", [])
-    # Keep only the latest review per author
-    latest_by_author: dict[str, PrApproval] = {}
-    for review in reviews:
+def _parse_reviews(pr_node: dict) -> list[PrApproval]:
+    """Extract approve / request-changes reviews from a PR's latest reviews.
+
+    ``latestReviews`` already returns the most recent review per reviewer, so
+    no per-author de-duplication is needed.
+    """
+    review_nodes = (pr_node.get("latestReviews") or {}).get("nodes") or []
+    approvals: list[PrApproval] = []
+    for review in review_nodes:
         state = review.get("state", "")
         if state not in ("APPROVED", "CHANGES_REQUESTED"):
             continue
-        author = review.get("author", {}).get("login", "unknown")
-        latest_by_author[author] = PrApproval(name=author, approved=state == "APPROVED")
-    return list(latest_by_author.values())
+        author = (review.get("author") or {}).get("login", "unknown")
+        approvals.append(PrApproval(name=author, approved=state == "APPROVED"))
+    return approvals
 
 
-def _parse_review_comments(details: dict) -> list[PrComment]:
-    threads = details.get("reviewThreads", [])
+def _parse_review_comments(pr_node: dict) -> list[PrComment]:
+    thread_nodes = (pr_node.get("reviewThreads") or {}).get("nodes") or []
     comments: list[PrComment] = []
-    for thread in threads:
+    for thread in thread_nodes:
         if thread.get("isResolved"):
             continue
-        thread_comments = thread.get("comments", [])
-        if not thread_comments:
+        comment_nodes = (thread.get("comments") or {}).get("nodes") or []
+        if not comment_nodes:
             continue
-        first_comment = thread_comments[0]
+        first_comment = comment_nodes[0]
         comments.append(
             PrComment(
-                author=first_comment.get("author", {}).get("login", "unknown"),
+                author=(first_comment.get("author") or {}).get("login", "unknown"),
                 file_path=first_comment.get("path", ""),
                 line=first_comment.get("line"),
                 body=first_comment.get("body", ""),

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -1,9 +1,16 @@
 import json
+import os
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+from sculptor.foundation.processes.local_process import run_blocking
 from sculptor.foundation.subprocess_utils import FinishedProcess
 from sculptor.primitives.ids import WorkspaceID
+from sculptor.web.pr_status import _GRAPHQL_PR_QUERY
+from sculptor.web.pr_status import _PR_QUERY_LIMIT
 from sculptor.web.pr_status import fetch_pr_status
 
 
@@ -17,50 +24,76 @@ WORKSPACE_ID = WorkspaceID()
 WORKING_DIR = Path("/tmp/repo")
 
 
-def _pr(number: int, state: str, base_ref: str = "main") -> dict:
-    """Build one `gh pr list --json ...` row in the given GitHub state."""
+def _pr_node(
+    number: int,
+    state: str,
+    base_ref: str = "main",
+    check_state: str | None = None,
+    reviews: list[dict] | None = None,
+    threads: list[dict] | None = None,
+) -> dict:
+    """Build one graphql ``pullRequests.nodes`` entry in the given GitHub state.
+
+    Mirrors the shape returned by the single ``gh api graphql`` query the
+    backend now issues: identity fields alongside the check/review/comment
+    detail (``statusCheckRollup`` is null when no checks have run).
+    """
+    rollup = {"state": check_state} if check_state is not None else None
     return {
         "number": number,
         "title": f"PR #{number}",
-        "baseRefName": base_ref,
-        "state": state,
         "url": f"https://github.com/org/repo/pull/{number}",
+        "state": state,
+        "baseRefName": base_ref,
+        "commits": {"nodes": [{"commit": {"statusCheckRollup": rollup}}]},
+        "latestReviews": {"nodes": reviews or []},
+        "reviewThreads": {"nodes": threads or []},
     }
 
 
-def _open_pr(number: int, base_ref: str = "main") -> dict:
-    return _pr(number, "OPEN", base_ref)
+def _open_node(number: int, base_ref: str = "main", **kwargs) -> dict:  # noqa: ANN003
+    return _pr_node(number, "OPEN", base_ref, **kwargs)
 
 
-def _merged_pr(number: int, base_ref: str = "main") -> dict:
-    return _pr(number, "MERGED", base_ref)
+def _merged_node(number: int, base_ref: str = "main") -> dict:
+    return _pr_node(number, "MERGED", base_ref)
 
 
-def _closed_pr(number: int, base_ref: str = "main") -> dict:
-    return _pr(number, "CLOSED", base_ref)
+def _closed_node(number: int, base_ref: str = "main") -> dict:
+    return _pr_node(number, "CLOSED", base_ref)
+
+
+def _graphql_stdout(nodes: list[dict]) -> str:
+    """Wrap PR nodes in the graphql response envelope gh emits."""
+    return json.dumps({"data": {"repository": {"pullRequests": {"nodes": nodes}}}})
 
 
 def _patch_cli(side_effect):  # noqa: ANN001
     return patch("sculptor.web.pr_status.run_cli_with_retry", side_effect=side_effect)
 
 
-def _pr_list_handler(prs: list[dict]):  # noqa: ANN001
-    """Build a cli_handler for the single `gh pr list --state=all` call.
+def _graphql_handler(nodes: list[dict]):  # noqa: ANN001
+    """Build a cli_handler for the single `gh api graphql` call.
 
-    The backend issues exactly one `gh pr list` query (across all states) and
-    then, for an open PR, a single combined `gh pr view` detail call that
-    bundles statusCheckRollup / reviews / reviewThreads. This handler returns
-    ``prs`` for the list call and an empty combined object for the detail call.
+    The backend issues exactly one graphql request that returns every PR on the
+    source branch (across all states) with its check/review/comment detail
+    bundled in. This handler returns ``nodes`` wrapped in the graphql envelope.
     """
 
     def handler(cmd, _working_dir):  # noqa: ANN001
-        if "list" in cmd:
-            return _make_finished(json.dumps(prs))
-        if "view" in cmd:
-            return _make_finished(json.dumps({"statusCheckRollup": [], "reviews": [], "reviewThreads": []}))
+        if "graphql" in cmd:
+            return _make_finished(_graphql_stdout(nodes))
         return _make_finished("[]")
 
     return handler
+
+
+def _captured_query(cmd: list[str]) -> str:
+    """Return the GraphQL query string passed as `-f query=...` in a gh command."""
+    for arg in cmd:
+        if arg.startswith("query="):
+            return arg[len("query=") :]
+    raise AssertionError(f"no query= argument found in command: {cmd}")
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +102,7 @@ def _pr_list_handler(prs: list[dict]):  # noqa: ANN001
 
 
 def test_open_pr_matching_target() -> None:
-    with _patch_cli(_pr_list_handler([_open_pr(100, base_ref="main")])):
+    with _patch_cli(_graphql_handler([_open_node(100, base_ref="main")])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "open"
@@ -83,7 +116,7 @@ def test_open_pr_matching_target() -> None:
 
 
 def test_open_pr_mismatched_target() -> None:
-    with _patch_cli(_pr_list_handler([_open_pr(200, base_ref="develop")])):
+    with _patch_cli(_graphql_handler([_open_node(200, base_ref="develop")])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "none"
@@ -98,7 +131,7 @@ def test_open_pr_mismatched_target() -> None:
 
 
 def test_no_prs_at_all() -> None:
-    with _patch_cli(_pr_list_handler([])):
+    with _patch_cli(_graphql_handler([])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "none"
@@ -111,7 +144,7 @@ def test_no_prs_at_all() -> None:
 
 
 def test_merged_pr_matching_target() -> None:
-    with _patch_cli(_pr_list_handler([_merged_pr(300, base_ref="main")])):
+    with _patch_cli(_graphql_handler([_merged_node(300, base_ref="main")])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "merged"
@@ -125,12 +158,12 @@ def test_merged_pr_matching_target() -> None:
 
 
 def test_multiple_open_prs_one_matches() -> None:
-    prs = [
-        _open_pr(400, base_ref="develop"),
-        _open_pr(401, base_ref="main"),
+    nodes = [
+        _open_node(400, base_ref="develop"),
+        _open_node(401, base_ref="main"),
     ]
 
-    with _patch_cli(_pr_list_handler(prs)):
+    with _patch_cli(_graphql_handler(nodes)):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "open"
@@ -144,12 +177,12 @@ def test_multiple_open_prs_one_matches() -> None:
 
 
 def test_multiple_open_prs_none_match() -> None:
-    prs = [
-        _open_pr(500, base_ref="develop"),
-        _open_pr(501, base_ref="staging"),
+    nodes = [
+        _open_node(500, base_ref="develop"),
+        _open_node(501, base_ref="staging"),
     ]
 
-    with _patch_cli(_pr_list_handler(prs)):
+    with _patch_cli(_graphql_handler(nodes)):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "none"
@@ -163,7 +196,7 @@ def test_multiple_open_prs_none_match() -> None:
 
 
 def test_closed_pr_matching_target() -> None:
-    with _patch_cli(_pr_list_handler([_closed_pr(800, base_ref="main")])):
+    with _patch_cli(_graphql_handler([_closed_node(800, base_ref="main")])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "closed"
@@ -179,13 +212,13 @@ def test_closed_pr_matching_target() -> None:
 
 def test_merged_takes_precedence_over_closed() -> None:
     # A branch whose first PR was closed and whose second PR landed: the single
-    # --state=all query returns both, and local dispatch must prefer merged.
-    prs = [
-        _merged_pr(820, base_ref="main"),
-        _closed_pr(810, base_ref="main"),
+    # query returns both, and local dispatch must prefer merged.
+    nodes = [
+        _merged_node(820, base_ref="main"),
+        _closed_node(810, base_ref="main"),
     ]
 
-    with _patch_cli(_pr_list_handler(prs)):
+    with _patch_cli(_graphql_handler(nodes)):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "merged"
@@ -193,33 +226,28 @@ def test_merged_takes_precedence_over_closed() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Open PR detail is fetched in a single combined `gh pr view` call
+# Open PR detail (checks, reviews, comments) comes from the single graphql call
 # ---------------------------------------------------------------------------
 
 
-def test_open_pr_details_fetched_in_single_view_call() -> None:
-    view_calls: list[list] = []
+def test_open_pr_details_fetched_in_single_graphql_call() -> None:
+    calls: list[list] = []
+
+    node = _open_node(
+        42,
+        check_state="SUCCESS",
+        reviews=[{"state": "APPROVED", "author": {"login": "alice"}}],
+        threads=[
+            {
+                "isResolved": False,
+                "comments": {"nodes": [{"author": {"login": "bob"}, "path": "a.py", "line": 3, "body": "fix"}]},
+            }
+        ],
+    )
 
     def handler(cmd, _working_dir):  # noqa: ANN001
-        if "list" in cmd:
-            return _make_finished(json.dumps([_open_pr(42)]))
-        if "view" in cmd:
-            view_calls.append(cmd)
-            return _make_finished(
-                json.dumps(
-                    {
-                        "statusCheckRollup": [{"status": "COMPLETED", "conclusion": "SUCCESS"}],
-                        "reviews": [{"state": "APPROVED", "author": {"login": "alice"}}],
-                        "reviewThreads": [
-                            {
-                                "isResolved": False,
-                                "comments": [{"author": {"login": "bob"}, "path": "a.py", "line": 3, "body": "fix"}],
-                            }
-                        ],
-                    }
-                )
-            )
-        return _make_finished("[]")
+        calls.append(cmd)
+        return _make_finished(_graphql_stdout([node]))
 
     with _patch_cli(handler):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
@@ -228,43 +256,124 @@ def test_open_pr_details_fetched_in_single_view_call() -> None:
     assert result.pipeline_status == "passed"
     assert [a.name for a in result.approvals] == ["alice"]
     assert len(result.unresolved_comments) == 1
-    # Exactly one `gh pr view`, and it bundles all three JSON fields in one call.
-    assert len(view_calls) == 1
-    assert view_calls[0][-1] == "statusCheckRollup,reviews,reviewThreads"
+    assert result.unresolved_comments[0].author == "bob"
+    # Exactly one CLI call, and it is a `gh api graphql` request (not the old
+    # `gh pr list` + `gh pr view` pair).
+    assert len(calls) == 1
+    assert calls[0][:3] == ["gh", "api", "graphql"]
 
 
 # ---------------------------------------------------------------------------
-# A non-rate-limit failure on the detail call still reports the open PR
+# Regression for the shipped bug: a failing check must reach pipeline_status.
+# An invalid `gh pr view --json` field used to poison the whole detail fetch,
+# so a failing CI never surfaced. The graphql rollup state must now map through.
 # ---------------------------------------------------------------------------
 
 
-def test_open_pr_detail_failure_degrades_gracefully() -> None:
+def test_failed_check_rollup_surfaces_as_failed_pipeline() -> None:
+    node = _open_node(59, check_state="FAILURE")
+    with _patch_cli(_graphql_handler([node])):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.pr_iid == 59
+    assert result.pipeline_status == "failed"
+
+
+@pytest.mark.parametrize(
+    ("rollup_state", "expected"),
+    [
+        ("FAILURE", "failed"),
+        ("ERROR", "failed"),
+        ("PENDING", "running"),
+        ("EXPECTED", "running"),
+        ("SUCCESS", "passed"),
+        (None, None),
+        ("SOMETHING_NEW", None),
+    ],
+)
+def test_status_check_rollup_state_maps_to_pipeline_status(rollup_state: str | None, expected: str | None) -> None:
+    node = _open_node(10, check_state=rollup_state)
+    with _patch_cli(_graphql_handler([node])):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pipeline_status == expected
+
+
+# ---------------------------------------------------------------------------
+# The query must request the fields the parser reads, via `gh api graphql`.
+# This is the unit-level guard against regressing to the broken approach
+# (mocks can never exercise real gh field validation — see the live test below).
+# ---------------------------------------------------------------------------
+
+
+def test_graphql_query_requests_the_fields_the_parser_reads() -> None:
+    captured: list[list] = []
+
     def handler(cmd, _working_dir):  # noqa: ANN001
-        if "list" in cmd:
-            return _make_finished(json.dumps([_open_pr(60)]))
-        if "view" in cmd:
-            return _make_finished("", returncode=1, stderr="HTTP 500 Internal Server Error")
-        return _make_finished("[]")
+        captured.append(cmd)
+        return _make_finished(_graphql_stdout([]))
+
+    with _patch_cli(handler):
+        fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[:3] == ["gh", "api", "graphql"]
+    query = _captured_query(cmd)
+    # Every field the parser navigates must be present in the query.
+    for field in ("statusCheckRollup", "state", "baseRefName", "latestReviews", "reviewThreads", "commits"):
+        assert field in query, f"query is missing field {field!r}"
+    # `reviewThreads` is requested directly (it is a valid GraphQL PullRequest
+    # field, unlike `gh pr view --json`'s curated subset that shipped the bug).
+    assert "reviewThreads" in query
+
+
+# ---------------------------------------------------------------------------
+# A non-rate-limit CLI failure is surfaced as its classified category.
+# (With a single combined call there is no partial result to degrade to.)
+# ---------------------------------------------------------------------------
+
+
+def test_transient_cli_failure_surfaces_error() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        return _make_finished("", returncode=1, stderr="HTTP 500 Internal Server Error")
 
     with _patch_cli(handler):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
-    assert result.pr_state == "open"
-    assert result.pr_iid == 60
-    assert result.pipeline_status is None
-    assert result.error_category is None
+    assert result.pr_state == "none"
+    assert result.error_category == "transient"
+    assert result.error_provider == "github"
 
 
 # ---------------------------------------------------------------------------
-# Rate-limit errors surface as a rate_limited category (list and detail calls)
+# An unknown-field / usage error is NOT misclassified as not_authenticated.
+# gh's help text lists "author", which used to match the loose 'auth' check.
 # ---------------------------------------------------------------------------
 
 
-def test_rate_limit_on_list_surfaces_error() -> None:
+def test_unknown_field_usage_error_not_classified_as_not_authenticated() -> None:
+    stderr = 'Unknown JSON field: "reviewThreads"\nAvailable fields:\n  author\n  authorAssociation\n  state\n'
+
     def handler(cmd, _working_dir):  # noqa: ANN001
-        if "list" in cmd:
-            return _make_finished("", returncode=1, stderr="API rate limit exceeded")
-        return _make_finished("[]")
+        return _make_finished("", returncode=1, stderr=stderr)
+
+    with _patch_cli(handler):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.error_category != "not_authenticated"
+    assert result.error_category == "transient"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit errors surface as a rate_limited category
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_surfaces_error() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        return _make_finished("", returncode=1, stderr="HTTP 403: API rate limit exceeded for user")
 
     with _patch_cli(handler):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
@@ -274,16 +383,71 @@ def test_rate_limit_on_list_surfaces_error() -> None:
     assert result.error_provider == "github"
 
 
-def test_rate_limit_on_detail_surfaces_error() -> None:
+def test_secondary_rate_limit_surfaces_error() -> None:
     def handler(cmd, _working_dir):  # noqa: ANN001
-        if "list" in cmd:
-            return _make_finished(json.dumps([_open_pr(70)]))
-        if "view" in cmd:
-            return _make_finished("", returncode=1, stderr="HTTP 403: API rate limit exceeded for user")
-        return _make_finished("[]")
+        return _make_finished("", returncode=1, stderr="You have exceeded a secondary rate limit.")
 
     with _patch_cli(handler):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.error_category == "rate_limited"
     assert result.error_provider == "github"
+
+
+# ---------------------------------------------------------------------------
+# Malformed / missing repository data degrades to no-PR rather than crashing.
+# ---------------------------------------------------------------------------
+
+
+def test_null_repository_in_payload_returns_none() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        return _make_finished(json.dumps({"data": {"repository": None}}))
+
+    with _patch_cli(handler):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pr_state == "none"
+    assert result.error_category is None
+
+
+# ---------------------------------------------------------------------------
+# Opt-in: validate the real query against GitHub's live GraphQL schema.
+#
+# Mocked tests cannot catch an invalid field name — that is exactly how the
+# `reviewThreads` bug shipped. Set SCULPTOR_PR_STATUS_LIVE_GH_TEST=1 (with an
+# authenticated `gh`) to run the actual query so an unrecognized field fails
+# loudly with a non-zero exit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("SCULPTOR_PR_STATUS_LIVE_GH_TEST"),
+    reason="opt-in: set SCULPTOR_PR_STATUS_LIVE_GH_TEST=1 to validate against real GitHub",
+)
+def test_graphql_query_is_valid_against_live_github() -> None:
+    if shutil.which("gh") is None:
+        pytest.skip("gh CLI not available")
+    result = run_blocking(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={_GRAPHQL_PR_QUERY}",
+            "-F",
+            "owner=imbue-ai",
+            "-F",
+            "name=sculptor",
+            "-f",
+            "branch=main",
+            "-F",
+            f"limit={_PR_QUERY_LIMIT}",
+        ],
+        timeout=30.0,
+        is_checked=False,
+        cwd=Path(__file__).parent,
+    )
+    assert result.returncode == 0, f"gh api graphql rejected the query: {result.stderr}"
+    payload = json.loads(result.stdout)
+    nodes = payload["data"]["repository"]["pullRequests"]["nodes"]
+    assert isinstance(nodes, list)

--- a/sculptor/tests/integration/frontend/test_backend_pr_polling.py
+++ b/sculptor/tests/integration/frontend/test_backend_pr_polling.py
@@ -27,46 +27,41 @@ from sculptor.testing.user_stories import user_story
 
 _FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
 
-# Fake gh CLI that always returns an open PR for "pr list" queries.
-# The backend issues a single `gh pr list --state=all` query and dispatches on
-# each row's "state" field, so the PR object must carry "state": "OPEN". For an
-# open PR it then issues a single combined `gh pr view --json
-# statusCheckRollup,reviews,reviewThreads` detail call.
+# Fake gh CLI that always returns an open PR.
+# The backend issues a single `gh api graphql` query that returns every PR on
+# the source branch (across all states) with its check/review/comment detail
+# bundled in, and dispatches on each node's "state" field. So the fake emits
+# the GraphQL response envelope with one node tagged "state": "OPEN" (no checks,
+# reviews, or threads). ``statusCheckRollup`` is null when no checks have run.
 _FAKE_GH_OPEN_PR_SCRIPT = """\
 #!/bin/bash
-if [[ "$*" == *"pr list"* ]]; then
-    echo '[{"number": 42, "title": "Test PR", "url": "https://github.com/test/repo/pull/42", "baseRefName": "main", "state": "OPEN"}]'
-elif [[ "$*" == *"pr view"* ]]; then
-    echo '{"statusCheckRollup": [], "reviews": [], "reviewThreads": []}'
+if [[ "$*" == *"graphql"* ]]; then
+    echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
 fi
 """
 
-# Fake gh CLI that returns a closed-not-merged PR for the single "pr list"
-# query. The backend dispatches on the "state" field, so the row is tagged
-# "state": "CLOSED".
+# Fake gh CLI that returns a closed-not-merged PR. The backend dispatches on
+# each node's "state" field, so the node is tagged "state": "CLOSED".
 _FAKE_GH_CLOSED_PR_SCRIPT = """\
 #!/bin/bash
-if [[ "$*" == *"pr list"* ]]; then
-    echo '[{"number": 77, "title": "Closed PR", "url": "https://github.com/test/repo/pull/77", "baseRefName": "main", "state": "CLOSED"}]'
-else
-    echo "[]"
+if [[ "$*" == *"graphql"* ]]; then
+    echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":77,"title":"Closed PR","url":"https://github.com/test/repo/pull/77","state":"CLOSED","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
 fi
 """
 
-# Fake gh that switches behavior via mode file (no_pr → open_pr)
+# Fake gh that switches behavior via mode file (no_pr → open_pr). Each mode
+# emits the GraphQL response envelope; no_pr returns an empty node list.
+# The mode-file path is injected via ``.replace("{mode_file}", ...)`` (not
+# ``.format``) so the JSON braces below don't need escaping.
 _FAKE_GH_MODE_SCRIPT = """\
 #!/bin/bash
 MODE=$(cat "{mode_file}")
 case "$MODE" in
     no_pr)
-        echo "[]"
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
         ;;
     open_pr)
-        if [[ "$*" == *"pr list"* ]]; then
-            echo '[{{"number": 42, "title": "Test PR", "url": "https://github.com/test/repo/pull/42", "baseRefName": "main", "state": "OPEN"}}]'
-        elif [[ "$*" == *"pr view"* ]]; then
-            echo '{{"statusCheckRollup": [], "reviews": [], "reviewThreads": []}}'
-        fi
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
         ;;
 esac
 """
@@ -148,7 +143,7 @@ def test_multiple_workspaces_independent_pr_status(sculptor_instance_: SculptorI
     """
     mode_file = tmp_path / "gh_mode"
     mode_file.write_text("open_pr")
-    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_MODE_SCRIPT.format(mode_file=mode_file))
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_MODE_SCRIPT.replace("{mode_file}", str(mode_file)))
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
     # Workspace 1: open PR
@@ -181,9 +176,9 @@ def test_closed_not_merged_pr_shows_closed_state(sculptor_instance_: SculptorIns
     button reflects the closed state instead of falling back to "Create PR".
 
     Mirrors the GitLab ``closed-not-merged`` MR handling. The fake ``gh`` CLI
-    returns the closed PR only for ``--state=closed`` queries, so a backend that
-    only consults ``--state=open`` and ``--state=merged`` (the bug) would render
-    "Create PR" and the assertion below would fail.
+    returns a single PR node tagged ``state: CLOSED``, so a backend that ignores
+    closed PRs (the bug) would render "Create PR" and the assertion below would
+    fail.
     """
     _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_CLOSED_PR_SCRIPT)
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)

--- a/sculptor/tests/integration/frontend/test_pr_button_errors.py
+++ b/sculptor/tests/integration/frontend/test_pr_button_errors.py
@@ -250,36 +250,20 @@ def test_github_cli_error_variants(sculptor_instance_: SculptorInstance, tmp_pat
 # Group 3: GitHub happy paths — one spawn, mode-switching fake gh
 # ---------------------------------------------------------------------------
 
+# The backend issues a single `gh api graphql` query for PR status, so each
+# mode emits the GraphQL response envelope: no_pr returns an empty node list,
+# open_pr returns one node tagged "state": "OPEN". The mode-file path is
+# injected via ``.replace("{mode_file}", ...)`` (not ``.format``) so the JSON
+# braces below don't need escaping.
 _FAKE_GH_HAPPY_SCRIPT = """\
 #!/bin/bash
 MODE=$(cat "{mode_file}")
 case "$MODE" in
     no_pr)
-        # Disambiguate per-subcommand so the backend's follow-up calls
-        # (status rollup / reviews / reviewThreads) don't parse "[]" as
-        # invalid JSON for the object-shaped responses they expect.
-        if [[ "$*" == *"pr list"* ]]; then
-            echo "[]"
-        elif [[ "$*" == *"statusCheckRollup"* ]]; then
-            echo '{{"statusCheckRollup": []}}'
-        elif [[ "$*" == *"reviews"* ]]; then
-            echo '{{"reviews": []}}'
-        elif [[ "$*" == *"reviewThreads"* ]]; then
-            echo '{{"reviewThreads": []}}'
-        else
-            echo "{{}}"
-        fi
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
         ;;
     open_pr)
-        if [[ "$*" == *"pr list"* ]]; then
-            echo '[{{"number": 42, "title": "Test PR", "url": "https://github.com/test/repo/pull/42", "baseRefName": "main", "state": "OPEN"}}]'
-        elif [[ "$*" == *"statusCheckRollup"* ]]; then
-            echo '{{"statusCheckRollup": []}}'
-        elif [[ "$*" == *"reviews"* ]]; then
-            echo '{{"reviews": []}}'
-        elif [[ "$*" == *"reviewThreads"* ]]; then
-            echo '{{"reviewThreads": []}}'
-        fi
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
         ;;
 esac
 """
@@ -289,7 +273,9 @@ esac
 def test_github_happy_paths(sculptor_instance_: SculptorInstance, tmp_path: Path) -> None:
     """No-PR and open-PR scenarios each show the correct button state."""
     mode_file = tmp_path / "gh_mode"
-    _create_fake_cli(sculptor_instance_.fake_bin_dir, "gh", _FAKE_GH_HAPPY_SCRIPT.format(mode_file=mode_file))
+    _create_fake_cli(
+        sculptor_instance_.fake_bin_dir, "gh", _FAKE_GH_HAPPY_SCRIPT.replace("{mode_file}", str(mode_file))
+    )
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
     # --- No PR exists → Create PR button ---


### PR DESCRIPTION
## Summary

Fixes two related bugs in GitHub PR-status polling that caused a PR with failing CI to surface **nothing** in the workspace PR button (and never signal the CI babysitter). The root cause was code, not auth/environment.

### Bug 1 (primary): an invalid `gh pr view` field killed the whole detail fetch
The detail fetch bundled `statusCheckRollup`, `reviews`, and `reviewThreads` into one `gh pr view --json` call. `reviewThreads` is **not** a valid field for `gh pr view --json`, and `gh` validates the entire `--json` field list up front — so the whole command failed (exit 1) and the check status and reviews were discarded along with it. Check status became `None`, so no failed-CI signal ever reached the UI or the babysitter.

### Bug 2 (secondary, masking): a usage error was misclassified as `not_authenticated`
`gh`'s "Unknown JSON field" error prints an available-fields list containing `author`, which matched the loose `"auth"` substring in `classify_cli_error()` — so the real failure was logged as `not_authenticated`, hiding the cause.

## Fix

- **Replace the GitHub `gh pr list` + `gh pr view` pair with a single `gh api graphql` query.** This halves the GraphQL requests per poll (2 → 1). On the GraphQL `PullRequest` type `reviewThreads` *is* a valid field, so unresolved-comment surfacing works. Requesting `statusCheckRollup { state }` (one aggregate enum) instead of every check context also lowers the per-poll point cost. `{owner}`/`{repo}` are resolved by `gh` from the working directory's `origin` remote, so no new plumbing was needed.
- The `StatusState` enum is mapped `FAILURE`/`ERROR` → failed, `PENDING`/`EXPECTED` → running, `SUCCESS` → passed, consistent with the previous behavior. Dispatch logic, rate-limit handling (raise on rate limit), the shared cross-worker throttle/cooldown, and terminal-PR backoff are all preserved.
- **The GitLab (`glab`) path is unchanged** — it uses separate `glab api .../discussions` and `.../approvals` endpoints with no bundled invalid field.
- **Harden `classify_cli_error`:** detect usage errors (unknown field/flag) first, and match auth keywords by word boundary so a bare `author` token in help text no longer reads as `not_authenticated`.

## Behavior change worth noting
With a single combined call, a non-rate-limit failure (e.g. HTTP 500) now surfaces as `error_category="transient"` rather than degrading to "open PR without check detail" — there is no longer a separate detail call that can partially succeed. The poller retries on the next cycle. The test was updated to reflect this.

## Testing
- `just format`, `just check`, `just test-unit` all pass.
- Tests now mock the single `gh api graphql` call. Added: a regression test that a `FAILURE` rollup surfaces as a failed pipeline, an enum-mapping parametrized test, a guard that the query requests the fields the parser reads, the unknown-field classifier test, and an **opt-in test** (`SCULPTOR_PR_STATUS_LIVE_GH_TEST=1`) that validates the query against GitHub's live GraphQL schema — the check mocked tests cannot do, and that would have caught the original invalid field. Verified the live test passes against the real API.

(Sent by Claude)
