### PR TITLE
Stop workspace branch pollers when the repo is torn down (SCU-1429)

### DIFF
--- a/sculptor/sculptor/primitives/threads.py
+++ b/sculptor/sculptor/primitives/threads.py
@@ -19,6 +19,17 @@ T = TypeVar("T")
 _POLL_THREAD_SHUTDOWN_TIMEOUT_IN_SECONDS = 10.0
 
 
+class StopPolling(Exception):
+    """Raised by a polling callback to permanently stop its polling source.
+
+    A ``StopGapBackgroundPollingStreamSource`` otherwise invokes its callback
+    forever on a fixed interval. When the resource being polled is gone for
+    good (e.g. a workspace whose git repo was torn down — see SCU-1429), the
+    callback raises this so the source stops its thread instead of retrying the
+    (now-pointless) work — and spamming git errors — until process shutdown.
+    """
+
+
 class StopGapBackgroundPollingStreamSource(Generic[T]):
     """
     DONT USE THIS PATTERN.

--- a/sculptor/sculptor/primitives/threads.py
+++ b/sculptor/sculptor/primitives/threads.py
@@ -55,7 +55,14 @@ class StopGapBackgroundPollingStreamSource(Generic[T]):
     def _poll_into_queue(self) -> None:
         # Wait at the beginning rather than end so that we don't race with stream tests
         while not self.stop_event.wait(self.check_interval_in_seconds):
-            next_value = self.polling_callback()
+            try:
+                next_value = self.polling_callback()
+            except StopPolling as e:
+                # The callback has determined the polled resource is gone for
+                # good; stop instead of retrying forever (SCU-1429).
+                logger.debug("Polling callback requested stop: {}", e)
+                self.stop_event.set()
+                return
             if next_value is not None and next_value != self.last_seen:
                 self.output_queue.put(next_value)
                 self.last_seen = next_value

--- a/sculptor/sculptor/primitives/threads_test.py
+++ b/sculptor/sculptor/primitives/threads_test.py
@@ -1,0 +1,77 @@
+"""Unit tests for :mod:`sculptor.primitives.threads`."""
+
+import time
+from queue import Queue
+
+from imbue_core.concurrency_group import ConcurrencyGroup
+from sculptor.primitives.threads import StopGapBackgroundPollingStreamSource
+from sculptor.primitives.threads import StopPolling
+
+
+def _wait_until_thread_done(source: StopGapBackgroundPollingStreamSource, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while source.thread.is_alive() and time.monotonic() < deadline:
+        time.sleep(0.02)
+
+
+def test_source_polls_and_emits_values(test_root_concurrency_group: ConcurrencyGroup) -> None:
+    """Baseline: a normal callback keeps emitting distinct values onto the queue."""
+    queue: Queue[int] = Queue()
+    values = iter([1, 2, 2, 3])
+
+    def callback() -> int | None:
+        try:
+            return next(values)
+        except StopIteration:
+            return None
+
+    source: StopGapBackgroundPollingStreamSource[int] = StopGapBackgroundPollingStreamSource(
+        polling_callback=callback,
+        output_queue=queue,
+        check_interval_in_seconds=0.01,
+        concurrency_group=test_root_concurrency_group,
+    )
+    source.start()
+    time.sleep(0.2)
+    source.stop()
+
+    drained = []
+    while not queue.empty():
+        drained.append(queue.get())
+    # Duplicate consecutive values are de-duplicated by the source.
+    assert drained == [1, 2, 3]
+
+
+def test_source_stops_itself_when_callback_raises_stop_polling(
+    test_root_concurrency_group: ConcurrencyGroup,
+) -> None:
+    """A callback that raises ``StopPolling`` must terminate its source's thread
+    *gracefully* — the source sets its stop event and the thread exits without
+    recording an exception. This is the mechanism that lets a poller give up on
+    a torn-down workspace repo instead of retrying forever (SCU-1429)."""
+    queue: Queue[int] = Queue()
+    call_count = {"n": 0}
+
+    def callback() -> int | None:
+        call_count["n"] += 1
+        raise StopPolling("resource is gone")
+
+    source: StopGapBackgroundPollingStreamSource[int] = StopGapBackgroundPollingStreamSource(
+        polling_callback=callback,
+        output_queue=queue,
+        check_interval_in_seconds=0.01,
+        concurrency_group=test_root_concurrency_group,
+    )
+    source.start()
+    _wait_until_thread_done(source)
+
+    assert not source.thread.is_alive(), "source thread should stop itself after StopPolling"
+    assert source.stop_event.is_set(), "source should mark itself stopped after StopPolling"
+    assert source.thread.exception_raw is None, "StopPolling should be handled gracefully, not crash the thread"
+    # The callback should not keep being invoked after it asked to stop.
+    invocations_at_stop = call_count["n"]
+    time.sleep(0.1)
+    assert call_count["n"] == invocations_at_stop, "callback must not be invoked again after StopPolling"
+
+    # stop() remains a safe no-op once the thread has already exited.
+    source.stop()

--- a/sculptor/sculptor/primitives/threads_test.py
+++ b/sculptor/sculptor/primitives/threads_test.py
@@ -3,7 +3,7 @@
 import time
 from queue import Queue
 
-from imbue_core.concurrency_group import ConcurrencyGroup
+from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.primitives.threads import StopGapBackgroundPollingStreamSource
 from sculptor.primitives.threads import StopPolling
 

--- a/sculptor/sculptor/web/repo_polling_manager.py
+++ b/sculptor/sculptor/web/repo_polling_manager.py
@@ -16,6 +16,7 @@ from sculptor.primitives.ids import ProjectID
 from sculptor.primitives.ids import RequestID
 from sculptor.primitives.ids import WorkspaceID
 from sculptor.primitives.threads import StopGapBackgroundPollingStreamSource
+from sculptor.primitives.threads import StopPolling
 from sculptor.service_collections.service_collection import CompleteServiceCollection
 from sculptor.services.data_model_service.api import CompletedTransaction
 from sculptor.services.git_repo_service.api import ReadOnlyGitRepo
@@ -27,13 +28,39 @@ from sculptor.web.derived import WorkspaceBranchInfo
 from sculptor.web.derived import WorkspaceRemoteBranchesInfo
 
 
+def _is_missing_repo_error(exc: BaseException) -> bool:
+    """Whether a git failure means the workspace repo is gone for good.
+
+    A torn-down workspace presents one of two ways (see SCU-1429):
+    - its working directory was removed entirely, which the git service surfaces
+      as a ``GitRepoNotFoundError`` (the repo path no longer exists);
+    - the directory survives but is no longer a git repo — e.g. a worktree whose
+      gitdir was pruned — which makes git print ``fatal: not a git repository``.
+
+    Both are permanent from this backend's perspective: a workspace's working
+    directory is stable for its lifetime, so once its repo vanishes the poller
+    will never succeed again and should stop rather than retry forever.
+    """
+    # NOTE: GitRepoNotFoundError is a GitRepoError subclass, so it must be
+    # checked first (it carries no stderr, so the stderr branch below misses it).
+    if isinstance(exc, GitRepoNotFoundError):
+        return True
+    if isinstance(exc, GitRepoError):
+        stderr = exc.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        return stderr is not None and "not a git repository" in stderr
+    return False
+
+
 def _get_branch_unless_repo_missing(repo: ReadOnlyGitRepo) -> str | None:
     try:
         return repo.get_current_git_branch()
     except GitRepoNotFoundError as e:
-        logger.debug("Failed to get current git branch because the repo doesn't exist: {}", e)
-        return None
+        raise StopPolling(f"workspace repo is gone (working dir missing): {e}") from e
     except GitRepoError as e:
+        if _is_missing_repo_error(e):
+            raise StopPolling(f"workspace repo is gone (not a git repository): {e}") from e
         if e.branch_name is not None:
             raise
         logger.debug("There is no current branch: {}", e)
@@ -233,6 +260,10 @@ class _WorkspaceBranchPollingCallback:
                 current_branch=current_branch,
                 workspace_id=self._workspace_id,
             )
+        except StopPolling:
+            # The repo is gone for good; let the polling source stop us rather
+            # than swallowing this into the generic failure path below.
+            raise
         except Exception as e:
             if self._first_failure_since_last_success is None:
                 self._first_failure_since_last_success = (datetime.datetime.now(), e)
@@ -272,6 +303,10 @@ class _WorkspaceRemoteBranchesPollingCallback:
                 remote_branches=tuple(branches),
             )
         except Exception as e:
+            if _is_missing_repo_error(e):
+                # The repo is gone for good; stop polling rather than retrying
+                # (and logging) every cycle until process shutdown (SCU-1429).
+                raise StopPolling(f"workspace repo is gone: {e}") from e
             if self._first_failure_since_last_success is None:
                 self._first_failure_since_last_success = (datetime.datetime.now(), e)
                 log_exception(

--- a/sculptor/sculptor/web/repo_polling_manager_test.py
+++ b/sculptor/sculptor/web/repo_polling_manager_test.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from imbue_core.concurrency_group import ConcurrencyGroup
+from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.primitives.ids import WorkspaceID
 from sculptor.primitives.threads import StopPolling
 from sculptor.service_collections.service_collection import CompleteServiceCollection
@@ -62,9 +62,7 @@ def healthy_worktree(
     yield base, worktree
 
 
-def _branch_callback(
-    worktree: Path, cg: ConcurrencyGroup
-) -> _WorkspaceBranchPollingCallback:
+def _branch_callback(worktree: Path, cg: ConcurrencyGroup) -> _WorkspaceBranchPollingCallback:
     return _WorkspaceBranchPollingCallback(
         workspace_id=WorkspaceID(),
         workspace_working_dir=worktree,
@@ -73,9 +71,7 @@ def _branch_callback(
     )
 
 
-def _remote_branches_callback(
-    worktree: Path, cg: ConcurrencyGroup
-) -> _WorkspaceRemoteBranchesPollingCallback:
+def _remote_branches_callback(worktree: Path, cg: ConcurrencyGroup) -> _WorkspaceRemoteBranchesPollingCallback:
     return _WorkspaceRemoteBranchesPollingCallback(
         workspace_id=WorkspaceID(),
         workspace_working_dir=worktree,

--- a/sculptor/sculptor/web/repo_polling_manager_test.py
+++ b/sculptor/sculptor/web/repo_polling_manager_test.py
@@ -1,0 +1,160 @@
+"""Unit tests for :mod:`sculptor.web.repo_polling_manager`.
+
+These cover the background branch/remote-branch pollers' behaviour when a
+workspace's git repo is torn down out from under them. A workspace repo can
+vanish two ways:
+
+* the working directory is removed entirely (``FileNotFoundError``), or
+* the directory survives but is no longer a git repo — e.g. a worktree whose
+  gitdir was pruned — which makes git print ``fatal: not a git repository``.
+
+In the orphaned-backend scenario from SCU-1429 neither poller ever gives up:
+they keep invoking git every few seconds (and the remote-branches poller keeps
+logging errors) until process shutdown, dragging the host. The pollers must
+instead raise :class:`StopPolling` so their source stops.
+
+The pollers are background-thread jobs with no UI trigger, so per the repo's
+test strategy these are exercised with unit tests rather than Playwright.
+"""
+
+import shutil
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+
+from imbue_core.concurrency_group import ConcurrencyGroup
+from sculptor.primitives.ids import WorkspaceID
+from sculptor.primitives.threads import StopPolling
+from sculptor.service_collections.service_collection import CompleteServiceCollection
+from sculptor.services.git_repo_service.default_implementation import LocalWritableGitRepo
+from sculptor.testing.local_git_repo import LocalGitRepo
+from sculptor.web.derived import WorkspaceBranchInfo
+from sculptor.web.derived import WorkspaceRemoteBranchesInfo
+from sculptor.web.repo_polling_manager import _WorkspaceBranchPollingCallback
+from sculptor.web.repo_polling_manager import _WorkspaceRemoteBranchesPollingCallback
+
+
+def _make_base_repo(base: Path, cg: ConcurrencyGroup) -> None:
+    base.mkdir(parents=True, exist_ok=True)
+    repo = LocalWritableGitRepo.from_new_repository(
+        repo_path=base, concurrency_group=cg, user_email="t@example.com", user_name="Tester"
+    )
+    (base / "f.txt").write_text("hi")
+    repo.stage_all_files()
+    repo.create_commit("init")
+
+
+def _add_worktree(base: Path, worktree: Path) -> None:
+    LocalGitRepo(base).run_git(["worktree", "add", str(worktree), "-b", "wsbranch"])
+
+
+@pytest.fixture
+def healthy_worktree(
+    tmp_path: Path, test_root_concurrency_group: ConcurrencyGroup
+) -> Generator[tuple[Path, Path], None, None]:
+    """A base repo plus a checked-out worktree that stands in for a workspace."""
+    base = tmp_path / "base"
+    worktree = tmp_path / "workspace"
+    _make_base_repo(base, test_root_concurrency_group)
+    _add_worktree(base, worktree)
+    yield base, worktree
+
+
+def _branch_callback(
+    worktree: Path, cg: ConcurrencyGroup
+) -> _WorkspaceBranchPollingCallback:
+    return _WorkspaceBranchPollingCallback(
+        workspace_id=WorkspaceID(),
+        workspace_working_dir=worktree,
+        concurrency_group=cg,
+        services=MagicMock(spec=CompleteServiceCollection),
+    )
+
+
+def _remote_branches_callback(
+    worktree: Path, cg: ConcurrencyGroup
+) -> _WorkspaceRemoteBranchesPollingCallback:
+    return _WorkspaceRemoteBranchesPollingCallback(
+        workspace_id=WorkspaceID(),
+        workspace_working_dir=worktree,
+        concurrency_group=cg,
+    )
+
+
+def test_branch_callback_returns_info_for_healthy_repo(
+    healthy_worktree: tuple[Path, Path], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    _base, worktree = healthy_worktree
+    result = _branch_callback(worktree, test_root_concurrency_group)()
+    assert isinstance(result, WorkspaceBranchInfo)
+    assert result.current_branch == "wsbranch"
+
+
+def test_remote_branches_callback_returns_info_for_healthy_repo(
+    healthy_worktree: tuple[Path, Path], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    _base, worktree = healthy_worktree
+    result = _remote_branches_callback(worktree, test_root_concurrency_group)()
+    assert isinstance(result, WorkspaceRemoteBranchesInfo)
+    # A fresh local worktree has no remotes.
+    assert result.remote_branches == ()
+
+
+def test_branch_callback_raises_stop_polling_when_working_dir_deleted(
+    healthy_worktree: tuple[Path, Path], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    _base, worktree = healthy_worktree
+    callback = _branch_callback(worktree, test_root_concurrency_group)
+    shutil.rmtree(worktree)
+    with pytest.raises(StopPolling):
+        callback()
+
+
+def test_branch_callback_raises_stop_polling_when_git_dir_dangling(
+    healthy_worktree: tuple[Path, Path], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    base, worktree = healthy_worktree
+    callback = _branch_callback(worktree, test_root_concurrency_group)
+    # The worktree dir survives, but its gitdir is gone, so git reports
+    # "fatal: not a git repository" — the exact SCU-1429 symptom.
+    shutil.rmtree(base / ".git")
+    assert worktree.exists()
+    with pytest.raises(StopPolling):
+        callback()
+
+
+def test_remote_branches_callback_raises_stop_polling_when_working_dir_deleted(
+    healthy_worktree: tuple[Path, Path], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    _base, worktree = healthy_worktree
+    callback = _remote_branches_callback(worktree, test_root_concurrency_group)
+    shutil.rmtree(worktree)
+    with pytest.raises(StopPolling):
+        callback()
+
+
+def test_remote_branches_callback_raises_stop_polling_when_git_dir_dangling(
+    healthy_worktree: tuple[Path, Path], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    base, worktree = healthy_worktree
+    callback = _remote_branches_callback(worktree, test_root_concurrency_group)
+    shutil.rmtree(base / ".git")
+    assert worktree.exists()
+    with pytest.raises(StopPolling):
+        callback()
+
+
+def test_branch_callback_does_not_stop_for_repo_without_commits(
+    tmp_path: Path, test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    """Guard: a valid repo that simply has no commits yet (unborn HEAD) is a
+    transient state, not a missing repo. The poller must keep going (return
+    ``None``), not raise ``StopPolling`` — otherwise a freshly-created workspace
+    would stop being polled before its first commit lands."""
+    empty_repo = tmp_path / "empty"
+    empty_repo.mkdir()
+    LocalGitRepo(empty_repo).run_git(["init"])
+    result = _branch_callback(empty_repo, test_root_concurrency_group)()
+    assert result is None


### PR DESCRIPTION
### Linked issue

Internal tracking: SCU-1429 (no public GitHub issue).

### What changed and why

A torn-down workspace used to leave its background branch and remote-branch
pollers running forever. Every few seconds each poller re-ran git against a
working dir whose repo was gone, failed, and — for the remote-branches poller —
logged the error on every cycle until process shutdown, keeping the backend
needlessly busy.

This adds a `StopPolling` signal. When a poller detects its repo is gone for
good it raises `StopPolling`, and the polling source stops its thread instead of
retrying pointless work. "Gone for good" is two shapes:

- the working dir was removed entirely → the git service raises
  `GitRepoNotFoundError`;
- the dir survives but is no longer a git repo (e.g. a worktree whose gitdir was
  pruned) → git prints `fatal: not a git repository`.

A repo that is merely missing a current branch (e.g. a fresh repo with no commits
yet) is deliberately left alone, so a brand-new workspace keeps being polled.

### How you verified it

New unit tests in `primitives/threads_test.py` and `web/repo_polling_manager_test.py`
cover both teardown shapes (deleted working dir, dangling gitdir) for both
pollers, plus the "no commits yet — keep polling" guard. They drive the real git
service rather than mocking exception types. `just check` (pyrefly) reports 0
errors and the new tests pass (9/9). Full frontend/sculpt unit suites were not
run as this change is backend-only.

### Checklist

- [ ] I understand what this change does and can explain it
- [ ] I opened an issue first and a maintainer approved it with `lgtm`
- [ ] `just format`, `just check`, and `just test-unit` pass
- [ ] This PR does one thing — no unrelated changes

(Sent by Claude)
