### PR TITLE
Persist new-workspace repo/branch selections across tab switches (SCU-1427)

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/promptDrafts.ts
+++ b/sculptor/frontend/src/common/state/atoms/promptDrafts.ts
@@ -14,3 +14,29 @@ export const promptDraftAtomFamily = atomFamily((taskId: TaskID) => {
 export const draftTabNameAtomFamily = atomFamily<string, PrimitiveAtom<string | null>>((draftId) => {
   return atomWithStorage<string | null>(`sculptor-draft-tab-name-${draftId}`, null);
 });
+
+// The repo/branch drafts below mirror the workspace-name draft so the whole
+// new-workspace form survives a tab switch (the page unmounts when another tab
+// is shown and remounts on return). They use `getOnInit: true` so the stored
+// value is read synchronously on mount, before AddWorkspacePage's project-load
+// effect runs — otherwise that effect would clobber a restored repo selection
+// with the most-recently-used default. See SCU-1427.
+
+/** Selected repo (project ID) draft keyed by new-workspace tab draft ID. */
+export const draftProjectIdAtomFamily = atomFamily<string, PrimitiveAtom<string | null>>((draftId) => {
+  return atomWithStorage<string | null>(`sculptor-draft-project-id-${draftId}`, null, undefined, { getOnInit: true });
+});
+
+/** Selected source-branch draft keyed by new-workspace tab draft ID. */
+export const draftSourceBranchAtomFamily = atomFamily<string, PrimitiveAtom<string | null>>((draftId) => {
+  return atomWithStorage<string | null>(`sculptor-draft-source-branch-${draftId}`, null, undefined, {
+    getOnInit: true,
+  });
+});
+
+/** Manually-edited branch-name override draft keyed by new-workspace tab draft ID. */
+export const draftBranchNameOverrideAtomFamily = atomFamily<string, PrimitiveAtom<string | null>>((draftId) => {
+  return atomWithStorage<string | null>(`sculptor-draft-branch-name-${draftId}`, null, undefined, {
+    getOnInit: true,
+  });
+});

--- a/sculptor/frontend/src/common/state/hooks/usePromptDraft.ts
+++ b/sculptor/frontend/src/common/state/hooks/usePromptDraft.ts
@@ -1,7 +1,13 @@
 import { useAtom } from "jotai";
 
 import type { TaskID } from "../../Types.ts";
-import { draftTabNameAtomFamily, promptDraftAtomFamily } from "../atoms/promptDrafts";
+import {
+  draftBranchNameOverrideAtomFamily,
+  draftProjectIdAtomFamily,
+  draftSourceBranchAtomFamily,
+  draftTabNameAtomFamily,
+  promptDraftAtomFamily,
+} from "../atoms/promptDrafts";
 
 export const usePromptDraft = (taskId: TaskID): [string | null, (value: string | null) => void] => {
   return useAtom(promptDraftAtomFamily(taskId));
@@ -9,4 +15,16 @@ export const usePromptDraft = (taskId: TaskID): [string | null, (value: string |
 
 export const useDraftTabName = (draftId: string): [string | null, (value: string | null) => void] => {
   return useAtom(draftTabNameAtomFamily(draftId));
+};
+
+export const useDraftProjectId = (draftId: string): [string | null, (value: string | null) => void] => {
+  return useAtom(draftProjectIdAtomFamily(draftId));
+};
+
+export const useDraftSourceBranch = (draftId: string): [string | null, (value: string | null) => void] => {
+  return useAtom(draftSourceBranchAtomFamily(draftId));
+};
+
+export const useDraftBranchNameOverride = (draftId: string): [string | null, (value: string | null) => void] => {
+  return useAtom(draftBranchNameOverrideAtomFamily(draftId));
 };

--- a/sculptor/frontend/src/pages/add-workspace/AddWorkspacePage.tsx
+++ b/sculptor/frontend/src/pages/add-workspace/AddWorkspacePage.tsx
@@ -36,7 +36,12 @@ import {
   convertNewWorkspaceToTabAtom,
   markDraftCreatingAtom,
 } from "../../common/state/atoms/workspaces.ts";
-import { useDraftTabName } from "../../common/state/hooks/usePromptDraft.ts";
+import {
+  useDraftBranchNameOverride,
+  useDraftProjectId,
+  useDraftSourceBranch,
+  useDraftTabName,
+} from "../../common/state/hooks/usePromptDraft.ts";
 import { useRepoInfo } from "../../common/state/hooks/useRepoInfo.ts";
 import { useTerminalAgentRegistrations } from "../../common/state/hooks/useTerminalAgentRegistrations.ts";
 import { BranchSelector } from "../../components/BranchSelector.tsx";
@@ -69,7 +74,14 @@ export const AddWorkspacePage = (): ReactElement => {
   // Project state — read from global atom so AddRepoDialog updates are reflected immediately
   const projects = useAtomValue(projectsArrayAtom);
   const updateProjects = useSetAtom(updateProjectsAtom);
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  // Repo/branch selections are persisted per draftId (like the workspace name)
+  // so they survive the unmount/remount that happens when the user switches to
+  // another tab and back. See SCU-1427.
+  const [selectedProjectId, setSelectedProjectId] = useDraftProjectId(draftId);
+  // Latest selection, read inside the one-shot project-load effect without
+  // making it a dependency (which would re-fetch projects on every change).
+  const selectedProjectIdRef = useRef(selectedProjectId);
+  selectedProjectIdRef.current = selectedProjectId;
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
 
   // Form state. Worktree is the default mode; clone and in-place are opt-in.
@@ -93,24 +105,32 @@ export const AddWorkspacePage = (): ReactElement => {
     (value: string) => setWorkspaceNameDraft(value || null),
     [setWorkspaceNameDraft],
   );
-  const [userSelectedBranch, setUserSelectedBranch] = useState<string | null>(null);
+  const [userSelectedBranch, setUserSelectedBranch] = useDraftSourceBranch(draftId);
   const [isPending, setIsPending] = useState(false);
   const [toast, setToast] = useState<ToastContent | null>(null);
   // `null` means "use the auto-filled preview"; any string means the user has
   // taken over and we render their override. Both the value and the manual flag
   // collapse into one piece of state so they can never disagree.
-  const [branchNameOverride, setBranchNameOverride] = useState<string | null>(null);
+  const [branchNameOverride, setBranchNameOverride] = useDraftBranchNameOverride(draftId);
   const isBranchNameManuallyEdited = branchNameOverride !== null;
 
-  const handleModeChange = useCallback((nextMode: WorkspaceInitializationStrategy): void => {
-    setMode(nextMode);
-    setBranchNameOverride(null);
-  }, []);
+  const handleModeChange = useCallback(
+    (nextMode: WorkspaceInitializationStrategy): void => {
+      setMode(nextMode);
+      setBranchNameOverride(null);
+    },
+    [setBranchNameOverride],
+  );
 
-  const handleProjectChange = useCallback((nextProjectId: string | null): void => {
-    setSelectedProjectId(nextProjectId);
-    setBranchNameOverride(null);
-  }, []);
+  const handleProjectChange = useCallback(
+    (nextProjectId: string | null): void => {
+      setSelectedProjectId(nextProjectId);
+      // Switching repos invalidates branch choices made against the old repo.
+      setBranchNameOverride(null);
+      setUserSelectedBranch(null);
+    },
+    [setSelectedProjectId, setBranchNameOverride, setUserSelectedBranch],
+  );
 
   // Single source of truth for the branch-name field. The hook owns preview
   // fetching and the debounced collision check; the parent owns the override.
@@ -152,12 +172,20 @@ export const AddWorkspacePage = (): ReactElement => {
         const activeProjects = projectsResponse.data ?? [];
         updateProjects(activeProjects);
 
-        // Default to MRU project (response is a project ID string), fallback to first project
-        const mruProjectId = mruResponse.data;
-        if (mruProjectId && activeProjects.some((p) => p.objectId === mruProjectId)) {
-          setSelectedProjectId(mruProjectId);
-        } else if (activeProjects.length > 0) {
-          setSelectedProjectId(activeProjects[0].objectId);
+        // Keep a persisted selection (restored from a previous visit to this
+        // draft tab) when it still points at an existing project. Only fall back
+        // to the MRU project — then the first project — when there is no valid
+        // selection yet, so navigating away and back doesn't reset the repo.
+        const restoredProjectId = selectedProjectIdRef.current;
+        const hasValidSelection =
+          restoredProjectId !== null && activeProjects.some((p) => p.objectId === restoredProjectId);
+        if (!hasValidSelection) {
+          const mruProjectId = mruResponse.data;
+          if (mruProjectId && activeProjects.some((p) => p.objectId === mruProjectId)) {
+            setSelectedProjectId(mruProjectId);
+          } else if (activeProjects.length > 0) {
+            setSelectedProjectId(activeProjects[0].objectId);
+          }
         }
       } catch (error) {
         console.error("Failed to load projects:", error);
@@ -175,7 +203,7 @@ export const AddWorkspacePage = (): ReactElement => {
     return (): void => {
       isCancelled = true;
     };
-  }, [updateProjects]);
+  }, [updateProjects, setSelectedProjectId]);
 
   // Auto-select newly added projects
   const prevProjectIdsRef = useRef(new Set(projects.map((p) => p.objectId)));
@@ -186,15 +214,20 @@ export const AddWorkspacePage = (): ReactElement => {
 
     if (newIds.length > 0) {
       setSelectedProjectId(newIds[newIds.length - 1].objectId);
+      // A freshly added repo replaces the selection, so a branch picked against
+      // the previous repo no longer applies.
+      setUserSelectedBranch(null);
     }
-  }, [projects]);
+  }, [projects, setSelectedProjectId, setUserSelectedBranch]);
 
-  // Refresh branch info when project changes
+  // Refresh branch info when the project changes. The source-branch reset lives
+  // in handleProjectChange / the new-project effect (i.e. on a real user-driven
+  // change) rather than here, so restoring a persisted project on remount does
+  // not wipe the persisted source branch.
   useEffect(() => {
     if (!selectedProjectId) return;
     fetchCurrentBranch();
     fetchRepoInfo();
-    setUserSelectedBranch(null);
   }, [selectedProjectId, fetchCurrentBranch, fetchRepoInfo]);
 
   const handleSubmit = useCallback(async (): Promise<void> => {
@@ -244,7 +277,13 @@ export const AddWorkspacePage = (): ReactElement => {
       // so the workspace is already in workspaceIdsAtom.  Replace the
       // pseudo-tab with the real workspace tab in its same position.
       convertNewWorkspaceToTab({ draftId, workspaceId });
+      // The draft has become a real workspace — drop all of its persisted
+      // form state so the (now-defunct) draftId doesn't leave stale entries
+      // behind in localStorage.
       setWorkspaceNameDraft(null);
+      setSelectedProjectId(null);
+      setUserSelectedBranch(null);
+      setBranchNameOverride(null);
 
       // If the remembered registered agent's registration is no longer present
       // (deleted since it was picked), fall back to Claude rather than leaving
@@ -332,6 +371,9 @@ export const AddWorkspacePage = (): ReactElement => {
     defaultModelPreference,
     navigateToAgent,
     setWorkspaceNameDraft,
+    setSelectedProjectId,
+    setUserSelectedBranch,
+    setBranchNameOverride,
     convertNewWorkspaceToTab,
     markDraftCreating,
     clearDraftCreating,

--- a/sculptor/tests/integration/frontend/test_add_workspace_page.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_page.py
@@ -96,6 +96,95 @@ def test_workspace_form_draft_persists_after_navigation(
     expect(workspace_name_input).to_have_value(draft_workspace_name)
 
 
+@user_story("to not lose my selected source branch and branch name when navigating away and back")
+def test_workspace_form_branch_state_persists_after_navigation(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Selected source branch and manually-edited branch name should persist after navigating away and back.
+
+    The workspace name already persists (it is keyed by draftId in localStorage),
+    but the repo, source branch, and branch-name selections used to be ephemeral
+    React state that reset to their defaults whenever the Add Workspace tab was
+    unmounted and remounted. The result was that switching tabs and returning
+    silently dropped the user's repo/branch choices while leaving the name intact
+    — which could open a workspace on the wrong branch (SCU-1427).
+
+    Steps:
+    1. Create an initial workspace so there is a tab to navigate to
+    2. Navigate back to the Add Workspace page via the "+" button
+    3. Fill in the workspace name, select a non-default source branch ("main",
+       since the test repo is checked out on "testing"), and type a custom branch name
+    4. Navigate away by clicking on the existing workspace tab
+    5. Navigate back to the Add Workspace page via the "Open Workspace" tab
+    6. Verify the source branch and branch name are still the user's selections
+    """
+    page = sculptor_instance_.page
+    add_ws_page = PlaywrightAddWorkspacePage(page=page)
+
+    # Step 1: Create a workspace so we have somewhere to navigate to.
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt="Setup task",
+        workspace_name="Initial Workspace",
+    )
+
+    # Step 2: Navigate back to Add Workspace page via the "+" button.
+    add_workspace_button = task_page.get_add_workspace_button()
+    expect(add_workspace_button).to_be_visible()
+    add_workspace_button.click()
+
+    submit_button = add_ws_page.get_submit_button()
+    expect(submit_button).to_be_visible()
+
+    # Step 3: Fill in the workspace name, pick a non-default source branch, and
+    # type a custom branch name. The test repo is checked out on "testing", so
+    # "main" is a non-current branch the user can deliberately select.
+    draft_workspace_name = "Branch State Workspace"
+    custom_branch_name = "my-custom-branch-name"
+
+    workspace_name_input = add_ws_page.get_workspace_name_input()
+    workspace_name_input.fill(draft_workspace_name)
+
+    add_ws_page.select_branch("main")
+    branch_selector = add_ws_page.get_branch_selector()
+    expect(branch_selector).to_contain_text("main")
+
+    branch_name_input = add_ws_page.get_branch_name_input()
+    branch_name_input.fill(custom_branch_name)
+    expect(branch_name_input).to_have_value(custom_branch_name)
+
+    # Step 4: Navigate away by clicking on the existing workspace tab.
+    workspace_tab = add_ws_page.get_workspace_tabs().first
+    expect(workspace_tab).to_be_visible()
+    workspace_tab.click()
+
+    # Confirm we navigated away — the chat panel of the existing workspace should appear.
+    chat_panel = PlaywrightTaskPage(page=page).get_chat_panel()
+    expect(chat_panel).to_be_visible()
+
+    # Step 5: Navigate back to the Add Workspace page via the "Open Workspace" tab.
+    # Use .last because a stale "new workspace" tab may persist from previous test
+    # cleanup when running on a shared instance with xdist reordering.
+    open_workspace_tab = add_ws_page.get_add_workspace_tabs().last
+    expect(open_workspace_tab).to_be_visible()
+    open_workspace_tab.click()
+
+    submit_button = add_ws_page.get_submit_button()
+    expect(submit_button).to_be_visible()
+
+    # Step 6: Verify the source branch and branch name survived the round trip.
+    # The workspace name is also checked to confirm the documented asymmetry
+    # (name persisted; branch/source did not) is fully resolved.
+    workspace_name_input = add_ws_page.get_workspace_name_input()
+    expect(workspace_name_input).to_have_value(draft_workspace_name)
+
+    branch_name_input = add_ws_page.get_branch_name_input()
+    expect(branch_name_input).to_have_value(custom_branch_name)
+
+    branch_selector = add_ws_page.get_branch_selector()
+    expect(branch_selector).to_contain_text("main")
+
+
 @user_story("to draft multiple workspaces in parallel, like browser tabs")
 def test_multiple_new_workspace_tabs_with_independent_drafts(
     sculptor_instance_: SculptorInstance,


### PR DESCRIPTION
## Summary

The Add Workspace page (`/ws/new`) persisted the draft **workspace name** across tab switches, but kept the selected **repo**, **source branch**, and **manually-edited branch name** in ephemeral React state. Switching to another tab unmounts the page; switching back remounts it, so the name survived while the repo/branch selections silently reset to their defaults — the project-load effect re-picked the most-recently-used repo, and a project-change effect wiped the source branch. A user could end up creating a workspace on the wrong repo/branch while the form still looked filled in.

## Fix

Persist all three selections per `draftId` in localStorage-backed atoms, mirroring the existing workspace-name draft. The stored repo is read synchronously on init (`getOnInit: true`) so it wins over the project-load effect's MRU fallback. The source-branch reset now fires only on a real user-driven repo change (`handleProjectChange` and the freshly-added-repo effect) rather than on every `selectedProjectId` change, so restoring a persisted repo on remount no longer wipes the persisted branch. All drafts are cleared on successful submit.

Fixes SCU-1427.

## Testing

- **New integration test** (`test_workspace_form_branch_state_persists_after_navigation`): selects a non-default source branch and a custom branch name, navigates to another tab and back, and asserts both survive the round trip. Fails before the fix, passes after.
- `just check` (lint, type check, ratchets, file hygiene) — green
- `just test-unit` (backend, frontend, foundation, sculpt CLI) — green
- Full integration suite — green; the add-workspace tests pass, and a handful of unrelated transient failures elsewhere in the suite were confirmed to pass on a serial rerun.

(Sent by Claude)
