### PR TITLE
Re-arm the JSON-column durability guard (empty frozen baseline)

### DIFF
--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -1,1 +1,2757 @@
-{}
+{
+  "SavedAgentMessage": {
+    "message": {
+      "AgentCrashedRunnerMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Note that (like EnvironmentCrashedRunnerMessage and UnexpectedErrorRunnerMessage),\nthis can happen before *or after* the agent has finished processing a given message.",
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/$defs/SerializedException"
+          },
+          "exitCode": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exitcode"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "AgentCrashedRunnerMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "RUNNER"
+          }
+        },
+        "required": [
+          "exitCode",
+          "error"
+        ],
+        "title": "AgentCrashedRunnerMessage",
+        "type": "object"
+      },
+      "BackgroundTaskNotificationAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Emitted when a background task completes.\n\nThe assistant turn that follows this message is a response to the background task\ncompletion, not a continuation of the previous conversation. message_conversion uses\nthis to separate the background response into its own chat message.\n\nThis is persistent (not ephemeral) because the separation must survive page reloads.\nThe entire background notification cycle (system/task_notification \u2192 system/init \u2192\nassistant streaming \u2192 result/success) happens within a single RequestStarted/\nRequestSuccess pair, so without this persisted marker the background response would\nbe concatenated with the preceding assistant message on replay.",
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "backgroundTaskId": {
+            "title": "Backgroundtaskid",
+            "type": "string"
+          },
+          "durationSeconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Durationseconds"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "BackgroundTaskNotificationAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "default": "",
+            "title": "Summary",
+            "type": "string"
+          },
+          "toolUseId": {
+            "title": "Tooluseid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "backgroundTaskId",
+          "toolUseId",
+          "status"
+        ],
+        "title": "BackgroundTaskNotificationAgentMessage",
+        "type": "object"
+      },
+      "ChatInputUserMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "EffortLevel": {
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "title": "EffortLevel",
+            "type": "string"
+          },
+          "LLMModel": {
+            "enum": [
+              "CLAUDE-4-OPUS",
+              "CLAUDE-4-OPUS-200K",
+              "CLAUDE-4-7-OPUS",
+              "CLAUDE-4-7-OPUS-200K",
+              "CLAUDE-4-6-OPUS",
+              "CLAUDE-4-6-OPUS-200K",
+              "CLAUDE-4-SONNET",
+              "CLAUDE-4-SONNET-200K",
+              "CLAUDE-4-HAIKU",
+              "CLAUDE-FABLE-5",
+              "FAKE_CLAUDE",
+              "FAKE_CLAUDE_2"
+            ],
+            "title": "LLMModel",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "description": "Approximate UTC timestamp when user message was created",
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "effort": {
+            "$ref": "#/$defs/EffortLevel",
+            "default": "xhigh",
+            "description": "Thinking effort level"
+          },
+          "enterPlanMode": {
+            "default": false,
+            "description": "Whether the user requested to enter plan mode",
+            "title": "Enterplanmode",
+            "type": "boolean"
+          },
+          "exitPlanMode": {
+            "default": false,
+            "description": "Whether the user requested to exit plan mode",
+            "title": "Exitplanmode",
+            "type": "boolean"
+          },
+          "fastMode": {
+            "default": false,
+            "description": "Whether to enable fast output mode",
+            "title": "Fastmode",
+            "type": "boolean"
+          },
+          "files": {
+            "description": "List of file paths (images, PDFs, etc., stored in Electron app folder) attached to this message",
+            "items": {
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "messageId": {
+            "description": "Unique identifier for the user message",
+            "title": "Messageid",
+            "type": "string"
+          },
+          "modelName": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LLMModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Selected LLM model for the chat request"
+          },
+          "objectType": {
+            "default": "ChatInputUserMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "sentVia": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Interface that sent this message, e.g. 'sculpt'",
+            "title": "Sentvia"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "USER"
+          },
+          "text": {
+            "description": "User input text content",
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "ChatInputUserMessage",
+        "type": "object"
+      },
+      "ClearContextUserMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "description": "Approximate UTC timestamp when user message was created",
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "description": "Unique identifier for the user message",
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "ClearContextUserMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "USER"
+          }
+        },
+        "title": "ClearContextUserMessage",
+        "type": "object"
+      },
+      "ContextClearedMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "ContextClearedMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "title": "ContextClearedMessage",
+        "type": "object"
+      },
+      "ContextSummaryMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "ContextSummaryMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "title": "ContextSummaryMessage",
+        "type": "object"
+      },
+      "EnvironmentCrashedRunnerMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/$defs/SerializedException"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "EnvironmentCrashedRunnerMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "RUNNER"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "EnvironmentCrashedRunnerMessage",
+        "type": "object"
+      },
+      "KilledAgentRunnerMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "KilledAgentRunnerMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "RUNNER"
+          }
+        },
+        "title": "KilledAgentRunnerMessage",
+        "type": "object"
+      },
+      "RemoveQueuedMessageAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "RemoveQueuedMessageAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "removedMessageId": {
+            "title": "Removedmessageid",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "removedMessageId"
+        ],
+        "title": "RemoveQueuedMessageAgentMessage",
+        "type": "object"
+      },
+      "RequestFailureAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/$defs/SerializedException"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "RequestFailureAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "requestId": {
+            "title": "Requestid",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "requestId",
+          "error"
+        ],
+        "title": "RequestFailureAgentMessage",
+        "type": "object"
+      },
+      "RequestSkippedAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "default": null,
+            "title": "Error",
+            "type": "null"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "RequestSkippedAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "requestId": {
+            "title": "Requestid",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "requestId"
+        ],
+        "title": "RequestSkippedAgentMessage",
+        "type": "object"
+      },
+      "RequestStartedAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "RequestStartedAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "requestId": {
+            "title": "Requestid",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "requestId"
+        ],
+        "title": "RequestStartedAgentMessage",
+        "type": "object"
+      },
+      "RequestStoppedAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/$defs/SerializedException"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "RequestStoppedAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "requestId": {
+            "title": "Requestid",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "requestId",
+          "error"
+        ],
+        "title": "RequestStoppedAgentMessage",
+        "type": "object"
+      },
+      "RequestSuccessAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "default": null,
+            "title": "Error",
+            "type": "null"
+          },
+          "interrupted": {
+            "default": false,
+            "title": "Interrupted",
+            "type": "boolean"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "RequestSuccessAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "requestId": {
+            "title": "Requestid",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "requestId"
+        ],
+        "title": "RequestSuccessAgentMessage",
+        "type": "object"
+      },
+      "ResponseBlockAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "ContextClearedBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "ContextClearedBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "text": {
+                "default": "Cleared successfully",
+                "title": "Text",
+                "type": "string"
+              },
+              "type": {
+                "const": "context_cleared",
+                "default": "context_cleared",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "title": "ContextClearedBlock",
+            "type": "object"
+          },
+          "ContextSummaryBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "ContextSummaryBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "text": {
+                "title": "Text",
+                "type": "string"
+              },
+              "type": {
+                "const": "context_summary",
+                "default": "context_summary",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "title": "ContextSummaryBlock",
+            "type": "object"
+          },
+          "DiffToolContent": {
+            "additionalProperties": true,
+            "description": "Content for diff-producing tools (Write, Edit, MultiEdit)",
+            "properties": {
+              "contentType": {
+                "const": "diff",
+                "default": "diff",
+                "title": "Contenttype",
+                "type": "string"
+              },
+              "diff": {
+                "description": "The git diff string",
+                "title": "Diff",
+                "type": "string"
+              },
+              "filePath": {
+                "description": "The file that was modified",
+                "title": "Filepath",
+                "type": "string"
+              }
+            },
+            "required": [
+              "diff",
+              "filePath"
+            ],
+            "title": "DiffToolContent",
+            "type": "object"
+          },
+          "ErrorBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "errorType": {
+                "description": "Type of error, i.e. name of the exception that was raised",
+                "title": "Errortype",
+                "type": "string"
+              },
+              "message": {
+                "description": "Error message",
+                "title": "Message",
+                "type": "string"
+              },
+              "objectType": {
+                "default": "ErrorBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "traceback": {
+                "description": "Error traceback",
+                "title": "Traceback",
+                "type": "string"
+              },
+              "type": {
+                "const": "error",
+                "default": "error",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "message",
+              "traceback",
+              "errorType"
+            ],
+            "title": "ErrorBlock",
+            "type": "object"
+          },
+          "FileBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "FileBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "source": {
+                "description": "A file path on the users local machine.",
+                "title": "Source",
+                "type": "string"
+              },
+              "type": {
+                "const": "file",
+                "default": "file",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source"
+            ],
+            "title": "FileBlock",
+            "type": "object"
+          },
+          "GenericToolContent": {
+            "additionalProperties": true,
+            "description": "Generic content for most tools - just a string",
+            "properties": {
+              "contentType": {
+                "const": "generic",
+                "default": "generic",
+                "title": "Contenttype",
+                "type": "string"
+              },
+              "text": {
+                "description": "The tool output as text",
+                "title": "Text",
+                "type": "string"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "title": "GenericToolContent",
+            "type": "object"
+          },
+          "ResumeResponseBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "ResumeResponseBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "type": {
+                "const": "resume_response",
+                "default": "resume_response",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "title": "ResumeResponseBlock",
+            "type": "object"
+          },
+          "TextBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "TextBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "text": {
+                "title": "Text",
+                "type": "string"
+              },
+              "type": {
+                "const": "text",
+                "default": "text",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "title": "TextBlock",
+            "type": "object"
+          },
+          "ToolResultBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "content": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/GenericToolContent"
+                  },
+                  {
+                    "$ref": "#/$defs/DiffToolContent"
+                  }
+                ],
+                "description": "Result content from the tool execution",
+                "title": "Content"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable description of what the tool call does",
+                "title": "Description"
+              },
+              "durationSeconds": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Wall-clock duration of the tool execution in seconds",
+                "title": "Durationseconds"
+              },
+              "interactiveRole": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "ask_user_question",
+                      "exit_plan_mode"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Set server-side from the harness when the originating tool is an interactive-backchannel surface; lets the frontend suppress the result (it renders inside the question panel) by role rather than by tool name. None for a regular tool.",
+                "title": "Interactiverole"
+              },
+              "invocationString": {
+                "description": "String representation of how the tool was invoked",
+                "title": "Invocationstring",
+                "type": "string"
+              },
+              "isError": {
+                "default": false,
+                "description": "Whether the tool execution resulted in an error",
+                "title": "Iserror",
+                "type": "boolean"
+              },
+              "objectType": {
+                "default": "ToolResultBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "toolName": {
+                "description": "Name of the tool that was used",
+                "title": "Toolname",
+                "type": "string"
+              },
+              "toolUseId": {
+                "description": "ID of the corresponding tool use",
+                "title": "Tooluseid",
+                "type": "string"
+              },
+              "type": {
+                "const": "tool_result",
+                "default": "tool_result",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "toolUseId",
+              "toolName",
+              "invocationString",
+              "content"
+            ],
+            "title": "ToolResultBlock",
+            "type": "object"
+          },
+          "ToolUseBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "description": "Unique identifier for this tool use",
+                "title": "Id",
+                "type": "string"
+              },
+              "input": {
+                "additionalProperties": true,
+                "description": "Input parameters for the tool",
+                "title": "Input",
+                "type": "object"
+              },
+              "interactiveRole": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "ask_user_question",
+                      "exit_plan_mode"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Set server-side from the harness when this tool is an interactive-backchannel surface (ask-user-question / exit-plan-mode); the frontend renders by this role rather than by tool name. None for a regular tool.",
+                "title": "Interactiverole"
+              },
+              "name": {
+                "description": "Name of the tool being used",
+                "title": "Name",
+                "type": "string"
+              },
+              "objectType": {
+                "default": "ToolUseBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "type": {
+                "const": "tool_use",
+                "default": "tool_use",
+                "title": "Type",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "title": "ToolUseBlock",
+            "type": "object"
+          },
+          "WarningBlock": {
+            "additionalProperties": true,
+            "properties": {
+              "message": {
+                "description": "Warning message",
+                "title": "Message",
+                "type": "string"
+              },
+              "objectType": {
+                "default": "WarningBlock",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "traceback": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Warning traceback",
+                "title": "Traceback"
+              },
+              "type": {
+                "const": "warning",
+                "default": "warning",
+                "title": "Type",
+                "type": "string"
+              },
+              "warningType": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Type of warning, i.e. name of the exception that was raised",
+                "title": "Warningtype"
+              }
+            },
+            "required": [
+              "message",
+              "traceback",
+              "warningType"
+            ],
+            "title": "WarningBlock",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "assistantMessageId": {
+            "title": "Assistantmessageid",
+            "type": "string"
+          },
+          "content": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/TextBlock"
+                },
+                {
+                  "$ref": "#/$defs/ToolUseBlock"
+                },
+                {
+                  "$ref": "#/$defs/ToolResultBlock"
+                },
+                {
+                  "$ref": "#/$defs/ErrorBlock"
+                },
+                {
+                  "$ref": "#/$defs/WarningBlock"
+                },
+                {
+                  "$ref": "#/$defs/ContextSummaryBlock"
+                },
+                {
+                  "$ref": "#/$defs/ContextClearedBlock"
+                },
+                {
+                  "$ref": "#/$defs/ResumeResponseBlock"
+                },
+                {
+                  "$ref": "#/$defs/FileBlock"
+                }
+              ]
+            },
+            "title": "Content",
+            "type": "array"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "ResponseBlockAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "parentToolUseId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Parenttooluseid"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "assistant",
+              "system"
+            ],
+            "title": "Role",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "role",
+          "assistantMessageId",
+          "content"
+        ],
+        "title": "ResponseBlockAgentMessage",
+        "type": "object"
+      },
+      "ResumeAgentResponseRunnerMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "EffortLevel": {
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "title": "EffortLevel",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "LLMModel": {
+            "enum": [
+              "CLAUDE-4-OPUS",
+              "CLAUDE-4-OPUS-200K",
+              "CLAUDE-4-7-OPUS",
+              "CLAUDE-4-7-OPUS-200K",
+              "CLAUDE-4-6-OPUS",
+              "CLAUDE-4-6-OPUS-200K",
+              "CLAUDE-4-SONNET",
+              "CLAUDE-4-SONNET-200K",
+              "CLAUDE-4-HAIKU",
+              "CLAUDE-FABLE-5",
+              "FAKE_CLAUDE",
+              "FAKE_CLAUDE_2"
+            ],
+            "title": "LLMModel",
+            "type": "string"
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "effort": {
+            "$ref": "#/$defs/EffortLevel",
+            "default": "xhigh",
+            "description": "Thinking effort level"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SerializedException"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "fastMode": {
+            "default": false,
+            "description": "Whether to enable fast output mode",
+            "title": "Fastmode",
+            "type": "boolean"
+          },
+          "forUserMessageId": {
+            "title": "Forusermessageid",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "modelName": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LLMModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Selected LLM model for the chat request"
+          },
+          "objectType": {
+            "default": "ResumeAgentResponseRunnerMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "RUNNER"
+          }
+        },
+        "required": [
+          "forUserMessageId"
+        ],
+        "title": "ResumeAgentResponseRunnerMessage",
+        "type": "object"
+      },
+      "SetModelUserMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Switch the running agent's model out-of-band (the pi `set_model` path).\n\nPersistent like `ClearContextUserMessage` so the harness picks it up through\nthe task runner and runs it between turns. Carries the `(provider, model_id)`\nof the chosen `ModelOption`; the pi adapter issues pi's `set_model` RPC and,\non success, updates the persisted current model. Claude never receives this \u2014\nits model rides each turn as `ChatInputUserMessage.model_name`.",
+        "properties": {
+          "approximateCreationTime": {
+            "description": "Approximate UTC timestamp when user message was created",
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "description": "Unique identifier for the user message",
+            "title": "Messageid",
+            "type": "string"
+          },
+          "modelId": {
+            "description": "The chosen model's id (pi's `modelId`)",
+            "title": "Modelid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "SetModelUserMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "provider": {
+            "description": "The chosen model's provider (e.g. 'anthropic')",
+            "title": "Provider",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "USER"
+          }
+        },
+        "required": [
+          "provider",
+          "modelId"
+        ],
+        "title": "SetModelUserMessage",
+        "type": "object"
+      },
+      "TurnMetricsAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "TurnMetrics": {
+            "additionalProperties": true,
+            "description": "Per-turn metrics attached to completed assistant messages.",
+            "properties": {
+              "autoCompactThreshold": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Threshold at which auto-compaction fires (denominator for the percent display)",
+                "title": "Autocompactthreshold"
+              },
+              "changedFiles": {
+                "description": "File paths changed during this turn (git-relative, all tools including Bash)",
+                "items": {
+                  "type": "string"
+                },
+                "title": "Changedfiles",
+                "type": "array"
+              },
+              "contextTotalTokens": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Total tokens in the context window at turn end (None if unavailable)",
+                "title": "Contexttotaltokens"
+              },
+              "durationSeconds": {
+                "description": "Wall-clock turn duration in seconds",
+                "title": "Durationseconds",
+                "type": "number"
+              },
+              "inputTokens": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Input tokens for this turn (None when interrupted before completion)",
+                "title": "Inputtokens"
+              },
+              "outputTokens": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Output tokens for this turn (None when interrupted before completion)",
+                "title": "Outputtokens"
+              },
+              "reasoningTokens": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Reasoning/thinking tokens (None if not applicable)",
+                "title": "Reasoningtokens"
+              }
+            },
+            "required": [
+              "durationSeconds"
+            ],
+            "title": "TurnMetrics",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "description": "Emitted by the output processor at the end of a turn with per-turn metrics.\n\nAlways arrives on the queue before the corresponding RequestSuccessAgentMessage\nor RequestStoppedAgentMessage, so message_conversion can attach it to the\nin-progress chat message before finalizing the request.\n\nPersistent so that metrics survive server restarts and are available during\nhistorical message replay.",
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "TurnMetricsAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          },
+          "turnMetrics": {
+            "$ref": "#/$defs/TurnMetrics"
+          }
+        },
+        "required": [
+          "turnMetrics"
+        ],
+        "title": "TurnMetricsAgentMessage",
+        "type": "object"
+      },
+      "UnexpectedErrorRunnerMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/$defs/SerializedException"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "UnexpectedErrorRunnerMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "RUNNER"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "title": "UnexpectedErrorRunnerMessage",
+        "type": "object"
+      },
+      "UserQuestionAnswerMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "AskUserQuestionData": {
+            "additionalProperties": true,
+            "properties": {
+              "planFilePath": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Absolute path of the plan file the agent wrote in this turn, when the question is the synthesized ExitPlanMode approval. Set by `make_plan_approval_question` and consumed by the frontend ExitPlanMode tool block to render a click-to-reopen link. None for non-plan-approval questions or when the agent didn't write a plan file in the current turn (e.g. re-using a plan from a prior turn).",
+                "title": "Planfilepath"
+              },
+              "questions": {
+                "items": {
+                  "$ref": "#/$defs/UserQuestion"
+                },
+                "title": "Questions",
+                "type": "array"
+              },
+              "toolUseId": {
+                "title": "Tooluseid",
+                "type": "string"
+              }
+            },
+            "required": [
+              "questions",
+              "toolUseId"
+            ],
+            "title": "AskUserQuestionData",
+            "type": "object"
+          },
+          "QuestionOption": {
+            "additionalProperties": true,
+            "properties": {
+              "description": {
+                "title": "Description",
+                "type": "string"
+              },
+              "label": {
+                "title": "Label",
+                "type": "string"
+              }
+            },
+            "required": [
+              "label",
+              "description"
+            ],
+            "title": "QuestionOption",
+            "type": "object"
+          },
+          "UserQuestion": {
+            "additionalProperties": true,
+            "properties": {
+              "header": {
+                "title": "Header",
+                "type": "string"
+              },
+              "multiSelect": {
+                "title": "Multiselect",
+                "type": "boolean"
+              },
+              "options": {
+                "items": {
+                  "$ref": "#/$defs/QuestionOption"
+                },
+                "title": "Options",
+                "type": "array"
+              },
+              "otherLabel": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Otherlabel"
+              },
+              "question": {
+                "title": "Question",
+                "type": "string"
+              }
+            },
+            "required": [
+              "question",
+              "header",
+              "options",
+              "multiSelect"
+            ],
+            "title": "UserQuestion",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "answers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Map from question text to answer text",
+            "title": "Answers",
+            "type": "object"
+          },
+          "approximateCreationTime": {
+            "description": "Approximate UTC timestamp when user message was created",
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "messageId": {
+            "description": "Unique identifier for the user message",
+            "title": "Messageid",
+            "type": "string"
+          },
+          "notes": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Map from question text to the freeform 'Other' text the user typed, when present. Mirrors the native AskUserQuestion tool's per-question `notes` annotation, which the result formatter renders as ` user notes: <text>` after the answer string.",
+            "title": "Notes",
+            "type": "object"
+          },
+          "objectType": {
+            "default": "UserQuestionAnswerMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "questionData": {
+            "$ref": "#/$defs/AskUserQuestionData",
+            "description": "The original questions for context"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "USER"
+          },
+          "toolUseId": {
+            "description": "The original ToolUseBlock ID",
+            "title": "Tooluseid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "answers",
+          "questionData",
+          "toolUseId"
+        ],
+        "title": "UserQuestionAnswerMessage",
+        "type": "object"
+      },
+      "WarningAgentMessage": {
+        "$defs": {
+          "AgentMessageSource": {
+            "description": "Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)",
+            "enum": [
+              "AGENT",
+              "USER",
+              "SCULPTOR_SYSTEM",
+              "RUNNER"
+            ],
+            "title": "AgentMessageSource",
+            "type": "string"
+          },
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "properties": {
+          "approximateCreationTime": {
+            "format": "date-time",
+            "title": "Approximatecreationtime",
+            "type": "string"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SerializedException"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "messageId": {
+            "title": "Messageid",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "WarningAgentMessage",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/$defs/AgentMessageSource",
+            "default": "AGENT"
+          }
+        },
+        "required": [
+          "error",
+          "message"
+        ],
+        "title": "WarningAgentMessage",
+        "type": "object"
+      }
+    }
+  },
+  "Task": {
+    "current_state": {
+      "AgentTaskStateV2": {
+        "$defs": {
+          "ModelOption": {
+            "additionalProperties": true,
+            "description": "One model a harness offers in its switcher.\n\n`provider` and `model_id` identify the model on the harness's own terms\n(pi sends them back as a `set_model` selection; for the Claude harness\n`model_id` is the `LLMModel` value). `display_name` is the selector label.",
+            "properties": {
+              "displayName": {
+                "title": "Displayname",
+                "type": "string"
+              },
+              "modelId": {
+                "title": "Modelid",
+                "type": "string"
+              },
+              "provider": {
+                "title": "Provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "modelId",
+              "displayName"
+            ],
+            "title": "ModelOption",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "description": "The state of a run_agent server task.\nThis is used to snapshot the state of the task at various points in time so that the agent can be resumed.",
+        "properties": {
+          "availableModels": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ModelOption"
+            },
+            "title": "Availablemodels",
+            "type": "array"
+          },
+          "currentModel": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ModelOption"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "lastProcessedMessageId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Lastprocessedmessageid"
+          },
+          "objectType": {
+            "default": "AgentTaskStateV2",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "terminalSessionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Terminalsessionid"
+          },
+          "terminalShellPid": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Terminalshellpid"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Title"
+          },
+          "workspaceId": {
+            "title": "Workspaceid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "workspaceId"
+        ],
+        "title": "AgentTaskStateV2",
+        "type": "object"
+      },
+      "NoOpTaskStateV1": {
+        "additionalProperties": true,
+        "description": "Test-only task state paired with NoOpTaskInputsV1.",
+        "properties": {
+          "objectType": {
+            "default": "NoOpTaskStateV1",
+            "title": "Objecttype",
+            "type": "string"
+          }
+        },
+        "title": "NoOpTaskStateV1",
+        "type": "object"
+      }
+    },
+    "error": {
+      "SerializedException": {
+        "$defs": {
+          "JsonTypeAlias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "$ref": "#/$defs/JsonTypeAlias"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "SerializedException": {
+            "additionalProperties": true,
+            "description": "A serializable dataclass that represents an exception",
+            "properties": {
+              "args": {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/SerializedException"
+                    },
+                    {
+                      "$ref": "#/$defs/JsonTypeAlias"
+                    }
+                  ]
+                },
+                "title": "Args",
+                "type": "array"
+              },
+              "exception": {
+                "title": "Exception",
+                "type": "string"
+              },
+              "tracebackDict": {
+                "$ref": "#/$defs/JsonTypeAlias"
+              },
+              "wasLoggedByLogException": {
+                "default": false,
+                "title": "Wasloggedbylogexception",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "exception",
+              "args",
+              "tracebackDict"
+            ],
+            "title": "SerializedException",
+            "type": "object"
+          }
+        },
+        "$ref": "#/$defs/SerializedException"
+      }
+    },
+    "input_data": {
+      "AgentTaskInputsV2": {
+        "$defs": {
+          "ClaudeCodeSDKAgentConfig": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "ClaudeCodeSDKAgentConfig",
+                "title": "Objecttype",
+                "type": "string"
+              }
+            },
+            "title": "ClaudeCodeSDKAgentConfig",
+            "type": "object"
+          },
+          "HelloAgentConfig": {
+            "additionalProperties": true,
+            "properties": {
+              "command": {
+                "default": "echo",
+                "title": "Command",
+                "type": "string"
+              },
+              "objectType": {
+                "default": "HelloAgentConfig",
+                "title": "Objecttype",
+                "type": "string"
+              }
+            },
+            "title": "HelloAgentConfig",
+            "type": "object"
+          },
+          "LLMModel": {
+            "enum": [
+              "CLAUDE-4-OPUS",
+              "CLAUDE-4-OPUS-200K",
+              "CLAUDE-4-7-OPUS",
+              "CLAUDE-4-7-OPUS-200K",
+              "CLAUDE-4-6-OPUS",
+              "CLAUDE-4-6-OPUS-200K",
+              "CLAUDE-4-SONNET",
+              "CLAUDE-4-SONNET-200K",
+              "CLAUDE-4-HAIKU",
+              "CLAUDE-FABLE-5",
+              "FAKE_CLAUDE",
+              "FAKE_CLAUDE_2"
+            ],
+            "title": "LLMModel",
+            "type": "string"
+          },
+          "PiAgentConfig": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "PiAgentConfig",
+                "title": "Objecttype",
+                "type": "string"
+              }
+            },
+            "title": "PiAgentConfig",
+            "type": "object"
+          },
+          "RegisteredTerminalAgentConfig": {
+            "additionalProperties": true,
+            "description": "A terminal agent that launches a registered program in its shell.\n\nLaunch parameters are stamped at creation from the registration so the\ntask stays self-describing even if the registration file later changes.",
+            "properties": {
+              "acceptsAutomatedPrompts": {
+                "default": false,
+                "title": "Acceptsautomatedprompts",
+                "type": "boolean"
+              },
+              "displayName": {
+                "title": "Displayname",
+                "type": "string"
+              },
+              "launchCommand": {
+                "title": "Launchcommand",
+                "type": "string"
+              },
+              "objectType": {
+                "default": "RegisteredTerminalAgentConfig",
+                "title": "Objecttype",
+                "type": "string"
+              },
+              "registrationId": {
+                "title": "Registrationid",
+                "type": "string"
+              },
+              "resumeCommandTemplate": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Resumecommandtemplate"
+              }
+            },
+            "required": [
+              "registrationId",
+              "displayName",
+              "launchCommand"
+            ],
+            "title": "RegisteredTerminalAgentConfig",
+            "type": "object"
+          },
+          "TerminalAgentConfig": {
+            "additionalProperties": true,
+            "properties": {
+              "objectType": {
+                "default": "TerminalAgentConfig",
+                "title": "Objecttype",
+                "type": "string"
+              }
+            },
+            "title": "TerminalAgentConfig",
+            "type": "object"
+          }
+        },
+        "additionalProperties": true,
+        "description": "The primary task for running an agent.\n\nContains the necessary information for the task runner.\n\nThe `agent_config` is used to configure the `Agent` itself. It contains the full (versioned) command to be run.\nThe `git_hash` records the starting commit for diff computation.",
+        "properties": {
+          "agentConfig": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/HelloAgentConfig"
+              },
+              {
+                "$ref": "#/$defs/ClaudeCodeSDKAgentConfig"
+              },
+              {
+                "$ref": "#/$defs/PiAgentConfig"
+              },
+              {
+                "$ref": "#/$defs/TerminalAgentConfig"
+              },
+              {
+                "$ref": "#/$defs/RegisteredTerminalAgentConfig"
+              }
+            ],
+            "title": "Agentconfig"
+          },
+          "defaultModel": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LLMModel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "gitHash": {
+            "title": "Githash",
+            "type": "string"
+          },
+          "objectType": {
+            "default": "AgentTaskInputsV2",
+            "title": "Objecttype",
+            "type": "string"
+          },
+          "systemPrompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Systemprompt"
+          }
+        },
+        "required": [
+          "agentConfig",
+          "gitHash"
+        ],
+        "title": "AgentTaskInputsV2",
+        "type": "object"
+      },
+      "MustBeShutDownTaskInputsV1": {
+        "additionalProperties": true,
+        "description": "Used in testing to make sure we can shut down tasks that do nothing but wait.",
+        "properties": {
+          "objectType": {
+            "default": "MustBeShutDownTaskInputsV1",
+            "title": "Objecttype",
+            "type": "string"
+          }
+        },
+        "title": "MustBeShutDownTaskInputsV1",
+        "type": "object"
+      },
+      "NoOpTaskInputsV1": {
+        "additionalProperties": true,
+        "description": "Test-only task input that runs a no-op handler and completes immediately.\n\nUsed by the task-service tests to exercise the non-agent task path.",
+        "properties": {
+          "objectType": {
+            "default": "NoOpTaskInputsV1",
+            "title": "Objecttype",
+            "type": "string"
+          }
+        },
+        "title": "NoOpTaskInputsV1",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/sculptor/sculptor/database/alembic/utils.py
+++ b/sculptor/sculptor/database/alembic/utils.py
@@ -17,6 +17,17 @@ from sculptor.database.alembic.json_migrations import Schemas
 FROZEN_SCHEMAS_PATH = Path(__file__).parent / "frozen_pydantic_schemas.json"
 
 
+class EmptyFrozenSchemasError(ValueError):
+    """Raised when attempting to persist an empty frozen JSON-schema baseline.
+
+    An empty baseline silently disables the JSON-column durability guard
+    (``get_potentially_breaking_changes`` only inspects keys present in the
+    baseline), which is how the guard was disarmed in SCU-1523. An empty result
+    almost always means the automanaged-model registry was not populated (import
+    ``sculptor.services.data_model_service.sql_implementation`` before regenerating).
+    """
+
+
 def drop_all_automanaged_triggers(connection: Connection) -> None:
     """Drop every database trigger before migrations run.
 
@@ -85,6 +96,11 @@ def get_frozen_database_model_nested_json_schemas() -> Schemas:
     return json.loads(FROZEN_SCHEMAS_PATH.read_text(encoding="utf-8"))
 
 
+_EMPTY_SCHEMAS_MESSAGE = "Refusing to overwrite the frozen JSON-schema baseline with an empty schema set: this would silently disable the JSON-column durability guard. The automanaged-model registry was likely not populated (import sculptor.services.data_model_service.sql_implementation before regenerating)."
+
+
 def update_frozen_database_model_nested_json_schemas(schemas: Schemas) -> None:
+    if not schemas:
+        raise EmptyFrozenSchemasError(_EMPTY_SCHEMAS_MESSAGE)
     content = json.dumps(schemas, sort_keys=True, indent=2) + "\n"
     FROZEN_SCHEMAS_PATH.write_text(content, encoding="utf-8")

--- a/sculptor/sculptor/database/alembic/utils_test.py
+++ b/sculptor/sculptor/database/alembic/utils_test.py
@@ -1,0 +1,15 @@
+import pytest
+
+from sculptor.database.alembic.utils import update_frozen_database_model_nested_json_schemas
+
+
+def test_update_frozen_schemas_refuses_to_write_empty_baseline() -> None:
+    """Persisting an empty baseline silently disables the JSON-column durability guard.
+
+    An empty ``frozen_pydantic_schemas.json`` makes ``get_potentially_breaking_changes``
+    inert (it only inspects keys present in the baseline), which is exactly how the guard
+    was disarmed in SCU-1523. The write helper must refuse to overwrite the committed
+    baseline with ``{}`` rather than silently disabling the guard.
+    """
+    with pytest.raises(ValueError):
+        update_frozen_database_model_nested_json_schemas({})

--- a/sculptor/sculptor/services/data_model_service/sql_implementation_test.py
+++ b/sculptor/sculptor/services/data_model_service/sql_implementation_test.py
@@ -289,6 +289,22 @@ def test_there_are_no_missing_json_schema_migrations() -> None:
     )
 
 
+def test_frozen_json_schema_baseline_covers_every_persisted_model() -> None:
+    """The frozen baseline must be non-empty and cover every persisted model.
+
+    ``get_potentially_breaking_changes`` only inspects keys that exist in the frozen
+    baseline, so an empty (or partial) baseline silently disables the JSON-column
+    durability guard checked by ``test_there_are_no_missing_json_schema_migrations``.
+    See SCU-1523, where the file was ``{}`` and the guard was permanently green.
+    """
+    frozen_schemas = get_frozen_database_model_nested_json_schemas()
+    latest_schemas = get_json_schemas_of_all_nested_models(tuple(AUTOMANAGED_MODEL_CLASSES))
+    empty_baseline_message = f"frozen_pydantic_schemas.json is empty; the JSON-column durability guard is silently disabled. Run `{BUMP_MIGRATIONS_COMMAND}` to regenerate the baseline."
+    assert frozen_schemas, empty_baseline_message
+    missing_models_message = f"The frozen baseline does not cover the same models as the live registry ({sorted(frozen_schemas)} vs {sorted(latest_schemas)}); the durability guard would not inspect the missing models. Run `{BUMP_MIGRATIONS_COMMAND}`."
+    assert set(frozen_schemas.keys()) == set(latest_schemas.keys()), missing_models_message
+
+
 # ============================================================================
 # MIGRATION CORRECTNESS TESTS
 # These tests verify that the Alembic migration chain produces a correct


### PR DESCRIPTION
## Original bug

> **Revive frozen_pydantic_schemas.json — JSON-column durability guard is silently disabled (file is `{}`)** ([SCU-1523](https://linear.app/imbue/issue/SCU-1523))
>
> `sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json` is currently `{}` (3 bytes). It should contain the frozen baseline of the JSON schemas of the persisted nested Pydantic models. While it is empty, the data-durability guard that depends on it is **silently disabled**.
>
> Alembic migrations only cover **table/column** structure; they are blind to the **contents** of SQLite JSON columns — specifically `SavedAgentMessage.message` (conversation history) and `Task` inputs/state. The frozen file plus `get_potentially_breaking_changes()` are the JSON-column analogue of migrations: a CI tripwire (`test_there_are_no_missing_json_schema_migrations`) that fails when a serialized model shape changes in a way that could break deserialization of already-persisted rows after an app upgrade.
>
> `get_potentially_breaking_changes(old_schemas, new_schemas)` only iterates over the keys of `old_schemas` (the frozen baseline). With `old_schemas = {}` the loop body never runs → it always returns zero findings → the test is permanently green. So a developer can ship a breaking change to the persisted JSON shapes with **no warning**.
>
> **Proposed fix:** (1) regenerate and commit the baseline; (2) harden against recurrence — assert at the write site that the freshly computed schemas are non-empty before trusting a "no breaking changes" result. Severity: P2 hygiene (disarmed safety net over the most important user data; nothing reads the file at runtime, so no active user-facing failure).

No ticket field was changed; the ticket is referenced for context only.

## Hypotheses considered

1. **The frozen baseline is `{}`, so the durability guard is inert** — `get_potentially_breaking_changes` only inspects keys present in the baseline, so an empty baseline always reports zero changes and `test_there_are_no_missing_json_schema_migrations` is permanently green. **REPRODUCED.**
2. **The write helper silently accepts an empty schema set** — `update_frozen_database_model_nested_json_schemas({})` overwrites the committed baseline with `{}` without complaint, which is exactly how the baseline got wiped and the guard disarmed (a regeneration run with the automanaged-model registry unpopulated). **REPRODUCED.**

## For each reproduced bug

### Empty frozen baseline disables the JSON-column durability guard

**Repro steps**
1. Inspect the committed baseline: `wc -c sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json` → `3` (the file is `{}`).
2. In a Python shell with the model registry imported:
   ```python
   from sculptor.services.data_model_service.sql_implementation import register_all_tables
   register_all_tables()
   from sculptor.database.alembic.json_migrations import get_json_schemas_of_all_nested_models, get_potentially_breaking_changes
   from sculptor.database.alembic.utils import get_frozen_database_model_nested_json_schemas
   from sculptor.database.automanaged import AUTOMANAGED_MODEL_CLASSES
   frozen = get_frozen_database_model_nested_json_schemas()      # {}
   latest = get_json_schemas_of_all_nested_models(tuple(AUTOMANAGED_MODEL_CLASSES))  # {'SavedAgentMessage': ..., 'Task': ...}
   len(get_potentially_breaking_changes(frozen, latest))         # -> 0  (inert)
   len(get_potentially_breaking_changes(latest, broken_latest))  # -> >0 (works when armed against a real baseline)
   ```
3. Confirm `test_there_are_no_missing_json_schema_migrations` passes even though the baseline covers nothing.

**Expected vs actual**
- Expected: the frozen baseline contains the persisted models, so the guard actually compares old vs new schemas and trips on breaking changes.
- Actual: the baseline is `{}`, the comparison loop never executes, and the guard reports zero findings for any change.

**Before**
```
$ uv run --project sculptor pytest \
    sql_implementation_test.py::test_frozen_json_schema_baseline_covers_every_persisted_model \
    utils_test.py::test_update_frozen_schemas_refuses_to_write_empty_baseline -v

test_frozen_json_schema_baseline_covers_every_persisted_model FAILED
    assert frozen_schemas, empty_baseline_message
E   AssertionError: frozen_pydantic_schemas.json is empty; the JSON-column durability guard is
    silently disabled. Run `uv run --project sculptor python sculptor/sculptor/scripts/bump_migrations.py`
    to regenerate the baseline.
E   assert {}
test_update_frozen_schemas_refuses_to_write_empty_baseline FAILED
E   Failed: DID NOT RAISE <class 'ValueError'>
============================== 2 failed in 0.15s ===============================
```

**Root cause**
`get_potentially_breaking_changes(old_schemas, new_schemas)` in `sculptor/sculptor/database/alembic/json_migrations.py` iterates `for model_name, old_model_schema in old_schemas.items():` and only reports types removed from / changed relative to the baseline. With `old_schemas == {}` (the committed `frozen_pydantic_schemas.json`) the loop body never runs, so it returns an empty tuple for every input. `test_there_are_no_missing_json_schema_migrations` asserts that tuple is empty, so it is permanently green and the guard inspects nothing. The file became empty during a pre-open-source regeneration that ran before the automanaged-model registry was populated, and the empty file then passed CI for exactly the reason above.

**Fix**
Regenerate `frozen_pydantic_schemas.json` from the current persisted models via `bump_migrations._update_frozen_schemas()` (with `register_all_tables()` called first so `AUTOMANAGED_MODEL_CLASSES` is populated). The baseline is now ~82 KB with the expected top-level keys `SavedAgentMessage` and `Task`, so the guard compares real schemas again. A new regression test asserts the committed baseline is non-empty and covers the same models as the live registry, so a future empty/partial baseline fails CI instead of silently passing.

**Test**
- Path: `sculptor/sculptor/services/data_model_service/sql_implementation_test.py`
- Kind: backend unit test. An end-to-end Playwright test is impossible here per the testing config's first "impossible" criterion: the buggy code path (a frozen-schema baseline, a CI tripwire test, and a dev-only regeneration script) is internal-only and not reachable from any UI surface.
- Failing-test commit: `42a3480e8c`
- Fix commit: `d52c953eb8`

**After**
```
$ uv run --project sculptor pytest \
    sql_implementation_test.py::test_frozen_json_schema_baseline_covers_every_persisted_model \
    sql_implementation_test.py::test_there_are_no_missing_json_schema_migrations \
    utils_test.py::test_update_frozen_schemas_refuses_to_write_empty_baseline -v

test_frozen_json_schema_baseline_covers_every_persisted_model PASSED
test_there_are_no_missing_json_schema_migrations PASSED
test_update_frozen_schemas_refuses_to_write_empty_baseline PASSED
============================== 3 passed in 0.08s ===============================
```

### Write helper silently accepts an empty baseline (recurrence guard)

**Repro steps**
1. Call the write helper with an empty schema set:
   ```python
   from sculptor.database.alembic.utils import update_frozen_database_model_nested_json_schemas
   update_frozen_database_model_nested_json_schemas({})   # silently writes "{}" to the baseline
   ```
2. Observe it returns normally and overwrites `frozen_pydantic_schemas.json` with `{}` — re-disabling the guard exactly as in the original regression.

**Expected vs actual**
- Expected: refusing to persist an empty baseline (which can only mean the model registry was not populated), so the guard can never be silently disarmed.
- Actual: the helper writes `{}` without complaint.

**Before**
```
test_update_frozen_schemas_refuses_to_write_empty_baseline FAILED
E   Failed: DID NOT RAISE <class 'ValueError'>
```
(captured together with the failing run above)

**Root cause**
`update_frozen_database_model_nested_json_schemas(schemas)` in `sculptor/sculptor/database/alembic/utils.py` unconditionally serialized `schemas` and wrote the file. When a regeneration ran with `AUTOMANAGED_MODEL_CLASSES` unpopulated, `get_json_schemas_of_all_nested_models(...)` returned `{}`, and the helper happily persisted it — the exact write that wiped the baseline and disarmed the guard, with no signal to the developer.

**Fix**
Add an early guard: when `schemas` is empty, raise a new `EmptyFrozenSchemasError(ValueError)` whose message explains that the registry was likely not populated and how to fix it, instead of overwriting the committed baseline. This is the single lowest-level write site, so it protects every caller (including `bump_migrations._update_frozen_schemas()`).

**Test**
- Path: `sculptor/sculptor/database/alembic/utils_test.py`
- Kind: backend unit test (same "impossible" criterion as above — the write helper is dev/CI-only and has no UI surface).
- Failing-test commit: `99d579c0b7`
- Fix commit: `46209d33d5`

**After**
```
test_update_frozen_schemas_refuses_to_write_empty_baseline PASSED
```
(see the 3-passed run above)

## Notes for reviewers

- `frozen_pydantic_schemas.json` is a **generated artifact** (~2.6k lines). It is produced by `bump_migrations`, not hand-edited; review the two `.py` changes and trust the regeneration for the JSON.
- Pre-commit verification on this branch: `ruff format --check` and `ruff check` pass, `pyrefly check` reports 0 errors, the full `ratchets check` passes (24/24 on `no-implicit-string-concat`), and the affected suites pass (`database/alembic/` 10 passed; full `sql_implementation_test.py` 79 passed).
- The branch is rebased onto current `main`; the regenerated baseline matches `main`'s present models.

## Review notes

- `sculptor/sculptor/scripts/bump_migrations.py` only calls `_update_frozen_schemas()` when `is_json_schema_migration_needed` is true, which is itself derived from `get_potentially_breaking_changes()`. While the baseline was `{}` that check was inert, so the documented regeneration command could not have self-healed an empty baseline — it had to be regenerated directly. The write-site guard in this PR makes the empty-baseline state non-recurring, so I did not change the `bump_migrations` gating in this PR. Flagging it in case the team wants the regeneration command to be robust to a future inert baseline.

(Sent by Claude)
