### PR TITLE
Fix Cmd+Enter in Add Repository dialog also creating a workspace

### DIFF
--- a/sculptor/frontend/src/components/RepoSelector.tsx
+++ b/sculptor/frontend/src/components/RepoSelector.tsx
@@ -97,7 +97,7 @@ export const RepoSelector = ({
           <Select.Item value={_NEW_REPO_SELECT_VALUE} data-testid={ElementIds.OPEN_NEW_REPO_BUTTON}>
             <Flex direction="row" align="center" gapX="2">
               <PlusIcon size={16} />
-              <Text>Open New Repo</Text>
+              <Text>Add new repository</Text>
             </Flex>
           </Select.Item>
         </Select.Content>

--- a/sculptor/frontend/src/components/add-repo/AddRepoDialog.tsx
+++ b/sculptor/frontend/src/components/add-repo/AddRepoDialog.tsx
@@ -49,7 +49,7 @@ export const AddRepoDialog = ({ open, onOpenChange, setToast }: AddRepoDialogPro
         <Dialog.Content maxWidth="480px" data-testid={ElementIds.ADD_REPO_DIALOG} style={{ overflow: "visible" }}>
           <Dialog.Title>
             <Text size="5" weight="bold">
-              Add Repository
+              Add new repository
             </Text>
           </Dialog.Title>
 
@@ -75,7 +75,7 @@ export const AddRepoDialog = ({ open, onOpenChange, setToast }: AddRepoDialogPro
               disabled={isValidating || !path.trim()}
               onClick={handleAddClick}
             >
-              {isValidating ? <Spinner size="2" /> : "Add Repository"}
+              {isValidating ? <Spinner size="2" /> : "Add new repository"}
             </Button>
           </Flex>
         </Dialog.Content>

--- a/sculptor/frontend/src/pages/add-workspace/components/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/pages/add-workspace/components/NewWorkspaceForm.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect } from "react";
 import type { RepoInfo } from "~/api";
 import { ElementIds } from "~/api";
 import { useKeybinding, useKeybindingDisplayText } from "~/common/keybindings/hooks.ts";
+import { isDismissibleOverlayOpen } from "~/common/overlayUtils.ts";
 import { useModifiedEnter } from "~/common/ShortcutUtils.ts";
 import { KeyboardHint } from "~/components/KeyboardHint.tsx";
 
@@ -71,10 +72,12 @@ export const NewWorkspaceForm = ({
   // Allow Cmd+Enter to submit from anywhere on the page, not just the input
   useEffect(() => {
     const handleGlobalKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === "Enter" && isModifierPressed(e)) {
-        e.preventDefault();
-        onSubmit();
-      }
+      if (e.key !== "Enter" || !isModifierPressed(e)) return;
+      // An overlay open over the page (e.g. the Add Repository dialog) owns
+      // Cmd+Enter for its own action; don't also create the workspace.
+      if (isDismissibleOverlayOpen()) return;
+      e.preventDefault();
+      onSubmit();
     };
 
     document.addEventListener("keydown", handleGlobalKeyDown);

--- a/sculptor/frontend/src/pages/settings/components/ReposSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/ReposSection.tsx
@@ -203,7 +203,7 @@ export const ReposSection = ({ setToast }: { setToast: (toast: ToastContent | nu
             data-testid={ElementIds.SETTINGS_ADD_REPO_BUTTON}
           >
             <PlusIcon size={14} />
-            Add repository
+            Add new repository
           </Button>
         </Box>
       </SettingsSectionLayout>

--- a/sculptor/tests/integration/regression/test_regression_add_repo_cmd_enter_stays_on_page.py
+++ b/sculptor/tests/integration/regression/test_regression_add_repo_cmd_enter_stays_on_page.py
@@ -1,0 +1,84 @@
+"""Regression test: Cmd+Enter in the Add Repo dialog should not create a workspace.
+
+Bug: On the Add Workspace page ("Name your workspace"), opening the repo selector
+and choosing the add-repository option opens a dialog with a path autocomplete.
+Pressing Cmd+Enter there is meant to *add the selected repository* and return to
+the Add Workspace page. Instead, the page's global "Cmd+Enter creates the
+workspace" listener also fired, so a single Cmd+Enter both added the repo and
+created a workspace, navigating the user straight through to the agent chat.
+
+The expected behavior is that Cmd+Enter inside the dialog only adds the repo and
+leaves the user on the Add Workspace page.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.pages.add_workspace_page import PlaywrightAddWorkspacePage
+from sculptor.testing.playwright_utils import navigate_to_add_workspace_page
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.test_repo_factory import TestRepoFactory
+from sculptor.testing.user_stories import user_story
+from sculptor.testing.utils import get_playwright_modifier_key
+
+
+@user_story("to add a repository with Cmd+Enter without being thrown into a new workspace")
+def test_add_repo_cmd_enter_stays_on_add_workspace_page(
+    sculptor_instance_: SculptorInstance,
+    test_repo_factory_: TestRepoFactory,
+) -> None:
+    """Cmd+Enter in the Add Repo dialog must only add the repo, not create a workspace.
+
+    Steps:
+    1. Create a second git repo to add.
+    2. Navigate to the Add Workspace page (a repo is already selected).
+    3. Open the repo selector and choose the add-repository option.
+    4. Type the new repo's path and press Cmd+Enter.
+    5. Verify the repo is added (dialog closes, new repo selected) and we remain
+       on the Add Workspace page — no workspace was created and no chat opened.
+    """
+    page = sculptor_instance_.page
+
+    # Step 1: Create a second git repo to add via the dialog.
+    target_repo_name = "cmd-enter-target-repo"
+    target_repo = test_repo_factory_.create_repo(name=target_repo_name, branch="main")
+    target_repo_path = str(target_repo.base_path.resolve())
+
+    # Step 2: Navigate to the Add Workspace page. This mounts NewWorkspaceForm
+    # (and its global Cmd+Enter listener), with the initial project selected.
+    navigate_to_add_workspace_page(page)
+    add_ws_page = PlaywrightAddWorkspacePage(page=page)
+    # Wait until the form is fully ready: the Create workspace button only
+    # becomes enabled once the repo info and the branch-name preview have
+    # loaded. This is the state in which the page's Cmd+Enter handler would
+    # actually create a workspace (it bails early on an empty branch name), so
+    # it's required to faithfully reproduce the bug.
+    expect(add_ws_page.get_submit_button()).to_be_enabled(timeout=30_000)
+
+    # Step 3: Open the repo selector and choose the add-repository option.
+    add_ws_page.get_project_selector().click()
+    add_ws_page.get_open_new_repo_button().click()
+    add_repo_dialog = add_ws_page.get_add_repo_dialog()
+    expect(add_repo_dialog).to_be_visible()
+
+    # Step 4: Type the new repo's path and press Cmd+Enter to add it.
+    path_input = add_repo_dialog.get_path_input()
+    path_input.fill(target_repo_path)
+    path_input.press(f"{get_playwright_modifier_key()}+Enter")
+
+    # The repo is validated and added, so the dialog closes.
+    expect(add_repo_dialog).to_be_hidden(timeout=30_000)
+
+    # Regression: Cmd+Enter inside the dialog must ONLY add the repo. Before the
+    # fix, the Add Workspace page's global "Cmd+Enter creates the workspace"
+    # listener also fired, creating a workspace and navigating to its chat panel.
+    # We must instead stay on the Add Workspace page.
+    #
+    # The Create workspace button is the robust signal: if the bug fired, the
+    # form would flip to its pending state (button disabled) and then unmount as
+    # the page navigated to the new workspace's chat, so the button would never
+    # be enabled here again.
+    expect(add_ws_page.get_submit_button()).to_be_enabled(timeout=30_000)
+    # The newly added repo is selected on the (still-present) Add Workspace page.
+    expect(add_ws_page.get_project_selector()).to_contain_text(target_repo_name)
+    # And no workspace chat was ever opened.
+    expect(add_ws_page.get_chat_panel()).not_to_be_visible()

--- a/sculptor/tests/integration/regression/test_regression_add_repo_cmd_enter_stays_on_page.py
+++ b/sculptor/tests/integration/regression/test_regression_add_repo_cmd_enter_stays_on_page.py
@@ -38,47 +38,30 @@ def test_add_repo_cmd_enter_stays_on_add_workspace_page(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create a second git repo to add via the dialog.
     target_repo_name = "cmd-enter-target-repo"
     target_repo = test_repo_factory_.create_repo(name=target_repo_name, branch="main")
     target_repo_path = str(target_repo.base_path.resolve())
 
-    # Step 2: Navigate to the Add Workspace page. This mounts NewWorkspaceForm
-    # (and its global Cmd+Enter listener), with the initial project selected.
     navigate_to_add_workspace_page(page)
     add_ws_page = PlaywrightAddWorkspacePage(page=page)
-    # Wait until the form is fully ready: the Create workspace button only
-    # becomes enabled once the repo info and the branch-name preview have
-    # loaded. This is the state in which the page's Cmd+Enter handler would
-    # actually create a workspace (it bails early on an empty branch name), so
-    # it's required to faithfully reproduce the bug.
+    # The page's Cmd+Enter handler bails on an empty branch name, so wait for the
+    # submit button to enable (branch-name preview loaded) before triggering it.
     expect(add_ws_page.get_submit_button()).to_be_enabled(timeout=30_000)
 
-    # Step 3: Open the repo selector and choose the add-repository option.
+    # Open the add-repository dialog from the repo selector.
     add_ws_page.get_project_selector().click()
     add_ws_page.get_open_new_repo_button().click()
     add_repo_dialog = add_ws_page.get_add_repo_dialog()
     expect(add_repo_dialog).to_be_visible()
 
-    # Step 4: Type the new repo's path and press Cmd+Enter to add it.
+    # Add the repo with Cmd+Enter; a successful add closes the dialog.
     path_input = add_repo_dialog.get_path_input()
     path_input.fill(target_repo_path)
     path_input.press(f"{get_playwright_modifier_key()}+Enter")
-
-    # The repo is validated and added, so the dialog closes.
     expect(add_repo_dialog).to_be_hidden(timeout=30_000)
 
-    # Regression: Cmd+Enter inside the dialog must ONLY add the repo. Before the
-    # fix, the Add Workspace page's global "Cmd+Enter creates the workspace"
-    # listener also fired, creating a workspace and navigating to its chat panel.
-    # We must instead stay on the Add Workspace page.
-    #
-    # The Create workspace button is the robust signal: if the bug fired, the
-    # form would flip to its pending state (button disabled) and then unmount as
-    # the page navigated to the new workspace's chat, so the button would never
-    # be enabled here again.
+    # Cmd+Enter must only add the repo: we stay on the Add Workspace page with
+    # the new repo selected and no workspace created.
     expect(add_ws_page.get_submit_button()).to_be_enabled(timeout=30_000)
-    # The newly added repo is selected on the (still-present) Add Workspace page.
     expect(add_ws_page.get_project_selector()).to_contain_text(target_repo_name)
-    # And no workspace chat was ever opened.
     expect(add_ws_page.get_chat_panel()).not_to_be_visible()


### PR DESCRIPTION
## Original bug

On the Add Repository dialog (opened from the Add Workspace page's repo
selector), pressing Cmd+Enter to *add* a repository also triggered the page's
global "Cmd+Enter creates the workspace" shortcut. A single Cmd+Enter both
added the repo and created a workspace, pushing the user straight past the
"Name your workspace" tab to the next page.

Separately, the same action was labeled inconsistently across the UI.

## Root cause

`NewWorkspaceForm` registers a global `document` keydown listener so Cmd+Enter
creates the workspace "from anywhere on the page". That listener fired even
while the Add Repository dialog — which has its own Cmd+Enter "add repo"
handler in `PathAutocomplete` — was open over the page. The dialog's
`PathAutocomplete` renders in a Radix portal mounted at `<body>` (outside the
React root), so `stopPropagation` from the dialog's handler cannot reliably
stop the document-level listener; the greedy global listener is the right
place to fix it.

## Fix

Guard the global listener with the existing `isDismissibleOverlayOpen()` helper
(already used to gate other page-level shortcuts in
`usePageLayoutKeyboardShortcuts`), so it ignores Cmd+Enter while a dismissible
overlay (dialog, menu, select, popover) owns the keyboard:

```ts
if (e.key !== "Enter" || !isModifierPressed(e)) return;
// An overlay open over the page (e.g. the Add Repository dialog) owns
// Cmd+Enter for its own action; don't also create the workspace.
if (isDismissibleOverlayOpen()) return;
e.preventDefault();
onSubmit();
```

When no overlay is open the behavior is unchanged.

## Label consistency

Unified four user-facing labels to **"Add new repository"**: the repo-selector
menu item (was "Open New Repo"), the dialog title and submit button (were
"Add Repository"), and the Settings > Repositories button (was
"Add repository").

## Proof of work

**Regression test** (`test_regression_add_repo_cmd_enter_stays_on_page.py`) —
fails on the buggy code, passes with the fix.

Before the fix:

```
>       expect(add_ws_page.get_submit_button()).to_be_enabled(timeout=30_000)
E       AssertionError: Locator expected to be enabled
E       Actual value: <element(s) not found>
E         - 2 × locator resolved to <button disabled ... data-testid="START_TASK_BUTTON">Create workspace</button>
E             - unexpected value "disabled"
============================== 1 failed in 41.02s ==============================
```

After the fix:

```
============================== 1 passed in 10.38s ==============================
```

The pre-commit gate (`just format`, `just check`, `just test-unit`) is green.

**Visual verification** (manual-test harness): all four labels now read
"Add new repository"; typing a repo path and pressing Cmd+Enter in the dialog
adds the repo and stays on the Add Workspace page (no workspace created, no
navigation). Before/after screenshots were captured in the workspace
attachments directory. The "purely visual" label change correctly has no
automated test, per the repo's testing policy.

## Test

- Path: `sculptor/tests/integration/regression/test_regression_add_repo_cmd_enter_stays_on_page.py`
- Kind: integration (Playwright)

(Sent by Claude)
