### PR TITLE
Link the pi-binary-not-found error to the Pi settings page

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.test.tsx
@@ -57,7 +57,9 @@ const renderErrorBlock = (props: {
 
 afterEach(() => {
   cleanup();
-  vi.restoreAllMocks();
+  // openSettingsSpy is hoisted and shared across tests; clear its call history
+  // so per-test call-count assertions stay isolated as more tests are added.
+  vi.clearAllMocks();
 });
 
 describe("AlphaErrorBlock", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.test.tsx
@@ -58,7 +58,7 @@ const renderErrorBlock = (props: {
 afterEach(() => {
   cleanup();
   // openSettingsSpy is hoisted and shared across tests; clear its call history
-  // so per-test call-count assertions stay isolated as more tests are added.
+  // so per-test call-count assertions stay isolated.
   vi.clearAllMocks();
 });
 
@@ -90,8 +90,6 @@ describe("AlphaErrorBlock", () => {
   });
 
   describe("ClaudeBinaryNotFoundError", () => {
-    // Regression: the Pi handling generalizes the original Claude-only block, so
-    // Claude must keep linking to its own (DEPENDENCIES) settings section.
     const claudeBlock = makeErrorBlock({
       message: "Claude binary not found or is invalid.",
       errorType: "sculptor.interfaces.agents.errors.ClaudeBinaryNotFoundError",

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.test.tsx
@@ -1,0 +1,113 @@
+import { Theme } from "@radix-ui/themes";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DependenciesStatus, ErrorBlock } from "~/api";
+import { TaskStatus } from "~/api";
+import { dependenciesStatusAtom } from "~/common/state/atoms/dependenciesStatus.ts";
+
+import { AlphaErrorBlock } from "./AlphaErrorBlock.tsx";
+
+// Spy on useOpenSettings so the tests can assert which settings section the
+// error block navigates to, without exercising the real router/navigation.
+const { openSettingsSpy } = vi.hoisted(() => ({
+  openSettingsSpy: vi.fn(),
+}));
+vi.mock("~/common/state/hooks/useOpenSettings.ts", () => ({
+  useOpenSettings: (): ((section?: string) => void) => openSettingsSpy,
+}));
+
+const makeErrorBlock = (overrides: Partial<ErrorBlock> = {}): ErrorBlock => ({
+  type: "error",
+  objectType: "ErrorBlock",
+  message: "Something went wrong.",
+  traceback: "Traceback (most recent call last): ...",
+  errorType: "builtins.Exception",
+  ...overrides,
+});
+
+const renderErrorBlock = (props: {
+  block: ErrorBlock;
+  isLastMessage?: boolean;
+  taskStatus?: TaskStatus;
+  onRetryRequest?: () => void;
+  dependenciesStatus?: DependenciesStatus | null;
+}): ReturnType<typeof render> => {
+  const store = createStore();
+  store.set(dependenciesStatusAtom, props.dependenciesStatus ?? null);
+
+  const Wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+    <Provider store={store}>
+      <Theme>{children}</Theme>
+    </Provider>
+  );
+
+  return render(
+    <AlphaErrorBlock
+      block={props.block}
+      isLastMessage={props.isLastMessage ?? true}
+      taskStatus={props.taskStatus ?? TaskStatus.RUNNING}
+      onRetryRequest={props.onRetryRequest}
+    />,
+    { wrapper: Wrapper },
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AlphaErrorBlock", () => {
+  describe("PiBinaryNotFoundError", () => {
+    const piBlock = makeErrorBlock({
+      message: "Pi binary not found or is invalid.",
+      errorType: "sculptor.interfaces.agents.errors.PiBinaryNotFoundError",
+    });
+
+    it("shows a friendly 'Pi Not Available' label with the error message", () => {
+      renderErrorBlock({ block: piBlock });
+      expect(screen.getByText("Pi Not Available")).toBeInTheDocument();
+      expect(screen.getByText(/Pi binary not found or is invalid\./)).toBeInTheDocument();
+    });
+
+    it("links to the Pi settings section where managed pi can be installed", () => {
+      renderErrorBlock({ block: piBlock });
+      fireEvent.click(screen.getByText("Go to Settings"));
+      expect(openSettingsSpy).toHaveBeenCalledTimes(1);
+      expect(openSettingsSpy).toHaveBeenCalledWith("PI");
+    });
+
+    it("offers a settings link instead of a retry button", () => {
+      renderErrorBlock({ block: piBlock, onRetryRequest: vi.fn() });
+      expect(screen.getByText("Go to Settings")).toBeInTheDocument();
+      expect(screen.queryByText(/Retry Request/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("ClaudeBinaryNotFoundError", () => {
+    // Regression: the Pi handling generalizes the original Claude-only block, so
+    // Claude must keep linking to its own (DEPENDENCIES) settings section.
+    const claudeBlock = makeErrorBlock({
+      message: "Claude binary not found or is invalid.",
+      errorType: "sculptor.interfaces.agents.errors.ClaudeBinaryNotFoundError",
+    });
+
+    it("shows 'Claude Not Available' and links to the Dependencies settings section", () => {
+      renderErrorBlock({ block: claudeBlock });
+      expect(screen.getByText("Claude Not Available")).toBeInTheDocument();
+      fireEvent.click(screen.getByText("Go to Settings"));
+      expect(openSettingsSpy).toHaveBeenCalledWith("DEPENDENCIES");
+    });
+  });
+
+  describe("generic errors", () => {
+    it("offers a retry button and no settings link", () => {
+      renderErrorBlock({ block: makeErrorBlock(), onRetryRequest: vi.fn() });
+      expect(screen.getByText(/Retry Request/)).toBeInTheDocument();
+      expect(screen.queryByText("Go to Settings")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaErrorBlock.tsx
@@ -5,12 +5,39 @@ import { ChevronRightIcon, RefreshCw } from "lucide-react";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
-import type { ErrorBlock } from "~/api";
+import type { DependenciesStatus, ErrorBlock } from "~/api";
 import { ElementIds, TaskStatus } from "~/api";
 import { dependenciesStatusAtom } from "~/common/state/atoms/dependenciesStatus";
 import { useOpenSettings } from "~/common/state/hooks/useOpenSettings.ts";
 
 import styles from "./AlphaChatView.module.scss";
+
+// Agent binaries that, when missing or invalid, surface a friendly "not
+// available" block with a link to the settings section where a managed copy can
+// be installed, instead of a raw traceback. `getInstalled` reads the live
+// dependency status so a green "installed" badge can appear if the binary
+// reappears after the error.
+type BinaryNotFoundTool = {
+  errorSuffix: string;
+  name: string;
+  settingsSection: string;
+  getInstalled: (status: DependenciesStatus) => boolean;
+};
+
+const BINARY_NOT_FOUND_TOOLS: ReadonlyArray<BinaryNotFoundTool> = [
+  {
+    errorSuffix: "ClaudeBinaryNotFoundError",
+    name: "Claude",
+    settingsSection: "DEPENDENCIES",
+    getInstalled: (status: DependenciesStatus): boolean => status.claude.installed,
+  },
+  {
+    errorSuffix: "PiBinaryNotFoundError",
+    name: "Pi",
+    settingsSection: "PI",
+    getInstalled: (status: DependenciesStatus): boolean => status.pi.installed,
+  },
+];
 
 export const AlphaErrorBlock = ({
   block,
@@ -24,35 +51,35 @@ export const AlphaErrorBlock = ({
   onRetryRequest?: () => void;
 }): ReactElement => {
   const dependenciesStatus = useAtomValue(dependenciesStatusAtom);
-  const isClaudeInstalled = dependenciesStatus?.claude?.installed ?? false;
   const [isExpanded, setIsExpanded] = useState(false);
   const [hasRetried, setHasRetried] = useState(false);
   const openSettings = useOpenSettings();
-  const isClaudeBinaryNotFound = block.errorType?.endsWith("ClaudeBinaryNotFoundError") ?? false;
+  const binaryNotFoundTool = BINARY_NOT_FOUND_TOOLS.find((tool) => block.errorType?.endsWith(tool.errorSuffix));
   const errorLabel = block.errorType ? block.errorType.split(".").pop() : "Request Failed";
-  const showRetry = !isClaudeBinaryNotFound && isLastMessage && taskStatus !== TaskStatus.ERROR && onRetryRequest;
+  const showRetry = !binaryNotFoundTool && isLastMessage && taskStatus !== TaskStatus.ERROR && onRetryRequest;
 
-  if (isClaudeBinaryNotFound) {
+  if (binaryNotFoundTool) {
+    const isInstalled = dependenciesStatus ? binaryNotFoundTool.getInstalled(dependenciesStatus) : false;
     return (
       <>
         <div className={styles.errorBlock} data-testid={ElementIds.ERROR_BLOCK}>
           <div className={styles.errorHeader}>
-            <Badge color={isClaudeInstalled ? "orange" : "red"} size="1" variant="soft">
-              Claude Not Available
+            <Badge color={isInstalled ? "orange" : "red"} size="1" variant="soft">
+              {binaryNotFoundTool.name} Not Available
             </Badge>
             <span className={styles.errorMessage}>
-              {block.message || "Claude binary not found or is invalid."}{" "}
-              <Link onClick={() => openSettings("DEPENDENCIES")} style={{ cursor: "pointer" }}>
+              {block.message || `${binaryNotFoundTool.name} binary not found or is invalid.`}{" "}
+              <Link onClick={() => openSettings(binaryNotFoundTool.settingsSection)} style={{ cursor: "pointer" }}>
                 Go to Settings
               </Link>
             </span>
           </div>
         </div>
-        {isClaudeInstalled && (
+        {isInstalled && (
           <Flex align="center" gap="1" style={{ paddingTop: "var(--space-1)" }}>
             <CheckCircledIcon color="var(--green-9)" />
             <Badge color="green" size="1" variant="soft">
-              Claude installed
+              {binaryNotFoundTool.name} installed
             </Badge>
           </Flex>
         )}


### PR DESCRIPTION
## Summary

When the pi binary can't be found or is invalid, the chat error block previously rendered the generic `PiBinaryNotFoundError` block — a red badge with a **Retry Request** button and no guidance — leaving the user with no obvious way to fix it. The equivalent Claude error already had a friendly "Go to Settings" treatment; pi did not.

This change gives the pi error the same treatment by generalizing the previously Claude-only binary-not-found block in `AlphaErrorBlock` into a small data-driven table covering both agents.

## What changed

- A missing/invalid **pi** binary now renders a **"Pi Not Available"** badge, the error message, and a **"Go to Settings"** link that opens the **Pi** settings section (where the managed pi binary is installed).
- The **Retry Request** button is hidden for binary-not-found errors, since retrying can't succeed while the binary is absent.
- **Claude** behavior is preserved unchanged — it still shows "Claude Not Available" and links to the Dependencies settings section.
- Added `AlphaErrorBlock.test.tsx` covering the pi case, a Claude regression case, and the generic-error case.

## Verification

- New unit tests pass, and `just check` (lint, typecheck, ratchets, file hygiene) plus the frontend unit suite are green.
- Manually verified in the running app: created a pi-agent workspace with pi not installed, sent a message, and confirmed the error block shows "Pi Not Available" + "Go to Settings" (no retry button), and that the link lands on the Pi (experimental) settings section.

(Sent by Claude)
