### PR TITLE
Fix SCU-1450: stop Cmd+Enter in repo autocomplete from creating the workspace

### DIFF
--- a/sculptor/frontend/src/components/path-autocomplete/PathAutocomplete.tsx
+++ b/sculptor/frontend/src/components/path-autocomplete/PathAutocomplete.tsx
@@ -171,8 +171,12 @@ export const PathAutocomplete = ({
         // Strip trailing slashes so consumers get a clean path (e.g. ~/code/repo, not ~/code/repo/)
         const submittedPath = inputValue.trim().replace(/\/+$/, "");
         if (isModifierPressed(e) && submittedPath) {
-          // Cmd+Enter (Mac) / Ctrl+Enter (non-Mac) submits regardless of dropdown state
+          // Cmd+Enter (Mac) / Ctrl+Enter (non-Mac) submits regardless of dropdown state.
+          // stopPropagation keeps the keystroke from bubbling to page-level Cmd+Enter
+          // handlers (e.g. NewWorkspaceForm's "submit from anywhere" listener), which
+          // would otherwise also fire and create the workspace (SCU-1450).
           e.preventDefault();
+          e.stopPropagation();
           closeDropdown();
           onSubmit(submittedPath);
         } else if (!isOpen && submittedPath) {

--- a/sculptor/sculptor/testing/pages/add_workspace_page.py
+++ b/sculptor/sculptor/testing/pages/add_workspace_page.py
@@ -2,6 +2,7 @@ from playwright.sync_api import Locator
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
+from sculptor.testing.elements.add_repo_dialog import PlaywrightAddRepoDialogElement
 from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 
 
@@ -22,6 +23,16 @@ class PlaywrightAddWorkspacePage(PlaywrightProjectLayoutPage):
 
     def get_open_new_repo_button(self) -> Locator:
         return self.get_by_test_id(ElementIDs.OPEN_NEW_REPO_BUTTON)
+
+    def open_add_repo_dialog(self) -> PlaywrightAddRepoDialogElement:
+        """Open the 'Add Repository' dialog from the repo selector."""
+        self.get_project_selector().click()
+        self.get_open_new_repo_button().click()
+        dialog = PlaywrightAddRepoDialogElement(
+            locator=self.get_by_test_id(ElementIDs.ADD_REPO_DIALOG), page=self._page
+        )
+        expect(dialog.get_path_input()).to_be_visible()
+        return dialog
 
     def get_task_input(self) -> Locator:
         return self.get_by_test_id(ElementIDs.TASK_INPUT)

--- a/sculptor/tests/integration/frontend/test_add_workspace_page.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_page.py
@@ -12,9 +12,11 @@ Tests verify:
 
 import re
 
+import pytest
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
+from sculptor.testing.elements.add_repo_dialog import PlaywrightAddRepoDialogElement
 from sculptor.testing.elements.chat_panel import select_model_by_name
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -415,6 +417,68 @@ def test_cmd_enter_in_workspace_name_creates_workspace(
 
     chat_panel = PlaywrightTaskPage(page=page).get_chat_panel()
     expect(chat_panel).to_be_visible()
+
+
+@user_story("to submit a repo path with Cmd+Enter without the New Workspace being created")
+def test_cmd_enter_in_repo_autocomplete_does_not_create_workspace(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Cmd+Enter in the repo path autocomplete must not also create the workspace.
+
+    Regression test for SCU-1450. On the New Workspace page the user opens the
+    "Open New Repo" dialog and presses Cmd+Enter to submit a path in the repo
+    autocomplete (the dropdown covers the Add button, so Cmd+Enter is the
+    shortcut to submit). That keystroke used to bubble up to NewWorkspaceForm's
+    document-level Cmd+Enter handler, which immediately created the workspace
+    and navigated away — skipping the chance to name the branch/workspace.
+
+    The autocomplete owns that keystroke; it must not leak to the outer form.
+    """
+    page = sculptor_instance_.page
+    mod_key = get_playwright_modifier_key()
+    add_ws_page = PlaywrightAddWorkspacePage(page=page)
+
+    # Wait until the form would actually submit on Cmd+Enter: a project is
+    # selected and the branch-name preview has loaded (so submit is enabled).
+    # This guarantees the bug reproduces if the keystroke leaks through.
+    submit_button = add_ws_page.get_submit_button()
+    expect(submit_button).to_be_enabled()
+
+    # Open the "Open New Repo" dialog from the repo selector.
+    add_ws_page.get_project_selector().click()
+    add_ws_page.get_open_new_repo_button().click()
+
+    add_repo_dialog = PlaywrightAddRepoDialogElement(
+        locator=page.get_by_test_id(ElementIDs.ADD_REPO_DIALOG), page=page
+    )
+    path_input = add_repo_dialog.get_path_input()
+    expect(path_input).to_be_visible()
+
+    # Type a path so the autocomplete dropdown opens — the real scenario where
+    # the dropdown hides the Add button and Cmd+Enter is needed to submit.
+    path_input.fill("~/")
+    expect(add_repo_dialog.get_path_autocomplete_items().first).to_be_visible()
+
+    # Submit the path with Cmd+Enter.
+    path_input.press(f"{mod_key}+Enter")
+
+    # Desired behaviour: the workspace is NOT created. Give the (buggy)
+    # workspace-creation path ample time to navigate to the chat panel; if it
+    # ever appears, the keystroke leaked to the outer form and created the
+    # workspace.
+    chat_panel = add_ws_page.get_chat_panel()
+    try:
+        expect(chat_panel).to_be_visible(timeout=10_000)
+    except AssertionError:
+        pass  # expected: no workspace created, so the chat panel never appears
+    else:
+        pytest.fail(
+            "Cmd+Enter in the repo autocomplete created the workspace and "
+            "navigated to the chat panel (SCU-1450 regression)"
+        )
+
+    # Confirm we are still on the New Workspace page (no navigation happened).
+    expect(chat_panel).not_to_be_visible()
 
 
 # ---------------------------------------------------------------------------

--- a/sculptor/tests/integration/frontend/test_add_workspace_page.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_page.py
@@ -16,7 +16,6 @@ import pytest
 from playwright.sync_api import expect
 
 from sculptor.constants import ElementIDs
-from sculptor.testing.elements.add_repo_dialog import PlaywrightAddRepoDialogElement
 from sculptor.testing.elements.chat_panel import select_model_by_name
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -445,27 +444,23 @@ def test_cmd_enter_in_repo_autocomplete_does_not_create_workspace(
     expect(submit_button).to_be_enabled()
 
     # Open the "Open New Repo" dialog from the repo selector.
-    add_ws_page.get_project_selector().click()
-    add_ws_page.get_open_new_repo_button().click()
-
-    add_repo_dialog = PlaywrightAddRepoDialogElement(
-        locator=page.get_by_test_id(ElementIDs.ADD_REPO_DIALOG), page=page
-    )
+    add_repo_dialog = add_ws_page.open_add_repo_dialog()
     path_input = add_repo_dialog.get_path_input()
-    expect(path_input).to_be_visible()
 
-    # Type a path so the autocomplete dropdown opens — the real scenario where
-    # the dropdown hides the Add button and Cmd+Enter is needed to submit.
+    # Type a path and confirm the input holds it. Cmd+Enter submits the path
+    # regardless of dropdown state, so this does not depend on the host home
+    # directory listing any subdirectories (which would flake on empty-home CI).
     path_input.fill("~/")
-    expect(add_repo_dialog.get_path_autocomplete_items().first).to_be_visible()
+    expect(path_input).to_have_value("~/")
 
     # Submit the path with Cmd+Enter.
     path_input.press(f"{mod_key}+Enter")
 
-    # Desired behaviour: the workspace is NOT created. Give the (buggy)
-    # workspace-creation path ample time to navigate to the chat panel; if it
-    # ever appears, the keystroke leaked to the outer form and created the
-    # workspace.
+    # Desired behaviour: the workspace is NOT created. Wait long enough for the
+    # (buggy) workspace-creation path to navigate to the chat panel — when the
+    # bug is present it does so within a few seconds — then conclude it did not.
+    # The 10s is a deliberate bounded wait for a negative assertion (the panel
+    # is expected to never appear), not a tightened positive timeout.
     chat_panel = add_ws_page.get_chat_panel()
     try:
         expect(chat_panel).to_be_visible(timeout=10_000)
@@ -474,7 +469,7 @@ def test_cmd_enter_in_repo_autocomplete_does_not_create_workspace(
     else:
         pytest.fail(
             "Cmd+Enter in the repo autocomplete created the workspace and "
-            "navigated to the chat panel (SCU-1450 regression)"
+            + "navigated to the chat panel (SCU-1450 regression)"
         )
 
     # Confirm we are still on the New Workspace page (no navigation happened).


### PR DESCRIPTION
## Summary

On the New Workspace page, opening the "Open New Repo" dialog and pressing **Cmd+Enter** to submit a path in the repo autocomplete would immediately create the workspace and navigate away — skipping the chance to name the branch/workspace.

The `PathAutocomplete` Cmd+Enter handler called `preventDefault` but not `stopPropagation`, so the keystroke bubbled up to `NewWorkspaceForm`'s document-level "submit from anywhere" Cmd+Enter listener, which also fired.

## Fix

When the autocomplete submits a path it now also stops propagation (mirroring this file's existing Escape handler), so the keystroke no longer reaches page-level handlers. The autocomplete fully owns the Cmd+Enter keystroke in that state.

## Testing

- Added an end-to-end regression test that opens the repo dialog, presses Cmd+Enter in the autocomplete, and asserts the workspace is **not** created. It fails on `main` before the fix and passes after.
- The test asserts on the submitted input value (rather than waiting on host-dependent dropdown contents) so it stays deterministic on CI, and routes through a new `PlaywrightAddWorkspacePage.open_add_repo_dialog()` POM method.

Ref: SCU-1450

(Sent by Claude)
