### PR TITLE
Plugin SDK: registerOverlay contribution type + app-global workspace hooks

### DIFF
--- a/sculptor/frontend/src/layouts/PageLayout.tsx
+++ b/sculptor/frontend/src/layouts/PageLayout.tsx
@@ -34,6 +34,7 @@ import { WarningStatusBanner } from "../components/WarningStatusBanner.tsx";
 import { useAutoUpdateListener } from "../hooks/useAutoUpdateListener.ts";
 import { workspaceDefaultLayout, workspacePanels } from "../pages/workspace/panels/workspacePanels.ts";
 import { PluginLoader } from "../plugins/PluginLoader.tsx";
+import { PluginOverlays } from "../plugins/PluginOverlays.tsx";
 import { pluginPanelsAtom } from "../plugins/pluginRegistry.ts";
 import { usePageLayoutKeyboardShortcuts } from "./hooks/usePageLayoutKeyboardShortcuts.ts";
 import styles from "./PageLayout.module.scss";
@@ -123,6 +124,7 @@ export const PageLayout = ({ showVersionIndicator = true }: PageLayoutProps): Re
             remains draggable. */}
         {isZenModeActive && <TitleBar className={styles.zenTitleBar} />}
         <PluginLoader />
+        <PluginOverlays />
         <PanelRegistryProvider panels={combinedPanels} defaultLayout={workspaceDefaultLayout}>
           <Outlet />
         </PanelRegistryProvider>

--- a/sculptor/frontend/src/plugins/PluginOverlays.tsx
+++ b/sculptor/frontend/src/plugins/PluginOverlays.tsx
@@ -1,0 +1,37 @@
+import { useAtomValue } from "jotai";
+import type { ReactElement } from "react";
+
+import { pluginOverlaysAtom } from "./pluginRegistry.ts";
+
+/**
+ * Renders every plugin-contributed overlay (`api.registerOverlay`) above the
+ * whole app. Mounted once from `PageLayout`, so overlays live *inside* the
+ * host's Router and Jotai/Theme/QueryClient providers — that is what lets an
+ * overlay use route- and store-backed SDK hooks (`useCurrentWorkspaceId`,
+ * `useWorkspaces`) even though it floats across every route.
+ *
+ * The layer is a fixed, full-viewport, click-through (`pointer-events: none`)
+ * container; each overlay must re-enable pointer events on its own interactive
+ * box. Entries are already wrapped by the loader in an error boundary and the
+ * plugin's PluginContext.
+ */
+export const PluginOverlays = (): ReactElement | null => {
+  const overlays = useAtomValue(pluginOverlaysAtom);
+  if (overlays.length === 0) return null;
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        pointerEvents: "none",
+        // Above app chrome; intentionally below Radix dialogs/popovers, which
+        // sit higher. Revisit if an overlay needs to cover modal content.
+        zIndex: 50,
+      }}
+    >
+      {overlays.map(({ id, component: Overlay }) => (
+        <Overlay key={id} />
+      ))}
+    </div>
+  );
+};

--- a/sculptor/frontend/src/plugins/WorkspaceContext.tsx
+++ b/sculptor/frontend/src/plugins/WorkspaceContext.tsx
@@ -15,8 +15,8 @@ export const useWorkspacePluginContext = (): WorkspacePluginContextValue => {
   const ctx = useContext(WorkspacePluginContext);
   if (!ctx) {
     throw new Error(
-      "Plugin SDK: useWorkspaceTasks / useWorkspaceId / useWorkspaceBranch called outside a workspace " +
-        "plugin mount. These hooks require the host's WorkspacePluginContext provider in the component tree.",
+      "Plugin SDK: useWorkspaceTasks called outside a workspace plugin mount. It requires the host's " +
+        "WorkspacePluginContext provider in the component tree (use useCurrentWorkspace in an overlay).",
     );
   }
   return ctx;

--- a/sculptor/frontend/src/plugins/pluginManager.tsx
+++ b/sculptor/frontend/src/plugins/pluginManager.tsx
@@ -348,8 +348,10 @@ export class PluginManager {
         // no WorkspacePluginContext: an overlay is app-global, so it reads the
         // current workspace through the SDK hooks instead of a fixed context.
         const PluginComponent = overlay.component;
+        // Attribute crashes to the owning plugin (manifest), matching the panel
+        // path — not to the overlay contribution id.
         const Wrapped = (): ReactElement => (
-          <PluginErrorBoundary pluginId={overlay.id} pluginName={overlay.id}>
+          <PluginErrorBoundary pluginId={manifest.id} pluginName={manifest.name}>
             <PluginContext.Provider value={{ pluginId: manifest.id }}>
               <PluginComponent />
             </PluginContext.Provider>

--- a/sculptor/frontend/src/plugins/pluginManager.tsx
+++ b/sculptor/frontend/src/plugins/pluginManager.tsx
@@ -9,13 +9,21 @@ import { installHostRuntime } from "./hostRuntime.ts";
 import { PluginContext } from "./PluginContext.tsx";
 import { PluginErrorBoundary } from "./PluginErrorBoundary.tsx";
 import {
+  pluginOverlaysAtom,
   pluginPanelsAtom,
   pluginSettingsComponentsAtom,
   pluginSourcesAtom,
   type PluginSourceState,
   pluginSourceStatesAtom,
 } from "./pluginRegistry.ts";
-import type { LoadedPlugin, PluginHostApi, PluginLoadError, PluginManifest, PluginModule } from "./types.ts";
+import type {
+  LoadedPlugin,
+  OverlayDefinition,
+  PluginHostApi,
+  PluginLoadError,
+  PluginManifest,
+  PluginModule,
+} from "./types.ts";
 import { WorkspacePluginContext } from "./WorkspaceContext.tsx";
 
 type JotaiStore = ReturnType<typeof createStore>;
@@ -331,6 +339,29 @@ export class PluginManager {
             delete next[manifest.id];
             return next;
           });
+        };
+        loadDisposers.push(undo);
+        return undo;
+      },
+      registerOverlay: (overlay: OverlayDefinition): (() => void) => {
+        // Like a panel, wrap in the error boundary and PluginContext, but with
+        // no WorkspacePluginContext: an overlay is app-global, so it reads the
+        // current workspace through the SDK hooks instead of a fixed context.
+        const PluginComponent = overlay.component;
+        const Wrapped = (): ReactElement => (
+          <PluginErrorBoundary pluginId={overlay.id} pluginName={overlay.id}>
+            <PluginContext.Provider value={{ pluginId: manifest.id }}>
+              <PluginComponent />
+            </PluginContext.Provider>
+          </PluginErrorBoundary>
+        );
+        Wrapped.displayName = `PluginOverlay(${overlay.id})`;
+        const entry = { id: overlay.id, component: Wrapped };
+
+        // Replace-by-id; undo by instance (see the panel undo above).
+        store.set(pluginOverlaysAtom, (prev) => [...prev.filter((o) => o.id !== overlay.id), entry]);
+        const undo = (): void => {
+          store.set(pluginOverlaysAtom, (prev) => prev.filter((o) => o !== entry));
         };
         loadDisposers.push(undo);
         return undo;

--- a/sculptor/frontend/src/plugins/pluginRegistry.ts
+++ b/sculptor/frontend/src/plugins/pluginRegistry.ts
@@ -19,6 +19,14 @@ export const pluginPanelsAtom = atom<ReadonlyArray<PanelDefinition>>([]);
 export const pluginSettingsComponentsAtom = atom<Readonly<Record<string, ComponentType>>>({});
 
 /**
+ * Always-on floating overlays contributed by plugins via `registerOverlay`.
+ * `PluginOverlays` renders each one above the whole app, in registration
+ * order. Each entry's component is already wrapped by the loader in an error
+ * boundary and the plugin's PluginContext.
+ */
+export const pluginOverlaysAtom = atom<ReadonlyArray<{ id: string; component: ComponentType }>>([]);
+
+/**
  * User-added plugin sources, persisted to localStorage. A source is a URL or
  * directory that contains a `manifest.json` (e.g. `http://localhost:5174/my-plugin`
  * or `/plugins/my-plugin`). Built-in sources are loaded separately and are not

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -1,47 +1,105 @@
-import { useAtom, useAtomValue } from "jotai";
-import { atomFamily, atomWithStorage } from "jotai/utils";
-import { useMemo } from "react";
+import { atom, useAtom, useAtomValue } from "jotai";
+import { atomFamily, atomWithStorage, selectAtom } from "jotai/utils";
+import { useContext, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
 
 import type { CodingAgentTaskView, Workspace } from "~/api";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
-import { workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
-import { useWorkspaceBranch as useHostWorkspaceBranch } from "~/common/state/hooks/useWorkspaceBranch.ts";
+import { workspaceBranchAtomFamily } from "~/common/state/atoms/workspaceBranch.ts";
+import { workspaceAtomFamily, workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
 
 import { usePluginContext } from "../PluginContext.tsx";
-import { useWorkspacePluginContext } from "../WorkspaceContext.tsx";
-
-/** Current workspace id, read from the host-provided plugin context. */
-export const useWorkspaceId = (): string => useWorkspacePluginContext().workspaceId;
+import { useWorkspacePluginContext, WorkspacePluginContext } from "../WorkspaceContext.tsx";
 
 /**
  * Every non-deleted workspace known to the host, or `undefined` until the
- * first batch has loaded. Unlike `useWorkspaceId`, this needs no workspace
- * context — it reads an app-global atom, so it works in an overlay (which
- * isn't bound to one workspace) as well as in a panel.
+ * first batch has loaded. App-global: it reads a shared atom and needs no
+ * workspace context, so it works in an overlay as well as a panel.
  */
 export const useWorkspaces = (): ReadonlyArray<Workspace> | undefined => useAtomValue(workspacesArrayAtom);
 
 /**
- * The id of the workspace the user is currently viewing, or `null` when the
- * route isn't a workspace page (settings, onboarding, etc.). Read straight
- * from the route, so it tracks navigation — the right "where am I" signal for
- * an app-global overlay.
+ * A curated, plugin-facing view of a single workspace: identity, label, and
+ * live git branch. Deliberately a subset — not the host's full `Workspace`
+ * model — so the plugin contract doesn't couple to backend internals.
  */
-export const useCurrentWorkspaceId = (): string | null => {
-  const { workspaceID } = useParams<{ workspaceID?: string }>();
-  return workspaceID ?? null;
+export type CurrentWorkspace = {
+  id: string;
+  description: string;
+  /** Live current branch, or `null` until the backend has reported it. */
+  branch: string | null;
+  targetBranch: string | null;
 };
 
+// One derived view atom per workspace id, composing the workspace model with
+// its live branch (which the host keeps in a separate atom) into the curated
+// CurrentWorkspace shape.
+const currentWorkspaceViewAtomFamily = atomFamily((id: string) =>
+  atom((get): CurrentWorkspace | null => {
+    const workspace = get(workspaceAtomFamily(id));
+    if (!workspace) return null;
+    return {
+      id: workspace.objectId,
+      description: workspace.description,
+      branch: get(workspaceBranchAtomFamily(id))?.currentBranch ?? null,
+      targetBranch: workspace.targetBranch ?? null,
+    };
+  }),
+);
+
+// Stable fallback for when there is no current workspace, so the hook's
+// memoized selection always has a constant source atom.
+const noCurrentWorkspaceAtom = atom<CurrentWorkspace | null>(null);
+
 /**
- * The current git branch of the workspace the plugin is mounted in, or `null`
- * until the backend has reported it. Useful for linking the workspace to
- * external systems (e.g. parsing a ticket id out of the branch name).
+ * The workspace the user is currently in — the panel's workspace when mounted
+ * in a panel, otherwise the current route — or `null` when there is none (e.g.
+ * an overlay on the home or settings screen). Named for its nullability and to
+ * avoid shadowing the host's by-id `useWorkspace`, which has different
+ * semantics.
+ *
+ * Pass a `selector` to subscribe to one field and re-render only when that
+ * field changes (backed by jotai's `selectAtom`):
+ *
+ *     const branch = useCurrentWorkspace((w) => w?.branch ?? null);
+ *
+ * The selector should be pure over the workspace (no external closure state):
+ * its identity may change between renders, but its logic must not.
  */
-export const useWorkspaceBranch = (): string | null => {
-  const { workspaceId } = useWorkspacePluginContext();
-  return useHostWorkspaceBranch(workspaceId)?.currentBranch ?? null;
-};
+export function useCurrentWorkspace<T = CurrentWorkspace | null>(
+  selector?: (workspace: CurrentWorkspace | null) => T,
+  equalityFn?: (a: T, b: T) => boolean,
+): T {
+  // Resolve the active id: the panel's workspace if mounted in one (read
+  // non-throwing, so overlays don't crash), else the current route.
+  const panelContext = useContext(WorkspacePluginContext);
+  const { workspaceID } = useParams<{ workspaceID?: string }>();
+  const workspaceId = panelContext?.workspaceId ?? workspaceID ?? null;
+
+  // selectAtom rebuilds its derived atom whenever the selector/equality
+  // *identity* changes — which an inline selector does every render. Keep the
+  // latest in refs and hand selectAtom stable wrappers, so a field selector
+  // subscribes once and re-renders only when that field changes.
+  const selectorRef = useRef(selector);
+  selectorRef.current = selector;
+  const equalityRef = useRef(equalityFn);
+  equalityRef.current = equalityFn;
+
+  const sourceAtom = useMemo(
+    () => (workspaceId ? currentWorkspaceViewAtomFamily(workspaceId) : noCurrentWorkspaceAtom),
+    [workspaceId],
+  );
+  const selectedAtom = useMemo(
+    () =>
+      selectAtom<CurrentWorkspace | null, T>(
+        sourceAtom,
+        (workspace) => (selectorRef.current ? selectorRef.current(workspace) : (workspace as unknown as T)),
+        (a, b) => (equalityRef.current ? equalityRef.current(a, b) : Object.is(a, b)),
+      ),
+    [sourceAtom],
+  );
+  return useAtomValue(selectedAtom);
+}
 
 // One persisted atom per (plugin, key). atomFamily caches by the full storage
 // key; getOnInit reads localStorage synchronously so the value is present on

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -1,9 +1,11 @@
 import { useAtom, useAtomValue } from "jotai";
 import { atomFamily, atomWithStorage } from "jotai/utils";
 import { useMemo } from "react";
+import { useParams } from "react-router-dom";
 
-import type { CodingAgentTaskView } from "~/api";
+import type { CodingAgentTaskView, Workspace } from "~/api";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
+import { workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
 import { useWorkspaceBranch as useHostWorkspaceBranch } from "~/common/state/hooks/useWorkspaceBranch.ts";
 
 import { usePluginContext } from "../PluginContext.tsx";
@@ -11,6 +13,25 @@ import { useWorkspacePluginContext } from "../WorkspaceContext.tsx";
 
 /** Current workspace id, read from the host-provided plugin context. */
 export const useWorkspaceId = (): string => useWorkspacePluginContext().workspaceId;
+
+/**
+ * Every non-deleted workspace known to the host, or `undefined` until the
+ * first batch has loaded. Unlike `useWorkspaceId`, this needs no workspace
+ * context — it reads an app-global atom, so it works in an overlay (which
+ * isn't bound to one workspace) as well as in a panel.
+ */
+export const useWorkspaces = (): ReadonlyArray<Workspace> | undefined => useAtomValue(workspacesArrayAtom);
+
+/**
+ * The id of the workspace the user is currently viewing, or `null` when the
+ * route isn't a workspace page (settings, onboarding, etc.). Read straight
+ * from the route, so it tracks navigation — the right "where am I" signal for
+ * an app-global overlay.
+ */
+export const useCurrentWorkspaceId = (): string | null => {
+  const { workspaceID } = useParams<{ workspaceID?: string }>();
+  return workspaceID ?? null;
+};
 
 /**
  * The current git branch of the workspace the plugin is mounted in, or `null`

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -4,5 +4,12 @@
  * and must bump the SDK major version.
  */
 export { PanelHeader } from "./components.ts";
-export { usePluginSetting, useWorkspaceBranch, useWorkspaceId, useWorkspaceTasks } from "./hooks.ts";
-export type { CodingAgentTaskView } from "~/api";
+export {
+  useCurrentWorkspaceId,
+  usePluginSetting,
+  useWorkspaceBranch,
+  useWorkspaceId,
+  useWorkspaces,
+  useWorkspaceTasks,
+} from "./hooks.ts";
+export type { CodingAgentTaskView, Workspace } from "~/api";

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -4,12 +4,6 @@
  * and must bump the SDK major version.
  */
 export { PanelHeader } from "./components.ts";
-export {
-  useCurrentWorkspaceId,
-  usePluginSetting,
-  useWorkspaceBranch,
-  useWorkspaceId,
-  useWorkspaces,
-  useWorkspaceTasks,
-} from "./hooks.ts";
+export type { CurrentWorkspace } from "./hooks.ts";
+export { useCurrentWorkspace, usePluginSetting, useWorkspaces, useWorkspaceTasks } from "./hooks.ts";
 export type { CodingAgentTaskView, Workspace } from "~/api";

--- a/sculptor/frontend/src/plugins/types.ts
+++ b/sculptor/frontend/src/plugins/types.ts
@@ -30,6 +30,22 @@ export type PluginManifest = {
  * contribute panels, commands, etc. Returning a disposer from `activate` lets
  * the host unmount/remove contributions when the plugin is unloaded.
  */
+/**
+ * An always-on, app-global floating contribution. Unlike a panel, an overlay
+ * is not tied to a zone or a single workspace: the host renders it above the
+ * whole app (across every route) for as long as the plugin is loaded. The
+ * component draws into a full-viewport, click-through layer, so it must opt
+ * its own interactive box back into pointer events. Use the workspace SDK
+ * hooks (`useWorkspaces`, `useCurrentWorkspaceId`) to react to app state —
+ * there is no single workspace context, because an overlay outlives any one
+ * workspace page.
+ */
+export type OverlayDefinition = {
+  /** Stable id; registering twice with the same id replaces the previous one. */
+  id: string;
+  component: ComponentType;
+};
+
 export type PluginHostApi = {
   registerPanel: (panel: PanelDefinition) => () => void;
   /**
@@ -39,6 +55,12 @@ export type PluginHostApi = {
    * disposer.
    */
   registerSettings: (component: ComponentType) => () => void;
+  /**
+   * Registers an always-on floating overlay rendered above the whole app.
+   * Wrapped, like panels, in a per-plugin error boundary and the host's
+   * PluginContext (so `usePluginSetting` works). Returns a disposer.
+   */
+  registerOverlay: (overlay: OverlayDefinition) => () => void;
 };
 
 export type PluginActivate = (api: PluginHostApi) => void | (() => void) | Promise<void | (() => void)>;


### PR DESCRIPTION
Expands the frontend plugin SDK surface so plugins can contribute always-on floating UI and react to app-wide state. No example plugin is bundled here — that lands in a stacked follow-up.

## What's added
- **`registerOverlay`** — a third contribution type alongside `registerPanel` and `registerSettings`. Overlays are app-global and always-on: `PluginOverlays` renders them in a fixed, click-through layer mounted inside the host providers (via `PageLayout`), so an overlay can use route- and store-backed hooks even though it floats across every route. Wrapped, like panels, in a per-plugin error boundary and `PluginContext`.
- **`useWorkspaces` / `useCurrentWorkspaceId`** — contextless workspace hooks reading the app-global workspace list and the current route. The existing per-workspace hooks rely on a panel-injected context an overlay doesn't have.
- Both hooks exported from the SDK barrel and the runtime stub.

## Notes
- Part of SCU-1496 (SDK surface). This PR intentionally does **not** close the ticket — the plugin contribution that exercises this API follows in a stacked PR on top of this branch.
- Behind the existing experimental "Frontend plugins" flag; no UX change when off.

(Sent by Claude)