### PR TITLE
docs: add product specification set under docs/specs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@
   reviewing changes, opening pull requests, and more.
 - **[Developer documentation](development/)** — how to work on Sculptor itself:
   setup, style guide, testing, and review rules.
+- **[Specification](specs/)** — the product spec set: what Sculptor is, the
+  measurable requirements and contracts it upholds, and the scenarios and test
+  coverage that verify its behavior.
 - **[History](history.md)** — how Sculptor came to be, and the architectural
   decisions behind it.
 - **[Competitors](competitors.md)** — how Sculptor compares to other coding

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,28 @@
+# Specification
+
+The product specification set for Sculptor — long-lived, maintained documents describing what the
+product is, the contracts it upholds, and how its behavior is verified.
+
+- **[SPEC.md](SPEC.md)** — the narrative product specification: what Sculptor is and how each feature
+  behaves, in prose (Overview, Scenarios, System Components, Domain Model, the feature-by-feature
+  Details, the `sculpt` CLI, non-functional behavior, the engineering substrate, and build/release).
+- **[requirements.md](requirements.md)** — the measurable and contractual facts the prose
+  deliberately leaves out: numeric targets, version/platform bars, persistence and migration
+  guarantees, integration contracts, and the open questions where the product pins no value yet.
+- **[scenarios.md](scenarios.md)** — every user-facing interaction expressed as a Given/When/Then
+  scenario (~446), the UI-level acceptance layer.
+- **[scenario_coverage.md](scenario_coverage.md)** — maps each scenario to the integration test that
+  demonstrates it (coverage and traceability).
+
+## How they relate
+
+`SPEC.md` is the source of truth for behavior; `requirements.md` pins the measurable targets and
+contracts that behavior rests on; `scenarios.md` turns the behavior into concrete acceptance checks;
+and `scenario_coverage.md` measures how well those checks are demonstrated by automated tests.
+
+| Document | Answers | Layer |
+|---|---|---|
+| `SPEC.md` | What is the product, and how does each feature behave? | Functional behavior, in prose |
+| `requirements.md` | What measurable targets, limits, and contracts does the product meet? | Requirements |
+| `scenarios.md` | What exactly happens on screen, action by action? | UI-level acceptance |
+| `scenario_coverage.md` | Which test demonstrates each scenario? | Coverage / traceability |

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -1,0 +1,998 @@
+# Sculptor — Product Specification
+
+## 1. Overview
+
+Sculptor is a desktop app for running coding agents in parallel — each in its own isolated copy of
+your repository. Instead of handing your working tree to a single agent and waiting, you spin up as
+many **workspaces** as you have tasks, point an **agent** at each, and let them work at the same
+time while you review, steer, or start more.
+
+The shape of the product is a short loop. You **connect a repo**, **create a workspace** (an
+isolated copy of your code), and **prompt an agent** in chat. You watch it work — its messages, its
+tool calls, and the changes it makes — and step in whenever you want: interrupt it, answer a
+question it asks, or queue the next instruction. When it's done you **review the changes**, commit
+them, and open a pull request, all without leaving the workspace. To explore a different task you
+open another workspace; to collaborate on the same one you add another agent.
+
+Sculptor runs entirely on your machine and offers the same capabilities two ways: a **desktop GUI**
+for interactive work, and the **`sculpt` CLI** for driving the very same workspaces and agents
+headlessly from a terminal, a script, or CI. On top of the basic loop it bundles a library of
+**skills** — reusable, multi-step workflows like spec-then-build or test-driven bug fixing — that
+run as their own agents.
+
+Sculptor is an experimental research preview: it is under active development, it will have rough
+edges, and it can change quickly.
+
+## 2. Problem Statement
+
+Coding agents are useful but awkward to run more than one at a time. Point an agent straight at your
+working tree and it competes with you for the same files; run several and they trample each other
+and your in-progress work. Keeping each agent's work on its own branch, reviewing what it did, and
+getting it safely into a pull request are all manual. And the moment you want to automate any of
+this — fan out a fleet of agents, or wire one into CI — a GUI-only tool runs out of room.
+
+Sculptor exists to make running coding agents **parallel, isolated, reviewable, and steerable** the
+default. It gives each agent an isolated copy of your repository so it can edit and run freely
+without disturbing you; it makes the agent's changes first-class to review and commit; it keeps you
+in control of what reaches the outside world; and it exposes everything through both a GUI and a
+scriptable CLI. What it is *not* responsible for is being your editor, hosting your code, or serving
+the models — it orchestrates agents over your local repositories.
+
+## 3. Goals and Non-Goals
+
+**Goals**
+- Run multiple coding agents concurrently, each isolated from your checkout and from each other.
+- Make agent work reviewable and safe to land: changes, diffs, commits, and PRs are first-class,
+  and nothing reaches a remote without your action.
+- Keep you in control of each agent: interrupt, steer, answer its questions, and recover your work
+  across restarts and crashes.
+- Offer the same capabilities headlessly via the `sculpt` CLI as in the GUI, so work can be scripted.
+- Bundle reusable, multi-step workflows (skills) that take work from idea to shipped code.
+- Run entirely on your machine, keeping your code private.
+
+**Non-Goals**
+- Not a general IDE or editor; it complements your editor rather than replacing it.
+- Not a hosted, multi-tenant cloud service (the container/remote backend is experimental and still
+  under your control).
+- Not a model provider; it orchestrates agent CLIs (Claude, Pi), it doesn't serve models.
+- Not a code host; your repositories and history stay yours.
+- Not a finished, stable product — it is an experimental research preview.
+
+## 4. Scenarios
+
+A set of realistic, named end-to-end narratives — each a short story of a stereotypical user
+accomplishing a real job.
+
+**S1 — Fix a bug, test-first, without breaking stride.** Dana hits a rounding bug in the checkout
+flow. She opens a workspace on a fresh branch off `main` and, rather than hand-write a prompt,
+invokes **`/sculptor-workflow:fix-bug`** with "checkout total is off by a cent on multi-item carts."
+The skill runs as its own agent and drives a **test-driven** fix: it first reproduces the bug with a
+*failing* test, then changes the code until that test — and the rest of the suite — passes, narrating
+each step as it goes. Dana goes back to her own editor while it works. A few minutes later she opens
+the workspace's **Changes**, sees the new regression test sitting alongside the one-line fix, reads
+the diff, commits, and opens a pull request — never having stashed or branched in her own checkout.
+(For a bug she's already confident about, she could instead invoke
+`/sculptor-workflow:fix-bug --autonomous` and let it run end-to-end and open the PR itself.)
+
+**S2 — Compare two approaches in parallel.** Unsure which approach is better, Priya creates two
+workspaces from the same starting branch and gives each agent the same task with a different steer
+("smallest possible change" vs. "refactor for clarity"). The two agents run at the same time in
+their separate copies; she watches both from their tabs, compares the resulting diffs, and keeps the
+one she prefers — discarding the other workspace. (Two *workspaces*, not two agents in one: agents
+sharing a workspace would edit the same files.)
+
+**S3 — Drive a feature from spec to shipped.** Sam has a larger feature. He invokes
+**`/sculptor-workflow:spec`**, which spawns a "Spec" agent that interviews him and writes an
+implementation spec he watches take shape in the diff viewer. When it's right, he hands off down the
+pipeline — each stage its own dedicated agent (renamed **Spec → Architect → Plan → Build**) that
+produces a durable artifact the next stage reads: the architecture document, then a folder of
+self-contained task files, then the built code committed task by task. (For a UI-heavy feature he'd
+slot in **mock** near the start to generate interactive HTML mockups to react to first.) The pipeline
+ends with **Review**: a final agent that checks the diff against the original spec, re-runs the tests,
+and writes up its findings in `review.md` for Sam to act on. Each stage offers to hand off to the
+next, so Sam can stop after any one, inspect its artifact, and resume the pipeline whenever he likes.
+
+**S4 — Automate Sculptor from the terminal.** Alex lives at the keyboard, so he drives Sculptor with
+the **`sculpt` CLI**: `sculpt run "regenerate the API client and fix any type errors" --follow`
+creates a workspace *and* an agent in one command and streams the result; a wrapper script reads the
+agent's status as JSON and, when it finishes, reads back the changes. Because both surfaces share one
+**local** backend, that same workspace is sitting in the desktop app if Alex wants to take over
+interactively — and conversely a workspace he started in the app is drivable from `sculpt`. This is
+how he wires a routine repo chore into a local `Makefile` target or a personal cron job, and how he
+fans several agents out from a single script. (Sculptor is a server running on *your* machine, so
+`sculpt` automates the Sculptor you already have open — not a fresh one conjured inside an ephemeral
+remote CI runner, which has no local backend or checkout to drive.)
+
+**S5 — Run a fleet; let the dots route your attention.** Maya is mid-sprint with a dozen things in
+flight at once. Three large features are each moving through the workflow skills in their own
+workspaces; another seven or eight smaller bugs are each handed to a `fix-bug` agent in a workspace
+of its own. She isn't watching any single one — she reads the **status dots** across the workspace
+tabs as a dashboard of where her attention is owed: a *ready* dot means an agent has finished and
+wants review, a *waiting* dot means one is blocked on a question or plan approval, an *error* dot
+means one needs a human. She hovers a tab to **peek** at that workspace's agents, branch, PR status,
+and diff stats without leaving the agent she's in, and uses **Cmd+P / Cmd+K** to jump straight to
+whichever workspace is asking for her. She approves a plan here, reviews and commits a finished bug
+fix there, unsticks a confused build agent — then drops back into her own work. The win isn't that
+any single agent is faster; it's that Sculptor lets her keep ten-plus autonomous agents productive at
+once by telling her exactly **where and when** to look, so nothing stalls silently and nothing
+demands constant supervision.
+
+**S6 — Ship a batch overnight with self-healing CI.** At the end of the day Raj clears a backlog of
+well-understood bugs by firing off **`/sculptor-workflow:fix-bug --autonomous`** in a workspace each:
+every one reproduces, fixes, verifies, and opens a pull request with no further input from him. He
+turns on the **CI babysitter** so that when a PR's pipeline fails, Sculptor automatically asks an
+agent to read the failure, fix it, and push — up to a configured retry cap — and to resolve simple
+merge conflicts the same way. He leaves his machine running and steps away for the night (Sculptor is
+a local server, so the agents and babysitter keep working only while his machine is on). By morning
+most of the PRs are green and ready to merge; the handful the babysitter couldn't rescue are flagged
+with an **error** or **waiting** dot for Raj to take over by hand. He spends the morning reviewing
+diffs and merging — not babysitting pipelines.
+
+The exhaustive, UI-level Given/When/Then list lives in `scenarios.md` (and `scenario_coverage.md`
+maps those to tests); this section holds only the rich narratives.
+
+## 5. System Overview & Components
+
+This section is the **engineering view** — the one place implementation is described. Product
+behavior is in §7/§9; the development and quality substrate is in §10.
+
+Sculptor runs entirely on your machine as a small set of cooperating pieces arranged around a
+**single local backend server**. Both product surfaces — the **Electron desktop GUI** and the
+**`sculpt` CLI** — are clients of that one server, talking to it over HTTP for actions and
+subscribing to a **live update stream** for state. There is no separate "CLI backend" and "GUI
+backend": a **Workspace** or **Agent** created from the terminal appears in the desktop app and vice
+versa, because both surfaces drive the same service and read the same persisted state. The backend
+owns the domain — **Projects (Repos)**, **Workspaces**, and **Agents** — and is responsible for
+shaping that domain into the view the surfaces render.
+
+The desktop GUI is a **thin client**: it does almost no business logic of its own, instead rendering
+backend-derived UI state that is pushed to it live (a full snapshot on connect, then deltas). To
+keep the two surfaces from drifting from the backend, **TypeScript types and the API clients are
+generated from the backend's models and OpenAPI spec**, so the contract is defined once on the
+server and consumed everywhere. Underneath the domain, an **agent runner** supervises the actual
+agent CLI process, an **isolation layer** gives each Workspace its own copy of the repo, and **local
+persistence** records everything.
+
+| Component | Responsibility |
+|---|---|
+| **Electron desktop GUI** (React) | Thin client that renders backend-derived UI state streamed live; sends user actions to the backend over HTTP. Built with React/Jotai/Radix, packaged via Electron Forge. |
+| **`sculpt` CLI** | First-class headless surface (terminal, scripts, CI) for driving the same local Sculptor as the GUI. See §8. |
+| **Local backend server** | The single local service both surfaces talk to — exposes the HTTP API and the live update stream, owns the Project/Workspace/Agent domain, and derives the shaped UI state the frontend renders. |
+| **Agent runner** | Launches and supervises the underlying agent CLI (Claude or Pi) for each Agent, relaying its messages, status, and tool activity back through the backend. |
+| **Isolation layer** | Backs each Workspace with an isolated copy of the repo — **worktree**, **clone**, or **in-place** — all running locally on your machine. |
+| **Custom backend (experimental)** | An opt-in escape hatch that relocates the *whole* backend off-host: a user-supplied launcher command (e.g. Docker, SSH, a VM) that the app connects to over a printed URL. It is **not** a per-workspace isolation mode — it moves the entire service, not one workspace's checkout (→ §7.12, §9.1). |
+| **Local persistence** | A local store (an append-only snapshot log plus a materialized current-state view, with versioned migrations) holding Projects, Workspaces, Agents, and conversation history. |
+
+Deeper detail on how these pieces are built and operated lives in **§10 (Engineering Substrate)**;
+the guarantees they uphold are spelled out in **§9**.
+
+## 6. Core Domain Model
+
+Sculptor's vocabulary is small and load-bearing; every feature in §7 is described in these terms.
+This section names **only concepts a user sees, names, or configures.** Internal abstractions with
+no user-facing presence (Environments, the task primitive, services, the streaming protocol) are not
+here — they live in §5 and §10.
+
+**Project (aka Repo).** A connected git repository — "Project" and "Repo" are the same thing; a
+project *is* the repo you pointed Sculptor at. It is the parent of its workspaces and carries
+repo-level settings the user can configure: a default system prompt, an optional workspace **setup
+command**, and a branch-naming pattern.
+
+**Workspace.** An isolated copy of a project's repository where agents do their work, so they never
+edit your own checkout directly. By default a workspace is a **git worktree** — it shares your repo's
+history but has its own branch, so the agent's commits land in your repo immediately and you can push
+them yourself. This is the standard mode in both the GUI and `sculpt run`. Two other modes exist as
+**experimental** opt-ins (→ §7.12): a full **clone** (a separate clone whose remotes mirror your
+repo's, where the agent's commits stay in the clone until you push the branch back — to a remote you
+share with your local repo, or directly to your on-disk repo) and **in-place** (the agent
+works directly in your checkout, with no isolation). A
+workspace's mode is fixed for its lifetime.
+
+A workspace also has a source branch, a **target branch** (what its changes and any PR are measured
+against), a **setup status** (if the project defines a setup command), and a set of **changes** that
+may still be computing just after the agent edits files. It is shown as a tab.
+
+**Agent.** One LLM conversation bound to a workspace — the user-facing unit of work, shown as a tab
+inside the workspace. An agent has a **status** the user sees as status dots and tab state:
+*building* (it's being set up), *running* (actively working), *ready* (idle / done), *waiting* (it
+asked a question or wants plan approval), *error*, or *request-error* (its last request failed but
+the agent is still usable). Several agents can run in one workspace; they share its files and git
+state but each keeps its own conversation and history.
+
+**Task (internal, not a product concept).** An agent is internally backed by a general-purpose
+**task** primitive, now vestigial — the only remaining non-agent task types are test-only. A user
+never sees or names a "task"; it survives only as a storage and scheduling detail behind an agent.
+Its internal status, and an agent's TODO-item statuses, are each distinct from the user-visible agent
+status above — don't conflate them.
+
+**Message.** A single unit of conversation within an agent — from the **user**, the **agent**, or
+the **system** (Sculptor itself, e.g. status and context notices). Messages appear incrementally as
+the agent works. Plans and questions are their own message types; tool calls and errors appear as
+blocks *within* a message rather than as messages of their own.
+
+**Change / Diff.** A workspace's modifications measured against its target branch — the basis of the
+Changes view (§7.5). Just after the agent edits files, the diff may briefly show as still computing.
+
+**Commit / Branch / Pull Request.** The git outputs of a workspace. A workspace owns a branch; the
+agent or user makes commits on it; and a workspace can open a **pull request** against its target
+branch, after which Sculptor tracks the PR's CI and review status (and can "babysit" CI → §7.6).
+
+**Skill.** An invocable, named workflow — bundled (the spec → architect → plan → build → review
+pipeline, plus `fix-bug`, `mock`, and `setup-repo`) or experimental (`handoff`, `stack`). Skills are invoked as
+slash commands and typically run as their own agent. (§7.8.)
+
+**Action / Note.** Workspace-scoped helpers around the conversation: **actions** are saved,
+re-runnable prompts (organized into groups); **notes** are scratch text the user can fold into a
+prompt. (§7.11.)
+
+**Notification.** A surfaced system or agent event (e.g. an agent finished, or needs attention).
+
+## 7. The Product, Feature by Feature
+
+This is the body of the spec — each feature described in prose: what it is, how it behaves, and its
+notable edge cases. The sections follow the product's own `docs/help/` decomposition.
+
+### 7.1 Onboarding & connecting a repo
+
+The first time you open Sculptor, a short **setup wizard** walks you through three steps — your
+details, dependencies, and connecting a repo — with a row of dots at the bottom tracking your
+progress. You can jump back to an earlier step at any time; steps you haven't reached yet stay locked
+until you get there. If you quit partway through, reopening Sculptor returns you to the first step you
+haven't finished.
+
+The first step collects your **details**. Enter your name and email and click **Get Started** to
+create an account (the button stays disabled until you've entered a valid-looking email address, i.e.
+one containing an `@`). If you'd rather
+not sign up, **Continue without an account** skips straight ahead. This step is also where you make
+your **telemetry** choice — a checkbox (on by default) governs whether Sculptor shares crash reports
+and usage data — alongside an optional marketing opt-in and a reminder that your code stays yours:
+Imbue does not store your repositories or train on your code. Your account email later lives under
+**Settings › Privacy**.
+
+Next, Sculptor checks the **dependencies** it needs — chiefly the Claude CLI and Git. Each shows up
+as a card: a green check with the detected path and version when it's ready, or a warning with an
+**Install** or **Sign in** button when it isn't. Sculptor can install and manage Claude for you
+(showing live install progress) or sign you in, and for anything you'd rather manage yourself you can
+expand a card to override the binary path or switch between a managed install and your system one. A
+**check again** link re-runs the checks. You can't move on until everything required is satisfied.
+
+Finally, you connect your first **repository** (→ §7.2 Workspaces). Point Sculptor at a repo by
+typing its path or, on desktop, browsing for a folder, then click **Add**. If the folder isn't a Git
+repo yet, or is a repo with no commits, Sculptor offers to initialize it or make an initial commit
+for you; a bad path surfaces an error you can dismiss. Once a valid repo is connected the wizard
+finishes and drops you into the app, ready to create a workspace and prompt your first agent.
+
+### 7.2 Workspaces
+
+A **workspace** is how you start work in Sculptor: you pick a project (repo) and Sculptor creates an
+isolated copy of it for agents to work in, rather than touching your own checkout. You create one
+from the **Add Workspace** form (titled "Name your workspace") — choosing the repo, the source branch
+to start from, a workspace name, the name for the workspace's new branch (with a live preview and a
+warning if that branch already exists), and the **type of the first agent** to create (Claude, a
+terminal agent, Pi where enabled, or a registered agent → §7.4). By default
+the workspace is a **worktree**: it shares your repo's history but gets its own branch, so the
+agent's commits show up in your repo right away and you can push them yourself. (The older **clone**
+mode and the unisolated **in-place** mode are experimental opt-ins that, once enabled in Settings,
+add a mode picker to this form — see §7.12.) Each open workspace is a **tab**.
+
+Inside a workspace, a header **banner** shows where you are: the repo, the workspace's branch (which
+you can copy), and a one-glance **diff summary**. For a repo whose `origin` is on **GitHub or
+GitLab**, the banner also shows the workspace's **target branch** (what its changes are diffed
+against — with a selector to change it and a warning if a PR's target wouldn't match); for other
+repos there is no target-branch concept and the banner simply shows the source branch the workspace
+started from. A non-default mode (clone or in-place) is shown as a strategy badge, and the banner collapses
+progressively as space tightens.
+
+If the project defines a **setup command**, it runs when the workspace is created; its progress and
+logs are surfaced, with controls to cancel or re-run, and the workspace's diff isn't meaningful
+until setup finishes.
+
+A workspace can hold **multiple agents**, shown as tabs within it. They all share the same files and
+git state — there is no locking between them, so two agents editing the same workspace can step on
+each other — but each has its own conversation, status, and history. You can add, rename
+(double-click), reorder, mark-unread, and delete agents, and a small **peek** popover previews other
+agents' state on hover.
+
+Deleting a workspace removes it and all of its agents; for worktree and clone workspaces this also
+cleans up the underlying git worktree or clone. A workspace whose underlying repo or working copy
+has gone away surfaces an error state rather than failing silently. _(→ Changes §7.5, Agents §7.4,
+Pull Requests §7.6; isolation guarantees §9.1.)_
+
+### 7.3 Chat & terminal agents
+
+An agent's main panel is one of two surfaces: the **chat** interface most agents use, or a full-pane
+**terminal** that you drive yourself. This subsection covers both — running and coordinating *several*
+agents at once is §7.4.
+
+#### 7.3.1 Rich chat agents — the core agent loop
+
+**Chat** is where you direct an agent. You compose a prompt in the input box at the bottom, and the
+agent's reply, its tool calls, and its progress stream into the panel above. Press the send
+keybinding (or click **Send**) to send; the editor and any attachments clear. The Send button
+explains itself when it can't act — for example when the editor is empty. The send keybinding is
+**Cmd/Ctrl+Enter**, so a plain **Enter** (or **Shift+Enter**) inserts a line break and a prompt can
+span several lines while still sending as one message.
+
+The input toolbar shapes how the agent handles your next message. A **model** picker chooses which
+model answers; an **effort** selector budgets how much thinking it spends per step (Low, Medium, High, Extra High,
+Max — Extra High by default);
+a **fast mode** toggle trades some depth for quicker output; and **plan mode** makes the agent
+investigate and propose a plan for your approval before it changes anything. The **+** button opens a
+menu for adding context — point the agent at specific **files and folders**, attach **images** (you
+can also drag-and-drop or paste them), or start a **skill** (→ §7.8 Skills); with the **Entity
+Mentions** experimental toggle on (→ §7.12) the same menu also lets you reference **workspaces and
+agents** and **repositories**. (The `+` menu is distinct from the inline triggers: typing `@` searches
+files and folders — and those same entities when enabled — and `/` opens skills directly.) Attached
+items show as small pills above the input, each removable with an **×**. Typing `/` opens
+the command picker for conversation commands — `/clear` to reset the agent's context, `/copy` to copy
+its last response, and `/btw` for a side question (below), alongside other built-ins like `/compact`,
+`/context`, `/simplify`, `/batch`, and `/loop` — and for skills.
+
+While the agent works, a **status indicator** above the input reports the live phase — Thinking…,
+Streaming…, Calling tools…, Compacting…, Stopping… / Stopped, and "Waiting for background tasks…" — with a
+running timer, and for multi-step work it
+shows progress like "3 / 8 · current step"; hover or click to expand the full checklist. You
+steer mid-turn without waiting for it to finish: a **stop** button (Ctrl+C) interrupts the running
+turn, you can **queue** a message to run after the current turn (it appears in a bar below the input,
+where you can edit or remove it), or you can **interrupt-and-send** to cut the turn short and deliver
+your new message immediately. Spawned **subagents** appear inline as pills showing their prompt and
+elapsed time, expandable to reveal what they did (→ §7.4 Agents).
+
+You can also ask a quick **side question** without derailing the turn. Typing **`/btw`** followed by
+a question (e.g. `/btw why did you take this approach?`) opens a small, draggable popup in the corner
+that streams a short, **read-only** answer based on the agent's current session — it doesn't post to
+the conversation, change anything, or interrupt the agent's work, and asking another `/btw` replaces
+the previous popup. Because it works from the agent's session, it's available only after you've sent
+at least one message. The side question is answered by a fast model (Haiku) forked read-only from the
+agent's **Claude** session, so it's a Claude-agent affordance: a terminal agent (which has no chat
+input) doesn't offer it, and a **Pi** agent has no equivalent side channel (→ §7.4).
+
+Sometimes the agent turns the question around and asks **you**. A **question panel** replaces the
+chat input, showing the question, its options, and an **Other** choice for a free-text answer.
+Questions can be single- or multi-select; when there are several you move between them with the
+progress dots or Tab, and submitting jumps to the next unanswered one until every question is
+answered and the panel closes. You can also **dismiss** the panel to decline. Answered questions
+remain in the chat history as plain text for the record.
+
+When a turn finishes, a **footer** summarizes it: duration (with a "Stopped" label if you interrupted
+it), token count, how much of the context window is in use, and a "N files changed" link that opens
+the affected files. If a message fails to send or a turn errors out, Sculptor surfaces the error —
+preserving your typed text so you can resend — and an errored agent offers a link to try to restore
+it (unless its workspace was deleted, in which case it can't be recovered).
+
+Beyond composing prompts, the chat offers a few conveniences for working in a long conversation:
+recall earlier prompts by pressing the up/down arrows in an empty input, search the transcript
+(Cmd/Ctrl+Shift+F), and switch tool calls between compact pills and expanded rows
+(Cmd/Ctrl+Shift+E).
+
+#### 7.3.2 Terminal agents
+
+Not every agent is a chat agent. A **terminal agent** is an agent type whose main panel is an
+interactive, full-pane terminal — a real shell session (a PTY) running inside the workspace — rather
+than a chat transcript. You type into the
+shell directly; Sculptor renders no message stream, model picker, or chat input for it, so the
+chat-only affordances above (plan mode, queued messages, `/btw`) don't apply. It is still a
+first-class agent — its own tab, name, status dot, history, and lifecycle, sharing the workspace's
+files and git state with its siblings (→ §7.4). The reason to use one is to run a coding tool that
+drives *its own* terminal UI — most importantly a CLI coding agent like Claude Code — alongside your
+chat agents, while Sculptor still tracks it as an agent and surfaces its edits in the Changes view.
+
+Terminal agents come in two flavors. A **plain Terminal** is just a bare login shell in the
+workspace, for running whatever you like by hand. A **registered terminal agent** additionally
+launches a specific command on start, and is defined by a small **registration**: one TOML file per
+agent under the Sculptor folder's `terminal_agents/` directory, named by a `registration_id` (the
+file's stem) and declaring a `display_name` (what the create menu shows), a `launch_command` to run
+when the agent starts, an optional `resume_command_template` (so the agent can reattach to the same
+underlying session after a Sculptor restart), and whether it `accepts_automated_prompts`. The
+directory is re-read on demand, so dropping in a new file makes a new agent type available with no
+restart; and the launch parameters are stamped onto the agent when you create it, so it keeps working
+even if you later edit or delete the registration file.
+
+Sculptor ships one registration out of the box — **"Claude CLI"**, which runs the Claude Code
+terminal UI in the workspace. It's installed automatically on first run into your `terminal_agents/`
+folder, where it's yours to edit or delete (deleting it sticks — Sculptor won't reinstall it). It
+launches Sculptor's managed Claude binary with the bundled Sculptor plugins loaded, and a companion
+hooks file wires the CLI back into Sculptor: as the agent works, the hooks call the **`sculpt signal`**
+CLI (→ §8) to report **busy / idle / waiting** status — lighting the same status dots a chat agent
+uses — and **files-changed** to refresh the Changes diff, and to hand back the session id Sculptor
+needs to resume the conversation later.
+
+This is the key distinction from the rich **Claude** chat agent described above: both run Claude, but
+the chat agent is driven *through Sculptor's own chat surface* (Sculptor renders its messages, tool
+calls, plans, and questions), whereas the "Claude CLI" terminal agent **is** the Claude Code TUI
+itself, drawn in a PTY, with Sculptor observing it from the outside via signals. You choose which
+kind of agent — a Claude or Pi chat agent, a plain Terminal, or a registered terminal agent — when
+you create it (→ §7.4 Agents).
+
+### 7.4 Agents — multiple roles & background
+
+A workspace can hold several **agents** at once, each its own conversation with its own history and
+pending changes, shown as a row of **tabs**. Each tab carries the agent's name and a **status dot**,
+and hovering the dot tells you the status and how long since its last activity. Click a tab (or use
+the next/previous-agent keybinding) to switch between them.
+
+Create a new agent with the **+** button at the end of the tab bar (or the new-agent keybinding); it
+creates an agent of your last-used **type**. Next to it, a small **chevron** opens a menu of the types
+you can create: the built-in **Claude** rich-chat agent (and the experimental **Pi** chat agent where
+enabled → §7.12), a plain **Terminal**, and then each **registered terminal agent** by its display
+name — out of the box that's **"Claude CLI"**, which runs the Claude Code TUI in the workspace (→ §7.3
+Chat). The menu marks your last-used type with a check, Sculptor remembers it, and a plain **+** click
+re-creates that type without opening the menu. **Double-click** a tab to rename it (Enter saves, Escape cancels), drag tabs to **reorder**
+them, and right-click for more: rename, **mark as unread**, delete, plus diagnostics. **Deleting** an
+agent (after confirming) moves you to the next one, or starts a fresh agent if it was the last.
+
+Because every agent in a workspace works on the same copy of your repo, **siblings share its files
+and Git state with no locking**. In practice it's rare to have two of them *actively editing* at the
+same moment — and you wouldn't want to, since with no lock to stop them, two agents touching the same
+file at once can step on each other. The real reason to keep several agents in one workspace is to
+hold **separate contexts and roles** over the same code: an *implementer* agent and a *reviewer*
+agent, say, or one agent carrying the main feature work while another is a scratch context for a side
+investigation or a quick experiment — each with its own conversation and history, all looking at the
+same files. When you do want genuinely *simultaneous* work, divide it across different parts of the
+codebase or stagger dependent tasks so the agents don't collide — though for fully independent,
+parallel work, separate **workspaces** are usually the better tool (→ §7.2, scenarios S2/S5). Beyond
+your siblings, a single agent can spin up its own **subagents** to fan out sub-tasks, and can run
+longer **background tasks** that keep going while you read its main reply (→ §7.3 Chat).
+
+To check on a workspace without leaving the one you're in, hover a workspace tab to open a **peek**
+popover: a quick preview of that workspace's status, its list of agents, branch, pull-request state,
+and diff stats. Moving between tabs swaps the preview instantly; for a busy workspace it shows the
+first few agents with a "+N more" control to reveal the rest. Click an agent row (or the header) to
+jump straight there.
+
+### 7.5 Changes — review & commit
+
+When an agent edits files, you review the result in the **Files** panel, which sits at the top-left
+of the workspace and carries three tabs: **Browse** (the workspace's full file tree, for opening any
+file), **Changes** (every modified file), and **Commits** (the workspace's commit history). The
+Changes and Commits tabs show a count badge when there's something to see. Nothing leaves the
+workspace until you choose to commit (→ §7.6 Pull Requests).
+
+The file tree can be shown as a nested **tree** or a flat list, and you can toggle between them,
+collapse every folder at once, or refresh to re-fetch. A search control filters the tree as you type
+— ancestor folders of matches expand automatically, and "No matches" appears when nothing fits. In the
+**Changes** view each file carries a status letter (modified, added, deleted, renamed) in a distinct
+color along with its added/removed line counts; folders roll those up into a change-count badge,
+deletions are struck through, and a file that failed to process shows an error badge. (The **Browse**
+tree lists the whole repository without these change decorations.) When the agent is actively touching
+a file, the tree scrolls to it, opens its ancestors, and briefly **highlights** the row so you can
+follow the work as it happens. Right-clicking a file or folder opens a menu with actions like opening
+its diff, viewing the file, and copying its path (full or relative) — plus, when Sculptor can reach
+your local filesystem, opening it in your OS's default app and revealing its containing folder.
+
+Clicking a file in the **Changes** tab opens it in the main **diff** view; clicking a file in
+**Browse** opens its read-only contents instead, since an unchanged file has no diff. A scope picker lets you look at only the
+**uncommitted** changes or, when the workspace has a target branch (GitHub/GitLab repos → §7.6),
+**all** changes measured against that target branch, with a count on each option. The diff itself can be shown **side-by-side** or **unified** (inline), with line-wrapping, a
+find-in-file search that highlights matches and counts them ("X of Y") as you step through, and an
+expand control that widens the diff across the whole window. A binary file replaces the diff with an
+explanatory banner, and renamed or deleted files show a banner above the diff — and for images, a
+before/after preview with zoom and pan — while a very large diff is truncated behind a "Show full diff" button. When the
+experimental **Rich markdown rendering** feature is enabled (→ §7.12), a markdown file can be flipped
+between its raw source and a rendered preview. You
+can also open a file's full read-only contents with syntax highlighting rather than a diff, and — with
+the experimental **Review All** feature enabled (→ §7.12) — a
+"Review All" option gathers every change into a single combined diff tab. In the **uncommitted** scope, each changed file has a
+**Discard changes** action that reverts just that file to its last committed state after you confirm.
+
+When you're satisfied, the **Commit** button at the top of the Changes tab, above the file list — labeled with the
+pending count, e.g. "Commit 2 changes," and disabled when there's nothing to commit — asks the agent
+to write a message and make the commit on the workspace branch. Committing does not push; the commit
+stays on the branch until you push it or open a PR/MR. Clicking the button does a **quick commit**
+with the default prompt; right-clicking it opens a dialog to **edit and save the commit-message
+prompt**, which then steers how messages are written on subsequent commits.
+
+The **Commits** tab shows the workspace's history as a **commit graph** with connecting dots and
+lines. Each entry shows the first line of its message, the file count, added/removed stats, a
+relative time, and a short hash; hovering reveals a popover with the commit's author, date,
+and short hash, and a copy button that copies the full hash, confirming by briefly swapping its icon for a checkmark. Clicking an entry expands it to
+list the files in that commit, and clicking one of those files opens a diff of that file against its
+parent. Merge commits can be expanded to follow the merged-in branch, and a marker at the bottom
+shows where the workspace's history forks from its starting point.
+
+### 7.6 Pull Requests
+
+The pull-request surface described here appears **only when the workspace's repo has a GitHub or
+GitLab `origin`**; for any other repo there is no target-branch selector and no PR/MR control, and you
+push the branch yourself. Given such a repo, once you've committed work on a workspace branch you can
+open a **pull request** (on GitHub) or **merge request** (on GitLab) straight from the workspace's
+top bar — Sculptor stays provider-neutral, so the control reads "Create PR" or "Create MR" to match
+your repo. Clicking it pushes the branch and
+asks the agent to open the request against the workspace's target branch. If you'd rather adjust how
+that's done first, the button's chevron menu offers **Edit prompt...**, which opens a dialog to revise
+the PR/MR-creation prompt before you create anything. While Sculptor is looking up status, the button
+shows a spinner with "Checking PR..."/"Checking MR...".
+
+Once a request exists, the button displays "PR #N"/"MR !N" alongside small status dots for its
+**pipeline/CI** and **review** state; hovering the dots explains them ("Pipeline running/passed/
+failed," "Approved/Review pending," and so on). Clicking the number opens the request in your browser.
+The chevron opens a **detail dropdown** with the title and link, checks/pipeline status, approvals and
+reviewer names, and any unresolved comments. If a **CI babysitter** is available, a switch in this
+dropdown lets you pause or resume it — when on, Sculptor keeps an eye on the request's CI for you —
+and the status text updates as you toggle it.
+
+When the request is **merged** or **closed**, the button switches to a merge icon reading "PR #N
+merged"/"closed," and clicking it still opens the request in the browser. If a request already exists
+but targets a different branch than the workspace does, the button becomes **Assign PR/MR**, offering
+to create a fresh request against the workspace's target or to switch the workspace's target to match
+the existing request. The target-branch selector itself flags the mismatch in a warning color, with a
+hover hint like "PR #N targets {branch} — retarget?". (A failing CI check itself just shows a red
+pipeline dot / "Failed" badge on the normal button.) If Sculptor can't *look up* the request's status
+at all — the provider CLI is missing, you're not authenticated, the host is rate-limiting, and so on
+— the button turns into an error state: a warning triangle for something you can act on, or an info
+icon otherwise, whose popover gives a title, description, optional details, and sometimes a copyable
+remediation command.
+
+### 7.7 Terminal
+
+Sculptor includes a built-in **workspace terminal** — a real shell that runs inside the current
+workspace, so anything you type operates on the very files the agent is working with. It's handy for
+starting a dev server, running tests or linters, inspecting git state, or any command that's quicker
+to run yourself than to ask the agent for. You open it from the command palette or the panel controls
+in the bottom bar, and it can sit open alongside a running agent without interfering with the
+conversation.
+
+You can keep several terminals going at once. The **+** in the tab bar adds another ("Terminal N"),
+double-clicking a tab renames it inline, and each tab is an independent shell in the same workspace;
+right-clicking offers rename, close, and "Close others," tabs can be reordered, and closing the last
+one spins up a fresh replacement. When output arrives in a tab you're not looking at, a pulsing
+**unread** dot appears on it and clears when you switch over. A starting terminal briefly shows
+"Starting terminal..." while it
+comes up; Ctrl+L clears the focused terminal; and your terminals — along with their scrollback —
+persist as you navigate around Sculptor rather than resetting each time.
+
+This section is about your own terminal. It is distinct from a **terminal agent** — an agent type
+whose main panel is a shell the *agent* drives rather than you (→ §7.3 Chat, §7.4 Agents).
+
+### 7.8 Skills & Workflows
+
+A **skill** is a reusable agent capability you invoke as a slash command from any chat input — type
+`/` to open the picker (which also lists built-in conversation commands like `/clear` and `/compact`
+alongside skills → §7.3). Skills run as full agents with their own tools, so they can read your
+codebase, spawn parallel subagents, and adapt to your repo. Sculptor surfaces three kinds: the
+**built-in** skills it ships with, the **Sculptor** plugin skills (the workflow and experimental sets
+below, plus the base `sculptor` plugin's `help` and `sculpt-cli`), and any **custom** skills you've
+installed under your home or repo `.claude/` directory. They all appear together in the picker, sorted
+alphabetically.
+
+The dedicated **skill library** panel lists every available skill grouped by type under collapsible
+headers. Hovering a skill opens a popover with its
+description; moving to another skill swaps the content instantly. Clicking a skill drops
+`/skill-name` into the chat input, ready to send (and a custom or Sculptor skill's chip carries an
+**Open in Sculptor** control that opens the skill's file in a viewer tab so you can read its definition). The
+panel has its own search box that filters as you type, with arrow-key navigation and a type filter to
+narrow which kinds are shown. While the agent is running, the chips are disabled; the panel also has
+clear loading, empty, and error states.
+
+The flagship bundled skills form the **engineering workflow** (the `sculptor-workflow` plugin): a
+pipeline that takes a feature from idea to shipped code in focused stages — **spec → mock → architect
+→ plan → build → review**. Each stage is its own skill and runs as its own dedicated agent, renamed
+to match the stage ("Spec", "Architect", "Plan", and so on) so you can tell the tabs apart, and each
+produces a durable artifact on disk that the next stage reads. `spec` writes the implementation spec
+through guided Q&A you watch take shape in the diff viewer; `mock` produces interactive HTML mocks
+(exploration mode generates several variants to compare, confirmation mode refines one); `architect`
+writes the architecture document; `plan` turns it into a folder of self-contained task files; `build`
+executes them one at a time, committing as it goes; and `review` checks the diff against the spec,
+re-runs the tests, and writes up its findings. You don't have to run the whole pipeline — every stage
+takes a feature *slug*, finds the earlier artifacts, and offers to **hand off** to the next stage
+when it finishes.
+
+Two more workflow skills stand alone. **`setup-repo`** is run once per repo to create the small
+config files that teach the other skills how your codebase builds, tests, and where it keeps docs
+(other stages invoke it for you if those configs are missing). **`fix-bug`** is a self-contained,
+test-driven bug fix: it reproduces the bug with a failing test, fixes the code, and verifies —
+interactively by default, or end-to-end with no questions when run autonomously, optionally opening a
+pull request if the repo allows it.
+
+### 7.9 Command Palette & Navigation
+
+Sculptor is organized into **tabs** along the top: a **Home** tab, a **Settings** tab, and a tab for
+each open workspace. You switch tabs by clicking, cycle through them with keyboard shortcuts (these
+keep working even in zen mode), drag to reorder them, and close them with the tab's minimize button, a middle-click,
+or a keyboard shortcut. Workspace tab labels truncate when long and carry a small **status dot**
+reflecting the agent's state; double-clicking a tab renames the workspace inline, and right-clicking
+opens a context menu to rename it, delete it, or close others/all. When too many tabs are open they overflow into a horizontal
+scroller that keeps the active tab in view, and closed workspaces collect into a pill you can reopen
+from. Tabs persist across restarts.
+
+The **Command Palette**, opened with **Cmd+K** from anywhere, is the fastest way to get around once
+you have several workspaces and agents open. It's a searchable list with the input focused and
+commands grouped (Workspaces, Navigation, Theme & Layout, Chat, Terminal, Help). Type to filter
+(fuzzy and case-insensitive, with groups reordering by best match), move with the arrow keys, press
+**Enter** to run a command — or **Cmd+Enter** to run it and keep the palette open for another. Some
+commands open **sub-pages** (shown with a chevron and reached with Tab) such as the workspace
+switcher, which **Cmd+P** opens directly. From the palette you can switch between or create workspaces
+and agents, show or hide panels, open Settings or Help, and toggle the theme. Commands
+that don't apply right now are greyed out with a reason ("Only one agent in this workspace", "No
+uncommitted changes"), and rows show their keyboard shortcut where one exists.
+
+The **bottom bar** carries toggle buttons for the left, bottom, and right side panels plus a
+focus-mode button. Clicking a toggle shows or hides that panel and updates its active state; a panel
+with no content is disabled with a "Panel is empty" tooltip; and hovering any toggle shows its name
+and keybinding. **Focus mode** (Cmd+\) collapses all side panels so the chat expands, and toggles
+back. **Zen mode** (Cmd+Shift+\) goes further, hiding the top bar and side panels entirely to leave
+just the chat with a draggable title bar; an "Exit zen mode" button appears when you move to the
+top-left corner. The app's **version number** sits in the bottom-right — in the workspace bottom bar
+and in the corner of the non-workspace pages; clicking it opens a popover with version details,
+update status, and diagnostics, and a colored dot plus toasts signal when an update is downloading or
+ready to install. A **Report a problem** button sits alongside the version indicator for sending
+feedback.
+
+### 7.10 Settings
+
+**Settings** (opened with Cmd+, or from the top bar) is a single page with a sidebar of sections; it
+remembers the last section you viewed and can be deep-linked to a specific one. Changing a setting
+saves on the spot with a "Setting updated" toast (or an error toast on failure).
+
+The **General** section controls appearance — the Light / Dark / System theme — and software updates,
+including the release channel and a "Check for updates" / "Install and restart" control. **Agent**
+sets the defaults applied to new agents: the default model, fast mode, and effort level.
+**Keybindings** lets you search, view, assign, clear, and reset every keyboard shortcut, warning you
+when a combination conflicts with an existing one. **Panels** governs the default panel layout —
+which zone each panel lives in, per-panel hotkeys, and which non-builtin panels are enabled — with a
+reset-to-defaults. **File Browser** sets diff defaults (split versus unified, line wrapping, the
+default split ratio), tab-close behavior, and the commit-message prompt.
+
+The repo-facing sections are **Repositories**, **Git**, and **CI**. Repositories lists your connected
+repos with their paths and agent counts and lets you add or remove them and configure each one's
+**setup command** and **branch-naming pattern**. Git holds the cross-repo defaults: the pull-request
+creation prompt, PR-status polling and its interval (plus a multiplier that throttles polling for
+closed workspaces), the default target branch, the global
+branch-naming pattern, and the branch-deletion policy. CI configures the **CI babysitter** that
+watches pipelines and asks an agent to fix failures — a toggle, a retry cap, and editable prompts for
+pipeline failures and merge conflicts.
+
+The remaining sections cover the environment and account. **Dependencies** manages the Claude CLI and
+git binaries Sculptor uses — switching between a managed install and a custom path, showing each one's
+version and health. **Pi (experimental)** is the parallel dependency manager for the experimental Pi
+agent harness — its binary (managed or custom path), version, and the API-key environment variable it
+needs. **Environment Variables** surfaces the global and per-repo `.sculptor/.env` files (which you edit
+directly) and controls whether they override existing variables. **Privacy** shows your (read-only) email address and
+the telemetry opt-out. **Actions** is the full manager for your saved prompts and groups, including
+import/export (→ §7.11). **Experimental** holds opt-in feature toggles and the custom backend command
+(→ §7.12). A **Theme Builder** section lets you fine-tune fonts, the code theme, accent and semantic
+colors, border radius, UI scaling, and panel translucency, with a component gallery and a reset.
+
+### 7.11 Actions & Notes
+
+**Actions** are saved, re-runnable prompts that live in a workspace panel as one-click chips,
+organized into **action groups** (the built-in "Sculptor" group — which ships `/help` and `/fix-bug`
+shortcuts — sits first, with any ungrouped actions at the bottom; collapsed group headers carry a count badge). Clicking an action either sends
+its prompt immediately (an auto-submit action, shown with a play icon) or appends it to the chat input
+for you to edit first (a draft action, shown with a text-cursor icon); a hover tooltip previews the
+prompt. While the agent is running, a right-click **Queue message** option on an action lets you queue
+its prompt to run after the current turn rather than sending it immediately. You create, edit, and delete actions through a dialog (Name, Prompt, Group, and an
+auto-submit toggle), manage groups inline (add, rename, delete), and drag actions and groups to
+reorder them or move an action between groups — built-in items can't be edited, deleted, or dragged.
+The same actions can be managed in bulk from Settings, including import and export to a JSON file
+(→ §7.10).
+
+**Notes** are a per-workspace scratchpad: a panel of free-form text you can type into, which persists
+as you switch away and back. When you're ready, **Add notes to prompt** folds the note text into the
+chat input (if the input already has content, it asks whether to overwrite), and a copy button copies
+the note out; both controls disable when there's nothing to act on.
+
+These helpers sit alongside the chat input's **mentions** and **path-autocomplete**. Typing `+` opens
+a category picker (Files & folders, Skills, Workspaces and Agents, Repositories, and Images where
+supported), `@` searches files and folders, and `/` searches skills — each inserting a **mention chip** into the
+prompt. In path fields (such as adding a repo), typing a path beginning with `/` or `~` brings up a
+directory autocomplete you can drill through before submitting.
+
+### 7.12 Experimental & in-development features
+
+Sculptor gathers its in-development capabilities under one banner — **Settings → Experimental**,
+described there as "Features that are still being developed. These may change or be removed." The
+product makes no finer distinction than that: a feature is either generally available or
+**experimental** (opt-in). The experimental surface as it stands today:
+
+**Experimental feature toggles** (Settings → Experimental), most an opt-in switch:
+- **Clone workspaces** and **In-place workspaces** — worktree is the only workspace mode out of the
+  box; enabling these adds the older **clone** mode (a full git clone whose remotes mirror your
+  repo's, where commits stay in the clone until you push the branch back to your repo) and the
+  unisolated **in-place** mode to the Add Workspace picker (→ §6, §7.2).
+- **Always interrupt and send** — a new message immediately interrupts the running agent instead of
+  being queued (→ §7.3).
+- **Smooth streaming** — animate streamed text smoothly rather than showing it in bursts. (Unlike the
+  other toggles here, this one is **on by default**.)
+- **Per-workspace panel layout** — panel visibility and sizes become local to each workspace (panel
+  positions stay shared).
+- **Review All** — adds the combined "Review all changes" diff view to the Files panel (→ §7.5).
+- **Entity Mentions** — type `+` in the chat input to mention repositories, workspaces, and agents
+  (→ §7.11).
+- **Rich markdown rendering** — render `.md` / `.markdown` files as formatted HTML in the file
+  viewer, toggled by the eye icon in the diff toolbar.
+- **Pi agent** — offer the experimental **Pi** agent as a choice when creating an agent (→ §7.4); an
+  already-running Pi agent keeps going regardless of the toggle.
+- **Custom backend command** — the entry point for the container / remote backend described below.
+
+The **CI babysitter** (→ §7.6, §7.10) is likewise experimental and off by default.
+
+**Experimental skills** (the `sculptor-experimental` plugin, invoked as slash commands, → §7.8):
+- **`handoff`** — hands the current work to a fresh agent seeded with a summary of where you are,
+  either as a new agent in the same workspace (sharing the branch and uncommitted files) or a
+  brand-new workspace on its own branch cut from the current one.
+- **`stack`** — a handoff into a new workspace whose branch is both based off and targets the current
+  branch, scoping the new workspace's diff and any pull request to just the work stacked on top.
+  Available only from worktree workspaces.
+
+**Experimental panels.** Optional, non-builtin panels can be enabled from Settings → Panels — most
+notably the in-app **Browser** panel (desktop-only), which embeds a browser beside the chat with an
+address bar and back/forward/reload/screenshot controls; outside the desktop app it shows a
+placeholder.
+
+**Container / remote execution backend.** Pointing the **custom backend command** at a launcher lets
+Sculptor run agents somewhere other than your host machine — inside a Docker container, on a remote
+server over SSH, or in a VM. The launcher starts the backend and prints a URL the app connects to;
+the GUI, workspace management, and agent orchestration are otherwise unchanged. A companion
+**backend-readiness timeout** sets how long the app waits for that URL to come up, and the app
+automatically restarts the custom backend (with backoff) if it crashes. The command can be set either
+in Settings or through an environment variable, and setting or clearing it requires restarting the app
+(→ §9.1 for the isolation and trust implications).
+
+## 8. The `sculpt` CLI  _(core product surface)_
+
+`sculpt` is a first-class way to drive Sculptor **headlessly** — from a terminal, a shell script, or
+CI — against the very same local Sculptor that the desktop app talks to. Anything you create with
+`sculpt` shows up in the GUI, and anything you create in the GUI is visible to `sculpt`: a
+**Workspace** you spin up on the command line opens as a real workspace in the app, and an **Agent**
+you start from a script streams its conversation into the same chat panel a person would watch. This
+makes `sculpt` the natural surface for automating Sculptor, scripting fleets of parallel agents, or
+wiring coding agents into a pipeline.
+
+The CLI is organized into a handful of command groups, each mapping to a domain noun or a job:
+
+| Group | What it's for |
+|---|---|
+| `sculpt repo` | List and show the **Projects (Repos)** Sculptor knows about — their paths and whether they're accessible. |
+| `sculpt workspace` | Create, list, show, rename, and delete **Workspaces**. Pick the isolation **strategy** (`--strategy`: `worktree`, `clone`, `in-place`); choose the source branch (`--branch`), a name for the workspace's new branch (`--branch-name`), its target (`--target-branch`), and a description (`--name`) at create time; `list` can span all repos (`--all`) or one (`--repo`), and `delete` takes `--yes`/`-y` to skip the prompt. |
+| `sculpt agent` | Manage **Agents** in a workspace: `create` one (with an opening `--prompt`, a `--model`, and a `--name`), list (filter by status, scope with `--all` / `--repo` / `--workspace`), show, `send` a message (with `--model` and repeatable `--file` attachments), check `status`, read `messages` (`--limit`/`--tail`), `interrupt` a running one, rename, and delete. `send`, `status`, and `messages` all accept `--follow` to stream live. Choose the **model** (`haiku`, `sonnet`, `opus`, `fable`, plus the `sonnet[1m]` / `opus[1m]` 1M-context variants). |
+| `sculpt run` | One-shot convenience: from a single prompt, create a workspace **and** an agent in one step, optionally `--follow` its output live. Accepts the same workspace-creation flags as `sculpt workspace create` (`--strategy`, `--branch`, `--target-branch`, …) plus `--model` and `--file`. |
+| `sculpt signal` | Run from **inside an agent's environment** to report state back to Sculptor — `busy`, `idle`, `waiting`, `files-changed` (refreshes the diff), or `session-id <id>` (which takes the session identifier as an argument). Lets terminal-based agents light up the same status indicators the GUI shows. |
+| `sculpt ui` | Let an agent **drive the app's UI** for the user: `open-file` (open a file or diff tab, with `--mode auto`/`diff`/`file`) and `webview-navigate` / `webview-refresh` (point or reload the in-app Browser panel, e.g. at a generated HTML report). |
+| `sculpt schema` | Print machine-readable **JSON Schemas** for command output (run with no argument to list the available schema names, including a dedicated `error` schema for `--json` failures), so scripts can validate and parse results reliably. |
+
+Two conventions make the CLI script-friendly. Commands that emit results accept **`--json`** for
+structured output (paired with `sculpt schema` for the exact shape) instead of human-readable text
+(`sculpt schema` itself already prints JSON), and
+**environment variables set sensible defaults** so you don't repeat IDs — most notably
+`SCULPT_WORKSPACE_ID` and `SCULPT_AGENT_ID` (and `SCULPT_PROJECT_ID`, which the shell inside every
+Sculptor workspace already sets); `SCULPT_API_PORT` (or a per-command `--base-url`) points the CLI at
+a non-default local server. Workspace-scoped commands also take an explicit `--workspace`/`-w` flag
+that overrides the env-var default, and the WebSocket-backed read commands (`agent show`, `status`,
+`messages`) accept a `--timeout`. IDs can be given as short prefixes rather than full values.
+
+A couple of example invocations:
+
+```bash
+# Kick off a fresh workspace + agent from a prompt and watch it work
+sculpt run "Fix the failing auth tests" --repo ~/code/myapp --model sonnet --follow
+
+# Drive an existing agent (workspace taken from $SCULPT_WORKSPACE_ID), as JSON
+sculpt agent create --prompt "Add a /health endpoint" --model opus --json
+sculpt agent send a1b2c3 "Also add a test for it" --follow
+
+# From inside an agent's environment: surface a generated report to the user
+sculpt ui webview-navigate file:///workspace/code/report.html
+sculpt signal files-changed
+```
+
+## 9. Non-Functional Behavior
+
+Beyond any single feature, Sculptor makes a set of cross-cutting promises about how it behaves — what
+your agents can touch, how your work survives a crash, and what leaves your machine. These guarantees
+hold across every workspace and agent.
+
+#### 9.1 Isolation & safety
+
+By default an agent works in an **isolated copy** of your repository, so it can read, edit, and run
+real commands freely without ever touching your own checkout — the files you have open stay exactly as
+you left them. Working **in place** in your actual checkout is the deliberate, opt-in exception. An
+agent's edits are committed onto a **workspace branch** that belongs to that workspace; nothing is
+ever pushed to a remote, and no pull request is opened, unless you take that action yourself. The
+trust posture is straightforward: agents run real shell commands inside their workspace and can do
+real work there, while you remain the gatekeeper for anything that reaches the outside world — pushes,
+PRs, and merges back to your code. An **experimental container/remote option** goes a step further and
+runs agents off your machine entirely (→ §7.12).
+
+#### 9.2 Concurrency
+
+You can run **many agents across many workspaces at once**, and they make progress in parallel without
+getting in each other's way. The one thing to watch: agents placed in the **same** workspace share the
+same files with no locking between them, so if you point two agents at overlapping work they can step
+on each other's changes. Keeping concurrent agents on separate concerns (or separate workspaces) is
+your responsibility (→ §7.4).
+
+#### 9.3 Crash recovery & resumption
+
+Quitting Sculptor — or having it crash — and reopening it **restores your workspaces, your agents, and
+the full conversation history** right where you left them. An agent that was running is reattached and
+resumed wherever that's possible, and a question an agent asked you before the interruption can still
+be answered after you reopen the app. When something does go wrong, the app **surfaces the error**
+rather than failing silently, and an agent left in an errored state can often be restored and
+continued rather than lost.
+
+#### 9.4 Responsiveness
+
+The UI stays **live**: an agent's output, its changing status, and the file changes it makes appear in
+real time as they happen, with no manual refresh. What you see stays consistent with what you clicked
+— the app reflects the true current state of each agent and workspace rather than a stale snapshot.
+
+#### 9.5 Persistence & durability
+
+Your work is **stored locally and is durable**. Workspaces, agents, the complete conversation history,
+and your settings are all saved on your own machine and survive both restarts and upgrades to a newer
+version of the app — installing an update preserves everything you've done.
+
+#### 9.6 Security & auth
+
+Sculptor is **local-first and single-user**: it runs on your machine for you, and your code stays
+there. Imbue does not store your repositories and does not train on your code. Credentials and keys the
+app needs to do its work are handled locally on your behalf, and the boundary stays the same one
+described in §9.1 — your code and secrets stay on your machine unless you explicitly send something
+out.
+
+#### 9.7 Telemetry & privacy
+
+Anonymous usage telemetry is **opt-out**. You make the choice during onboarding, and you can change it
+at any time in **Settings → Privacy**. When it's on, what's collected is high-level, anonymized
+product-usage and error-reporting signal — which features are used and when things break. The
+product-usage telemetry is designed to keep private content such as file names, branch names, and
+prompts out of what is sent (for example, by masking captured page text); error reports are gated on
+the same consent. Turning it
+off is respected across restarts.
+
+## 10. Testability & Engineering Substrate
+
+The systems below are **not user-visible and not technically part of the product**, but Sculptor
+cannot be built with high quality without them.
+
+**Why this is a top-level concern:** Sculptor's correctness is mostly *emergent behavior* of
+nondeterministic agents acting over real repositories — it can't be specified into existence, it
+has to be made **reproducible, observable, and verifiable** during development. Each substrate below
+exists because Sculptor depends on something nondeterministic, external, slow, or hard to observe.
+
+#### 10.1 Test doubles & determinism
+The single most important piece is **FakeClaude**: a drop-in replacement for the `claude` CLI that
+the agent runner launches during tests. Instead of calling a model, it reads the prompt and — when
+the prompt carries a `fake_claude:<command>` directive — performs a scripted behavior (emit text,
+stream text with delays, write or edit a file, run bash, update a TODO list, ask the user a
+question, spawn a subagent, trigger compaction, …) while producing exactly the JSONL stream and
+session files the real harness would. This turns the product's most nondeterministic dependency
+into a precise instrument: a test can demand a specific sequence of tool calls and assert the UI
+that results. A companion primitive, **`FakeClaudePause`**, freezes the fake agent mid-stream and
+releases it on command, so transient states (a streaming cursor, a "compacting" indicator, an open
+question panel) can be observed deterministically. The same idea recurs for other external
+dependencies: CI stubs the real `claude` binary, and **test repo factories** synthesize throwaway
+git repositories so tests never depend on a real checkout.
+
+#### 10.2 The end-to-end harness
+Frontend integration tests drive the *real* app in a real browser via Playwright, structured as a
+**Page Object Model**: a `SculptorInstance` owns the backend process, browser page, and test repo,
+and typed page/element objects expose semantic actions ("create a task", "open the diff") instead of
+raw selectors. The UI honors a stable **test-id contract** (the `ElementIDs` enum), and integration tests are
+tagged with a **`@user_story(...)`** describing the behavior they validate — the thread that links a
+test back to a scenario.
+
+#### 10.3 Test taxonomy & fidelity tiers
+Tests are stratified by a deliberate determinism-vs-fidelity trade: **unit** tests (colocated,
+backend and frontend); **integration** tests (Playwright + FakeClaude, the bulk of user-visible
+coverage); **regression** tests (one per fixed bug); and the model-backed **`real_claude`** and
+**`real_pi`** tiers that run the same flows against the actual model CLIs to catch protocol drift.
+The real-model tiers are slow and cost API usage, so they're excluded from CI and run deliberately.
+Further pytest markers segregate tests by **launch mode** — e.g. `electron`, `electron_custom_command`,
+and `packaged_electron` (the last combined with `release`) — and by sandbox needs (e.g.
+`custom_sculptor_folder`), so a test runs only in the environment it requires.
+
+#### 10.4 Scenarios-as-tests methodology
+This spec, the exhaustive **`scenarios.md`** (≈446 Given/When/Then behaviors), and
+**`scenario_coverage.md`** (which maps each scenario to the integration test covering it) together
+form the **English-level acceptance layer**: the spec is the source of truth, the scenarios are
+concrete acceptance checks against it, and the coverage report measures how well the product is
+actually demonstrated. This methodology is itself testability infrastructure — it is the reason the
+scenario corpus exists.
+
+#### 10.5 CI execution substrate
+Tests run at scale on **offload**, which fans work out across many parallel sandboxes on Modal
+(hundreds for integration, dozens for unit) with a **cached base image** — slow dependency layers are
+checkpointed and only a thin source diff is applied per run, keeping feedback fast. A separate
+**packaged-test** stage runs the integration suite against the *built* desktop artifact (the
+DMG/AppImage), not source, to verify the thing that actually ships — including DMG validation.
+
+#### 10.6 Static quality gates
+Beyond tests, a set of gates keeps quality from eroding silently. **Ratchets** are per-rule violation
+budgets that can only be reduced, never raised without justification — they let the codebase tighten
+over time (e.g. forbidding raw CSS selectors or `time.sleep()` in integration tests, capping
+`logger.warning` use). Alongside them: formatting, linting, and type-checking (ruff, eslint,
+pyrefly, tsc), a **design-token stylelint plugin** that forbids hardcoded style values, and
+file-hygiene and shell checks.
+
+#### 10.7 Cross-surface contract generation
+Sculptor has three surfaces over one backend (GUI, CLI, API), kept from drifting by **generation
+rather than hand-maintenance**: TypeScript types and the frontend API client are generated from the
+FastAPI/OpenAPI schema, the `sculpt` client is generated similarly, and a **frozen model-schema
+snapshot** (→ §10.8) detects unintended backend-model changes. A backend-model change that isn't reflected across surfaces shows
+up as a regenerated diff or a failing check, not a runtime surprise.
+
+#### 10.8 Data-durability machinery
+User data lives in a local SQLite database, and migrations are first-class: every Alembic migration
+ships with a **version test** that exercises the upgrade against representative data, and a frozen
+Pydantic-schema snapshot is wired in to guard the versioned JSON fields against unintended change. This is what lets the product evolve its
+data model across releases without corrupting users' existing state.
+
+#### 10.9 Diagnosability
+Finally, infrastructure for understanding failures that escape the tests: distributed **tracing**,
+**Sentry** error reporting, structured logging conventions, in-app **debug / diagnostics** views
+(per-agent diagnostics, the chat debug view), the **auto-qa** headless-browser harness for
+visual/manual QA, and **Storybook** for inspecting components in isolation.
+
+## 11. Build, Release & Distribution
+
+This section describes how Sculptor is built and how it reaches users.
+
+#### 11.1 Build & packaging
+
+Sculptor ships as a **desktop application** that combines a **React frontend** with a **packaged
+backend**, bundled together into an **Electron app** via Electron Forge. The release pipeline builds
+for **macOS** (Apple Silicon) and **Linux** (x64, with arm64 as a best-effort, non-blocking target).
+The **`sculpt` CLI** is built and
+shipped alongside the app (together with a `sculptor_migrate` data-folder migration helper), so the
+command-line surface is available wherever Sculptor is installed.
+
+#### 11.2 Release & versioning
+
+Builds flow through three channels. **Dev builds** are cut from `main` (always carrying a `.dev`
+version suffix) for everyday testing. From there a release is cut onto a **release branch**, first as
+a **release candidate** and then promoted to a **stable release**, with hotfix branches available for
+an already-published release. Releases are **tag-driven**: pushing the release tag drives CI to build,
+sign, package, and publish the artifacts, and the version is checked against the build context so a
+tag build can never publish an inconsistent version.
+
+#### 11.3 Distribution & auto-update
+
+Users download Sculptor as a **signed and notarized macOS `.dmg`** or a **Linux `.AppImage`** (linked
+from the README and Imbue's download page). Once installed, the app keeps itself current with **in-app
+auto-update**: it detects a newer release on the chosen channel, and a toast offers to **install and
+restart** in place — no manual re-download required.
+
+#### 11.4 Help docs
+
+User-facing help lives under **`docs/help/`** — getting started, workspaces, chat, terminal, agents,
+changes, pull requests, skills, the command palette, settings, and the experimental container backend.
+These docs are **audited and refreshed for each release** so they match the shipped version, including
+re-captured screenshots.
+
+## 12. Open Issues
+
+Unresolved questions to settle as the spec matures. Each names a specific place the spec is currently
+inconsistent about the §9-product-behavior vs. §10-engineering-substrate line:
+
+- **Do user-facing diagnostics belong in §7 or §10?** The diagnostics a user can actually open — the
+  chat **debug view** (and its timestamp toggle), per-agent **diagnostics** from the agent context
+  menu, and the **diagnostics** in the version popover — are currently filed under §10.9
+  (Diagnosability) as engineering substrate, yet they're user-visible features that would otherwise
+  belong in §7. They're documented in neither place right now. Decide the rule (user-openable ⇒ §7?)
+  and apply it.
+- **Auto-update is split across three sections** with no single home: the version popover and update
+  toasts (§7.9), the guarantee that updating preserves your work (§9.5), and the update mechanism
+  (§11.3). Confirm this is intentional faceting rather than something to consolidate.
+- **The cross-surface consistency guarantee** — that a workspace or agent created via `sculpt`
+  appears in the GUI and vice versa — is asserted in §5 and §8 but has no entry among the §9
+  guarantees, where a user-facing cross-cutting promise would normally live. Decide whether to add
+  one.
+
+## Appendix A — Glossary
+
+The core nouns are defined in §6 (Core Domain Model). This is a quick reference for secondary terms
+used throughout:
+
+- **Target branch** — the branch a workspace's changes and pull request are measured against.
+- **Plan mode** — an agent investigates and proposes a plan for your approval before changing files.
+- **Fast mode** — trades some response depth for quicker output.
+- **Effort** — how much thinking an agent spends per step (Low … Max).
+- **Peek** — the hover popover previewing another workspace's agents, branch, and status.
+- **CI babysitter** — an opt-in helper that watches a pull request's CI and asks an agent to fix
+  failures.
+- **Slug** — the short feature identifier the workflow skills (spec → … → review) use to find each
+  other's artifacts.
+- **Skill** — a reusable, slash-invoked workflow that runs as its own agent.
+- **Zen / Focus mode** — view modes that hide panels (and, for zen, the top bar) to maximize the chat.

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -1,0 +1,404 @@
+# Sculptor — Requirements
+
+This document specifies the product's measurable targets, limits, compatibility bars, data and
+integration contracts, and cross-cutting guarantees as they exist today.
+
+## How to read this document
+
+This is the requirements leg of the specification set. `SPEC.md` describes *what the product is and
+how each feature behaves*; this document pins the **measurable and contractual** facts that prose
+deliberately leaves out — numeric targets, version/platform bars, persistence and migration
+guarantees, integration contracts, and where the product is intentionally configurable or currently
+unspecified.
+
+| Document | Answers | Layer |
+|---|---|---|
+| `SPEC.md` | *What is the product, and how does each feature behave?* | Functional behavior, in prose |
+| `scenarios.md` | *What exactly happens on screen, action by action?* (~446 Given/When/Then) | UI-level acceptance |
+| `scenario_coverage.md` | *Which test demonstrates each scenario?* | Coverage / traceability to tests |
+| **`requirements.md`** (this doc) | *What measurable targets, limits, and contracts does the product meet?* | Requirements |
+
+**This document does not restate functional behavior.** Where a requirement is "behave as described,"
+it points at the spec section and scenario area rather than re-deriving the behavior (which would
+duplicate and drift). What it adds is everything the descriptive spec intentionally omits.
+
+### Conventions
+
+- **Requirement IDs** are stable (`REQ-<AREA>-NNN`) so tests, tickets, and reviews can cite them.
+  Areas: `FUNC` (functional), `NFR` (non-functional, measurable), `COMPAT` (platform/deps),
+  `DATA` (persistence/migration), `INT` (external integrations), `SEC` (security/privacy/telemetry).
+- **RFC 2119 keywords**, scoped to the product: **MUST** = a guarantee the product always upholds;
+  **SHOULD** = the product's default/expected behavior, with deliberate or configurable exceptions;
+  **MAY** = optional or user-configurable.
+- **Criticality** — how central a capability is to the product: **Core**, **Standard**, **Optional**,
+  **Experimental**. (Experimental capabilities are opt-in; see `SPEC.md` §7.12.)
+- **Source values** are quoted from the current implementation with repo-relative `path:line`
+  citations, so each number in this doc is verifiable. A requirement tagged **[Unspecified]** is one
+  the product does **not** currently pin down — these are real gaps in the specification, collected in
+  §7 (Open questions).
+- Citations use repo-relative paths; line numbers are as of this writing and may drift — treat the
+  symbol/constant name as the durable reference.
+
+---
+
+## 1. Functional requirements
+
+The functional behavior lives in `SPEC.md` §7–§8 and is verified, action-by-action, by `scenarios.md`.
+Rather than copy it, this section indexes the product's capabilities with a criticality rating and
+pointers to their spec/scenario home.
+
+| ID | Capability | Spec | Scenarios | Criticality |
+|---|---|---|---|---|
+| REQ-FUNC-001 | Onboarding & connecting a repo (wizard, dependency checks, repo add/init) | §7.1 | `ONB`, `ADDREPO` | Core |
+| REQ-FUNC-002 | Workspaces: create (worktree default), banner, setup command, lifecycle, delete | §7.2 | `ADDWS`, `WS` | Core |
+| REQ-FUNC-003 | Rich chat agent loop: compose/send, streaming, tools, status, steer (stop/queue/interrupt), questions, footer, errors | §7.3.1 | `CHAT`, `MSG` | Core |
+| REQ-FUNC-004 | `/btw` read-only side question | §7.3.1 | `CHAT` | Optional |
+| REQ-FUNC-005 | Terminal agents (plain Terminal + registered, e.g. "Claude CLI") | §7.3.2 | `WS`, `CHAT` | Standard |
+| REQ-FUNC-006 | Multiple agents per workspace: tabs, status dots, create/rename/reorder/delete, peek, subagents, background tasks | §7.4 | `WS`, `CHAT` | Core |
+| REQ-FUNC-007 | Changes: Browse/Changes/Commits, diff view, scope picker, discard, commit | §7.5 | `PANEL` | Core |
+| REQ-FUNC-008 | Pull/Merge requests: create, status dots, detail dropdown, retarget, CI babysitter toggle | §7.6 | `WS` | Core |
+| REQ-FUNC-009 | Built-in workspace terminal(s) | §7.7 | `PANEL` | Standard |
+| REQ-FUNC-010 | Skills & workflows: picker, library panel, `sculptor-workflow` pipeline, `fix-bug`, `setup-repo` | §7.8 | `SKILL`, `CMDP` | Standard |
+| REQ-FUNC-011 | Command palette & navigation: tabs, Cmd+K / Cmd+P, bottom bar, focus/zen mode, version popover | §7.9 | `SHELL`, `CMDP`, `HELP` | Core |
+| REQ-FUNC-012 | Settings (all sections) | §7.10 | `SET` | Core |
+| REQ-FUNC-013 | Actions & notes; mentions & path autocomplete | §7.11 | `ACT`, `MENT` | Optional |
+| REQ-FUNC-014 | Experimental surface (toggles, experimental skills/panels, container backend) | §7.12 | `SET`, `PANEL` | Experimental |
+| REQ-FUNC-015 | `sculpt` CLI: full command surface, `--json`, env-var defaults, cross-surface visibility | §8 | (CLI-level, see §5.4) | Standard |
+
+- **REQ-FUNC-100 (MUST).** Every behavior enumerated in `scenarios.md` is a product requirement; that
+  corpus — not the table above — is the exhaustive functional contract, and `scenario_coverage.md`
+  measures how well each behavior is demonstrated by an automated test. The table only rates
+  criticality.
+- **REQ-FUNC-101 (MUST).** **Cross-surface consistency.** A Workspace or Agent created via `sculpt`
+  MUST appear in the GUI, and vice versa, because both surfaces are clients of one local backend over
+  one persisted store (`SPEC.md` §5, §8). _This is `SPEC.md` Open Issue #3 — it has no §9 guarantee
+  there today; this requirement is its home._
+- **REQ-FUNC-102 (SHOULD).** Feature gating: every capability marked experimental in `SPEC.md` §7.12
+  is opt-in and off by default, **except** Smooth streaming, which is on by default (`SPEC.md` §7.12).
+
+---
+
+## 2. Non-functional requirements (measurable)
+
+`SPEC.md` §9 states the cross-cutting guarantees qualitatively ("the UI stays live," "durable,"
+"make progress in parallel"). This section attaches the **measurable bars** the product holds to,
+and flags the targets it does not currently define.
+
+### 2.1 Responsiveness & live updates (→ SPEC §9.4)
+
+- **REQ-NFR-001 (MUST).** Agent output, status changes, and file-change indicators appear in the UI
+  without manual refresh, driven by the live update stream (full snapshot on connect, then deltas).
+- **REQ-NFR-002 (SHOULD).** Default in-flight request timeout is **10 s**
+  (`sculptor/frontend/src/common/state/requestTracking.ts`); a request exceeding it surfaces an error
+  rather than hanging.
+- **REQ-NFR-003 (SHOULD).** UI debounce/throttle budgets that shape perceived responsiveness:
+  - agent status: **500 ms** (`.../chat-alpha/useAgentStatus.ts`)
+  - auto-scroll / jump-to-bottom / in-file search: **150 ms** (`.../chat-alpha/hooks/`, `diffPanel/useInFileSearch.ts`)
+  - active-prompt scroll throttle: **100 ms**; mark-read: **1000 ms**; panel-layout sync: **2000 ms**
+  - branch-name preview: **250 ms**; branch-name collision check: **300 ms** (`add-workspace/hooks/useBranchNamePreview.ts`)
+- **REQ-NFR-004 [Unspecified].** The product defines no explicit end-to-end **streaming latency**
+  budget (model token emitted → rendered) or **interaction latency** (click → visible response) target.
+  → OPEN-1 (§7).
+
+### 2.2 Concurrency & scale (→ SPEC §9.2)
+
+- **REQ-NFR-010 (MUST).** Many agents across many workspaces run concurrently and make independent
+  progress. Agents in the **same** workspace share files with **no locking** — this is documented,
+  accepted behavior, not a defect (`SPEC.md` §9.2, §7.4).
+- **REQ-NFR-011 (SHOULD).** PR/CI status polling runs a bounded worker pool of **4** with a global
+  minimum spacing of **1.5 s** between provider API calls across workers, so polling cannot stampede a
+  provider (`sculptor/sculptor/web/pr_polling_service.py`).
+- **REQ-NFR-012 [Unspecified].** The product enforces **no cap** on max concurrent agents, max
+  workspaces, or subagent fan-out (searched; none found). Whether these should be bounded — and the
+  resource model that makes "uncapped" safe — is undefined. → OPEN-2 (§7).
+
+### 2.3 Crash recovery & resumption (→ SPEC §9.3)
+
+- **REQ-NFR-020 (MUST).** Quit/crash + reopen restores all workspaces, agents, and full conversation
+  history. A running agent is reattached/resumed where possible; an unanswered question asked before
+  the interruption remains answerable after reopen.
+- **REQ-NFR-021 (MUST).** Failures surface visibly (never silent); an errored agent SHOULD offer a
+  restore/continue path unless its workspace was deleted.
+- **REQ-NFR-022 (SHOULD).** Resumption uses the agent CLI's own session continuation (Claude
+  `--resume <session_id>`; Pi `--session-dir`+`--session-id`) and tolerates a **corrupt session tail**
+  by resuming from the valid prefix
+  (`sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils.py`). See REQ-INT-021.
+
+### 2.4 Persistence & durability (→ SPEC §9.5)
+
+- **REQ-NFR-030 (MUST).** Workspaces, agents, full conversation history, and settings persist locally
+  and survive both restart and in-place upgrade to a newer app version. (Detailed data requirements:
+  §4.)
+- **REQ-NFR-031 (SHOULD).** The local DB runs in **WAL** journal mode with a **15 s** busy timeout to
+  tolerate concurrent access (`sculptor/sculptor/database/core.py`).
+
+### 2.5 Custom/remote backend timing (→ SPEC §7.12, §9.1)
+
+- **REQ-NFR-040 (SHOULD).** Backend-readiness timeout (app waits for the launcher's printed URL):
+  **20 s** production, **10 s** dev, **60 s** testing (`sculptor/frontend/src/electron/main.ts`). The
+  app auto-restarts a crashed custom backend with backoff.
+- **REQ-NFR-041 [Unspecified].** The custom-backend restart **backoff schedule** (base, factor, cap,
+  max attempts) is delegated to the retry library and not pinned in product config. → OPEN-3 (§7).
+
+### 2.6 Diff & input limits
+
+- **REQ-NFR-050 (SHOULD).** A diff over **500 lines** is gated behind "Show full diff"
+  (`.../diffPanel/LargeDiffGate.tsx`). Binary files and renames/deletes show an explanatory banner
+  instead of a diff (`SPEC.md` §7.5).
+- **REQ-NFR-051 (SHOULD).** Max single file/image upload is **20 MB**
+  (`sculptor/frontend/src/components/FileUploadUtils.ts`).
+- **REQ-NFR-052 [Unspecified].** Max **attachment count** per message is not enforced. → OPEN-4 (§7).
+- **REQ-NFR-053 (MAY).** Default file-browser split ratio is **50/50**; split-vs-unified, wrapping,
+  and tab-close behavior are user-configurable (`sculptor/sculptor/config/user_config.py`; `SPEC.md` §7.10).
+
+### 2.7 Polling & freshness defaults
+
+- **REQ-NFR-060 (SHOULD).** PR/CI status polling defaults: interval **30 s**, floor **10 s**;
+  closed-workspace multiplier **6×**; merged/closed (terminal) multiplier **10×**; not-ready retry
+  **30 s**; provider rate-limit cooldown **60 s** (`sculptor/sculptor/config/user_config.py`,
+  `sculptor/sculptor/web/pr_polling_service.py`). Interval and multiplier are user-configurable (`SPEC.md` §7.10).
+- **REQ-NFR-061 (SHOULD).** Local workspace/remote-branch polling interval is **3 s**
+  (`sculptor/sculptor/web/repo_polling_manager.py`); git-info lookups time out at **10 s**, branch-name preview
+  git calls at **5 s**.
+- **REQ-NFR-062 (SHOULD).** CI babysitter defaults: **off**, retry cap **3**
+  (`sculptor/sculptor/config/user_config.py`).
+
+### 2.8 Agent defaults
+
+- **REQ-NFR-070 (MUST).** New-agent defaults: model = **most-recently-used** (no hardcoded default),
+  effort = **Extra High (`xhigh`)**, fast mode = **off** (`sculptor/sculptor/config/user_config.py`). All three
+  are user-overridable in Settings → Agent (`SPEC.md` §7.10).
+
+---
+
+## 3. Platform & dependency compatibility (→ SPEC §11)
+
+`SPEC.md` §11 names the OS targets; this section pins the versions the product builds, runs, and
+depends on.
+
+### 3.1 Build & runtime platforms
+
+- **REQ-COMPAT-001 (MUST).** Sculptor ships a **macOS (Apple Silicon / arm64)** build. macOS x64 is
+  **not** a target (CI builds arm64 only; the managed Claude binary has no darwin-x64) —
+  `.github/workflows/build-desktop.yml`, `sculptor/sculptor/services/managed_tools.py`.
+- **REQ-COMPAT-002 (SHOULD).** Sculptor ships a **Linux x64** build; **Linux arm64** is best-effort /
+  non-blocking (`.github/workflows/build-desktop.yml`; `SPEC.md` §11.1).
+- **REQ-COMPAT-003 [Unspecified].** The supported **minimum macOS version** is not stated as a
+  product requirement (CI builds/tests on macOS 14 Sonoma; Electron 37's own floor is macOS 12), and
+  the **minimum Linux glibc** is likewise unpinned. → OPEN-5 (§7).
+
+### 3.2 Toolchain / framework baselines
+
+The product is built against the following baselines (informational; relevant to anyone building or
+packaging Sculptor):
+
+| Component | Pinned value | Source |
+|---|---|---|
+| REQ-COMPAT-010 Python | **>=3.11, <3.13** (pinned 3.11) | `pyproject.toml`, `.python-version` |
+| REQ-COMPAT-011 Node.js | **20.13.1** | `sculptor/frontend/.nvmrc` |
+| REQ-COMPAT-012 Electron | **37.6.0** (Forge **7.8.3**) | `sculptor/frontend/package.json` |
+| REQ-COMPAT-013 uv (Python pkg mgr) | **>=0.7.22** | `pyproject.toml` |
+| REQ-COMPAT-014 TypeScript / React / Jotai / Radix Themes / Vite | **5.5 / 18.3 / 2.9 / 3.1 / 5.4** | `sculptor/frontend/package.json` |
+
+### 3.3 Required external binaries
+
+- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.170,
+  minimum 2.1.170, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
+  **linux-x64** (`sculptor/sculptor/services/managed_tools.py`). Sculptor can install/manage it and can use a
+  user-supplied binary (`SPEC.md` §7.1, §7.10).
+- **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no
+  minimum-version check** (searched; none found). The minimum supported git version is undefined
+  (worktree support is the relevant capability). → OPEN-6 (§7).
+- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness (experimental agent) pins **0.78.0**; platforms
+  darwin-arm64, darwin-x64, linux-x64, with per-platform sha256 checksums
+  (`sculptor/sculptor/services/managed_tools.py`). A version mismatch fails clearly (REQ-INT-022).
+- **REQ-COMPAT-023 (MUST, conditional).** The PR/MR surface requires the matching provider CLI —
+  **`gh`** (GitHub) or **`glab`** (GitLab) — present and authenticated; absence/non-auth degrades to a
+  documented error state, never a crash (§5.1, `SPEC.md` §7.6).
+
+---
+
+## 4. Data persistence, durability & migration (→ SPEC §9.5, §10.8)
+
+`SPEC.md` quarantines SQLite/Alembic as implementation. They are first-class here because the product
+makes durability and upgrade-survival guarantees (§9.5) that rest directly on this layer.
+
+### 4.1 On-disk layout & store
+
+- **REQ-DATA-001 (MUST).** User data lives in a single **Sculptor folder**: `~/.sculptor` (stable),
+  `~/.dev-sculptor` (dev builds), or `<repo>/.dev_sculptor` (running from source), overridable via the
+  `SCULPTOR_FOLDER` env var; the workspaces path is separately overridable via
+  `SCULPTOR_WORKSPACES_FOLDER` (`sculptor/sculptor/utils/build.py`).
+- **REQ-DATA-002 (MUST).** Within it: `internal/database.db` (SQLite), `internal/config.toml`
+  (settings), `internal/logs/`, `internal/uploads/`, `internal/artifacts/`, `workspaces/`, and a
+  top-level `.format_version` marker (`sculptor/sculptor/utils/build.py`, `sculptor/sculptor/utils/migration.py`).
+- **REQ-DATA-003 (MUST).** The store keeps an **append-only immutable snapshot table per entity plus a
+  materialized `<entity>_latest` view maintained by DB triggers**; the immutable log is the source of
+  truth (`sculptor/sculptor/database/core.py`, `automanaged.py`). The externally-observable guarantee is that
+  full history is retained and current state is cheap to read.
+- **REQ-DATA-004 (MUST).** Persisted entities: **UserSettings, Project, Workspace, Task,
+  SavedAgentMessage, Notification** (`sculptor/sculptor/database/models.py`). _("Task" is the vestigial internal
+  primitive backing an Agent — see `SPEC.md` §6; it is a storage concern, not a product concept.)_
+
+### 4.2 Durability & upgrade survival
+
+- **REQ-DATA-010 (MUST).** Settings, the database (projects/workspaces/agent history/messages),
+  workspace directories, logs, and uploads survive an in-place app upgrade (covered by
+  `test_migration.py`; `SPEC.md` §9.5).
+- **REQ-DATA-011 (MUST).** Alembic migrations run automatically at startup, upgrading the DB to head;
+  a detected **downgrade** (DB newer than app) fails with a clear, actionable error rather than
+  corrupting data (`sculptor/sculptor/database/core.py`). Migrations are **forward-only** in practice
+  (downgrade stubs are mostly no-ops).
+- **REQ-DATA-012 (MUST).** Every Alembic migration ships a **companion version test** under
+  `sculptor/sculptor/database/alembic/version_tests/` (seed → migrate → verify), enforced by
+  `test_every_migration_has_a_test_fixture()` (`sculptor/sculptor/database/README.md`) — the process guarantee
+  that lets the schema evolve safely.
+- **REQ-DATA-013 (MUST).** Versioned JSON columns (e.g. `Task.task_inputs`, `SavedAgentMessage.message`,
+  which store unions of agent-message/input variants) are guarded by a **frozen Pydantic-schema
+  snapshot** (`alembic/frozen_pydantic_schemas.json`); a model change that isn't reflected fails a test
+  until a migration is authored or the change is confirmed back-compatible (`alembic/json_migrations.py`).
+
+### 4.3 Backward compatibility & folder migration
+
+- **REQ-DATA-020 [Unspecified].** The product does not state a **back-compat horizon** — how far back
+  older data folders / DB versions are guaranteed readable. → OPEN-7 (§7).
+- **REQ-DATA-021 (SHOULD).** A **data-folder migration helper** (`sculptor_migrate`, i.e.
+  `scripts/migrate_sculptor_folder.py`) relocates/restructures the folder (legacy `~/.sculptor_data`
+  → `~/.sculptor`): it is **idempotent** and **resumable** (renames to `.migrating`), backs up the DB
+  via SQLite native backup, rewrites embedded workspace paths (`workspace.environment_id` / `_latest`),
+  migrates Claude session folders to match new workspace paths, and writes `.format_version`.
+- **REQ-DATA-022 (SHOULD).** Startup tolerates an old/unversioned folder by bootstrapping the
+  structure and writing `.format_version` (`sculptor/sculptor/utils/migration.py`); config loading tolerates
+  legacy fields via model validators (e.g. old `claude_binary_mode` folding, invalid `custom_actions`
+  silently dropped) rather than crashing (`sculptor/sculptor/config/user_config.py`).
+
+---
+
+## 5. External integration contracts (→ SPEC §5, §6, §7.6, §8)
+
+Each external boundary is a contract the product upholds, **including its failure modes** — the spec
+describes the happy path and the error *surfaces*; this section pins the contract and the degradation
+rules behind them.
+
+### 5.1 Git host providers
+
+- **REQ-INT-001 (MUST).** The provider is detected from the `origin` remote hostname (parsing SSH and
+  HTTP(S) forms): hostname containing **"github"** → GitHub via **`gh`**; containing **"gitlab"** →
+  GitLab via **`glab`**. Any other host has **no** PR/MR surface and no target-branch concept
+  (`SPEC.md` §7.6; `sculptor/sculptor/web/pr_polling_service.py`).
+- **REQ-INT-002 (MUST).** Operations performed via the provider CLI: **list** requests for a branch,
+  **view** a request's status-check/pipeline rollup, **reviews/approvals**, and **unresolved
+  comments/discussions**; **push** the branch and **open** a request; poll status thereafter. (GitHub:
+  `gh pr list/view`; GitLab: `glab mr list/view` + `glab api …/approvals` and `…/discussions`.)
+- **REQ-INT-003 (MUST).** The failure taxonomy is classified and surfaced distinctly (not collapsed
+  into "error"): **cli_missing**, **not_authenticated**, **rate_limited** (→ 60 s host cooldown),
+  **network_error** (permanent) vs **transient** (retried once)
+  (`sculptor/sculptor/web/cli_status_utils.py`, `pr_polling_service.py`). Each maps to the actionable
+  warning/info button states in `SPEC.md` §7.6.
+
+### 5.2 Agent model CLIs
+
+- **REQ-INT-021 (MUST).** **Claude** is launched as a long-lived process speaking **stream-json over
+  JSONL** on stdin/stdout (with `--verbose`, hook events, MCP config, and `AskUserQuestion`/`ExitPlanMode`
+  disallowed so Sculptor renders those itself); resumed with `--resume <session_id>`. Session files at
+  `~/.claude/projects/-code/<session_id>.jsonl` are validated (≥1 user/assistant message with matching
+  `sessionId`) and **a corrupt tail is tolerated** by reading the valid prefix
+  (`sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils.py`). The contract — not the exact
+  flags — is the requirement; flags track the upstream CLI (REQ-COMPAT-020).
+- **REQ-INT-022 (SHOULD).** **Pi** is launched in **`--mode rpc`** with `--session-dir`/`--session-id`
+  (same dir+id resumes); multiplexed JSONL channels (`response`, `extension_ui_request`,
+  `AgentSessionEvent`); API keys injected from named env vars at startup and **never persisted**; a
+  version mismatch raises a clear error (`sculptor/sculptor/agents/pi_agent/agent_wrapper.py`).
+- **REQ-INT-023 (MUST).** A missing binary for either CLI raises a specific, surfaced error
+  (`ClaudeBinaryNotFoundError` / `PiBinaryNotFoundError`), not a generic failure.
+
+### 5.3 Terminal-agent registration
+
+- **REQ-INT-030 (SHOULD).** Registered terminal agents are TOML files under
+  `<sculptor_folder>/terminal_agents/`, one per agent, keyed by **`registration_id` = filename stem**
+  (must match `[a-z0-9][a-z0-9_-]*`), declaring **`display_name`** (required), **`launch_command`**
+  (required), **`resume_command_template`** (optional), **`accepts_automated_prompts`** (optional,
+  default false) (`sculptor/sculptor/services/terminal_agent_registry/registry.py`).
+- **REQ-INT-031 (SHOULD).** Placeholders are substituted by literal replacement (not `.format()`):
+  `{sculptor_directory}` and `{terminal_agents_directory}` in `launch_command`; those plus **at most
+  one** `{session_id}` in `resume_command_template`; unknown placeholders are rejected. The directory
+  is **re-read on demand** (no restart needed to add an agent), and launch params are **stamped onto the
+  agent at creation** so it survives later edits/deletion of the file (`SPEC.md` §7.3.2; `registry.py`).
+
+### 5.4 `sculpt` CLI ↔ backend
+
+- **REQ-INT-040 (SHOULD).** `sculpt` reaches the local backend at `http://localhost:<port>` where port
+  = **`SCULPT_API_PORT`** (default **5050**), or an explicit `--base-url`; it fetches a session token
+  and sends it as the `x-session-token` header. A connection failure exits with a clear "could not
+  connect to Sculptor server" message (`tools/sculpt/sculpt/auth.py`).
+- **REQ-INT-041 (SHOULD).** The CLI client is **generated** from the backend OpenAPI schema (same
+  contract as the GUI client) — see `SPEC.md` §10.7 and the Appendix. Env-var defaults
+  (`SCULPT_WORKSPACE_ID`, `SCULPT_AGENT_ID`, `SCULPT_PROJECT_ID`) and short-prefix IDs work as in
+  `SPEC.md` §8.
+
+### 5.5 Environment-variable injection
+
+- **REQ-INT-050 (SHOULD).** Sculptor loads a **global `~/.sculptor/.env`** and a **per-repo
+  `.sculptor/.env`**, with **project values overriding global**, injecting them into agent/terminal
+  environments; the format supports `KEY=value`, `export KEY=value`, quotes, and `#` comments
+  (`sculptor/sculptor/services/workspace_service/environment_manager/env_file_parser.py`; `SPEC.md` §7.10). An
+  override toggle governs whether these replace pre-existing variables.
+
+---
+
+## 6. Security, privacy & telemetry (→ SPEC §9.1, §9.6, §9.7)
+
+- **REQ-SEC-001 (MUST).** **Trust boundary.** By default an agent works only inside its isolated
+  workspace copy and MAY run real shell commands there; **nothing is pushed to a remote and no PR/MR is
+  opened without an explicit user action**. In-place mode (editing the real checkout) and the
+  container/remote backend are the deliberate, opt-in exceptions (`SPEC.md` §9.1). This boundary holds
+  for both the GUI and `sculpt`.
+- **REQ-SEC-002 (MUST).** **Local-first, single-user.** Code and secrets stay on the user's machine;
+  Imbue does not store repositories or train on user code (`SPEC.md` §9.6). Pi API keys and similar
+  secrets are read from the environment and **never persisted to config** (REQ-INT-022).
+- **REQ-SEC-003 (MUST).** Build & distribution security: the macOS artifact is **signed and notarized**
+  (`.dmg`); releases are **tag-driven** with the version checked against build context so a tag build
+  cannot publish an inconsistent version (`SPEC.md` §11.2–§11.3).
+- **REQ-SEC-010 (MUST).** **Telemetry is consent-gated.** Error reporting (Sentry, frontend-only) and
+  product analytics (PostHog) are each gated on explicit consent flags
+  (`is_error_reporting_enabled`, `is_product_analytics_enabled`, `is_session_recording_enabled`,
+  `is_telemetry_level_set`, `is_privacy_policy_consented`) and the choice persists across restarts
+  (`sculptor/sculptor/config/user_config.py`; `SPEC.md` §9.7). Product telemetry masks private content
+  (file/branch names, prompts).
+- **REQ-SEC-011 [Unspecified].** **Default-state discrepancy.** `SPEC.md` §7.1/§9.7 describe telemetry
+  as *opt-out / on by default*, but the stored consent flags **default to `false`** until the user
+  makes a choice. Which is authoritative (the onboarding default vs. the persisted default) is
+  unresolved, and spec and code should be reconciled. → OPEN-8 (§7).
+
+---
+
+## 7. Open questions & unspecified behaviors
+
+Consolidated from the **[Unspecified]** tags above — points where the product currently pins **no**
+value, so this specification is genuinely incomplete until each is decided and the relevant requirement
+updated.
+
+| ID | Open question | Requirement |
+|---|---|---|
+| OPEN-1 | Streaming & interaction **latency budgets** + how they're measured | REQ-NFR-004 |
+| OPEN-2 | **Concurrency caps** (max agents / workspaces / subagent fan-out), or a documented "safe uncapped" resource model | REQ-NFR-012 |
+| OPEN-3 | Custom-backend **restart backoff schedule** | REQ-NFR-041 |
+| OPEN-4 | Max **attachment count** per message | REQ-NFR-052 |
+| OPEN-5 | Supported **minimum macOS version** and **Linux glibc** floor | REQ-COMPAT-003 |
+| OPEN-6 | **Minimum git version** | REQ-COMPAT-021 |
+| OPEN-7 | **Data back-compat horizon** — which prior `~/.sculptor` DB/folder versions are guaranteed readable | REQ-DATA-020 |
+| OPEN-8 | Telemetry **default state** — reconcile spec's opt-out/on-by-default with the code's default-false consent flags | REQ-SEC-011 |
+
+These complement, and do not duplicate, `SPEC.md` §12 (which tracks the §9-product-vs-§10-substrate
+line); resolving §12 may add or retire requirements here.
+
+---
+
+## Appendix — relationship to the test & quality substrate
+
+The verification machinery the product depends on (FakeClaude determinism, the Playwright POM +
+`ElementIDs` test-id contract, the fidelity tiers, ratchets, contract generation, migration version
+tests, diagnosability) is documented in `SPEC.md` §10 and is **not** re-specified here — but note that
+several requirements above are only *checkable* because that substrate exists: REQ-FUNC-100 (scenarios
+as acceptance), REQ-DATA-012/013 (migration + frozen-schema tests), REQ-INT-041 / REQ-COMPAT-014
+(generated cross-surface clients). Treat `SPEC.md` §10 as the binding companion to this document.

--- a/docs/specs/scenario_coverage.md
+++ b/docs/specs/scenario_coverage.md
@@ -1,0 +1,624 @@
+# Sculptor — Scenario Test Coverage Report (integration tests only)
+
+This report assesses, for every scenario in [`scenarios.md`](./scenarios.md), whether the
+existing **integration** test suite adequately covers it, and names the specific integration
+tests to add where coverage is missing or partial.
+
+## Scope of this report
+
+**Only integration tests count as coverage here**, so the report reflects end-to-end coverage that
+drives the real UI and asserts user-visible outcomes.
+
+Integration tests considered:
+
+- `sculptor/tests/integration/frontend/test_*.py` — Playwright-driven, FakeClaude-backed UI tests
+  (the bulk of deterministic user-visible coverage).
+- `sculptor/tests/integration/regression/test_*.py` — regression tests.
+- `sculptor/tests/integration/real_claude/` and `real_pi/` — model-backed end-to-end flows.
+
+## Status definitions
+
+- **Complete** — an integration test performs the user action *and* asserts the user-visible
+  outcome the scenario describes.
+- **Partial** — an integration test exists but misses part of the Given/When/Then (only the happy
+  path, only one state of several, drives the action but asserts nothing visible, etc.).
+- **Missing** — no integration test meaningfully covers it.
+
+> Note on SET-* : several settings scenarios are umbrella entries covering multiple controls in one
+> section; they are Partial when only some controls in that section have an integration test.
+
+## Executive summary
+
+| Area | Complete | Partial | Missing | Total |
+|------|---------:|--------:|--------:|------:|
+| SHELL | 22 | 12 | 14 | 48 |
+| ROUTE | 1 | 1 | 4 | 6 |
+| HELP | 0 | 2 | 1 | 3 |
+| HOME | 2 | 4 | 14 | 20 |
+| ADDWS | 7 | 14 | 3 | 24 |
+| ADDREPO | 1 | 5 | 2 | 8 |
+| ONB | 10 | 10 | 13 | 33 |
+| WS | 39 | 19 | 18 | 76 |
+| CHAT | 21 | 15 | 9 | 45 |
+| MSG | 14 | 12 | 10 | 36 |
+| PANEL | 23 | 19 | 14 | 56 |
+| CMDP | 4 | 9 | 18 | 31 |
+| SET | 11 | 16 | 10 | 37 |
+| DEV | 3 | 1 | 0 | 4 |
+| MENT | 5 | 2 | 3 | 10 |
+| SKILL | 2 | 1 | 0 | 3 |
+| ACT | 2 | 3 | 1 | 6 |
+| **Total** | **167** | **145** | **134** | **446** |
+
+**Under the integration-only standard, 37% of scenarios are completely covered, 33% partially, and
+30% not at all.** (Counts are derived directly from the two sections below.)
+
+The per-scenario detail is split into two sections: **Coverage gaps — Partial & Missing** (every
+scenario needing work, with the test to add) and **Complete coverage** (every scenario already fully
+covered, with the test that covers it). Each scenario appears in exactly one.
+
+## Coverage gaps — Partial & Missing
+
+Every scenario that is **not** Complete, grouped by area. **Missing** = no integration coverage (the *to add* column describes a new test to write); **Partial** = some integration coverage exists (the *Existing* column shows what, the *to add* column the assertion still needed).
+
+### SHELL / ROUTE / HELP
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| SHELL-002 | Partial | test_home_page_tab.py::test_home_page_opens_as_tab (uses navigate helper, not the top-bar Home button) | Click the top-bar Home button (and one pressing the Home keybinding); assert a Home tab appears/re-activates with the home page shown. |
+| SHELL-004 | Partial | test_home_page_tab.py::test_clicking_workspace_replaces_home_tab (clicks a workspace row, not a non-active tab) | With 2+ open tabs, click a non-active tab and assert it becomes active and its content renders. |
+| SHELL-005 | Missing | — | With multiple tabs, press Cmd+] and assert the next tab activates, including wrap from last to first. |
+| SHELL-006 | Missing | — | Press Cmd+[ and assert the previous tab activates, including wrap from first to last. |
+| SHELL-008 | Missing | — | Middle-click a non-active tab and assert it closes while the active tab is unchanged. |
+| SHELL-010 | Missing | — | Drag-reorder one tab past another; assert the drop indicator, the order change on release, and an unchanged active tab. |
+| SHELL-011 | Missing | — | Open more tabs than fit; dispatch a wheel event over the tab bar; assert horizontal scroll position changes. |
+| SHELL-012 | Missing | — | With overflowing tabs, activate an off-screen tab (keyboard cycle); assert it scrolls into the viewport. |
+| SHELL-013 | Missing | — | Long-titled tab at constrained width; assert the label is ellipsis-truncated. |
+| SHELL-014 | Partial | test_terminal_agent_signals.py::test_terminal_agent_signals_drive_tab_status_dot | Assert the visual variants: pulsing running vs solid waiting/ready, red error dot, two-dot mixed-status case. |
+| SHELL-015 | Partial | test_workspace_tab_context_menu_icons.py::test_workspace_context_menu_rename; test_tab_context_menus.py::test_terminal_tab_context_menu_close_others | Right-click a workspace tab and assert the full menu set (Close, Close others, Close all, Rename, Delete, git actions). |
+| SHELL-018 | Partial | test_tab_context_menus.py::test_terminal_tab_context_menu_close_others (terminal tabs only) | On workspace tabs, exercise "Close others" and "Close all"; assert all-others/all close and "Close all" lands on the Add Workspace page. |
+| SHELL-019 | Partial | test_restarts.py::test_tasks_persist_on_restart; test_restart_mru.py::test_restart_restores_active_workspace_and_agent | Open 3+ tabs in a specific order with a known active one, restart, assert same tabs/order/active tab. |
+| SHELL-026 | Partial | test_keybindings.py::test_help_dialog_reflects_customized_bindings (opens via Cmd+/, not the Help button) | Click the top-bar Help (?) button and assert the keyboard-shortcuts dialog opens. |
+| SHELL-027 | Missing | — | Hover a top-bar button and assert a tooltip showing the button name plus its keyboard shortcut. |
+| SHELL-033 | Partial | test_regression_terminal_theme_toggle.py::test_terminal_theme_updates_on_toggle (presses Cmd+Shift+D; asserts xterm colors, not the app-level theme) | Press Cmd+Shift+D and assert the app-level light/dark theme flips without a reload. |
+| SHELL-034 | Missing | — | Assert the version number is visible bottom-right on a non-workspace page, and hidden in zen mode. |
+| SHELL-035 | Partial | test_auto_update_browser.py::test_null_initial_state_version_popover | Assert the opened popover shows the diagnostics fields: platform, uptime, active agents, disk, paths, Claude CLI info. |
+| SHELL-038 | Partial | test_auto_update_browser.py::test_ready_status_shows_persistent_toast; test_auto_update_electron.py::test_update_available_and_ready | Click "Install and restart"; assert the button changes to "Restarting…" and the restart path is invoked. |
+| SHELL-041 | Partial | test_tanstack_devtools_panel.py::test_tanstack_devtools_panel_mounts_with_content (TanStack Devtools only) | Toggle "React Grab" and "TanStack event log" from the version popover and assert each dev tool appears/disappears. |
+| SHELL-042 | Missing | — | Make the backend unresponsive and assert the yellow bottom banner reads "Backend not responding. Please try restarting the app." |
+| SHELL-043 | Missing | — | Inject a backend health warning and assert a yellow warning banner with the message (and link if present). |
+| SHELL-044 | Partial | test_project_path_monitoring.py::test_project_path_monitoring (currently skipped) | Un-skip/rewrite to assert the "Project folder not found: {name}." banner with a "Learn more" link that opens the dialog. |
+| SHELL-045 | Missing | — | Assert the backend loading splash shows the Sculptor logo, "Loading" message, and progress bar until ready. |
+| SHELL-047 | Missing | — | In dev/from-source mode, assert the bottom-left dev-mode indicator renders and hovering shows a "Running from source" tooltip with the workspace id. |
+| SHELL-048 | Missing | — | Press Cmd+= / Cmd+- / Cmd+0; assert the zoom scales up/down/resets to 100% and persists across restart. |
+| ROUTE-002 | Partial | test_restart_mru.py::test_restart_with_no_mru_lands_on_new; test_add_workspace_page.py::test_workspace_form_draft_persists_after_navigation | Navigate to bare `/ws/new` and assert the URL is rewritten to `/ws/new/{draftId}` with the Add Workspace form displayed. |
+| ROUTE-003 | Missing | — | Navigate to an unknown route; assert the Not-Found page shows the logo, "The page you are looking for does not exist.", and a home link. |
+| ROUTE-004 | Missing | — | Force a loader/component to throw; assert the error page renders a generic message plus error details in a scrollable box. |
+| ROUTE-005 | Missing | — | On the route error page, click "Copy Error to Clipboard"; assert the clipboard contains the error text. |
+| ROUTE-006 | Missing | — | Set a custom backend command, trigger the error page, click "Clear Custom Backend Command"; assert the button disables and its label changes to the "cleared — restart" state. |
+| HELP-001 | Partial | test_keybindings.py::test_help_dialog_reflects_customized_bindings; ::test_help_dialog_hides_unbound | Add opening via the Help button (see SHELL-026) and assert the modal title is "Help" with shortcuts grouped by category. |
+| HELP-002 | Missing | — | Open the help dialog and assert a shortcut renders an OS-formatted key badge (e.g. `Cmd+K` on macOS, `Ctrl+K` elsewhere). |
+| HELP-003 | Partial | test_keybindings.py::test_help_dialog_reflects_customized_bindings (closes via dialog.close()/Escape) | Assert both the X button and the Escape key close the help dialog. |
+
+### HOME / ADDWS / ADDREPO
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| HOME-001 | Missing | — | Delay the workspace-list fetch and assert the list-area spinner is visible. |
+| HOME-003 | Partial | test_home_page.py::test_workspace_search_filters_list (uses get_search_input) | Assert placeholder "Search workspaces…" and that the input is focused on load. |
+| HOME-004 | Partial | test_home_page.py::test_workspace_search_filters_list (filters by name only) | Extend to assert filtering by branch and project, plus case-insensitivity. |
+| HOME-005 | Missing | — | Type a non-matching query; assert centered `No results for "{query}"`. |
+| HOME-006 | Missing | — | Fill search, press Escape; assert query cleared, full list back, focus returns to the search input. |
+| HOME-007 | Missing | — | Create 3+ workspaces with distinct activity; assert most-recent-first row order. |
+| HOME-008 | Missing | — | Create >25 workspaces; assert 25 rows + "Show more (N remaining)"; click reveals next 25. |
+| HOME-009 | Missing | — | After "Show more", type a query; assert visible count resets to first 25 filtered. |
+| HOME-010 | Partial | test_home_page.py::test_workspace_row_shows_current_branch_not_source_branch; test_backend_pr_polling.py::test_home_page_shows_pr_badge | Add row assertions for status dot, name, project name on hover, relative last-activity time, hover-revealed delete button. |
+| HOME-011 | Missing | — | Hover/focus a row; assert background change and project name + delete button become visible. |
+| HOME-012 | Missing | — | From the search box, ArrowDown focuses first row (scrolled into view); ArrowUp from first row returns to search box. |
+| HOME-014 | Missing | — | Cmd/Ctrl-click a row (and "Open in New Tab" via context menu) opens it in a new tab with Home still visible. |
+| HOME-015 | Missing | — | Right-click a row; assert "Open in New Tab" and a red "Delete Workspace" entry. |
+| HOME-016 | Missing | — | Hover-click the trash icon (and via context menu) opens the delete-confirmation dialog. |
+| HOME-017 | Missing | — | Assert "Delete workspace?" title, warning naming the workspace, Cancel, and a red default-focused Delete button. |
+| HOME-018 | Missing | — | Open dialog, click Cancel / press Escape; assert dialog closes and row remains. |
+| HOME-019 | Missing | — | Open dialog from a home row, click Delete; assert dialog closes and row disappears. (test_optimistic_deletion.py covers the tab menu, not the home-row dialog.) |
+| HOME-020 | Partial | test_backend_pr_polling.py::test_home_page_shows_pr_badge; ::test_multiple_workspaces_independent_pr_status | Add home-row assertions for "Checking PR…", "Create PR"/"Create MR", merged/closed badge, "Assign PR", error button. |
+| ADDWS-001 | Partial | test_add_workspace_page.py (asserts form/submit button) | Delay project fetch; assert the centered spinner before the form. |
+| ADDWS-002 | Partial | test_multi_repo.py::test_mru_project_updates_after_creating_workspace | Add the no-MRU case (first project pre-selected). |
+| ADDWS-003 | Partial | test_add_workspace_page.py::test_cmd_i_focuses_prompt_input | Assert placeholder "Untitled workspace (optional)" and autofocus on initial load. |
+| ADDWS-004 | Partial | test_worktree_create_happy_path.py::test_worktree_create_with_empty_workspace_name_random_slug | Assert created workspace named "Untitled workspace" (+ whitespace-only case). |
+| ADDWS-006 | Partial | test_multi_repo.py::test_create_new_project_from_add_workspace_page; ::test_adding_duplicate_repo_shows_error | Open selector; assert all projects plus an "Add Repository" entry. |
+| ADDWS-007 | Partial | test_multi_repo.py::test_create_workspaces_in_multiple_projects_and_switch | Assert selecting another project reloads the branch selector and clears any branch-name override. |
+| ADDWS-008 | Partial | test_multi_repo.py::test_create_new_project_from_add_workspace_page (adds via Settings UI) | Trigger "Add Repository" from the repo-selector dropdown; assert the new project is auto-selected. |
+| ADDWS-009 | Missing | — | Assert the branch control shows spinner + "Loading …" and is disabled while branch info loads. |
+| ADDWS-010 | Partial | test_worktree_create_happy_path.py::test_worktree_create_with_default_branch_name | Open the branch selector; assert recent branches + "Fetch more branches"; selecting one updates the source branch and clears the override. |
+| ADDWS-011 | Missing | — | In-place mode: assert the branch selector is disabled with the in-place tooltip. |
+| ADDWS-012 | Partial | test_clone_mode_branch_name.py; test_worktree_create_happy_path.py | Assert branch-name field across all three modes (Worktree required / Clone optional / In-place absent). |
+| ADDWS-014 | Partial | test_worktree_create_happy_path.py::test_worktree_create_with_custom_branch_name | Assert auto-fill stops, a reset link appears, and clicking reset restores the preview. |
+| ADDWS-018 | Partial | test_worktree_edge_cases.py::test_clone_mode_hidden_when_flag_off | Add the neither-experimental-mode case: selector hidden, defaults to Worktree. |
+| ADDWS-019 | Partial | test_clone_mode_branch_name.py; test_worktree_edge_cases.py::test_clone_mode_hidden_when_flag_off | Switch modes and assert branch fields update live (Clone optional; In-place removes field + disables selector). |
+| ADDWS-020 | Partial | test_branch_name_collisions.py::test_worktree_mode_collision_blocks_creation | Assert the Create button's explanatory disabled tooltips and the "Cmd/Ctrl+↵" ready tooltip. |
+| ADDWS-023 | Partial | test_branch_name_collisions.py::test_worktree_mode_collision_blocks_creation (pre-submit) | Force a submit-time 409; assert toast "Branch '{name}' already exists" and the form stays open. |
+| ADDWS-024 | Missing | — | Force creation to fail; assert "Failed to create workspace"/"Failed to create agent" toast with details. |
+| ADDREPO-001 | Partial | test_multi_repo.py::test_adding_duplicate_repo_shows_error; test_regression_settings_delete_repo_stays_on_page.py::test_adding_repo_stays_on_settings_page | Assert the path input is focused on open and a Browse button is present on desktop. |
+| ADDREPO-002 | Missing | — | Open the dialog, click Cancel / Escape / overlay; assert it closes with no changes. |
+| ADDREPO-003 | Partial | test_path_autocomplete_keyboard.py::test_cmd_enter_submits_path | While validation is in progress, attempt to close; assert the dialog stays open. |
+| ADDREPO-004 | Partial | test_multi_repo.py::test_create_new_project_from_add_workspace_page (adds via Settings UI) | Focused dialog test: enter a valid path, click "Add Repository"; assert it closes and the new repo is selected in the dropdown. |
+| ADDREPO-005 | Missing | — | Type a path, close the dialog, reopen it; assert the path input is empty. |
+| ADDREPO-006 | Partial | test_path_autocomplete_keyboard.py::test_autocomplete_shows_submit_hint; test_path_tilde_display.py::test_path_autocomplete_shows_tilde_for_home_directory | Assert the debounce spinner before results and the "No matching directories" message when empty. |
+| ADDREPO-008 | Partial | test_path_autocomplete_keyboard.py::test_autocomplete_shows_submit_hint; ::test_cmd_enter_submits_path | Assert all three footer hints verbatim ("Esc: close", "↵: open", "{Meta}↵: add") and the Enter-with-dropdown-closed submit path. |
+
+### ONB / MENT / SKILL / ACT
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| ONB-001 | Missing | — | Assert the step indicator renders 3 dots, current distinct, past clickable, future disabled. |
+| ONB-003 | Missing | — | From the Email step, click the Installation/Add-Repo dots; assert the wizard does NOT advance. |
+| ONB-004 | Partial | test_telemetry_opt_out.py::test_onboarding_email_with_telemetry_opt_out | Assert full-name autofocus, marketing checkbox unchecked, terms/privacy links, and the "Your code is yours…" message. |
+| ONB-005 | Missing | — | Type empty / no-`@` email; assert Get Started disabled. |
+| ONB-006 | Partial | test_onboarding.py::test_full_onboarding_flow (implicitly) | Explicit test: typing an email with `@` flips Get Started to enabled. |
+| ONB-007 | Partial | test_onboarding.py::test_full_onboarding_flow | Assert the button shows a spinner / is disabled while the email request is in flight. |
+| ONB-010 | Partial | test_telemetry_opt_out.py::test_onboarding_email_with_telemetry_opt_out (asserts persisted flags) | Add a direct UI assertion that clicking the marketing/telemetry checkboxes toggles their checked state. |
+| ONB-011 | Missing | — | Assert "Let's get you set up" / "The following are required to use Sculptor" headers. |
+| ONB-012 | Missing | — | Drive a `loading` dependency state; assert spinner + "—" path/version. |
+| ONB-015 | Missing | — | Stub a wrong version; assert red error + (expanded) current/required versions. |
+| ONB-017 | Partial | test_onboarding.py::test_claude_not_authenticated | Assert the visible "authenticating" spinner + the `claude auth login` help message during the in-progress window. |
+| ONB-018 | Missing | test_claude_binary_installation.py::test_onboarding_managed_mode_auto_installs_claude (SKIPPED — SCU-355) | Add a hermetic managed-install test asserting "installing" with a circular progress percentage. |
+| ONB-019 | Missing | — | Add an onboarding-card install-failure test asserting error + retry/re-check. |
+| ONB-020 | Partial | test_onboarding.py::test_dependency_path_and_version_display / test_onboarding_without_claude_installed | Assert the chevron flips and mode controls appear on expand. |
+| ONB-021 | Missing | — | Open the Install affordance; assert popover shows the install command (e.g. `brew install …`) and a docs link. |
+| ONB-023 | Missing | — | Expand a card, click "Use System PATH" / "Use Managed"; assert the mode switches and UI updates. |
+| ONB-025 | Missing | — | Click "check again"; assert text flips to "Checking…" briefly and cards refresh. |
+| ONB-027 | Partial | test_onboarding.py::test_full_onboarding_flow | Assert "Add your first repo" header, the `~/path/to/repo` placeholder, and input autofocus. |
+| ONB-028 | Missing | — | On desktop, click "Or browse for a folder", select a folder; assert the path input is populated. |
+| ONB-029 | Missing | — | Assert Add disabled + tooltip "Enter a repository path above" when empty; enabled after typing; spinner while validating. |
+| ONB-031 | Partial | test_multi_repo.py::test_git_init_dialog_for_non_git_directories (via Add Workspace page, not onboarding) | Add the same flow on the onboarding Add-Repo step; assert "Setting up repository…" and Cancel-returns. |
+| ONB-032 | Partial | test_multi_repo.py::test_empty_repo_initial_commit_dialog (via Settings, not onboarding) | Cover the empty-repo prompt on the onboarding Add-Repo step incl. Cancel-returns. |
+| ONB-033 | Partial | test_multi_repo.py::test_adding_duplicate_repo_shows_error (via Settings) | Add an onboarding-step test for a nonexistent/inaccessible path → error dialog with a Close button. |
+| MENT-001 | Partial | test_at_mention_file_chip_click_opens_tab.py::test_file_chip_click_opens_file_view_tab; ::test_nested_file_chip_click_opens_correct_tab | Add coverage that hovering a file mention chip shows the full-path popover + action hint. |
+| MENT-002 | Missing | — | Hover a skill mention chip; assert a popover with type badge, skill id, description; chip not clickable. |
+| MENT-003 | Missing | — | Drive an entity mention chip: workspace/agent click navigates; repository/deleted not clickable + strike-through; hover shows detail popover. |
+| MENT-004 | Missing | — | Open agent/workspace/repository detail popovers; assert icon/title/badge/body/meta footer and the deleted "no longer exists" note. |
+| MENT-009 | Partial | test_image_upload.py (file input, not the `+` picker Images category) | Selecting the Images category from the `+` picker fires the image-upload trigger; row hidden when unsupported. |
+| SKILL-002 | Partial | test_skill_autocomplete.py::test_plugin_skill_appears_in_autocomplete_with_sculptor_badge; test_pseudo_skills.py::test_builtin_skills_appear_in_autocomplete_with_badges (badge text only) | Hover chip A then chip B; assert popover content swaps instantly; scrolling suppresses flapping. |
+| ACT-002 | Partial | test_custom_actions.py::test_builtin_chips (built-in group exposes no delete) | Right-click a regular action chip; assert "Queue message" (run-only), "Edit action", "Move to group…" (current disabled), red "Delete action". |
+| ACT-003 | Partial | test_custom_actions.py::test_create_action_from_settings; ::test_edit_action_from_settings; ::test_action_with_skill_mention_displays_cleanly_in_settings | Assert Save disabled until Name+Prompt non-empty, and `Cmd+Enter` submits when valid. |
+| ACT-005 | Partial | test_custom_actions.py::test_create_group_from_settings; ::test_builtin_chips | Add inline rename (Enter/blur confirm, Escape cancel, no collapse-toggle) and header-click collapse/expand (chevron + count badge). |
+| ACT-006 | Missing | — | Drag-simulation: drop indicators before/after, drop into group moves action, drop outside removes; built-ins not draggable. |
+
+### WS
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| WS-001 | Partial | test_queued_messages.py::test_queued_message_bar_appears_and_shows_content (editor clears) | Assert the attachments preview clears after sending a message that had an image attached. |
+| WS-002 | Partial | test_queued_messages.py::test_chat_input_disabled_while_message_queued | Assert Send disabled when editor empty and a hover tooltip shows the disabled reason. |
+| WS-005 | Missing | — | Drag files over chat input → "Drop to attach images" overlay; on drop files appear in preview list. |
+| WS-009 | Partial | test_regression_model_selection.py::test_new_agent_inherits_model_from_existing_agent | Open model selector, pick a model; assert it is highlighted and applied to the next sent message. |
+| WS-013 | Missing | — | Shift+Enter inserts a line break and editor grows; sending submits the whole multiline text as one message. |
+| WS-022 | Missing | — | While PR status loads, assert spinner with "Checking PR…"/"Checking MR…". |
+| WS-023 | Partial | test_pr_button_errors.py::test_github_happy_paths (Create PR visible) | Click Create PR; assert the default PR-creation prompt (incl. target branch) is sent to the agent. |
+| WS-024 | Missing | — | Open Create-PR chevron, click "Edit prompt…", edit and Save; assert prompt updated and dialog closes. |
+| WS-025 | Partial | test_pr_button_errors.py::test_github_happy_paths ("PR #42") | Assert pipeline and review status dots render on the open-PR button. |
+| WS-026 | Missing | — | Click the PR number; assert PR/MR opens in browser (intercept window.open / browser-open RPC). |
+| WS-027 | Missing | — | Open chevron popover; assert title/link, checks/pipeline status, approvals with reviewer names, unresolved comments. |
+| WS-029 | Partial | test_backend_pr_polling.py::test_closed_not_merged_pr_shows_closed_state | Add the merged-PR case: merge icon + "merged" text; clicking opens browser. |
+| WS-030 | Missing | — | Hover pipeline/review dots; assert tooltip text ("Pipeline running/passed/failed/No pipeline", "Approved/Review pending/No reviewers"). |
+| WS-031 | Missing | — | PR with different target shows "Assign PR"/"Assign MR"; opening offers "Create PR → {target}" and "switch target to {target}". |
+| WS-032 | Partial | test_pr_button_errors.py::test_github_cli_error_variants; ::test_gitlab_cli_error_variants | Assert warning-triangle vs info icon distinction and the remediation-command copy icon turning to a checkmark briefly. |
+| WS-033 | Partial | test_target_branch.py::test_switching_to_all_scope_shows_target_branch_diff; test_pr_management.py::test_banner_hides_pr_ui_for_non_gitlab_origin | Click the selector; assert the dropdown lists remote branches; select one; assert target updates. |
+| WS-034 | Missing | — | Target differs from PR target → warning color; hover "PR #N targets {branch}"; selecting matching branch updates target. |
+| WS-035 | Missing | — | Click repo segment; assert menu (Open folder, Copy path, Copy relative path, Open in installed apps); each action fires; chosen app remembered. |
+| WS-038 | Partial | test_workspace_banner_overflow.py::test_collapsed_banner_has_no_inert_overflow_menu | Assert collapse priority order at successive widths: PR button → diff summary → repo segment. |
+| WS-039 | Partial | test_regression_copy_branch_name.py::test_copy_branch_name_copies_workspace_branch | Assert the "Copied!" tooltip appears briefly after clicking the banner branch name. |
+| WS-042 | Partial | test_multi_agent_workspace.py::test_workspaces_have_isolated_agent_tabs (click switches) | Add a next/previous-agent keybinding test asserting the view switches. |
+| WS-043 | Missing | — | Hover agent status dot; assert tooltip shows status label + time-since-activity/creation. |
+| WS-046 | Partial | test_agent_tab_context_menu.py::test_agent_context_menu_rename | Add double-click-to-rename + Enter; add Escape-cancels-rename. |
+| WS-050 | Missing | — | Drag an agent tab to a new position; assert the tab order updates. |
+| WS-057 | Partial | test_ask_user_question.py::test_ask_user_question_navigation_state; ::test_ask_user_question_next_button | Add Tab/Shift+Tab and arrow-key navigation; assert progress dots show answered/unanswered/current. |
+| WS-060 | Missing | — | Agent errored + workspace deleted → input shows "deleted / cannot be restored" with no restore link. |
+| WS-061 | Partial | test_workspace_peek.py::test_workspace_peek_popover_idle_state; ::test_workspace_peek_popover_waiting_state; ::test_peek_popover_shows_diff_stats | Assert a single popover surfaces status, agent list, PR/MR info, branch, and diff stats together. |
+| WS-062 | Partial | test_workspace_peek.py::test_workspace_peek_popover_hover_mechanics; test_regression_workspace_peek_stuck_on_close.py::test_workspace_peek_dismissed_on_middle_click_close | Assert content swaps instantly within grace period and close-after-delay on leaving all tabs. |
+| WS-063 | Missing | — | Workspace with >5 agents shows only 5 + "+N more agents" button that reveals the rest. |
+| WS-064 | Missing | — | Click peek agent row/header closes popover and opens workspace/agent; click branch copies it with "Copied!". |
+| WS-065 | Partial | test_side_toggle.py::test_right_side_toggle_hides_and_shows_panels; test_zen_mode.py::test_focus_mode_hides_panels_but_keeps_chrome | Assert left, bottom, right toggle buttons + focus-mode button all present (and hidden in zen mode). |
+| WS-067 | Missing | — | Empty panel toggle is disabled, shows "Panel is empty" tooltip, does nothing on click. |
+| WS-068 | Missing | — | Hover a panel toggle; assert tooltip shows the panel name and its keybinding. |
+| WS-069 | Partial | test_panel_zones.py::test_inner_vertical_split_height_persists_after_navigation | Assert the expand outcome (the cited fullscreen test only clicks, asserts nothing); add divider-drag-collapses-diff and expand-maximizes-diff+collapses-chat. |
+| WS-071 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches; ::test_search_bar_does_not_flash_red_while_typing_matching_query | Assert the "0/0" counter with the input turning red when there are no matches. |
+| WS-072 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches (Enter nav) | Add Shift+Enter (previous) and up/down arrow navigation. |
+| WS-073 | Missing | — | Press Escape or click close → search bar closes and highlights clear. |
+
+### CHAT
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| CHAT-001 | Partial | test_alpha_chat_intro.py::test_alpha_chat_intro_shows_names_and_reacts_to_renames; ::test_intro_text_renders_above_first_message | Assert intro also shows project/branch, creation time, source-branch info, shared-code warning, and the `/sculptor:help` hint. |
+| CHAT-002 | Missing | — | Assert intro wording per workspace type: "Working directly in {branch}", "Branched off {branch}", "Cloned {branch} from {project}". |
+| CHAT-003 | Partial | test_workspace_setup_status.py::test_setup_card_shows_succeeded | Assert the card's setup-step label, progress indicator, and elapsed-time fields specifically. |
+| CHAT-006 | Partial | test_status_pill.py::test_status_pill_shows_animation; test_status_pill_background_wait.py::test_status_pill_shows_waiting_during_background_task; test_regression_auto_compact_indicator.py::test_auto_compaction_indicator_lifecycle | Assert "Thinking…"/"Streaming…"/"Calling Tools…" label text and the frozen-vs-live elapsed counter. |
+| CHAT-007 | Missing | — | Assert the pill shows "X / N · {task subject}" while the agent is active with a plan (existing tests cover only the post-turn "X of N done" summary). |
+| CHAT-009 | Partial | test_status_pill.py::test_status_pill_shows_stop_button; test_status_pill_plan_mode_stop.py::test_status_pill_disappears_after_single_stop_post_plan_approval | Assert "Stop (Ctrl+C)" tooltip; assert Ctrl+C interrupts; assert disabled-with-tooltip when interruption unsupported. |
+| CHAT-012 | Partial | test_task_page_plan_tab.py::test_plans_update_with_completion; test_status_pill_tasks_widget.py::test_hover_opens_tasks_popover | Assert in-progress bar / pending box glyphs and green/blue/outline colors; assert description text. |
+| CHAT-013 | Missing | — | Assert downstream pending tasks fade with distance. |
+| CHAT-015 | Partial | test_status_pill_tasks_widget.py::test_large_dag_scale_rules (60 nodes render) | Assert compact (small-node) vs normal rendering at the 15-task threshold. |
+| CHAT-017 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches; test_alpha_scroll_search.py::test_alpha_search_flow | Assert the input is focused AND its text selected on open. |
+| CHAT-018 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches; test_alpha_scroll_search.py::test_alpha_search_flow | Assert a visible highlight element wraps the active/all matches and the active match scrolls into view. |
+| CHAT-020 | Partial | test_alpha_scroll_search.py::test_alpha_search_flow (Escape → bar hidden) | Assert focus returns to chat and highlights clear; assert the close-button click path. |
+| CHAT-021 | Missing | — | Switching agent/task while search is open auto-closes the search bar. |
+| CHAT-022 | Missing | — | Assert auto-scroll is suppressed while search is open during streaming. |
+| CHAT-024 | Partial | test_alpha_scroll_auto_scroll.py::test_user_can_scroll_during_streaming; test_alpha_scroll_behaviors.py::test_jump_button_appears_and_works | Assert the down-arrow icon and bottom-right positioning of the button. |
+| CHAT-029 | Partial | test_alpha_scroll_padding_agent_switch.py::test_dynamic_padding_survives_agent_switch | Exercise window resize and the tool-density toggle, asserting the viewed message stays anchored. |
+| CHAT-033 | Missing | — | "+N" collapsed-rail indicator: clicking expands the rail, clicking outside collapses it. |
+| CHAT-037 | Missing | — | Click a subagent pill to open the popover; assert prompt text, nested tool pills, rendered-markdown response; Escape closes it. |
+| CHAT-038 | Missing | — | Arrow-key navigation in the subagent popover (left/right through nested tool pills, up/down between rows). |
+| CHAT-039 | Partial | test_stopped_turn_footer.py::test_stopped_turn_footer_shows_duration_after_content_streamed; ::test_turn_footer_shows_metrics_after_completed_turn; test_turn_summary.py::test_turn_footer_shows_file_count_after_write_file | Assert context-usage % in the footer. |
+| CHAT-040 | Partial | test_turn_footer_interactions.py::test_token_popover_shows_breakdown_on_click | Assert the reasoning-tokens line and the context current/threshold values in the popover. |
+| CHAT-043 | Partial | test_alpha_ask_user_question.py::test_alpha_auq_pill_dismissed_state | Assert the dimmed-options styling on the dismissed block. |
+| CHAT-044 | Partial | test_alpha_chat_view.py::test_debug_view_displays_blocks | Assert role, id, timestamp, and tool_use/tool_result names per message. |
+| CHAT-045 | Missing | — | Clicking a debug-view timestamp toggles between relative and absolute formats. |
+
+### MSG
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| MSG-003 | Partial | test_alpha_chat_view.py::test_alpha_view_displays_messages (text only, no timestamp) | Assert a user message renders a human-readable timestamp below the text. |
+| MSG-004 | Partial | test_alpha_chat_view.py::test_alpha_copy_button (button attached only); test_regression_copy_user_message_html.py::test_copy_user_message_with_mention_copies_plain_text | Assert the checkmark-icon feedback (~1.5s) after clicking copy on a user message. |
+| MSG-005 | Partial | test_inline_media_display.py::test_assistant_img_tag_renders_file_preview; test_alpha_chat_chip_rendering.py | Assert the "via {method}" badge for a `sentVia` user message, and a file-attachment preview on a user message. |
+| MSG-006 | Partial | test_markdown_gfm.py::test_markdown_renders_gfm_and_neutralises_unsafe; test_alpha_nested_list_rendering.py::test_nested_ordered_list_round_trip; test_alpha_ordered_list_numbering.py::test_non_sequential_ordered_list_preserves_markers | Add assertions for blockquote and emoji rendering. |
+| MSG-010 | Missing | — | Hover a blockquote, click copy; assert the quoted text (with "> " prefixes) is copied + checkmark feedback. |
+| MSG-011 | Missing | — (no integration test asserts the plain→highlighted token swap) | Assert a fenced code block first renders plain monospace then swaps to colored syntax tokens. |
+| MSG-012 | Missing | — | Hover a code block, click copy; assert the trimmed code is copied + checkmark for ~1.5s. |
+| MSG-013 | Missing | — | Drive chat search; assert `<mark>` overlays syntax-highlighted code in the live chat view. |
+| MSG-015 | Missing | — | Hover a table, click copy; assert it is copied as markdown + checkmark. |
+| MSG-016 | Partial | test_alpha_tool_pill_*.py (pills render with Read/Grep labels) | Assert the per-tool icon mapping (Bash terminal / Read file / Edit pencil / Grep search + wrench fallback). |
+| MSG-017 | Missing | — | Assert a running Bash/Monitor pill shows a pulsing dot in place of the icon. |
+| MSG-018 | Partial | test_alpha_chat_bash_block.py::test_bash_block_shows_error_badge (error pill renders) | Assert the red error styling/class on an errored tool pill. |
+| MSG-022 | Partial | test_alpha_tool_pill_hover.py::test_hover_opens_pill_popover (Read popover shows file path) | Assert line-count meta, copy-path action, open-in-Sculptor action, and the outside-workspace icon+tooltip. |
+| MSG-024 | Partial | test_alpha_tool_pill_hover.py::test_hover_sibling_swaps_popover_content (Grep popover shows the pattern) | Assert the Grep popover shows the quoted pattern, search path, and match-count meta. |
+| MSG-025 | Missing | — (test_alpha_chat_bash_block.py::test_bash_block_shows_error_badge asserts the pill, not the badge states) | Assert BashStatusBadge states: running=elapsed+spinner, success=duration+checkmark, error=duration+X, background=arrow icon. |
+| MSG-027 | Missing | — | Assert a running file chip shows "Writing…"/"Editing…" (disabled) and an errored chip shows error styling. |
+| MSG-029 | Partial | test_error_states.py::test_api_error_shows_error_block_and_agent_stays_running; ::test_usage_limit_clears_thinking_indicator_and_shows_error; test_claude_errors.py | Click an error block; assert the traceback expands. |
+| MSG-031 | Missing | — (test_missing_claude_binary.py only asserts the retry button is absent for that error) | Error as last message in a non-terminal state: assert "Retry Request" shows, clicking retries, then the button disables with an "already retried" tooltip. |
+| MSG-032 | Partial | test_alpha_chat_view.py::test_alpha_warning_block; test_regression_streaming_warning.py::test_simple_followup_does_not_produce_warning_block | Assert the orange badge type/message, click-to-expand traceback when present, non-clickable when none. |
+| MSG-033 | Partial | test_regression_compaction_message_position.py::test_post_compaction_message_appears_after_context_summary; test_regression_auto_compact_indicator.py::test_auto_compaction_indicator_lifecycle; ::test_auto_compaction_summary_ordering | Click the context-summary pill; assert the popover opens with the full summary as scrollable markdown. |
+| MSG-035 | Missing | — | Assert the folder-output icon + "Path outside of the workspace" tooltip for a tool-result path outside the workspace. |
+| MSG-036 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches; test_alpha_scroll_search.py::test_alpha_search_flow | Assert all matches render as highlights and the active occurrence is styled distinctly. |
+
+### PANEL
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| PANEL-003 | Missing | — | Click the tree/list toggle; assert the same file list renders nested vs flat. |
+| PANEL-005 | Partial | test_file_browser.py::test_refresh_button_reflects_file_operations; ::test_refresh_button_updates_uncommitted_tab_for_external_changes | Assert the refresh icon shows the animated/spinning state while re-fetching. |
+| PANEL-009 | Missing | — | Focus tree; Up/Down moves selection, Right/Left expand/collapse, Enter opens the focused file. |
+| PANEL-010 | Partial | test_file_browser.py::test_file_tree_shows_status_indicators (A); ::test_moved_file_shows_r_status_without_rename_label (R); test_file_browser_uncommitted.py::test_diff_header_line_stats_reflect_uncommitted_only (M) | Assert D status + strike-through, per-row +/− stats, folder change-count badge, processing-error badge. |
+| PANEL-011 | Missing | — | Agent edits a nested file; assert tree auto-scrolls, expands ancestors, applies highlight/focus styling. |
+| PANEL-012 | Partial | test_file_browser.py::test_copy_file_path_for_absolute_path_file; test_regression_copy_file_path.py::test_copy_file_path_uses_workspace_code_path; test_diff_tab_close_others.py::test_diff_tab_close_others | Assert each menu item acts: Open diff view, View file, Copy relative path, Open in OS, folder Expand all/Collapse all. |
+| PANEL-013 | Partial | test_file_browser.py::test_file_browser_populates_after_workspace_created_without_prompt | Assert the "No files yet" empty state and the animated skeleton/loading rows. |
+| PANEL-016 | Partial | test_commit_from_changes_tab.py::test_commit_button_sends_commit_message (enabled) | Assert the button is disabled (label reflects 0) when no changes exist. |
+| PANEL-018 | Missing | — | Right-click commit button → "Edit prompt…", edit, Save; assert prompt persists and dialog closes. |
+| PANEL-019 | Partial | test_history_panel.py::test_history_panel_shows_commits; ::test_terminus_visible_with_no_commits | Assert the "Loading history…" and error-message states. |
+| PANEL-022 | Partial | test_history_panel.py::test_commit_hover_popover_shows_details; ::test_click_dismisses_popover | Click the copy-hash button; assert the hash is copied and the "Copied" indicator shows. |
+| PANEL-025 | Partial | test_file_browser.py::test_multiple_tabs_and_close; ::test_clicking_tab_switches_displayed_file; ::test_cmd_w_closes_active_diff_tab; test_diff_tab_close_others.py::test_diff_tab_close_others | Assert tab drag-reorder, MRU-vs-adjacent close per setting, "Close all" menu item, full-path tooltip on hover. |
+| PANEL-026 | Partial | test_file_browser.py::test_split_view_toggle; ::test_line_wrap_toggle; ::test_in_file_search_bar; ::test_close_diff_panel_button; test_diff_scope_and_fullscreen.py::test_expand_toggle_expands_and_collapses; test_expand_escape.py::test_escape_exits_expand_mode | Assert expand/fullscreen hides the file browser (current tests assert chat-panel hide). |
+| PANEL-027 | Partial | test_file_browser.py::test_diff_file_header_shows_line_stats; test_file_browser_uncommitted.py::test_diff_header_line_stats_reflect_uncommitted_only; test_history_panel_diffs.py::test_commit_diff_file_header_shows_line_counts | Assert the breadcrumb path and the three-dot file-operations menu in the diff header. |
+| PANEL-028 | Partial | test_history_panel.py::test_clicking_renamed_file_in_commits_shows_rename_banner | Assert the "Deleted" banner and the "Binary file (cannot display)" message. |
+| PANEL-029 | Missing | — (test_regression_large_diff_crash.py checks no-crash only) | Open a diff over the threshold; assert truncated diff + "Show full diff" button; click → full diff renders. |
+| PANEL-030 | Partial | test_file_browser.py::test_in_file_search_bar; ::test_in_file_search_works_in_file_view | Assert the "X of Y" counter, Enter/Shift+Enter (or arrows) navigation, Escape closing. |
+| PANEL-036 | Partial | test_terminal_agent_basic.py::test_terminal_agent_basic; test_registered_terminal_agent.py (tab data-dot-status read/unread) | Produce output in a non-active tab; assert a pulsing unread dot appears, then clears after switching to it. |
+| PANEL-037 | Missing | — (test_terminal.py references "Starting terminal…" only incidentally in an .or_(), not as a deterministic assertion) | Assert the "Starting terminal…" message renders while a terminal is starting. |
+| PANEL-038 | Partial | test_notes_panel.py::test_enable_notes_panel_reveals_icon_and_renders_editor; ::test_notes_content_is_scoped_per_workspace | Type notes, switch to another panel/tab and back; assert content preserved. |
+| PANEL-039 | Missing | — | Click "Add notes to prompt"; assert notes inserted; with existing prompt text, assert the merge-conflict dialog appears. |
+| PANEL-040 | Missing | — | Copy copies notes when populated, disabled when empty; "Add to prompt" disabled with no notes / no task. |
+| PANEL-041 | Missing | — | Assert skills grouped into Custom/Sculptor/Built-in collapsible headers with a count badge when collapsed. |
+| PANEL-042 | Missing | — | Hover a skill chip → description popover; hover another → swaps; mouse-leave closes after delay. |
+| PANEL-044 | Missing | — | Open a custom/sculptor skill popover, click "open in Sculptor"; assert a file-view tab opens; built-in skills lack the option. |
+| PANEL-045 | Partial | test_skills_panel.py::test_skills_panel_search_filters_list; ::test_skills_panel_keyboard_navigation_inserts_chip; ::test_skills_panel_click_inserts_mention_chip | Assert selection auto-scroll, Escape closing search, and the type-filter popover toggling which types show. |
+| PANEL-046 | Missing | — | Assert Loading / error / "No skills found" / "Skills unavailable" states and chips disabled while the agent is running. |
+| PANEL-047 | Partial | test_custom_actions.py::test_builtin_chips (Sculptor group first; no delete on builtin) | Assert collapsible group headers with count badges when collapsed and ungrouped actions at the bottom. |
+| PANEL-048 | Partial | test_custom_actions.py::test_draft_action_populates_and_focuses_chat_input; ::test_builtin_chips | Assert an auto-submit action sends immediately and chips are disabled while the agent runs. |
+| PANEL-049 | Missing | — | Agent running, action chip context menu → "Queue message"; assert prompt queued (not auto-submitted). |
+| PANEL-051 | Partial | test_custom_actions.py::test_create_group_from_settings; ::test_delete_group_deletes_actions_from_settings; ::test_delete_group_deletes_actions_from_panel | Assert inline group rename (Enter/blur confirms) and Escape-cancel on group create. |
+| PANEL-052 | Missing | — | Drag an action/group → drop indicator + order updates; move action between groups; built-in items not draggable. |
+| PANEL-056 | Partial | test_file_browser.py::test_split_view_toggle_persists_across_panel_reopen; ::test_line_wrap_toggle_persists_across_panel_reopen; test_panel_zones.py::test_inner_vertical_split_height_persists_after_navigation | Assert folder-expansion, scroll position, active-tab, view-mode (tree/flat), and diff-scope restored after switching tabs/files and returning. |
+
+### CMDP
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| CMDP-001 | Partial | test_command_palette.py::test_open_command_palette_via_topbar_button; ::test_open_command_palette_via_keyboard_shortcut (palette visible + input focused only) | Assert group headers render in spec order (Workspaces → Navigation → Theme & Layout → Chat → Terminal → Help) with the first row selected on open. |
+| CMDP-002 | Missing | — | Press Cmd+P; assert the palette opens on the "Go to workspace" sub-page (breadcrumb + "Find a workspace…" placeholder). |
+| CMDP-003 | Missing | — | Open via Cmd+K, press Cmd+K again; assert the palette closes and no command ran. |
+| CMDP-005 | Partial | test_command_palette.py::test_command_palette_filters_on_input (empty-state element only) | Assert the exact `No matches for '{query}'` copy including the typed query string. |
+| CMDP-006 | Missing | — (test_command_palette_filters_on_input clears search with no post-assert) | Clear input; assert all commands reappear in group order with the first row re-selected. |
+| CMDP-007 | Partial | test_command_palette.py::test_command_palette_escape_closes (empty-root close only) | Add: (a) non-empty search: Escape clears search first, second Escape closes; (b) sub-page: Escape returns to root without closing. |
+| CMDP-008 | Missing | — | Open palette (no pending command), click the overlay/backdrop; assert the palette closes. |
+| CMDP-009 | Missing | — | Press Down/Up; assert selection moves, scrolls into view, and wraps at both ends. |
+| CMDP-013 | Partial | test_command_palette.py::test_command_palette_subpage_push_pop (breadcrumb visible/absent only) | Assert the breadcrumb shows the page title and its X control returns to root. |
+| CMDP-014 | Missing | — | Surface a context-disabled command; assert the row is greyed out and shows its reason as subtitle/tooltip. |
+| CMDP-015 | Missing | — | Assert the trailing area shows a kbd-badge shortcut / right chevron on page-openers / group label during search per case. |
+| CMDP-016 | Missing | — | Run an async command; assert the row shows a spinner and the palette refuses to close until it completes. |
+| CMDP-017 | Partial | test_command_palette.py::test_command_palette_navigates_to_settings; ::test_command_palette_creates_new_agent | Add Open home navigates home, New workspace opens add-workspace, and assert New agent disabled/hidden off a workspace. |
+| CMDP-018 | Partial | test_command_palette.py::test_command_palette_keep_open_command (runs theme.toggle but does NOT assert the appearance changed); ::test_command_palette_subpage_push_pop | Assert running a theme command actually changes the applied appearance. |
+| CMDP-019 | Missing | — | On a workspace, run panel/mode toggles; assert the panel/mode visibly toggled (focus/zen close palette; zone toggles keep it open). |
+| CMDP-020 | Missing | — | On a chat workspace: focus input / open chat search / jump-to-bottom / tool-density toggle with visible outcomes; chat commands hidden without a chat panel. |
+| CMDP-021 | Partial | test_command_palette.py::test_command_palette_report_problem_opens_popover | Add Clear terminal clears the active terminal; Show keyboard shortcuts opens the dialog; terminal command hidden without a terminal panel. |
+| CMDP-022 | Missing | — | With 2+ workspaces, open "Go to workspace…"; assert status dots + current disabled; select another to navigate. |
+| CMDP-023 | Missing | — | With 2+ tabs, run Next/Previous workspace tab; assert the active tab changes. |
+| CMDP-024 | Missing | — | Open "Workspace actions…"; assert the labeled actions list; run one (e.g. Rename) end-to-end. |
+| CMDP-025 | Missing | — | On a local backend, open "Open in…"; assert ordering (preferred first) + a disabled-on-remote case + an app launching. |
+| CMDP-026 | Missing | — | In a multi-agent workspace, open "Go to agent…"; assert current disabled; select another to navigate; opener disabled with one agent. |
+| CMDP-027 | Missing | — | Open "Agent actions…" and run each (rename dialog / marked unread / delete confirmation) from the palette. |
+| CMDP-028 | Partial | test_command_palette.py::test_command_palette_cross_page_reveal_finds_subpage_item (visibility only) | Open "Go to settings…", select a section (e.g. Keybindings); assert that section is shown. |
+| CMDP-029 | Missing | — | Under real pointer events, assert the first pointer move is ignored (keyboard selection stays) and a subsequent hover selects the hovered row. |
+| CMDP-030 | Partial | test_command_palette.py::test_command_palette_top_result_is_not_scrolled_past; ::test_command_palette_list_does_not_animate_scrolls | Assert the list scroll position resets to top on each open and the first row is selected. |
+| CMDP-031 | Missing | — | Render a very long agent/workspace title in the palette; assert it truncates with "…". |
+
+### SET / DEV
+
+| Scenario | Status | Existing integration test(s) | Integration tests to add |
+|----------|--------|------------------------------|--------------------------|
+| SET-001 | Partial | test_settings_tab.py::test_settings_opens_as_tab; piecemeal section-clicks across test_settings_integration.py, test_agent_settings.py, test_keybindings.py, test_panels_settings.py, test_claude_binary_installation.py, test_pi_managed_install.py, test_telemetry_opt_out.py, test_theme_builder.py, test_custom_actions.py | One nav test clicking every sidebar item (all 15 sections) asserting active content; cover the mobile dropdown; CI, File Browser, Git, Env-Vars, Experimental are never opened-and-asserted as a nav target. |
+| SET-002 | Missing | — | Load `/#/settings?section=<x>` and assert it opens directly to that section. |
+| SET-003 | Missing | — | View a non-default section, reopen Settings; assert the last-viewed section is restored. |
+| SET-004 | Partial | test_settings_integration.py::test_env_vars_override_toggle_saves_setting; test_agent_settings.py; test_keybindings.py; test_custom_actions.py (success toast broadly) | Assert the "Failed to update setting" error-toast path (induce a save failure). |
+| SET-005 | Missing | — | In General, pick Light/Dark/System; assert app appearance changes immediately. |
+| SET-006 | Partial | test_auto_update_browser.py::test_channel_switch_calls_ipc_and_shows_pending; ::test_check_for_updates_button; ::test_disabled_status_grays_out_settings_controls; test_auto_update_electron.py::test_channel_switch_stable_to_rc; test_auto_update_disabled_electron.py | Assert the channel-change confirmation toast and the "Install and restart"/"Restarting…" button state from within General. |
+| SET-012 | Partial | test_panels_settings.py::test_zone_select_moves_panel; ::test_diagram_drag_moves_panel; ::test_shortcut_round_trip_panels_to_keybindings; ::test_disabled_panel_shortcut_is_inert | Assert panel-hotkey conflict checking; assert the zone select disabled where rules/enabled-state prevent it. |
+| SET-015 | Partial | test_claude_binary_installation.py::test_settings_install_managed_binary; ::test_onboarding_claude_override_invalid_path | Add a Settings-page custom-path entry + Apply + active-path display test; assert the running progress-bar UI. |
+| SET-018 | Partial | test_pi_managed_install.py::test_pi_settings_managed_shows_managed_controls_and_no_manual_install; ::test_pi_settings_custom_shows_binary_path_and_manual_install; ::test_pi_settings_install_button_invokes_managed_install_and_surfaces_error | Assert install progress bar; distinct status states (outside-pinned/not-installed/no-path); detected-vs-pinned version rows; custom-path Apply + active-path. |
+| SET-019 | Missing | — | In Pi section, add an API-key env-var name then remove it; assert list updates + "Setting updated" toast. |
+| SET-020 | Partial | test_multi_repo.py::test_create_workspaces_in_multiple_projects_and_switch; test_regression_settings_delete_repo_stays_on_page.py | Assert per-repo path, agent count, and the accessibility/missing-path warning. |
+| SET-021 | Partial | test_workspace_setup_command.py::test_setup_command_input_visible_in_settings; ::test_setup_command_saves_on_blur; ::test_setup_edit_button_deep_links_to_focused_textarea; test_regression_setup_command_backfill.py | Cover the branch-naming pattern field and the setup-command "Using default"/"Reset to default" affordances. |
+| SET-022 | Partial | test_delete_last_repo.py::test_deleting_last_repo_shows_onboarding_add_repo_step; test_regression_settings_delete_repo_stays_on_page.py::test_deleting_repo_stays_on_settings_page | Assert the confirmation dialog showing the agent count and the success/error toast on remove. |
+| SET-023 | Missing | — (no Git-settings UI test) | Edit PR-creation prompt (+reset), toggle PR polling (dependent fields disable), poll-interval 10–300s validation, closed-workspace multiplier 1–120× validation, default target branch — each with save toast. |
+| SET-024 | Missing | — | Edit default branch-naming pattern (toast); set branch-deletion policy Never / Delete-if-safe / Always (toast). |
+| SET-025 | Missing | — (test_ci_babysitter.py configures via API, not the Settings UI) | Toggle babysitter, retry-cap 1–10 validation, edit pipeline-failed & merge-conflict prompts (+reset), dependent fields disable when off, save toast. |
+| SET-026 | Missing | — | Split-ratio 20–80%, tab-close behavior, line-wrapping, default diff view, commit prompt (+reset) — each with save toast. |
+| SET-027 | Partial | test_settings_integration.py::test_env_vars_section_shows_setup_instructions; ::test_env_vars_override_toggle_saves_setting; ::test_env_vars_loaded_names_shows_no_vars_without_env_file; test_project_env_vars.py::test_env_var_names_shown_in_settings | Cover the refresh button and the global-vs-repo-specific grouping of the loaded list. |
+| SET-029 | Partial | test_settings_integration.py::test_settings_experimental_has_review_all_toggle; ::test_enable_review_all_via_settings_shows_button (Review All only) | Toggle the other 8 experimental switches via UI and assert the "Setting updated" toast for each. |
+| SET-030 | Missing | — | Set custom backend command and readiness timeout in Experimental/Advanced; assert the "restart required" toast. |
+| SET-031 | Partial | test_custom_actions.py::test_create_action_from_settings; ::test_edit_action_from_settings; ::test_delete_action_from_settings; ::test_create_group_from_settings; ::test_delete_group_deletes_actions_from_settings; ::test_builtin_chips | Cover Export ("sculptor-actions.json" download, disabled-when-empty) and Import (file picker, validate+merge+count toast). |
+| SET-032 | Partial | test_custom_actions.py::test_create_action_from_settings; ::test_edit_action_from_settings | Assert Save disabled until valid, Cmd+Enter submits, and the Auto-submit toggle behavior within the dialog. |
+| SET-033 | Partial | test_custom_actions.py::test_create_group_from_settings; ::test_delete_group_deletes_actions_from_settings | Assert drag-to-reorder and inline group rename + success toast. |
+| SET-034 | Partial | test_theme_builder.py::test_theme_builder_navigation; ::test_theme_builder_change_accent_color | Exercise changing appearance mode, primary font, code font, and code theme and verify the UI updates. |
+| SET-035 | Partial | test_theme_builder.py::test_theme_builder_change_accent_color; ::test_theme_builder_reset_to_defaults | Cover custom hex entry, the light/dark hex override toggle, invalid-hex-shown-red, and the Gray/Success/Warning/Info swatches. |
+| SET-036 | Missing | — | Click a radius / scaling / panel-background option and assert the live UI updates. |
+| DEV-001 | Partial | test_tanstack_devtools_panel.py::test_tanstack_devtools_panel_mounts_with_content (panel mounts only) | Cover header Dock/Float/Close controls, floating drag + resize within viewport, docked resize-from-top-edge + pushes content up, and closing hides it. |
+
+---
+
+## Complete coverage
+
+Every scenario an integration test fully covers — it performs the user action *and* asserts the user-visible outcome — with the test(s) that cover it. Partial and Missing scenarios are in the gaps section above, not here.
+
+### SHELL / ROUTE / HELP
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| SHELL-001 | test_workspace_tab_enhancements.py::test_cmd_t_opens_new_workspace_page |
+| SHELL-003 | test_settings_tab.py::test_settings_opens_as_tab |
+| SHELL-007 | test_workspace_tab_enhancements.py::test_new_workspace_tab_x_navigates_to_mru_workspace; test_home_page_tab.py::test_home_tab_is_closeable |
+| SHELL-009 | test_workspace_tab_enhancements.py::test_cmd_w_closes_workspace_tab_without_deletion; ::test_cmd_w_on_new_workspace_page_navigates_to_mru_workspace |
+| SHELL-016 | test_workspace_tab_context_menu_icons.py::test_workspace_context_menu_rename; ::test_workspace_context_menu_rename_escape_cancels |
+| SHELL-017 | test_workspace_tab_enhancements.py::test_context_menu_delete_removes_workspace |
+| SHELL-020 | test_closed_workspaces_dropdown.py::test_pill_visibility_toggles_with_closed_workspace_count |
+| SHELL-021 | test_closed_workspaces_dropdown.py::test_dropdown_opens_and_shows_closed_workspace_rows |
+| SHELL-022 | test_closed_workspaces_dropdown.py::test_reopen_workspace_from_dropdown |
+| SHELL-023 | test_closed_workspaces_dropdown.py::test_open_all_reopens_all_closed_workspaces |
+| SHELL-024 | test_closed_workspaces_dropdown.py::test_delete_workspace_from_dropdown |
+| SHELL-025 | test_command_palette.py::test_open_command_palette_via_topbar_button |
+| SHELL-028 | test_zen_mode.py::test_zen_mode_hides_chrome_and_panels |
+| SHELL-029 | test_zen_mode.py::test_exit_zen_mode_button_works |
+| SHELL-030 | test_zen_mode.py::test_workspace_tab_navigation_works_in_zen_mode |
+| SHELL-031 | test_zen_mode.py::test_focus_mode_hides_panels_but_keeps_chrome |
+| SHELL-032 | test_zen_mode.py::test_panel_toggle_in_zen_mode_persists_on_exit; test_panels_settings.py::test_regression_focus_mode_toggle |
+| SHELL-036 | test_auto_update_browser.py::test_update_dot_appears_when_ready; ::test_update_dot_appears_when_downloading |
+| SHELL-037 | test_auto_update_browser.py::test_downloading_status_shows_progress |
+| SHELL-039 | test_auto_update_browser.py::test_error_status_shows_error |
+| SHELL-040 | test_auto_update_browser.py::test_dismissed_download_toast_stays_dismissed |
+| SHELL-046 | test_backend_shutdown_stall.py::test_shutdown_stall_recovery_after_timeout; ::test_shutdown_spinner_remains_before_timeout |
+| ROUTE-001 | test_restart_mru.py::test_restart_restores_active_workspace_and_agent; ::test_restart_with_no_mru_lands_on_new |
+
+### HOME / ADDWS / ADDREPO
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| HOME-002 | test_home_page.py::test_empty_state_shown_for_new_user |
+| HOME-013 | test_home_page.py::test_clicking_workspace_row_navigates_to_workspace; test_home_page_tab.py::test_clicking_workspace_replaces_home_tab |
+| ADDWS-005 | test_add_workspace_page.py::test_workspace_form_draft_persists_after_navigation; ::test_multiple_new_workspace_tabs_with_independent_drafts |
+| ADDWS-013 | test_worktree_create_happy_path.py::test_worktree_create_with_default_branch_name |
+| ADDWS-015 | test_branch_name_collisions.py::test_worktree_mode_collision_blocks_creation; ::test_clone_mode_collision_blocks_creation |
+| ADDWS-016 | test_add_workspace_agent_type.py::test_agent_type_select_visible_with_claude_default; ::test_pi_option_gated_behind_pi_agent_flag; test_agent_type_menu.py::test_registered_terminal_agent_appears_in_menu_and_creates |
+| ADDWS-017 | test_add_workspace_agent_type.py::test_first_agent_type_defaults_to_shared_last_used; test_agent_type_menu.py::test_agent_type_menu_creates_terminal_agent_and_remembers_type |
+| ADDWS-021 | test_worktree_create_happy_path.py::test_worktree_create_with_default_branch_name; test_add_workspace_agent_type.py::test_cmd_enter_in_workspace_name_creates_workspace |
+| ADDWS-022 | test_add_workspace_page.py::test_arrow_down_focuses_name_input_when_nothing_focused; ::test_arrow_up_focuses_name_input_when_nothing_focused |
+| ADDREPO-007 | test_path_autocomplete_keyboard.py::test_enter_on_directory_highlights_first_subentry; ::test_selected_folder_submit_shows_correct_repo_name |
+
+### ONB / MENT / SKILL / ACT
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| ONB-002 | test_onboarding.py::test_back_navigation_preserves_email |
+| ONB-008 | test_onboarding.py::test_invalid_email_surfaces_validation_error |
+| ONB-009 | test_telemetry_opt_out.py::test_onboarding_skip_account_setup |
+| ONB-013 | test_onboarding.py::test_onboarding_without_git_installed; test_claude_binary_installation.py::test_onboarding_claude_not_found_shows_override |
+| ONB-014 | test_onboarding.py::test_dependency_path_and_version_display |
+| ONB-016 | test_onboarding.py::test_claude_not_authenticated |
+| ONB-022 | test_onboarding.py::test_invalid_override_path_shows_error; test_claude_binary_installation.py::test_onboarding_claude_override_invalid_path |
+| ONB-024 | test_onboarding.py::test_onboarding_without_git_installed / test_onboarding_without_claude_installed; ::test_installation_step_skips_add_repo_when_project_exists |
+| ONB-026 | test_onboarding.py::test_full_onboarding_flow; ::test_installation_step_skips_add_repo_when_project_exists |
+| ONB-030 | test_onboarding.py::test_full_onboarding_flow |
+| MENT-005 | test_mention_picker_completion.py::test_plus_opens_prefilter_picker; ::test_plus_filters_categories_by_query; ::test_plus_drill_into_files/skills/workspaces/repositories_via_enter; ::test_mention_toolbar_button_opens_picker |
+| MENT-006 | test_at_mention_completion.py; test_at_mention_keyboard_navigation.py; test_at_mention_tab_drill_and_shift_tab.py; test_at_mention_path_mode.py |
+| MENT-007 | test_skill_autocomplete.py; test_pseudo_skills.py; test_slash_command_enter_accepts_suggestion.py; test_mention_picker_completion.py::test_plus_drill_into_skills_via_enter |
+| MENT-008 | test_entity_picker_workspace_drill.py::test_tab_on_workspace_drills_into_agent_list; ::test_click_on_workspace_drills_into_agent_list; ::test_shift_tab_steps_back_from_workspace_drill; ::test_enter_on_agent_after_drill_commits_agent_chip |
+| MENT-010 | test_path_autocomplete_keyboard.py::test_enter_on_directory_highlights_first_subentry; ::test_cmd_enter_submits_path; ::test_selected_folder_submit_shows_correct_repo_name; ::test_autocomplete_shows_submit_hint; test_path_tilde_display.py::test_path_autocomplete_shows_tilde_for_home_directory |
+| SKILL-001 | test_skills_panel.py::test_skills_panel_click_inserts_mention_chip; ::test_skills_panel_lists_workspace_skill; ::test_skills_panel_keyboard_navigation_inserts_chip; test_skill_without_frontmatter.py |
+| SKILL-003 | test_skills_panel.py::test_skills_panel_search_filters_list; ::test_skills_panel_keyboard_navigation_inserts_chip; test_skill_autocomplete.py; test_pseudo_skills.py::test_autocomplete_filters_pseudo_skills |
+| ACT-001 | test_custom_actions.py::test_draft_action_populates_and_focuses_chat_input; ::test_builtin_chips; ::test_create_action_from_panel |
+| ACT-004 | test_custom_actions.py::test_delete_action_from_settings; ::test_delete_group_deletes_actions_from_settings; ::test_delete_group_deletes_actions_from_panel |
+
+### WS
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| WS-003 | test_queued_messages.py::test_keyboard_shortcut_interrupt_and_send_queued_message; test_interrupt_and_continue.py::test_interrupt_and_continue |
+| WS-004 | test_chat_input_send_error.py::test_send_error_surfaces_attribute_and_toast_without_clearing_editor |
+| WS-006 | test_image_upload.py::test_image_upload_from_chat_input |
+| WS-007 | test_image_upload.py::test_remove_attached_image; test_image_thumbnail_strip.py::test_thumbnail_click_opens_lightbox |
+| WS-008 | test_at_mention_completion.py::test_at_mention_opens_suggestion_popup |
+| WS-010 | test_agent_settings.py::test_effort_level_persists_without_sending_message; ::test_effort_level_persists_across_workspace_switches |
+| WS-011 | test_fast_mode_persistence.py::test_fast_mode_persists_after_sending_message_and_switching_agents |
+| WS-012 | test_plan_mode.py::test_plan_first_toggle_activates_and_deactivates; ::test_plan_first_toggle_persists_after_send |
+| WS-014 | test_pseudo_skills.py::test_clear_pseudo_skill_clears_context |
+| WS-015 | test_pseudo_skills.py::test_copy_pseudo_skill_shows_toast |
+| WS-016 | test_btw.py::test_btw_happy_path_while_main_busy; ::test_btw_first_message_shows_unavailable_toast |
+| WS-017 | test_queued_messages.py::test_queued_message_bar_appears_and_shows_content |
+| WS-018 | test_queued_messages.py::test_cancel_queued_message |
+| WS-019 | test_queued_messages.py::test_edit_queued_message_into_empty_editor |
+| WS-020 | test_queued_messages.py::test_edit_dialog_overwrite_replaces_editor_content; ::test_edit_dialog_remove_discards_queued_message; ::test_edit_dialog_cancel_requeues_message |
+| WS-021 | test_queued_messages.py::test_interrupt_and_send_queued_message; test_regression_queued_messages_after_restart.py::test_queued_message_dispatched_after_graceful_restart |
+| WS-028 | test_ci_babysitter.py::test_scenario_4_pause_toggle_prevents_prompt |
+| WS-036 | test_workspace_banner.py::test_repo_segment_shows_mode_label |
+| WS-037 | test_zen_mode.py::test_zen_mode_hides_chrome_and_panels; ::test_focus_mode_hides_panels_but_keeps_chrome |
+| WS-040 | test_workspace_banner.py::test_banner_shows_diff_stats; ::test_banner_click_navigates_to_changes_all |
+| WS-041 | test_multi_agent_workspace.py::test_multiple_agent_tabs_shown_for_shared_workspace; ::test_single_agent_shows_one_agent_tab |
+| WS-044 | test_multi_agent_workspace.py::test_create_second_agent_in_existing_workspace |
+| WS-045 | test_agent_type_menu.py::test_agent_type_menu_creates_terminal_agent_and_remembers_type; ::test_agent_type_menu_gates_pi_behind_pi_agent_flag; ::test_registered_terminal_agent_appears_in_menu_and_creates |
+| WS-047 | test_agent_tab_context_menu.py::test_agent_context_menu_has_rename_and_delete; test_agent_diagnostics_context_menu.py::test_agent_diagnostics_disabled_without_session; ::test_agent_diagnostics_copy_session_id_and_transcript_path |
+| WS-048 | test_agent_tab_context_menu.py::test_agent_context_menu_delete; test_multi_agent_workspace.py::test_workspace_survives_when_other_agents_remain |
+| WS-049 | test_mark_unread.py::test_mark_adjacent_tab_unread; test_read_unread_status.py::test_unread_indicator_when_switching_agents_within_workspace |
+| WS-051 | test_terminal_agent_basic.py::test_terminal_agent_basic |
+| WS-052 | test_terminal_agent_basic.py::test_terminal_agent_basic (switch away/back, scrollback restored); test_terminal_tab_enhancements.py::test_terminal_compact_layout_no_heading |
+| WS-053 | test_ask_user_question.py::test_ask_user_question_full_flow; test_alpha_ask_user_question.py::test_alpha_auq_pill_shows_answered_summary |
+| WS-054 | test_ask_user_question.py::test_ask_user_question_full_flow |
+| WS-055 | test_ask_user_question.py::test_ask_user_question_multiselect |
+| WS-056 | test_ask_user_question.py::test_ask_user_question_other_option; ::test_ask_user_question_multiselect_with_other |
+| WS-058 | test_ask_user_question.py::test_ask_user_question_next_button; ::test_ask_user_question_dismiss; test_ask_user_question_continue.py::test_ask_user_question_and_continue |
+| WS-059 | test_error_states.py::test_crash_puts_task_in_error_state |
+| WS-066 | test_side_toggle.py::test_right_side_toggle_hides_and_shows_panels; ::test_bottom_toggle_hides_and_shows_terminal |
+| WS-070 | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches |
+| WS-074 | test_workspace_setup_command.py::test_setup_config_prompt_deep_links_to_focused_textarea; test_regression_setup_command_backfill.py; test_regression_setup_command_rerun.py::test_setup_rerun_button_runs_command_again |
+| WS-075 | test_btw.py::test_btw_happy_path_while_main_busy |
+| WS-076 | test_btw.py::test_btw_popup_is_draggable; ::test_btw_popup_closes_on_escape; ::test_btw_empty_shows_inline_toast |
+
+### CHAT
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| CHAT-004 | test_workspace_setup_status.py::test_setup_card_shows_succeeded / ::test_setup_card_shows_failed / ::test_setup_rerun_replays_command / ::test_setup_cancel_stops_running_command / ::test_setup_truncation_banner / ::test_setup_run_button_appears_when_command_added_after_creation |
+| CHAT-005 | test_status_pill.py::test_status_pill_disappears_after_completion |
+| CHAT-008 | test_status_pill_tasks_widget.py::test_status_pill_shows_count_summary_after_turn; ::test_count_summary_updates_on_follow_up |
+| CHAT-010 | test_status_pill_tasks_widget.py::test_hover_opens_tasks_popover / ::test_click_pins_tasks_popover / ::test_outside_click_closes_pinned_popover / ::test_graph_toggle_opens_and_closes_graph |
+| CHAT-011 | test_status_pill_tasks_widget.py::test_empty_state_popover_before_tasks_arrive |
+| CHAT-014 | test_status_pill_tasks_widget.py::test_non_linear_shows_waiting_badge_and_toggle; ::test_large_dag_scale_rules |
+| CHAT-016 | test_status_pill_tasks_widget.py::test_row_click_expands_inline_detail |
+| CHAT-019 | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches; test_alpha_scroll_search.py::test_alpha_search_flow |
+| CHAT-023 | test_alpha_scroll_to_top.py::test_filling_to_pin_transition |
+| CHAT-025 | test_alpha_scroll_auto_scroll.py::test_auto_scroll_and_jump_to_bottom |
+| CHAT-026 | test_alpha_scroll_behaviors.py::test_jump_button_appears_and_works; test_alpha_scroll_auto_scroll.py::test_auto_scroll_and_jump_to_bottom |
+| CHAT-027 | test_alpha_scroll_auto_scroll.py::test_user_can_scroll_during_streaming; test_alpha_scroll_to_top.py::test_reengagement_after_scroll_to_top |
+| CHAT-028 | test_alpha_scroll_task_switch.py::test_scroll_position_restored_on_task_switch |
+| CHAT-030 | test_alpha_prompt_navigator_interactions.py::test_dot_rail_shows_one_dot_per_user_prompt |
+| CHAT-031 | test_alpha_prompt_navigator_interactions.py::test_clicking_dot_scrolls_and_highlights_prompt; ::test_active_dot_tracks_scroll_position; ::test_arrow_keys_continue_after_dot_click |
+| CHAT-032 | test_alpha_prompt_navigator_interactions.py::test_hovering_dot_shows_popover; ::test_popover_swaps_content_between_dots; ::test_popover_contains_copy_button_and_prompt_label |
+| CHAT-034 | test_alpha_prompt_navigator_interactions.py::test_popover_copy_button_copies_and_flips_icon; ::test_right_click_dot_opens_copy_context_menu |
+| CHAT-035 | test_alpha_chat_subagent.py::test_background_subagent_launch_ack_not_visible |
+| CHAT-036 | test_alpha_chat_subagent.py::test_background_subagent_launch_ack_not_visible; ::test_subagent_tool_result_not_visible |
+| CHAT-041 | test_turn_footer_interactions.py::test_file_click_in_popover_opens_diff_panel |
+| CHAT-042 | test_alpha_ask_user_question.py::test_alpha_auq_pill_shows_answered_summary; ::test_alpha_auq_comma_in_option_label |
+
+### MSG
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| MSG-001 | test_alpha_chat_mixed_tools.py::test_mixed_write_bash_read_renders_all_types; ::test_text_and_tools_coexist; ::test_bash_with_error_and_write_coexist; test_alpha_chat_view.py::test_alpha_view_displays_tool_calls |
+| MSG-002 | test_alpha_streaming_cursor.py::test_streaming_cursor_visible_during_streaming; ::test_streaming_cursor_hidden_after_completion; ::test_streaming_cursor_visible_during_tool_then_text; ::test_streaming_cursor_absent_after_multiple_turns |
+| MSG-007 | test_markdown_gfm.py::test_markdown_renders_gfm_and_neutralises_unsafe (external anchors target=_blank + rel) |
+| MSG-008 | test_markdown_gfm.py::test_markdown_renders_gfm_and_neutralises_unsafe (images suppressed) |
+| MSG-009 | test_alpha_chat_view.py::test_alpha_file_path_link |
+| MSG-014 | test_alpha_chat_table_wrap_toggle.py::test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat |
+| MSG-019 | test_alpha_tool_pill_pin.py::test_click_pins_popover_open; ::test_click_pinned_pill_again_closes; ::test_escape_closes_pinned_popover; test_alpha_tool_pill_hover.py::test_hover_opens_pill_popover; ::test_hover_leave_closes_popover |
+| MSG-020 | test_alpha_tool_pill_keyboard.py::test_arrow_keys_move_open_popover_within_row; ::test_escape_closes_popover_and_restores_focus; ::test_enter_on_focused_pill_opens_popover |
+| MSG-021 | test_alpha_chat_tool_density.py::test_toggle_to_expanded_density_stacks_rows; ::test_density_persists_across_reload; ::test_default_density_renders_pills_inline |
+| MSG-023 | test_alpha_chat_bash_block.py::test_bash_block_expands_on_click; ::test_bash_description_persists_after_completion; test_alpha_chat_bash_block_advanced.py::test_bash_block_shows_command_text; ::test_bash_block_output_contains_stdout; ::test_bash_block_error_shows_output_on_click |
+| MSG-026 | test_alpha_chat_chip_row.py::test_chip_row_renders_for_write_tool; test_alpha_chat_chip_row_advanced.py::test_chip_row_renders_for_edit_tool; ::test_view_full_diff_for_multi_edit_file_shows_correct_line_count |
+| MSG-028 | test_alpha_chat_chip_row.py::test_chip_popover_opens_on_click; ::test_chip_popover_closes_on_second_click; ::test_chip_popover_swaps_on_different_chip_click; test_alpha_chat_chip_row_advanced.py::test_chip_popover_shows_diff_content; ::test_chip_row_hover_opens_popover |
+| MSG-030 | test_missing_claude_binary.py::test_missing_claude_binary_shows_friendly_error; test_claude_binary_installation.py::test_settings_claude_cli_section_visible; ::test_onboarding_claude_not_found_shows_override |
+| MSG-034 | test_plan_mode.py::test_exit_plan_mode_shows_approval_prompt; ::test_exit_plan_mode_revision_flow; ::test_exit_plan_mode_revision_auto_expands; test_alpha_chat_view.py::test_alpha_exit_plan_mode_approve |
+
+### PANEL
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| PANEL-001 | test_file_browser.py::test_filter_tabs_switch_between_all_and_changes; ::test_changes_tab_shows_count; test_file_browser_tabs.py::test_tab_switching_shows_correct_content |
+| PANEL-002 | test_file_browser.py::test_review_all_button_opens_combined_diff; ::test_review_all_shows_all_branch_files; test_review_all_visibility.py::test_review_all_visible_with_uncommitted_changes |
+| PANEL-004 | test_file_browser.py::test_collapse_all_folders_button; ::test_collapse_all_changes_folders_button; ::test_collapse_all_commits_button |
+| PANEL-006 | test_file_browser.py::test_file_search; ::test_file_search_filters_visible_rows; ::test_file_search_escape_closes; ::test_file_search_no_matches_shows_empty_state; ::test_file_search_folders_are_collapsible |
+| PANEL-007 | test_file_browser.py::test_folder_expand_and_collapse; ::test_collapse_all_folders_button |
+| PANEL-008 | test_file_browser.py::test_click_file_opens_diff_panel; ::test_changes_tab_click_opens_diff; test_file_open_diff_modes.py::test_browse_tab_opens_file_view |
+| PANEL-014 | test_diff_scope_switching.py::test_scope_switch_toggles_active_scope; test_file_open_diff_modes.py::test_committed_file_visible_in_all_scope_only; test_file_browser_tabs.py::test_tab_switching_shows_correct_content |
+| PANEL-015 | test_discard_file.py::test_discard_file_removes_from_changes; ::test_discard_cancel_preserves_file; test_discard_preserves_all_tab.py::test_discard_last_uncommitted_keeps_all_tab_populated |
+| PANEL-017 | test_commit_from_changes_tab.py::test_commit_button_sends_commit_message |
+| PANEL-020 | test_history_panel.py::test_commit_entry_shows_metadata_line; ::test_merge_commit_shows_spur |
+| PANEL-021 | test_file_browser.py::test_collapse_all_commits_button; test_history_panel_diffs.py::test_click_file_in_multi_file_commit; ::test_switch_files_within_same_commit |
+| PANEL-023 | test_history_panel_diffs.py::test_commit_diff_shows_committed_content_not_uncommitted; ::test_commit_diff_file_header_shows_line_counts; ::test_same_file_two_commits_shows_correct_content |
+| PANEL-024 | test_history_panel.py::test_merge_commit_shows_spur; ::test_terminus_shows_fork_point_hash; ::test_terminus_visible_with_no_commits |
+| PANEL-031 | test_file_open_diff_modes.py::test_browse_tab_opens_file_view; test_sculpt_ui_open_file.py::test_mode_file_opens_file_view_tab; test_open_in_viewer.py::test_open_created_file_in_diff_viewer |
+| PANEL-032 | test_auto_collapse_combined_diff.py::test_many_files_start_collapsed_in_review_all; ::test_few_files_start_expanded_in_review_all; test_file_browser.py::test_review_all_button_opens_combined_diff |
+| PANEL-033 | test_markdown_render_toggle.py::test_markdown_toggle_switches_views; ::test_markdown_toggle_hidden_for_non_markdown_files; ::test_markdown_toggle_disabled_when_flag_off |
+| PANEL-034 | test_terminal.py::test_add_terminal_tab_creates_new_session; ::test_close_terminal_tab_switches_to_neighbor; ::test_terminal_tab_reuses_lowest_available_number; test_terminal_tab_enhancements.py::test_terminal_tab_double_click_rename; ::test_terminal_context_menu_has_close_all_and_rename |
+| PANEL-035 | test_terminal.py::test_opt_left_moves_cursor_back_by_word; ::test_ctrl_c_cancels_input; ::test_ctrl_d_shows_process_exited_message; test_terminal_agent_basic.py::test_terminal_agent_basic |
+| PANEL-043 | test_skills_panel.py::test_skills_panel_click_inserts_mention_chip |
+| PANEL-050 | test_custom_actions.py::test_create_action_from_panel; ::test_edit_action_from_settings; ::test_delete_action_from_settings; ::test_builtin_chips |
+| PANEL-053 | test_browser_panel.py::test_browser_panel_navigation_tour; ::test_browser_panel_screenshot; ::test_browser_panel_url_input_polish |
+| PANEL-054 | test_browser_panel.py::test_browser_panel_navigation_tour; ::test_browser_panel_url_input_polish |
+| PANEL-055 | test_browser_panel.py::test_browser_panel_toggle_shows_and_hides_icon; ::test_browser_panel_electron_mode_hides_web_placeholder |
+
+### CMDP
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| CMDP-004 | test_command_palette.py::test_command_palette_filters_on_input |
+| CMDP-010 | test_command_palette.py::test_command_palette_navigates_to_settings |
+| CMDP-011 | test_command_palette.py::test_command_palette_cmd_enter_keeps_palette_open |
+| CMDP-012 | test_command_palette.py::test_command_palette_subpage_push_pop |
+
+### SET / DEV
+
+| Scenario | Existing integration test(s) |
+|----------|------------------------------|
+| SET-007 | test_agent_settings.py::test_agent_settings_persist_and_apply_to_new_agents; test_fast_mode_persistence.py; test_model_capability_gating.py |
+| SET-008 | test_keybindings.py::test_search_filters_keybindings |
+| SET-009 | test_keybindings.py::test_record_new_keybinding; ::test_escape_cancels_recording; ::test_click_outside_cancels_recording; ::test_starting_second_recording_cancels_first |
+| SET-010 | test_keybindings.py::test_duplicate_detection_reassign; ::test_duplicate_detection_cancel |
+| SET-011 | test_keybindings.py::test_clear_keybinding; ::test_reset_all_to_defaults |
+| SET-013 | test_panels_settings.py::test_disable_hides_panel; ::test_reset_to_defaults_preserves_shortcuts |
+| SET-014 | test_claude_binary_installation.py::test_settings_claude_cli_section_visible; ::test_settings_mode_selector_persists; ::test_settings_managed_mode_shows_install_button |
+| SET-016 | test_claude_binary_installation.py::test_settings_git_section_visible |
+| SET-017 | test_pi_managed_install.py::test_pi_settings_section_visible_with_pi_agent_disabled |
+| SET-028 | test_telemetry_opt_out.py::test_privacy_settings_telemetry_switch; ::test_onboarding_email_with_telemetry_opt_out; ::test_onboarding_skip_account_setup |
+| SET-037 | test_theme_builder.py::test_theme_builder_component_gallery_button; ::test_theme_builder_reset_to_defaults; test_component_gallery_tab.py::test_component_gallery_opens_as_tab |
+| DEV-002 | test_markdown_gfm.py::test_gfm_features_render_in_read_only_preview (external anchors target=_blank + rel) |
+| DEV-003 | test_markdown_gfm.py::test_gfm_features_render_in_read_only_preview (fragment anchors inert + "not supported" title) |
+| DEV-004 | test_markdown_gfm.py::test_gfm_features_render_in_read_only_preview (relative anchors inert + "not supported" title) |
+
+---
+
+## How to use this report
+
+- **Fill Missing first** where the behavior is user-critical and entirely untested by integration
+  tests (see "Highest-value gaps" above).
+- **Upgrade Partials** by adding the single missing assertion named in the right-hand column — these
+  are cheap because a related integration test already drives the relevant state.
+- Add new integration tests under `sculptor/tests/integration/frontend/` using the
+  `write-integration-test` skill (FakeClaude for deterministic agent behavior). Reach for
+  `real_claude`/`real_pi` only when the behavior genuinely needs a live model.
+- The command palette (CMDP) is the single biggest integration gap: most commands have no end-to-end
+  "ran the command → saw the on-screen result" assertion. A focused pass over `test_command_palette.py`
+  that opens each sub-page and asserts the visible outcome would move ~18 scenarios from
+  Missing/Partial to Complete.
+
+*Coverage assessed by reading the cited integration tests, not filenames alone. Counts are derived
+from the per-area tables; where a single scenario spans multiple controls (notably SET-*), status
+reflects the weakest uncovered part.*

--- a/docs/specs/scenarios.md
+++ b/docs/specs/scenarios.md
@@ -1,0 +1,2507 @@
+# Sculptor — User-Facing Scenarios
+
+This document enumerates every user-facing interaction and behavior in the Sculptor
+frontend, expressed as Given/When/Then scenarios. It is intended as the source of truth
+for building a test plan and integration tests that exercise **100% of user-visible
+behavior**.
+
+## Conventions
+
+- **Given** = the precondition / app state the user can observe or that is set up before the action.
+- **When** = the concrete user action (a click, key press, hover, drag, type, etc.).
+- **Then** = the result that is **visible on screen**. Every assertion in a Then must be
+  something a person can see in the UI — visible text, an icon, a color/state change, a
+  panel appearing/disappearing, navigation, a toast, a tooltip, focus moving, etc. Do **not**
+  assert on invisible markers (DOM attributes, atoms, localStorage, network calls) as the
+  primary observable; those may be referenced parenthetically as implementation hints only.
+- Each scenario has a stable ID (`AREA-NNN`) so tests can reference it.
+- Keybindings are written in the macOS form (`Cmd`); the Windows/Linux equivalent is `Ctrl`.
+
+## Areas / ID prefixes
+
+| Prefix | Area |
+|--------|------|
+| `SHELL` | App shell: tabs, top bar, window controls, zen/focus mode, version, status banners |
+| `ROUTE` | Routing, redirects, error/404 pages, startup |
+| `HELP` | Keyboard-shortcuts (Help) dialog |
+| `HOME` | Home page / recent-workspaces list |
+| `ONB` | Onboarding wizard |
+| `ADDWS` | Add-workspace page (create workspace form) |
+| `ADDREPO` | Add-repository flow and dialogs |
+| `WS` | Workspace shell (chat input, banner, PR button, agent tabs, peek, etc.) |
+| `CHAT` | Chat-alpha interface, status, search, navigation, subagents, tasks, questions |
+| `MSG` | Chat message & tool-content rendering |
+| `PANEL` | Workspace side panels (files, changes, history, diff, terminal, notes, skills, actions, browser) |
+| `CMDP` | Command palette |
+| `SET` | Settings page |
+| `ACT` | Actions feature components |
+| `SKILL` | Skills UI components |
+| `MENT` | Mentions, mention pickers, path autocomplete, mention chips |
+| `DEV` | Dev/debug panels and markdown-diff anchors |
+
+---
+
+# SHELL — App shell, tabs & navigation
+
+## Tabs
+
+- **SHELL-001 — Open a new workspace tab**
+  - Given: the app is open on any page.
+  - When: the user clicks the `+` button at the end of the tab bar, or presses `Cmd+T`.
+  - Then: a new "New Workspace" tab appears, becomes active, and the Add Workspace form is shown.
+
+- **SHELL-002 — Open the Home tab**
+  - Given: the app is open.
+  - When: the user clicks the Home button in the top bar, or presses the Home keybinding.
+  - Then: a "Home" tab is shown (created if absent, otherwise re-activated) and the home page is displayed.
+
+- **SHELL-003 — Open the Settings tab**
+  - Given: the app is open.
+  - When: the user clicks the Settings (gear) button in the top bar, or presses the Settings keybinding.
+  - Then: a "Settings" tab is shown and the settings page is displayed.
+
+- **SHELL-004 — Switch tabs by clicking**
+  - Given: multiple tabs are open.
+  - When: the user clicks a non-active tab.
+  - Then: that tab becomes highlighted/active and its content is shown.
+
+- **SHELL-005 — Cycle to next tab**
+  - Given: multiple tabs are open.
+  - When: the user presses `Cmd+]`.
+  - Then: the next tab to the right becomes active, wrapping to the first after the last.
+
+- **SHELL-006 — Cycle to previous tab**
+  - Given: multiple tabs are open.
+  - When: the user presses `Cmd+[`.
+  - Then: the previous tab becomes active, wrapping to the last before the first.
+
+- **SHELL-007 — Close a tab via its X button**
+  - Given: a tab is present.
+  - When: the user clicks the tab's X (close) button.
+  - Then: the tab disappears; an adjacent tab becomes active, or the Add Workspace page is shown if it was the last tab.
+
+- **SHELL-008 — Close a tab via middle-click**
+  - Given: multiple tabs are open.
+  - When: the user middle-clicks a tab.
+  - Then: that tab closes without changing which tab is active (unless the active one was closed).
+
+- **SHELL-009 — Close the current tab via keyboard**
+  - Given: a workspace/Home/Settings tab is active.
+  - When: the user presses `Cmd+W`.
+  - Then: the active tab closes and a remaining tab (or the Add Workspace page) is shown.
+
+- **SHELL-010 — Reorder tabs by dragging**
+  - Given: multiple tabs are open.
+  - When: the user drags a tab horizontally past another.
+  - Then: a drop indicator appears, and on release the tabs reorder; the active tab is unchanged.
+
+- **SHELL-011 — Tab overflow scrolling**
+  - Given: more tabs are open than fit in the bar.
+  - When: the user scrolls (wheel or trackpad) over the tab bar.
+  - Then: the tab strip scrolls horizontally to reveal hidden tabs.
+
+- **SHELL-012 — Active tab auto-scrolls into view**
+  - Given: tabs overflow and the active tab is off-screen.
+  - When: a tab becomes active (e.g., via keyboard cycle).
+  - Then: the strip scrolls so the active tab is visible.
+
+- **SHELL-013 — Tab label truncates**
+  - Given: a tab with a long title.
+  - When: the tab is rendered at a constrained width.
+  - Then: the label is truncated with an ellipsis.
+
+- **SHELL-014 — Workspace tab status dots**
+  - Given: a workspace tab whose agents have a status.
+  - When: the tab is displayed.
+  - Then: status dot(s) appear next to the name (pulsing for running, solid for waiting/ready, red for error, two dots for mixed states).
+
+- **SHELL-015 — Tab right-click context menu**
+  - Given: a tab is present.
+  - When: the user right-clicks the tab.
+  - Then: a context menu appears with at least Close / Close others / Close all (and Rename/Delete + git actions for workspace tabs).
+
+- **SHELL-016 — Rename a workspace tab inline**
+  - Given: a workspace tab's context menu is open, or the user double-clicks the tab.
+  - When: the user chooses Rename (or double-clicks), types a new name, and presses Enter.
+  - Then: the tab label updates to the new name; pressing Escape instead cancels and restores the old name.
+
+- **SHELL-017 — Delete a workspace from its tab**
+  - Given: a workspace tab context menu is open.
+  - When: the user chooses Delete and confirms in the dialog.
+  - Then: the tab disappears and an adjacent tab/page is shown.
+
+- **SHELL-018 — Close others / Close all from tab menu**
+  - Given: multiple tabs open and a tab's context menu is open.
+  - When: the user chooses "Close others" or "Close all".
+  - Then: all other tabs (or all tabs) close accordingly; "Close all" navigates to the Add Workspace page.
+
+- **SHELL-019 — Tabs persist across restart**
+  - Given: the user has tabs open in a particular order with one active.
+  - When: the app is closed and reopened.
+  - Then: the same tabs reappear in the same order and the previously active tab is shown.
+
+## Closed-workspaces pill
+
+- **SHELL-020 — Closed-workspaces pill appears**
+  - Given: the user has closed one or more workspace tabs.
+  - When: viewing the top bar.
+  - Then: a "Closed N" pill is visible.
+
+- **SHELL-021 — Open the closed-workspaces menu**
+  - Given: the closed-workspaces pill is visible.
+  - When: the user clicks it.
+  - Then: a dropdown lists recently-closed workspaces (showing a spinner while loading).
+
+- **SHELL-022 — Reopen a closed workspace**
+  - Given: the closed-workspaces dropdown is open.
+  - When: the user clicks a workspace row.
+  - Then: that workspace tab reopens and is shown; the dropdown closes.
+
+- **SHELL-023 — Open all closed workspaces**
+  - Given: the closed-workspaces dropdown is open.
+  - When: the user clicks "Open all".
+  - Then: all closed workspace tabs reopen in the bar; the dropdown closes.
+
+- **SHELL-024 — Delete a closed workspace from the menu**
+  - Given: the closed-workspaces dropdown is open.
+  - When: the user triggers delete on a row and confirms.
+  - Then: that row disappears from the list and the workspace is gone.
+
+## Top-bar buttons
+
+- **SHELL-025 — Command palette button**
+  - Given: the top bar is visible.
+  - When: the user clicks the search/command icon (tooltip "Command palette").
+  - Then: the command palette opens with its input focused.
+
+- **SHELL-026 — Help button**
+  - Given: the top bar is visible.
+  - When: the user clicks the Help (?) icon.
+  - Then: the keyboard-shortcuts dialog opens.
+
+- **SHELL-027 — Top-bar button tooltips**
+  - Given: the top bar is visible.
+  - When: the user hovers a top-bar button.
+  - Then: a tooltip shows the button name and its keyboard shortcut.
+
+## Zen & focus modes
+
+- **SHELL-028 — Enter zen mode**
+  - Given: the user is on a workspace page.
+  - When: the user presses `Cmd+Shift+\`.
+  - Then: the top bar and side panels hide, leaving only the chat; a draggable title bar is shown.
+
+- **SHELL-029 — Exit zen mode via floating button**
+  - Given: zen mode is active.
+  - When: the user moves the mouse to the top-left hot zone.
+  - Then: an "Exit zen mode" button appears; clicking it restores the normal layout.
+
+- **SHELL-030 — Tab cycling works in zen mode**
+  - Given: zen mode is active.
+  - When: the user presses `Cmd+[` / `Cmd+]`.
+  - Then: the active tab changes even though the top bar remains hidden.
+
+- **SHELL-031 — Toggle focus mode**
+  - Given: the user is on a workspace page.
+  - When: the user presses `Cmd+\`.
+  - Then: all side panels collapse and the chat expands; pressing again restores the panels.
+
+- **SHELL-032 — Toggle individual panels via keyboard**
+  - Given: the user is on a workspace page.
+  - When: the user presses `Cmd+Alt+Left` / `Cmd+Alt+Down` / `Cmd+Alt+Right`.
+  - Then: the left / bottom / right panel toggles hidden/visible respectively.
+
+## Theme
+
+- **SHELL-033 — Toggle theme via keyboard**
+  - Given: the app is focused.
+  - When: the user presses `Cmd+Shift+D`.
+  - Then: the app switches between light and dark mode immediately, with no reload.
+
+## Version indicator & updates
+
+- **SHELL-034 — Version number shown**
+  - Given: the user is on a non-workspace page (and not in zen mode).
+  - When: the page renders.
+  - Then: the version number is visible in the bottom-right corner.
+
+- **SHELL-035 — Open version popover**
+  - Given: the version number is visible.
+  - When: the user clicks it (or the adjacent bug icon).
+  - Then: a popover opens showing version details, update status, and diagnostics (platform, uptime, active agents, disk, paths, Claude CLI info).
+
+- **SHELL-036 — Update-available dot**
+  - Given: an update is downloading or ready.
+  - When: viewing the version indicator.
+  - Then: a colored dot appears next to the version number.
+
+- **SHELL-037 — Downloading-update toast**
+  - Given: an update download begins.
+  - When: the download is in progress.
+  - Then: a toast shows "Downloading update…" with a percentage.
+
+- **SHELL-038 — Update-ready toast & install**
+  - Given: an update finished downloading.
+  - When: the toast appears with "Install and restart" and the user clicks it.
+  - Then: the button shows "Restarting…" and the app restarts.
+
+- **SHELL-039 — Update-error toast**
+  - Given: the auto-updater errors.
+  - When: the error occurs.
+  - Then: an error toast appears and auto-dismisses after a few seconds.
+
+- **SHELL-040 — Dismiss download toast**
+  - Given: a downloading-update toast is showing.
+  - When: the user dismisses it.
+  - Then: the toast disappears and does not reappear while the same download continues.
+
+- **SHELL-041 — Dev-tools toggles in version popover**
+  - Given: the version popover is open.
+  - When: the user toggles "React Grab", "TanStack Devtools", or "TanStack event log".
+  - Then: the corresponding dev tool appears/disappears.
+
+## Status banners
+
+- **SHELL-042 — Backend-unresponsive banner**
+  - Given: the backend becomes unresponsive.
+  - When: the status changes.
+  - Then: a yellow banner appears at the bottom: "Backend not responding. Please try restarting the app."
+
+- **SHELL-043 — Backend health-warning banner**
+  - Given: the backend reports a health warning.
+  - When: the status changes.
+  - Then: a yellow warning banner appears with the warning message (and optional link).
+
+- **SHELL-044 — Missing project-folder banner**
+  - Given: the active workspace's project folder is not found.
+  - When: the page renders.
+  - Then: a banner reads "Project folder not found: {name}." with a "Learn more" link that opens a dialog.
+
+- **SHELL-045 — Backend loading splash**
+  - Given: the app is starting and the backend is launching.
+  - When: viewing the screen.
+  - Then: a splash with the Sculptor logo, "Loading" message, and progress bar is shown until the backend is ready.
+
+- **SHELL-046 — Backend shutting-down screen**
+  - Given: the app is quitting / restarting the backend.
+  - When: the status becomes shutting-down.
+  - Then: a "Shutting down…" message with a progress bar is shown; if stalled past ~30s a recovery message appears.
+
+- **SHELL-047 — Dev-mode indicator**
+  - Given: the app is running from source (not packaged).
+  - When: viewing the page.
+  - Then: a dev-mode indicator is shown (bottom-left); hovering it shows a "Running from source" tooltip with the workspace id.
+
+## Window & zoom
+
+- **SHELL-048 — Zoom in / out / reset**
+  - Given: the app is focused.
+  - When: the user presses `Cmd+=`, `Cmd+-`, or `Cmd+0`.
+  - Then: the UI scales up, down, or back to 100% respectively, and the zoom level persists across restarts.
+
+---
+
+# ROUTE — Routing, startup & error pages
+
+- **ROUTE-001 — Startup redirect to last active tab**
+  - Given: the user had tabs open previously.
+  - When: the app launches and loads `/`.
+  - Then: it redirects to the previously active tab's page (or the Add Workspace page if none).
+
+- **ROUTE-002 — New-workspace route generates a draft**
+  - Given: the user navigates to `/ws/new`.
+  - When: the route loads.
+  - Then: it redirects to `/ws/new/{draftId}` and shows the Add Workspace form.
+
+- **ROUTE-003 — 404 page for unknown route**
+  - Given: the user navigates to a URL that matches no route.
+  - When: the page loads.
+  - Then: a Not-Found page shows the Sculptor logo and "The page you are looking for does not exist." with a link back to home.
+
+- **ROUTE-004 — Route error boundary**
+  - Given: a route loader or component throws.
+  - When: the error occurs.
+  - Then: an error page is shown with a generic message and the error details in a scrollable box.
+
+- **ROUTE-005 — Copy error to clipboard**
+  - Given: the route error page is shown.
+  - When: the user clicks "Copy Error to Clipboard".
+  - Then: the error text is copied (a person can paste it elsewhere).
+
+- **ROUTE-006 — Clear custom-backend command from error page**
+  - Given: a custom backend command is set and causing errors, and the error page shows the clear button.
+  - When: the user clicks "Clear Custom Backend Command".
+  - Then: the button becomes disabled and its label changes to indicate the command was cleared and a restart is needed.
+
+---
+
+# HELP — Keyboard shortcuts dialog
+
+- **HELP-001 — Open the help dialog**
+  - Given: the app is focused.
+  - When: the user clicks the Help button or presses `Cmd+/`.
+  - Then: a modal titled "Help" opens listing all keybindings grouped by category.
+
+- **HELP-002 — Shortcuts formatted per OS**
+  - Given: the help dialog is open.
+  - When: viewing a shortcut.
+  - Then: it is shown in a key-badge formatted for the current OS (e.g., `Cmd+K` on macOS, `Ctrl+K` elsewhere).
+
+- **HELP-003 — Close the help dialog**
+  - Given: the help dialog is open.
+  - When: the user clicks the X or presses Escape.
+  - Then: the dialog closes.
+
+---
+
+# HOME — Home page / recent workspaces
+
+The home page and the Add Workspace page share the recent-workspaces list and its rows.
+
+- **HOME-001 — Loading state**
+  - Given: the workspace list is being fetched.
+  - When: the page first renders.
+  - Then: a spinner is shown in the list area.
+
+- **HOME-002 — Empty state (no workspaces)**
+  - Given: the user has no workspaces.
+  - When: the list loads.
+  - Then: a centered folder icon, "No workspaces yet" heading, and a "Describe what you need above to create your first workspace." message are shown.
+
+- **HOME-003 — Search bar present & autofocused**
+  - Given: at least one workspace exists.
+  - When: the page loads.
+  - Then: a search input with placeholder "Search workspaces…" is shown and focused.
+
+- **HOME-004 — Filter workspaces by query**
+  - Given: the workspace list is populated.
+  - When: the user types in the search box.
+  - Then: the list filters in real time by workspace name, branch, and project (case-insensitive).
+
+- **HOME-005 — No search results**
+  - Given: a search query matches nothing.
+  - When: filtering completes.
+  - Then: a centered message `No results for "{query}"` is shown.
+
+- **HOME-006 — Escape clears search**
+  - Given: the search box has text and focus.
+  - When: the user presses Escape.
+  - Then: the query clears, the full list returns, and focus returns to the search input.
+
+- **HOME-007 — Sort order**
+  - Given: multiple workspaces.
+  - When: the list is shown.
+  - Then: workspaces are ordered by most recent activity first.
+
+- **HOME-008 — Pagination "Show more"**
+  - Given: more than 25 workspaces exist.
+  - When: the list loads.
+  - Then: only 25 rows show, with a "Show more (N remaining)" button; clicking it reveals the next 25.
+
+- **HOME-009 — Search resets visible count**
+  - Given: more than 25 rows are shown after "Show more".
+  - When: the user types a search query.
+  - Then: the visible count resets to the first 25 filtered results.
+
+- **HOME-010 — Workspace row contents**
+  - Given: a workspace exists.
+  - When: the row is shown.
+  - Then: it shows a status dot, the workspace name, the branch name (monospace), a PR/MR button if a branch exists, the project name (revealed on hover), a relative last-activity time, and a delete button (revealed on hover).
+
+- **HOME-011 — Row hover/focus styling**
+  - Given: a workspace row.
+  - When: the user hovers or keyboard-focuses it.
+  - Then: the row background changes and the project name and delete button become visible.
+
+- **HOME-012 — Keyboard navigation into the list**
+  - Given: the search box is focused.
+  - When: the user presses ArrowDown.
+  - Then: the first row gains focus and scrolls into view; ArrowUp from the first row returns focus to the search box.
+
+- **HOME-013 — Open a workspace with Enter / click**
+  - Given: a row is focused or visible.
+  - When: the user presses Enter on it (or clicks it without a modifier).
+  - Then: the current tab becomes that workspace and it opens.
+
+- **HOME-014 — Open a workspace in a new tab**
+  - Given: a workspace row is visible.
+  - When: the user Cmd/Ctrl-clicks it (or chooses "Open in New Tab" from its right-click menu).
+  - Then: the workspace opens in a new tab while the home page remains visible.
+
+- **HOME-015 — Row context menu**
+  - Given: a workspace row.
+  - When: the user right-clicks it.
+  - Then: a menu with "Open in New Tab" and "Delete Workspace" (in red) appears.
+
+- **HOME-016 — Delete via row button / menu**
+  - Given: a row is hovered (delete button visible) or its context menu is open.
+  - When: the user clicks the delete trash icon or "Delete Workspace".
+  - Then: a delete-confirmation dialog opens.
+
+- **HOME-017 — Delete confirmation dialog**
+  - Given: the delete dialog is open.
+  - When: viewing it.
+  - Then: it shows "Delete workspace?", a warning naming the workspace, a Cancel button, and a red Delete button (focused by default).
+
+- **HOME-018 — Cancel deletion**
+  - Given: the delete dialog is open.
+  - When: the user clicks Cancel or presses Escape.
+  - Then: the dialog closes and the workspace remains.
+
+- **HOME-019 — Confirm deletion**
+  - Given: the delete dialog is open.
+  - When: the user clicks Delete (or presses Enter).
+  - Then: the dialog closes and the row disappears from the list immediately.
+
+- **HOME-020 — PR/MR button states on a row**
+  - Given: a workspace row with a branch.
+  - When: the PR status is known.
+  - Then: the button reflects the state: a spinner + "Checking PR…" while loading; "Create PR"/"Create MR" when none exists; "PR #N"/"MR !N" with pipeline & review status dots when open; a merged/closed badge when merged/closed; an "Assign PR" option when a PR targets a different branch; and an error button (warning/info icon) on failure.
+  - (See WS-PR scenarios for full PR-button behavior; rows reuse the same component.)
+
+---
+
+# ONB — Onboarding wizard
+
+## Step indicator
+
+- **ONB-001 — Step indicator shows three steps**
+  - Given: the onboarding wizard is shown.
+  - When: viewing the bottom indicator.
+  - Then: three dots represent Email, Installation, and Add-Repo; the current step is visually distinct, past steps are clickable, future steps are disabled.
+
+- **ONB-002 — Navigate to a past step**
+  - Given: the user is on the Installation step.
+  - When: the user clicks the Email step dot.
+  - Then: the wizard returns to the Email step.
+
+- **ONB-003 — Future steps not clickable**
+  - Given: the user is on the Email step.
+  - When: the user clicks the Installation/Add-Repo dots.
+  - Then: nothing happens (they appear disabled).
+
+## Email / welcome step
+
+- **ONB-004 — Email step fields**
+  - Given: the Email step is shown.
+  - When: viewing the form.
+  - Then: a "Full name" input (autofocused), an "Email address" input, a marketing opt-in checkbox (unchecked), a telemetry checkbox (checked), and terms/privacy links are visible, along with the message "Your code is yours — Imbue does not store your repositories or train on your code".
+
+- **ONB-005 — Get Started disabled without valid email**
+  - Given: the Email step is shown.
+  - When: the email field is empty or lacks an "@".
+  - Then: the "Get Started" button is disabled.
+
+- **ONB-006 — Get Started enabled with valid email**
+  - Given: the Email step is shown.
+  - When: the user types an email containing "@".
+  - Then: the "Get Started" button becomes enabled.
+
+- **ONB-007 — Submit email (loading)**
+  - Given: a valid email is entered.
+  - When: the user clicks "Get Started" (or presses Enter).
+  - Then: the button shows a spinner and is disabled while the request is in flight; on success the wizard advances to the Installation step.
+
+- **ONB-008 — Submit email error**
+  - Given: a valid email is submitted.
+  - When: the request fails.
+  - Then: a red error message appears below the button.
+
+- **ONB-009 — Continue without an account**
+  - Given: the Email step is shown.
+  - When: the user clicks "Continue without an account".
+  - Then: the link/button disables while in flight and the wizard advances to the Installation step.
+
+- **ONB-010 — Toggle marketing / telemetry checkboxes**
+  - Given: the Email step is shown.
+  - When: the user clicks the marketing or telemetry checkbox.
+  - Then: that checkbox toggles checked/unchecked.
+
+## Installation step
+
+- **ONB-011 — Installation step header**
+  - Given: the Installation step is shown.
+  - When: viewing the page.
+  - Then: "Let's get you set up" and "The following are required to use Sculptor" are shown.
+
+- **ONB-012 — Dependency card: loading**
+  - Given: the Installation step loads.
+  - When: dependency status is being fetched.
+  - Then: each dependency card shows a spinner and "—" for path/version.
+
+- **ONB-013 — Dependency card: not installed**
+  - Given: a dependency (Claude/Git) is not installed.
+  - When: status loads.
+  - Then: the card shows a red error icon, "not installed", and an Install button.
+
+- **ONB-014 — Dependency card: installed**
+  - Given: a dependency is installed at the right version (and authenticated for Claude).
+  - When: status loads.
+  - Then: the card shows a green checkmark and the path/version.
+
+- **ONB-015 — Dependency card: wrong version**
+  - Given: a dependency is installed at the wrong version.
+  - When: status loads.
+  - Then: the card shows a red error and, when expanded, the current and required versions.
+
+- **ONB-016 — Claude card: needs auth**
+  - Given: Claude is installed but not signed in.
+  - When: status loads.
+  - Then: the card shows a yellow warning, "not signed in", and a Sign-in button.
+
+- **ONB-017 — Claude card: authenticating**
+  - Given: the user clicked Sign in.
+  - When: authentication is in progress.
+  - Then: a spinner and "authenticating" appear with a help message about running `claude auth login` in a terminal.
+
+- **ONB-018 — Claude managed install (progress)**
+  - Given: Claude is managed and not installed.
+  - When: installation runs (auto-triggered on load or via Install).
+  - Then: the card shows "installing" with a circular progress percentage.
+
+- **ONB-019 — Install error & retry**
+  - Given: an install fails.
+  - When: the failure occurs.
+  - Then: the card shows an error; the user can retry / re-check.
+
+- **ONB-020 — Expand dependency card**
+  - Given: a dependency card is shown.
+  - When: the user clicks it.
+  - Then: a details section expands revealing path, version, and mode controls; the chevron flips.
+
+- **ONB-021 — Install popover / command**
+  - Given: a dependency is not installed.
+  - When: the user opens the Install affordance.
+  - Then: a popover shows the install command (e.g., `brew install claude-code`) and a docs link.
+
+- **ONB-022 — Override binary path**
+  - Given: a dependency card is expanded.
+  - When: the user clicks "override", enters a path, and clicks Apply.
+  - Then: a valid path updates the card; an invalid path shows "No executable found at this path".
+
+- **ONB-023 — Switch managed/custom mode**
+  - Given: a dependency card is expanded.
+  - When: the user clicks "Use System PATH" / "Use Managed".
+  - Then: the mode switches and the UI updates accordingly.
+
+- **ONB-024 — Continue button gating**
+  - Given: the Installation step is shown.
+  - When: any required dependency is missing/unauthenticated.
+  - Then: the Continue button is disabled; once all are satisfied it is enabled.
+
+- **ONB-025 — Check again**
+  - Given: the Installation step is shown.
+  - When: the user clicks the "check again" link.
+  - Then: the text changes to "Checking…" briefly and the cards refresh with current status.
+
+- **ONB-026 — Continue from installation**
+  - Given: dependencies are satisfied and Continue is enabled.
+  - When: the user clicks Continue (or presses Enter).
+  - Then: if the user already has projects, onboarding completes; otherwise the Add-Repo step is shown.
+
+## Add-repo step
+
+- **ONB-027 — Add-repo step header & input**
+  - Given: the Add-Repo step is shown.
+  - When: viewing the page.
+  - Then: "Add your first repo" with a path input (placeholder `~/path/to/repo`, autofocused) is shown.
+
+- **ONB-028 — Browse for folder (desktop)**
+  - Given: the Add-Repo step on desktop.
+  - When: the user clicks "Or browse for a folder" and selects a folder.
+  - Then: the path input is populated with the chosen path.
+
+- **ONB-029 — Add button gating**
+  - Given: the Add-Repo step.
+  - When: the path is empty.
+  - Then: the Add button is disabled with tooltip "Enter a repository path above"; entering a path enables it; clicking it shows a spinner while validating.
+
+- **ONB-030 — Valid repo added**
+  - Given: a path to a valid git repo with commits is entered.
+  - When: the user clicks Add.
+  - Then: validation succeeds, the wizard completes, and the user is taken into the app.
+
+- **ONB-031 — Not-a-git-repo prompt**
+  - Given: a path to a non-git directory is entered.
+  - When: the user clicks Add.
+  - Then: a dialog offers to initialize git; choosing "Initialize Git" shows "Setting up repository…" and on success adds the repo; Cancel returns to the step.
+
+- **ONB-032 — Empty-repo prompt**
+  - Given: a git repo with no commits is entered.
+  - When: the user clicks Add.
+  - Then: a dialog offers "Make Initial Commit"; choosing it creates the commit and adds the repo; Cancel returns.
+
+- **ONB-033 — Invalid path error**
+  - Given: a nonexistent/inaccessible path is entered.
+  - When: the user clicks Add.
+  - Then: the dialog shows an error message with a Close button.
+
+---
+
+# ADDWS — Add-workspace page (create workspace)
+
+- **ADDWS-001 — Page loading then form**
+  - Given: the Add Workspace page is opening.
+  - When: projects are being fetched.
+  - Then: a centered spinner is shown; once loaded the creation form appears.
+
+- **ADDWS-002 — Default project selection**
+  - Given: projects exist.
+  - When: the page loads.
+  - Then: the most-recently-used project (or the first project if no MRU) is pre-selected in the repo selector.
+
+- **ADDWS-003 — Workspace name input**
+  - Given: the form is shown.
+  - When: viewing it.
+  - Then: a name input with placeholder "Untitled workspace (optional)" is shown and autofocused; typing shows the text.
+
+- **ADDWS-004 — Empty / whitespace name defaults**
+  - Given: the name is empty or only whitespace.
+  - When: the user creates the workspace.
+  - Then: it is created as "Untitled workspace".
+
+- **ADDWS-005 — Name draft persists**
+  - Given: the user typed a name and navigated away.
+  - When: the user returns to the same draft.
+  - Then: the previously typed name is restored.
+
+- **ADDWS-006 — Repo selector dropdown**
+  - Given: the repo selector is shown.
+  - When: the user clicks it.
+  - Then: a dropdown lists all projects plus an "Add Repository" entry.
+
+- **ADDWS-007 — Select a different project**
+  - Given: the repo dropdown is open.
+  - When: the user clicks another project.
+  - Then: the selection changes, the branch selector reloads, and any branch-name override clears.
+
+- **ADDWS-008 — Add repository from selector**
+  - Given: the repo dropdown is open.
+  - When: the user clicks "Add Repository".
+  - Then: the Add Repository dialog opens; on success the new project is auto-selected.
+
+- **ADDWS-009 — Branch selector loading**
+  - Given: a project is selected and branch info is loading.
+  - When: viewing the branch control.
+  - Then: it shows a spinner and "Loading …" and is disabled.
+
+- **ADDWS-010 — Branch selector dropdown & selection**
+  - Given: branch info loaded.
+  - When: the user opens the branch selector and clicks a branch.
+  - Then: the dropdown lists recent branches (and a "Fetch more branches" option), and selecting one updates the source branch and clears any branch-name override.
+
+- **ADDWS-011 — Branch selector disabled for in-place**
+  - Given: the mode is In-place.
+  - When: viewing the branch selector.
+  - Then: it is disabled with a tooltip explaining in-place workspaces use the current branch.
+
+- **ADDWS-012 — Branch-name field visibility & label**
+  - Given: the mode is Worktree / Clone / In-place.
+  - When: viewing the form.
+  - Then: Worktree shows a required branch-name field; Clone shows an optional one; In-place shows no branch-name field.
+
+- **ADDWS-013 — Branch-name auto-fill preview**
+  - Given: Worktree mode and the user typed a workspace name.
+  - When: the form is shown.
+  - Then: the branch-name field auto-fills a preview (with a "…" spinner while fetching) derived from the name, updating as the name changes.
+
+- **ADDWS-014 — Manual branch-name override & reset**
+  - Given: the branch-name field has an auto-filled preview.
+  - When: the user types into it.
+  - Then: the manual value takes over, auto-fill stops, and a reset link appears; clicking reset restores the preview.
+
+- **ADDWS-015 — Branch-name collision error**
+  - Given: a branch name is entered that already exists in the repo.
+  - When: the collision check completes.
+  - Then: a red message "Branch '{name}' already exists" appears below the field and clears when the user edits the name.
+
+- **ADDWS-016 — Agent-type selector options**
+  - Given: the form is shown.
+  - When: the user opens the agent-type selector.
+  - Then: it lists Claude, Terminal, Pi (only if enabled), and any registered custom agents; re-opening rescans for newly registered agents.
+
+- **ADDWS-017 — Select agent type & MRU**
+  - Given: the agent-type dropdown is open.
+  - When: the user selects a type.
+  - Then: the button shows the new type; the selection is remembered as the default for next time. A previously-selected type that is no longer available falls back to Claude.
+
+- **ADDWS-018 — Mode selector visibility**
+  - Given: clone and/or in-place workspaces are enabled in settings.
+  - When: viewing the form.
+  - Then: an environment/mode selector is shown (Worktree always; Clone and/or In-place when enabled); if neither experimental mode is enabled, the selector is hidden and defaults to Worktree.
+
+- **ADDWS-019 — Change mode updates branch fields**
+  - Given: a mode is selected.
+  - When: the user switches to Clone or In-place.
+  - Then: the branch-name field changes to optional (Clone) or disappears and the branch selector disables (In-place).
+
+- **ADDWS-020 — Create button gating & tooltips**
+  - Given: the form is shown.
+  - When: required fields are incomplete (e.g., Worktree branch name empty or still loading) or creation is in progress.
+  - Then: the Create button is disabled with an explanatory tooltip ("Waiting for branch name…", "Agent is being created…"); when ready it is enabled with tooltip "Cmd/Ctrl+↵ to create workspace".
+
+- **ADDWS-021 — Create the workspace**
+  - Given: all fields are valid.
+  - When: the user clicks "Create workspace" or presses `Cmd+Enter`.
+  - Then: the workspace and its first agent are created and the user is navigated into the new workspace/agent tab.
+
+- **ADDWS-022 — Keyboard focus into form**
+  - Given: the page loads with nothing focused.
+  - When: the user presses ArrowDown/ArrowUp.
+  - Then: focus moves to the workspace-name input.
+
+- **ADDWS-023 — Create error: branch exists**
+  - Given: the user submits with a branch name that already exists.
+  - When: the request returns a conflict.
+  - Then: an error toast "Branch '{name}' already exists" appears and the form stays open for editing.
+
+- **ADDWS-024 — Create error: generic failure**
+  - Given: the user submits the form.
+  - When: workspace or agent creation fails.
+  - Then: an error toast ("Failed to create workspace" / "Failed to create agent") with details is shown.
+
+---
+
+# ADDREPO — Add-repository dialog & path autocomplete
+
+- **ADDREPO-001 — Open add-repo dialog**
+  - Given: the repo selector dropdown is open (or another add-repo entry point).
+  - When: the user clicks "Add Repository".
+  - Then: a modal opens with a path input (focused) and, on desktop, a Browse button.
+
+- **ADDREPO-002 — Cancel dialog**
+  - Given: the dialog is open and not validating.
+  - When: the user clicks Cancel / Escape / clicks the overlay.
+  - Then: the dialog closes with no changes.
+
+- **ADDREPO-003 — Prevent close during validation**
+  - Given: validation is in progress.
+  - When: the user tries to close the dialog.
+  - Then: it stays open.
+
+- **ADDREPO-004 — Add valid repo**
+  - Given: a valid path is entered.
+  - When: the user clicks "Add Repository".
+  - Then: on success the dialog closes and the new repo is selected in the dropdown.
+
+- **ADDREPO-005 — Dialog resets on reopen**
+  - Given: the user previously typed a path and closed the dialog.
+  - When: the dialog is reopened.
+  - Then: the path input is empty.
+
+- **ADDREPO-006 — Path autocomplete dropdown**
+  - Given: a path input.
+  - When: the user types a path containing "/" or starting with "~".
+  - Then: after a short debounce a spinner shows, then a list of matching directories appears (or "No matching directories").
+
+- **ADDREPO-007 — Navigate directories in autocomplete**
+  - Given: the autocomplete list is shown.
+  - When: the user clicks a directory.
+  - Then: the path gains a trailing "/" and the next level of directories is fetched.
+
+- **ADDREPO-008 — Autocomplete keyboard hints & submit**
+  - Given: the autocomplete dropdown has items.
+  - When: viewing the footer.
+  - Then: hints "Esc: close", "↵: open", "{Meta}↵: add" are shown; pressing Enter with the dropdown closed (or `Cmd+Enter` anytime) submits the trimmed path.
+
+---
+
+# WS — Workspace shell (chat input, banner, PR, agents, peek)
+
+## Chat input & sending
+
+- **WS-001 — Type and send a message**
+  - Given: a workspace with an active agent.
+  - When: the user types in the chat input and clicks Send (or presses the send keybinding).
+  - Then: the message is sent, the editor clears, and any attachments clear.
+
+- **WS-002 — Send button disabled states**
+  - Given: the chat input.
+  - When: the editor is empty, or the agent is busy (for non-`/btw` content).
+  - Then: the Send button is disabled; hovering shows the reason.
+
+- **WS-003 — Interrupt-and-send**
+  - Given: the agent is busy and the user typed a message.
+  - When: the user presses the interrupt-and-send keybinding.
+  - Then: the running turn is interrupted and the new message is sent.
+
+- **WS-004 — Send failure feedback**
+  - Given: the user sends a message.
+  - When: sending fails.
+  - Then: an error toast appears, the editor text is preserved, and the Send button reflects the error on hover.
+
+- **WS-005 — Attach files via drag-and-drop**
+  - Given: file attachment is supported.
+  - When: the user drags files over the chat input.
+  - Then: a "Drop to attach images" overlay appears; on drop the files are added to a preview list.
+
+- **WS-006 — Attach files via upload button**
+  - Given: file attachment is supported.
+  - When: the user clicks the upload button and selects files.
+  - Then: the files are added to the attachment preview list.
+
+- **WS-007 — Remove an attached file**
+  - Given: files are attached.
+  - When: the user clicks a file's remove button.
+  - Then: that file is removed from the preview list.
+
+- **WS-008 — Mention/insert menu**
+  - Given: the chat input.
+  - When: the user clicks the "+" toolbar button (or types a trigger).
+  - Then: a picker opens offering files, skills/commands, and entities (see MENT scenarios).
+
+- **WS-009 — Model selector**
+  - Given: the chat input toolbar.
+  - When: the user opens the model selector and picks a model.
+  - Then: the selection is highlighted and applied to future messages.
+
+- **WS-010 — Effort selector**
+  - Given: the chat input toolbar.
+  - When: the user opens the effort selector and picks a level.
+  - Then: the choice is applied to future messages.
+
+- **WS-011 — Fast-mode toggle**
+  - Given: the model supports fast mode.
+  - When: the user toggles fast mode.
+  - Then: the toggle state changes and is applied to future messages.
+
+- **WS-012 — Plan-mode toggle**
+  - Given: an agent that supports interactive plan mode.
+  - When: the user toggles plan mode and sends a message.
+  - Then: the toggle's styling changes when active; sending enters plan mode (or exits it if already in plan mode).
+
+- **WS-013 — Multiline input**
+  - Given: the chat input.
+  - When: the user inserts line breaks (Shift+Enter).
+  - Then: the editor grows to show multiple lines; sending submits the whole text as one message.
+
+- **WS-014 — `/clear` pseudo-command**
+  - Given: the agent supports context reset.
+  - When: the user types `/clear` and sends.
+  - Then: the context is cleared and a success toast appears (or, if unsupported, a "capability unsupported" toast).
+
+- **WS-015 — `/copy` pseudo-command**
+  - Given: there is an assistant message.
+  - When: the user types `/copy` and sends.
+  - Then: the last assistant message is copied and a "copied" toast appears (or an error toast if there is none).
+
+- **WS-016 — `/btw` side chat**
+  - Given: an active session exists.
+  - When: the user types `/btw <question>` and sends.
+  - Then: a side-chat popup opens showing the question and the agent's streamed answer (or a toast if no session yet).
+
+## Queued messages
+
+- **WS-017 — Queued-message bar appears**
+  - Given: the agent is running and the user queued a message.
+  - When: viewing the chat.
+  - Then: a queued-message bar appears below the input showing the queued text.
+
+- **WS-018 — Remove a queued message**
+  - Given: a queued message is shown.
+  - When: the user clicks its remove icon.
+  - Then: the queued message is deleted and the bar disappears.
+
+- **WS-019 — Edit a queued message (empty editor)**
+  - Given: a queued message is shown and the editor is empty.
+  - When: the user clicks edit.
+  - Then: the queued message is removed and its text is restored to the editor.
+
+- **WS-020 — Edit-conflict dialog**
+  - Given: a queued message exists and the editor already has unsaved text.
+  - When: the user clicks edit.
+  - Then: an Undo/Queued dialog opens offering "Keep queued", "Remove", and "Overwrite", plus a copy button; each option behaves as labeled.
+
+- **WS-021 — Interrupt-and-send a queued message**
+  - Given: a queued message bar is shown and interruption is supported.
+  - When: the user clicks the interrupt-and-send (arrow-up) button.
+  - Then: the running turn is interrupted and the queued message is sent; the button is hidden if interruption is unsupported.
+
+## PR / MR button
+
+- **WS-022 — Checking PR/MR status**
+  - Given: a workspace with a branch.
+  - When: PR status is loading.
+  - Then: a spinner with "Checking PR…" / "Checking MR…" is shown.
+
+- **WS-023 — Create PR/MR**
+  - Given: no PR exists for the branch.
+  - When: the user clicks "Create PR"/"Create MR".
+  - Then: a default PR-creation prompt (including the target branch) is sent to the agent.
+
+- **WS-024 — Edit PR prompt before creating**
+  - Given: the Create PR button is shown.
+  - When: the user opens its chevron menu and clicks "Edit prompt…".
+  - Then: a dialog opens to edit the prompt; Save updates it and closes.
+
+- **WS-025 — Open PR display**
+  - Given: an open PR/MR exists.
+  - When: viewing the button.
+  - Then: it shows "PR #N"/"MR !N" with pipeline and review status dots.
+
+- **WS-026 — Open PR in browser**
+  - Given: an open PR button is shown.
+  - When: the user clicks the PR number.
+  - Then: the PR/MR opens in the browser.
+
+- **WS-027 — PR detail dropdown**
+  - Given: an open PR button is shown.
+  - When: the user clicks the chevron.
+  - Then: a popover shows PR title/link, checks/pipeline status, approvals with reviewer names, and unresolved comments.
+
+- **WS-028 — CI babysitter toggle in PR dropdown**
+  - Given: CI babysitter is enabled and the PR dropdown is open.
+  - When: the user toggles the babysitter switch.
+  - Then: it pauses/resumes and the status text updates.
+
+- **WS-029 — Merged/closed PR**
+  - Given: the PR was merged or closed.
+  - When: viewing the button.
+  - Then: it shows a merge icon with "PR #N merged"/"closed"; clicking opens it in the browser.
+
+- **WS-030 — PR pipeline & review dot tooltips**
+  - Given: an open PR with pipeline/review status.
+  - When: the user hovers the dots.
+  - Then: tooltips show "Pipeline running/passed/failed/No pipeline" and "Approved/Review pending/No reviewers".
+
+- **WS-031 — Assign PR (target mismatch)**
+  - Given: a PR exists for a different target than the workspace's.
+  - When: viewing the button.
+  - Then: an "Assign PR"/"Assign MR" button is shown; opening it offers "Create PR → {target}" and "switch target to {target}".
+
+- **WS-032 — PR error states**
+  - Given: PR status checking failed.
+  - When: viewing the button.
+  - Then: an error button with a warning triangle (actionable) or info icon (non-actionable) is shown; opening it shows a popover with a title, description, optional details, and an optional copyable remediation command (copy icon turns to a checkmark briefly).
+
+## Target branch & repo segment
+
+- **WS-033 — Target-branch selector**
+  - Given: a workspace with a target branch.
+  - When: viewing the banner.
+  - Then: the target branch name is shown; clicking it opens a dropdown of remote branches, and selecting one updates the target.
+
+- **WS-034 — Target-branch PR mismatch warning**
+  - Given: the workspace target differs from an existing PR's target.
+  - When: viewing the selector.
+  - Then: the branch is shown in a warning color; hovering shows "PR #N targets {branch} — retarget?"; selecting the matching branch updates the target.
+
+- **WS-035 — Repo segment menu**
+  - Given: the banner shows the repo name.
+  - When: the user clicks the repo segment.
+  - Then: a dropdown offers Open folder, Copy path, Copy relative path, and Open in installed apps (VS Code, etc.), each performing its labeled action; the chosen app is remembered.
+
+- **WS-036 — Initialization-strategy badge**
+  - Given: the workspace uses clone or in-place mode.
+  - When: viewing the banner.
+  - Then: a "clone" or "in-place" badge is shown next to the repo name (no badge for worktree).
+
+## Banner & diff summary
+
+- **WS-037 — Banner visibility**
+  - Given: the user is/ is not in zen mode.
+  - When: viewing the workspace.
+  - Then: the banner with repo/branch/PR info is shown normally and hidden in zen mode.
+
+- **WS-038 — Banner progressive collapse**
+  - Given: the viewport narrows.
+  - When: space becomes constrained.
+  - Then: banner elements collapse in priority order (PR button → diff summary → repo segment).
+
+- **WS-039 — Copy branch name from banner**
+  - Given: the branch name is shown in the banner.
+  - When: the user clicks it.
+  - Then: it is copied and a "Copied!" tooltip appears briefly.
+
+- **WS-040 — Diff summary button**
+  - Given: the workspace has uncommitted changes.
+  - When: viewing the banner.
+  - Then: a "+X −Y · Z files" summary is shown (with a shimmer while loading); clicking it opens the file browser's Changes tab scoped to the target branch.
+
+## Agent tabs
+
+- **WS-041 — Agent tabs shown**
+  - Given: a workspace with one or more agents.
+  - When: viewing the workspace.
+  - Then: a tab per agent is shown with its title and status dot.
+
+- **WS-042 — Switch agents**
+  - Given: multiple agent tabs.
+  - When: the user clicks another agent tab (or presses the next/previous-agent keybinding).
+  - Then: the view switches to that agent's chat/state.
+
+- **WS-043 — Agent status-dot tooltip**
+  - Given: an agent tab.
+  - When: the user hovers its status dot.
+  - Then: a tooltip shows the status label and time since last activity / creation.
+
+- **WS-044 — Create a new agent**
+  - Given: agent tabs are shown.
+  - When: the user clicks the "+" button.
+  - Then: a new agent of the default type is created and shown.
+
+- **WS-045 — Choose agent type when creating**
+  - Given: the "+" chevron menu.
+  - When: the user opens it.
+  - Then: it lists Claude, Pi (if enabled), Terminal, and registered custom agents; selecting one creates that type and remembers it.
+
+- **WS-046 — Rename an agent (double-click)**
+  - Given: an agent tab.
+  - When: the user double-clicks the title, types a name, and presses Enter.
+  - Then: the agent is renamed; Escape cancels.
+
+- **WS-047 — Agent context menu**
+  - Given: an agent tab.
+  - When: the user right-clicks it.
+  - Then: a menu offers Rename, Mark as unread, Delete, and a Diagnostics submenu (Debug View toggle; copy Claude session id / transcript path / Sculptor transcript path — disabled when unavailable).
+
+- **WS-048 — Delete an agent**
+  - Given: an agent context menu (or close button) is used.
+  - When: the user deletes and confirms.
+  - Then: the agent is removed and navigation moves to the next agent (or a fresh one if it was the last).
+
+- **WS-049 — Mark agent unread**
+  - Given: a read agent.
+  - When: the user chooses "Mark as unread".
+  - Then: the agent's status indicator changes to unread.
+
+- **WS-050 — Reorder agent tabs**
+  - Given: multiple agent tabs.
+  - When: the user drags a tab to a new position.
+  - Then: the order updates.
+
+## Terminal agent panel
+
+- **WS-051 — Terminal agent shows a terminal**
+  - Given: a terminal-type agent (no chat interface).
+  - When: viewing the agent.
+  - Then: a full-pane terminal is shown instead of the chat, streaming output.
+
+- **WS-052 — Terminal persists across agent switches**
+  - Given: a terminal agent is active.
+  - When: the user switches away and back.
+  - Then: the terminal reconnects and previous scrollback is restored.
+
+## Ask-user-question (input area)
+
+- **WS-053 — Question panel replaces input**
+  - Given: the agent issues an AskUserQuestion.
+  - When: the question arrives.
+  - Then: a question panel replaces the chat input, showing a category chip, the question, options (plus "Other"), and navigation controls.
+
+- **WS-054 — Single-select answer**
+  - Given: a single-select question.
+  - When: the user clicks an option and submits.
+  - Then: only that option is selected and the answer is sent.
+
+- **WS-055 — Multi-select answer**
+  - Given: a multi-select question.
+  - When: the user checks multiple options and submits.
+  - Then: all selected options are sent.
+
+- **WS-056 — Custom "Other" answer**
+  - Given: a question with an alternative option.
+  - When: the user clicks "Other" and types text.
+  - Then: a textarea captures the custom answer.
+
+- **WS-057 — Navigate between questions**
+  - Given: multiple questions.
+  - When: the user uses Tab/Shift+Tab, arrows, or the progress dots.
+  - Then: the current question changes and dots show answered/unanswered/current.
+
+- **WS-058 — Submit / next / dismiss**
+  - Given: questions are shown.
+  - When: the user submits.
+  - Then: if unanswered questions remain the button reads "Next" and jumps to the first unanswered; when all answered, submitting sends all answers and closes the panel; a Dismiss option closes without answering.
+
+## Error input / restore
+
+- **WS-059 — Agent error state with restore**
+  - Given: the agent is in an error state and its workspace still exists.
+  - When: viewing the input area.
+  - Then: an error message with "Click here to try to restore the agent" is shown; clicking attempts restore.
+
+- **WS-060 — Deleted-workspace error state**
+  - Given: the agent errored and its workspace was deleted.
+  - When: viewing the input area.
+  - Then: a message states the workspace was deleted and cannot be restored (no restore link).
+
+## Workspace peek
+
+- **WS-061 — Peek popover on hover**
+  - Given: workspace tabs are shown.
+  - When: the user hovers a workspace tab for a moment.
+  - Then: a peek popover appears showing status, agent list, PR/MR info, branch, and diff stats.
+
+- **WS-062 — Smooth peek transitions**
+  - Given: a peek popover is open.
+  - When: the user moves between tabs within the grace period.
+  - Then: the popover content swaps instantly; leaving all tabs closes it after a short delay.
+
+- **WS-063 — Expand more agents in peek**
+  - Given: a workspace with more than 5 agents.
+  - When: viewing its peek popover.
+  - Then: only 5 agents show with a "+N more agents" button that reveals the rest.
+
+- **WS-064 — Navigate from peek**
+  - Given: the peek popover is open.
+  - When: the user clicks an agent row or the header.
+  - Then: the popover closes and the workspace/agent opens; clicking the branch copies it ("Copied!").
+
+## Bottom bar & layout
+
+- **WS-065 — Panel toggle buttons**
+  - Given: not in zen mode.
+  - When: viewing the bottom bar.
+  - Then: toggle buttons for the left, bottom, and right panels and a focus-mode button are shown.
+
+- **WS-066 — Toggle a panel from the bottom bar**
+  - Given: a panel has content.
+  - When: the user clicks its toggle button.
+  - Then: the panel hides/shows and the button's active state updates.
+
+- **WS-067 — Empty-panel toggle disabled**
+  - Given: a panel has no content.
+  - When: viewing/hovering its toggle button.
+  - Then: the button is disabled with a "Panel is empty" tooltip and does nothing on click.
+
+- **WS-068 — Panel toggle tooltips show keybinding**
+  - Given: a panel toggle button.
+  - When: the user hovers it.
+  - Then: a tooltip shows the name and keybinding.
+
+- **WS-069 — Diff split resize / collapse / expand**
+  - Given: the diff panel is open beside the chat.
+  - When: the user drags the divider.
+  - Then: the panels resize; dragging past a threshold collapses the diff panel; an expand control maximizes the diff and collapses the chat, and vice-versa.
+
+## Chat search bar (workspace-level)
+
+- **WS-070 — Open chat search**
+  - Given: a chat panel is visible.
+  - When: the user presses `Cmd+Shift+F` (or `Cmd+F` in the chat).
+  - Then: a search bar opens above the chat with its input focused.
+
+- **WS-071 — Search and match counter**
+  - Given: the chat search bar is open.
+  - When: the user types a query.
+  - Then: matches are highlighted and a "X/Y" counter is shown ("0/0" with the input turning red when none).
+
+- **WS-072 — Navigate matches**
+  - Given: search has matches.
+  - When: the user presses Enter / Shift+Enter (or the up/down arrows).
+  - Then: focus moves to the next / previous match.
+
+- **WS-073 — Close chat search**
+  - Given: the chat search bar is open.
+  - When: the user presses Escape or clicks close.
+  - Then: the search bar closes and highlights clear.
+
+## Setup config & BTW popup
+
+- **WS-074 — Setup config prompt**
+  - Given: a workspace with no setup command configured.
+  - When: viewing the chat intro.
+  - Then: a prompt with a "Configure a workspace setup command" link is shown; clicking it opens settings to the repositories section.
+
+- **WS-075 — BTW popup display & streaming**
+  - Given: the user ran `/btw`.
+  - When: the side chat processes.
+  - Then: a draggable popup appears in the corner showing the question and the streamed answer (with a blinking cursor while streaming).
+
+- **WS-076 — BTW popup drag / close / error**
+  - Given: the BTW popup is open.
+  - When: the user drags its handle / clicks close or Escape / an error occurs.
+  - Then: it moves and stays within the viewport / closes and returns focus to the input / shows an error in red.
+
+---
+
+# CHAT — Chat interface, status, search, navigation, subagents, tasks
+
+## Chat intro / empty state
+
+- **CHAT-001 — Chat intro on empty conversation**
+  - Given: a workspace with no messages.
+  - When: the page loads.
+  - Then: an intro card shows the project/branch, workspace name, agent name, creation time, source-branch info, a shared-code warning, and a `/sculptor:help` hint.
+
+- **CHAT-002 — Intro reflects workspace type**
+  - Given: the workspace is in-place / branched / cloned.
+  - When: the intro renders.
+  - Then: it shows "Working directly in {branch}", "Branched off {branch}", or "Cloned {branch} from {project}" accordingly.
+
+- **CHAT-003 — Setup status card in intro**
+  - Given: the workspace has pending setup commands.
+  - When: the intro renders.
+  - Then: a setup status card appears below the intro showing the setup step, progress, and elapsed time.
+
+- **CHAT-004 — Setup card controls**
+  - Given: the setup status card is shown.
+  - When: the user hovers/clicks it.
+  - Then: a popover reveals the setup command, output, and edit/play/stop controls; running shows live scrolling output; success shows a checkmark; failure shows an error.
+
+## Status pill
+
+- **CHAT-005 — Status pill hidden when idle**
+  - Given: the agent is idle with no tasks.
+  - When: viewing the chat.
+  - Then: no status pill is shown.
+
+- **CHAT-006 — Status pill states**
+  - Given: the agent is active.
+  - When: it transitions between phases.
+  - Then: the pill shows "Thinking…", "Streaming…", "Calling Tools…", "Waiting on agent…", "Compacting…", or "Stopped" with an animated icon and a live elapsed-time counter (frozen when stopped/compacting/complete).
+
+- **CHAT-007 — Task progress in pill**
+  - Given: a plan with tasks exists and the agent is active.
+  - When: the pill renders.
+  - Then: it shows "X / N · {task subject}".
+
+- **CHAT-008 — All-tasks-complete celebration**
+  - Given: all tasks reach completed.
+  - When: the last task completes.
+  - Then: the pill shows "X of N done" without a timer and lingers briefly.
+
+- **CHAT-009 — Stop button in pill**
+  - Given: the agent is running and supports interruption.
+  - When: the pill is shown.
+  - Then: a square stop button is shown (with a "Stop (Ctrl+C)" tooltip); clicking it or pressing Ctrl+C interrupts; if interruption is unsupported the button is disabled with an explanatory tooltip.
+
+- **CHAT-010 — Task graph on pill hover/click**
+  - Given: the pill with tasks is shown.
+  - When: the user hovers (or clicks to pin) the pill.
+  - Then: a popover shows the task graph with nodes colored by status (completed/in-progress/pending); clicking again or outside closes it.
+
+## Agent tasks panel & graph
+
+- **CHAT-011 — Tasks empty state**
+  - Given: no plan/tasks.
+  - When: the tasks popover opens.
+  - Then: a "No tasks" message is shown.
+
+- **CHAT-012 — Task list with status icons**
+  - Given: tasks exist.
+  - When: the panel opens.
+  - Then: a scrollable list shows each task's status icon (checkmark/bar/box), subject, and description, colored green/blue/outline for completed/in-progress/pending.
+
+- **CHAT-013 — Pending tasks fade downstream**
+  - Given: an in-progress task with downstream pending tasks.
+  - When: the panel renders.
+  - Then: downstream pending tasks fade with distance.
+
+- **CHAT-014 — Waiting/blocked badge**
+  - Given: a task is blocked by others.
+  - When: it is shown.
+  - Then: a "Waiting on #1, #2 (+N more)" badge is shown.
+
+- **CHAT-015 — Graph compact vs normal**
+  - Given: 15+ tasks vs fewer.
+  - When: the panel opens.
+  - Then: the graph renders in compact mode (small nodes) for 15+ tasks, larger nodes otherwise.
+
+- **CHAT-016 — Expand a task**
+  - Given: a task with a description.
+  - When: the user clicks the task row.
+  - Then: the row expands to show the full description/active form.
+
+## In-chat search
+
+- **CHAT-017 — Open in-chat search**
+  - Given: the chat is loaded.
+  - When: the user opens search (`Cmd+F`).
+  - Then: a search bar slides in at the top with the input focused and selected.
+
+- **CHAT-018 — Search results & highlight**
+  - Given: the search bar is open.
+  - When: the user types a query.
+  - Then: an "active/total" count is shown and matches are highlighted; the active match scrolls into view.
+
+- **CHAT-019 — Next/previous match with wrap**
+  - Given: matches exist.
+  - When: the user presses Enter / Shift+Enter (or clicks next/prev).
+  - Then: the active match advances/retreats, wrapping at the ends.
+
+- **CHAT-020 — Close in-chat search**
+  - Given: the search bar is open.
+  - When: the user presses Escape or clicks close.
+  - Then: the bar closes, focus returns to the chat, and highlights clear.
+
+- **CHAT-021 — Search auto-closes on task switch**
+  - Given: search is open with a query.
+  - When: the user navigates to a different agent/task.
+  - Then: the search bar closes automatically.
+
+- **CHAT-022 — Auto-scroll suppressed during search**
+  - Given: the agent is streaming and search is open.
+  - When: new messages arrive.
+  - Then: the chat does not jump to the bottom while searching.
+
+## Jump-to-bottom & scrolling
+
+- **CHAT-023 — Jump button hidden at bottom**
+  - Given: the chat is scrolled to the bottom.
+  - When: at rest.
+  - Then: no jump-to-bottom button is shown.
+
+- **CHAT-024 — Jump button appears when scrolled up**
+  - Given: the user scrolled up.
+  - When: after a short debounce.
+  - Then: a "Jump" button with a down-arrow appears at the bottom-right.
+
+- **CHAT-025 — "New activity" label while streaming**
+  - Given: the user is scrolled up and the agent is streaming.
+  - When: new content arrives below the viewport.
+  - Then: the button label changes to "New activity", reverting to "Jump" after streaming.
+
+- **CHAT-026 — Click jump-to-bottom**
+  - Given: the jump button is visible.
+  - When: the user clicks it.
+  - Then: the chat smoothly scrolls to the latest message and the button disappears.
+
+- **CHAT-027 — Auto-scroll engagement**
+  - Given: the chat is at the bottom and the agent is streaming.
+  - When: new messages arrive.
+  - Then: the chat auto-scrolls; scrolling up disengages auto-scroll; returning to the bottom re-engages it.
+
+- **CHAT-028 — Scroll position persists per task**
+  - Given: the user scrolled to a position.
+  - When: they switch to another agent/task and back.
+  - Then: the scroll position is restored.
+
+- **CHAT-029 — Viewport stability on resize / density toggle**
+  - Given: a message above the viewport changes height (or tool density toggles).
+  - When: the change occurs.
+  - Then: the currently viewed message stays anchored without jumping.
+
+## Prompt navigator (dot rail)
+
+- **CHAT-030 — Dot rail visibility**
+  - Given: the chat has user messages.
+  - When: the chat loads.
+  - Then: a vertical dot rail appears on the right edge with one dot per user prompt (hidden when there are none).
+
+- **CHAT-031 — Active dot & navigation**
+  - Given: multiple prompts.
+  - When: the user clicks a dot.
+  - Then: the chat scrolls to that prompt and the dot becomes active.
+
+- **CHAT-032 — Dot preview popover**
+  - Given: the dot rail is shown.
+  - When: the user hovers a dot.
+  - Then: a popover shows "PROMPT N", the full prompt text, and a copy button; the popover switches instantly between dots while hovering.
+
+- **CHAT-033 — Collapsed rail with many prompts**
+  - Given: many user messages with limited height.
+  - When: the rail renders.
+  - Then: a "+N" collapsed indicator appears; clicking it expands the rail, and clicking outside collapses it.
+
+- **CHAT-034 — Copy prompt from rail**
+  - Given: a dot popover (or its right-click menu).
+  - When: the user clicks copy / "Copy prompt".
+  - Then: the prompt text is copied (copy icon shows a checkmark briefly).
+
+## Subagents
+
+- **CHAT-035 — Subagent pill while running**
+  - Given: a subagent is running.
+  - When: its pill renders.
+  - Then: an animated icon, the subagent prompt text, and a live elapsed time are shown.
+
+- **CHAT-036 — Subagent pill completed**
+  - Given: a subagent finished.
+  - When: its pill renders.
+  - Then: a result icon replaces the animation and the elapsed time is frozen.
+
+- **CHAT-037 — Subagent popover**
+  - Given: a subagent pill.
+  - When: the user clicks it (or hovers).
+  - Then: a popover shows the prompt, the nested tools the subagent used, and its response (rendered markdown); Escape closes it.
+
+- **CHAT-038 — Subagent keyboard navigation**
+  - Given: a subagent popover is open in a row.
+  - When: the user presses arrow keys.
+  - Then: focus moves left/right through nested tool pills and up/down to adjacent rows.
+
+## Turn footer
+
+- **CHAT-039 — Turn footer metrics**
+  - Given: an assistant turn finished.
+  - When: viewing the footer.
+  - Then: it shows the duration, a "Stopped" label if interrupted, the token count, context usage %, and a "N files changed" link, separated by bullets.
+
+- **CHAT-040 — Token breakdown popover**
+  - Given: a token count is shown.
+  - When: the user clicks it.
+  - Then: a popover breaks down input, output, reasoning tokens, and the context current/threshold.
+
+- **CHAT-041 — Files-changed popover & open diff**
+  - Given: a turn changed files.
+  - When: the user clicks "N files changed" and then a file.
+  - Then: a list of modified files with status badges is shown; clicking a file opens its diff in the side panel.
+
+## Ask-user-question block (in-chat history)
+
+- **CHAT-042 — Answered question in history**
+  - Given: a question was answered.
+  - When: viewing it in the chat history.
+  - Then: it shows the selected options as static text (custom text in a code block), with no inputs.
+
+- **CHAT-043 — Dismissed question in history**
+  - Given: a question was dismissed.
+  - When: viewing it.
+  - Then: a "DISMISSED" badge is shown and the options appear dimmed.
+
+## Debug chat view
+
+- **CHAT-044 — Debug view content**
+  - Given: Debug View is enabled for an agent.
+  - When: viewing the chat.
+  - Then: each message is listed with role, id, timestamp, and block types; tool_use/tool_result names are listed.
+
+- **CHAT-045 — Debug timestamp toggle**
+  - Given: the debug view shows timestamps.
+  - When: the user clicks a timestamp.
+  - Then: it toggles between relative and absolute formats.
+
+---
+
+# MSG — Message & tool-content rendering
+
+## Messages
+
+- **MSG-001 — Assistant message grouping**
+  - Given: an assistant message with mixed content.
+  - When: it renders.
+  - Then: text, tools, errors, warnings, context summaries, and files are grouped and shown in order.
+
+- **MSG-002 — Streaming cursor**
+  - Given: the agent is streaming text in the last message.
+  - When: text is arriving.
+  - Then: a blinking cursor is shown at the end of the streamed content.
+
+- **MSG-003 — User message text & timestamp**
+  - Given: a user message.
+  - When: it renders.
+  - Then: the text renders as markdown with a human-readable timestamp below.
+
+- **MSG-004 — Copy a user message**
+  - Given: a user message with text.
+  - When: the user hovers it and clicks copy.
+  - Then: the text is copied (icon shows a checkmark for ~1.5s).
+
+- **MSG-005 — User message attachments & "via" badge**
+  - Given: a user message with files and/or a `sentVia` method.
+  - When: it renders.
+  - Then: file previews are shown and a "via {method}" badge appears above the message when applicable.
+
+## Markdown
+
+- **MSG-006 — Markdown elements render**
+  - Given: assistant/user text with markdown.
+  - When: it renders.
+  - Then: paragraphs, headings, ordered/unordered lists (markers preserved), and emoji render correctly.
+
+- **MSG-007 — Links open externally**
+  - Given: a markdown link.
+  - When: the user clicks it.
+  - Then: it opens in a new browser tab (external).
+
+- **MSG-008 — Images suppressed**
+  - Given: a markdown image.
+  - When: it renders.
+  - Then: the image is not displayed.
+
+- **MSG-009 — Inline file-path linkification**
+  - Given: text/inline-code containing a workspace file path.
+  - When: it renders.
+  - Then: the path becomes a clickable link (monospace); clicking (or Enter/Space when focused) opens the file in the diff/file view.
+
+- **MSG-010 — Blockquote with copy**
+  - Given: a markdown blockquote.
+  - When: the user hovers it and clicks copy.
+  - Then: the quoted text (with "> " prefixes) is copied (checkmark for ~1.5s).
+
+## Code blocks
+
+- **MSG-011 — Code block plain → highlighted**
+  - Given: a fenced code block with a language.
+  - When: it first renders, then syntax highlighting loads.
+  - Then: it shows as plain monospace then swaps to colored tokens with no layout shift.
+
+- **MSG-012 — Copy code block**
+  - Given: a code block.
+  - When: the user hovers it and clicks copy.
+  - Then: the (trimmed) code is copied (checkmark for ~1.5s).
+
+- **MSG-013 — Code search highlight**
+  - Given: an active chat search with matches inside code.
+  - When: rendered.
+  - Then: matches are highlighted over the syntax coloring.
+
+## Tables
+
+- **MSG-014 — Table horizontal scroll & wrap toggle**
+  - Given: a wide table.
+  - When: it renders / the user hovers and clicks the wrap toggle.
+  - Then: the table scrolls horizontally with fade indicators; toggling switches to wrapped cells (fades disappear) and back.
+
+- **MSG-015 — Copy table as markdown**
+  - Given: a table.
+  - When: the user hovers it and clicks copy.
+  - Then: the table is copied as markdown (checkmark for ~1.5s).
+
+## Tool pills & rows
+
+- **MSG-016 — Tool pill icon & label**
+  - Given: a tool call.
+  - When: it renders.
+  - Then: a pill shows the tool-specific icon (Bash terminal, Read file, Edit pencil, Grep search, etc.; a wrench fallback for unknown tools) and label.
+
+- **MSG-017 — Executing tool indicator**
+  - Given: a command-style tool (Bash/Monitor) is running.
+  - When: the pill renders.
+  - Then: a pulsing dot replaces the icon while it runs.
+
+- **MSG-018 — Tool pill error state**
+  - Given: a tool finished with an error.
+  - When: the pill renders.
+  - Then: it shows error styling (red).
+
+- **MSG-019 — Open a tool popover**
+  - Given: a tool pill.
+  - When: the user clicks it (or hovers in default density).
+  - Then: a popover opens with the tool's details; clicking pins it, clicking again unpins, scrolling the chat closes it, Escape closes it.
+
+- **MSG-020 — Tool pill keyboard navigation**
+  - Given: a focused tool pill / open popover.
+  - When: the user presses arrow keys.
+  - Then: focus moves between pills in the row and across rows.
+
+- **MSG-021 — Expanded tool density**
+  - Given: tool density is "expanded".
+  - When: a tool row renders.
+  - Then: each tool is a full-width row with inline icon, label, title, and meta (duration/line count); clicking opens the popover (no hover-open).
+
+- **MSG-022 — Tool popover: Read**
+  - Given: a Read tool result.
+  - When: the popover opens.
+  - Then: it shows the file path (with optional line range and an outside-workspace icon+tooltip), line-count meta, copy-path and open-in-Sculptor actions, and the file content.
+
+- **MSG-023 — Tool popover: Bash/Monitor**
+  - Given: a Bash/Monitor tool.
+  - When: the popover opens.
+  - Then: it shows an optional description, the command (code style), live/elapsed duration, a copy-command action, and auto-scrolling output (with a streaming cursor while running) and a copy-output action.
+
+- **MSG-024 — Tool popover: Grep**
+  - Given: a Grep tool.
+  - When: the popover opens.
+  - Then: it shows the quoted pattern, search path, match-count meta, and matching lines.
+
+- **MSG-025 — Bash status badge**
+  - Given: a Bash tool.
+  - When: it renders.
+  - Then: a badge shows running (elapsed + spinner), success (duration + checkmark), error (duration + X), or background (with an arrow icon).
+
+## File chips (diff tools)
+
+- **MSG-026 — File chip stats**
+  - Given: a Write/Edit tool.
+  - When: the chip renders.
+  - Then: it shows the filename with green "+N" (and red "−N" unless a new file); skeletons show while stats load.
+
+- **MSG-027 — File chip executing/error**
+  - Given: the file tool is running or errored.
+  - When: the chip renders.
+  - Then: it shows "Writing…"/"Editing…" (disabled) or error styling.
+
+- **MSG-028 — File chip diff popover**
+  - Given: a finished file chip.
+  - When: the user clicks it (or hovers).
+  - Then: a popover shows the file path and a syntax-highlighted unified diff with word-level highlights; it offers open-in-diff-panel (or open-in-file-view for plan/outside-workspace files) and copy-path; scrolling the chat closes it.
+
+## Other blocks
+
+- **MSG-029 — Error block**
+  - Given: an error block.
+  - When: it renders.
+  - Then: a red badge with the error type and message is shown; clicking expands a traceback (when present).
+
+- **MSG-030 — Claude-binary-missing error**
+  - Given: a Claude-binary-not-found error.
+  - When: it renders.
+  - Then: a special layout with installation status and a link to the dependencies settings is shown (with a "Claude installed" badge when applicable).
+
+- **MSG-031 — Retry request**
+  - Given: an error is the last message and the task is not in a terminal error state.
+  - When: viewing the block.
+  - Then: a red "Retry Request" button is shown; clicking retries and then disables with an "already retried" tooltip.
+
+- **MSG-032 — Warning block**
+  - Given: a warning block.
+  - When: it renders.
+  - Then: an orange badge with the type/message is shown; clicking expands a traceback when present (non-clickable when none).
+
+- **MSG-033 — Context summary**
+  - Given: a context-compaction/clearing event.
+  - When: it renders.
+  - Then: a pill with a label and a truncated preview is shown; clicking opens a scrollable popover with the full summary as markdown.
+
+- **MSG-034 — Exit-plan-mode block states**
+  - Given: a plan review block.
+  - When: it renders.
+  - Then: it shows the appropriate state — "Plan ready for review" (pulsing dot, click opens the plan file), inline plan markdown when provided, "Plan approved" (green), "Plan review dismissed" (gray), "Plan revision requested" (orange, expandable feedback), or "Plan reviewed" (historical, no actions).
+
+- **MSG-035 — Outside-workspace icon**
+  - Given: a tool result file path outside the workspace.
+  - When: it renders.
+  - Then: a folder-output icon appears with a "Path outside of the workspace" tooltip.
+
+- **MSG-036 — Search-match highlight in messages**
+  - Given: an active chat search.
+  - When: messages render.
+  - Then: all matches are highlighted, with the active occurrence styled distinctly.
+
+---
+
+# PANEL — Workspace side panels
+
+## File browser
+
+- **PANEL-001 — Browse / Changes / Commits tabs**
+  - Given: the file browser panel.
+  - When: the user clicks the Browse, Changes, or Commits tab.
+  - Then: the corresponding view is shown; Changes and Commits show a count badge when there are changes/commits.
+
+- **PANEL-002 — Review all**
+  - Given: changes/commits exist and the Review-all feature is enabled.
+  - When: the user clicks "Review all".
+  - Then: a combined diff tab opens showing all files.
+
+- **PANEL-003 — Toggle tree/flat view**
+  - Given: a file list view.
+  - When: the user clicks the tree/list toggle.
+  - Then: the list switches between a nested tree and a flat list.
+
+- **PANEL-004 — Collapse all folders**
+  - Given: a tree with expanded folders.
+  - When: the user clicks collapse-all.
+  - Then: all folders collapse.
+
+- **PANEL-005 — Refresh file tree**
+  - Given: the file tree.
+  - When: the user clicks refresh.
+  - Then: the icon spins and the tree re-fetches.
+
+- **PANEL-006 — File search**
+  - Given: the Browse tab.
+  - When: the user clicks the search icon and types.
+  - Then: the header becomes a search input, the list filters in real time, ancestor folders of matches auto-expand, and "No matches" shows when empty; Escape/close exits search.
+
+- **PANEL-007 — Expand/collapse folders**
+  - Given: a folder in the tree.
+  - When: the user clicks its chevron/row.
+  - Then: it expands/collapses to show/hide children.
+
+- **PANEL-008 — Open a file**
+  - Given: a file in the tree/flat list.
+  - When: the user clicks it.
+  - Then: a diff view tab opens for that file.
+
+- **PANEL-009 — Tree keyboard navigation**
+  - Given: the tree is focused.
+  - When: the user presses arrows / Enter.
+  - Then: Up/Down move between visible rows, Right/Left expand/collapse folders, Enter opens the focused file.
+
+- **PANEL-010 — File status & stats**
+  - Given: files with git status.
+  - When: shown in the tree.
+  - Then: each shows a status letter (M/A/D/R) with a color, +added/−removed stats, a change-count badge on folders, an error badge on processing errors, and strike-through styling for deletions.
+
+- **PANEL-011 — Focus highlight on agent file activity**
+  - Given: the agent operates on a file.
+  - When: the file appears in the tree.
+  - Then: the tree scrolls to it, expands its ancestors, and highlights the row.
+
+- **PANEL-012 — File context menu**
+  - Given: a file/folder in the tree.
+  - When: the user right-clicks it.
+  - Then: a menu offers Open diff view, View file, Copy file path, Copy relative path, Open in OS, and (folders) Expand all / Collapse all, plus Close tab / Close other tabs when a diff tab is open — each performing its labeled action.
+
+- **PANEL-013 — Empty / loading file tree**
+  - Given: no files / the tree is loading.
+  - When: the Browse tab is shown.
+  - Then: "No files yet" / animated skeleton rows are shown.
+
+## Changes & commit
+
+- **PANEL-014 — Diff scope picker**
+  - Given: the Changes tab with a target branch.
+  - When: the user picks "All" vs "Uncommitted".
+  - Then: the list shows all changes vs target or only uncommitted changes, with counts per segment.
+
+- **PANEL-015 — Discard a change**
+  - Given: a changed file with a discard control.
+  - When: the user clicks it and confirms in the dialog.
+  - Then: the file reverts to HEAD and leaves the changes list; Cancel keeps it.
+
+- **PANEL-016 — Commit button states**
+  - Given: the Changes tab.
+  - When: changes exist / none exist.
+  - Then: "Commit N changes" is enabled / disabled accordingly.
+
+- **PANEL-017 — Quick commit**
+  - Given: the commit button is enabled.
+  - When: the user clicks it.
+  - Then: the default commit prompt is sent to the agent.
+
+- **PANEL-018 — Edit commit prompt**
+  - Given: the commit button.
+  - When: the user right-clicks it and chooses "Edit prompt…", edits, and saves.
+  - Then: the commit prompt updates and the dialog closes.
+
+## History
+
+- **PANEL-019 — History loading / empty / error**
+  - Given: the Commits tab.
+  - When: history is loading / absent / failed.
+  - Then: "Loading history…" / "No history available" / an error message is shown.
+
+- **PANEL-020 — Commit graph & entries**
+  - Given: commits loaded.
+  - When: the tab renders.
+  - Then: a commit graph with dots/lines is shown; each entry shows the first line of the message, file count, +/− stats, relative time, and short hash.
+
+- **PANEL-021 — Expand commit files**
+  - Given: a commit entry.
+  - When: the user clicks it.
+  - Then: it expands to list the files in that commit (each with status and stats); clicking again collapses.
+
+- **PANEL-022 — Commit hover popover & copy hash**
+  - Given: a commit entry.
+  - When: the user hovers it.
+  - Then: a popover shows the full message, author, date, full hash with a copy button, and stats; clicking copy copies the hash with a "Copied" indicator.
+
+- **PANEL-023 — Open a commit's file diff**
+  - Given: a commit is expanded.
+  - When: the user clicks a file.
+  - Then: a diff tab opens comparing that file in the commit vs its parent.
+
+- **PANEL-024 — Merge commits & terminus**
+  - Given: a merge commit / the end of history.
+  - When: rendered / expanded.
+  - Then: a merge indicator allows expanding the second-parent branch chain; a terminus/fork-point indicator is shown at the bottom.
+
+## Diff panel / viewer
+
+- **PANEL-025 — Diff tabs**
+  - Given: files opened in the diff panel.
+  - When: the user opens/switches/closes tabs.
+  - Then: each file opens in a tab, clicking switches, the X closes (activating MRU or adjacent per setting); right-click offers Close other / Close all; tabs can be reordered; labels show the filename (full path on hover).
+
+- **PANEL-026 — Diff view controls**
+  - Given: a diff is shown.
+  - When: the user toggles split/unified, line-wrapping, find, or expand.
+  - Then: the layout switches side-by-side/unified, wraps or scrolls long lines, opens an in-file search, or expands the diff to full width (hiding the file browser); a close control closes the panel.
+
+- **PANEL-027 — Diff file header**
+  - Given: a diff tab.
+  - When: it renders.
+  - Then: it shows the breadcrumb path, filename, +/− stats, and a three-dot menu with file operations.
+
+- **PANEL-028 — Special file states**
+  - Given: a renamed/deleted/binary file.
+  - When: the diff renders.
+  - Then: a "Renamed from X to Y" banner, a "Deleted" banner, or a "Binary file (cannot display)" message is shown.
+
+- **PANEL-029 — Large-diff truncation**
+  - Given: a diff exceeding the line threshold.
+  - When: it renders.
+  - Then: a truncated diff with a "Show full diff" button is shown; clicking renders the full diff.
+
+- **PANEL-030 — In-file search**
+  - Given: a diff is shown.
+  - When: the user opens find and types.
+  - Then: matches are highlighted with an "X of Y" counter; Enter/Shift+Enter (or arrows) navigate; Escape/close closes it.
+
+- **PANEL-031 — File view (full content)**
+  - Given: a file opened via "View file".
+  - When: the tab renders.
+  - Then: the full file content is shown read-only with syntax highlighting (not a diff).
+
+- **PANEL-032 — Combined diff view**
+  - Given: the Review-all combined diff is open.
+  - When: it renders.
+  - Then: each file is a collapsible section with breadcrumb and +/− stats; expand/collapse-all and a "Commit N changes" button are available.
+
+- **PANEL-033 — Markdown render toggle**
+  - Given: a markdown file in the diff (rich-rendering feature).
+  - When: the toggle is available.
+  - Then: the user can switch between source and rendered views (toggle disabled with a hint when the feature is off).
+
+## Terminal panel
+
+- **PANEL-034 — Terminal tabs**
+  - Given: the terminal panel.
+  - When: the user clicks + / switches / double-clicks to rename / closes a tab.
+  - Then: a new "Terminal N" is created / the selected terminal is shown / an inline rename input appears (Enter confirms, Escape cancels) / the tab closes (closing the last one creates a fresh replacement); right-click offers "Close others"; tabs can be reordered.
+
+- **PANEL-035 — Terminal interaction**
+  - Given: an active terminal.
+  - When: the user types a command.
+  - Then: input goes to the shell and output is displayed; scrollback is available.
+
+- **PANEL-036 — Terminal unread badge**
+  - Given: output arrives in a non-active terminal tab.
+  - When: it occurs.
+  - Then: a pulsing unread dot appears on that tab, cleared when switching to it.
+
+- **PANEL-037 — Terminal starting state**
+  - Given: a terminal is starting.
+  - When: the panel mounts.
+  - Then: a "Starting terminal…" message is shown.
+
+## Notes panel
+
+- **PANEL-038 — Edit & persist notes**
+  - Given: the notes panel.
+  - When: the user types.
+  - Then: the content updates and is preserved when switching away and back.
+
+- **PANEL-039 — Add notes to prompt**
+  - Given: notes with content.
+  - When: the user clicks "Add notes to prompt".
+  - Then: the notes are inserted into the chat prompt; if the prompt already has text, a conflict dialog offers how to merge.
+
+- **PANEL-040 — Copy notes / disabled states**
+  - Given: the notes panel.
+  - When: notes have content / are empty.
+  - Then: the copy button copies the text / is disabled; "Add to prompt" is disabled when there are no notes or no task.
+
+## Skills panel
+
+- **PANEL-041 — Skill type sections**
+  - Given: skills loaded.
+  - When: the panel renders.
+  - Then: skills are grouped by type (Custom, Sculptor, Built-in) with collapsible headers; collapsed headers show a count badge.
+
+- **PANEL-042 — Skill hover popover**
+  - Given: a skill chip.
+  - When: the user hovers it.
+  - Then: a popover shows the description; hovering another chip swaps content instantly; leaving closes it after a short delay.
+
+- **PANEL-043 — Invoke a skill**
+  - Given: a skill chip.
+  - When: the user clicks it.
+  - Then: `/skill-name` is inserted into the chat input.
+
+- **PANEL-044 — Open skill in Sculptor**
+  - Given: a custom/sculptor skill popover.
+  - When: the user clicks "open in Sculptor".
+  - Then: a file-view tab opens showing the skill file (built-in skills have no such option).
+
+- **PANEL-045 — Skills search & filter**
+  - Given: the skills panel.
+  - When: the user opens search and types, navigates with arrows, presses Enter, or filters by type.
+  - Then: the list filters in real time, the selection moves and auto-scrolls, Enter inserts the selected skill, Escape closes search, and the type-filter popover toggles which types are shown (active filters highlight the icon).
+
+- **PANEL-046 — Skills empty / loading / error / unavailable**
+  - Given: skills are loading / failed / none exist / unsupported / the agent is running.
+  - When: the panel renders.
+  - Then: "Loading…" / an error / "No skills found" / "Skills unavailable" is shown, and chips appear disabled while the agent is running.
+
+## Actions panel
+
+- **PANEL-047 — Action groups**
+  - Given: actions with groups.
+  - When: the panel renders.
+  - Then: collapsible group headers (with count badges when collapsed) are shown, the built-in "Sculptor" group first, and ungrouped actions at the bottom.
+
+- **PANEL-048 — Trigger an action**
+  - Given: an action chip.
+  - When: the user clicks it.
+  - Then: an auto-submit action sends its prompt immediately; a manual action appends its prompt to the input; chips are disabled while the agent is running.
+
+- **PANEL-049 — Queue an action**
+  - Given: the agent is running and an action chip's context menu.
+  - When: the user chooses "Queue message".
+  - Then: the action prompt is queued instead of auto-submitted.
+
+- **PANEL-050 — Add / edit / delete an action**
+  - Given: the actions panel.
+  - When: the user adds (+), edits, or deletes an action via the menu.
+  - Then: an action dialog opens for add/edit (Save persists), and delete shows a confirmation; built-in actions offer no edit/delete.
+
+- **PANEL-051 — Group management**
+  - Given: the actions panel.
+  - When: the user adds a group, renames a group inline, or deletes a custom group.
+  - Then: a group is created (Enter confirms, Escape cancels), renamed (Enter/blur confirms), or deleted via a confirmation dialog.
+
+- **PANEL-052 — Reorder actions & groups by drag**
+  - Given: custom actions/groups.
+  - When: the user drags an action or group.
+  - Then: a drop indicator appears and the order updates on drop; actions can be moved between groups; built-in items are not draggable.
+
+## Browser panel
+
+- **PANEL-053 — Browser controls (desktop)**
+  - Given: the browser panel in the desktop app.
+  - When: the user enters a URL and presses Enter / clicks back / forward / reload / screenshot.
+  - Then: it navigates to the URL / goes back / forward / reloads / copies a screenshot to the clipboard; back/forward/screenshot are disabled when unavailable.
+
+- **PANEL-054 — Browser URL behavior & errors**
+  - Given: the address bar.
+  - When: the page navigates or an invalid URL is entered.
+  - Then: the address bar follows navigation, the URL is selected on focus, an invalid URL shows an error banner, and an empty URL submit does nothing.
+
+- **PANEL-055 — Browser web-mode placeholder**
+  - Given: not running in the desktop app.
+  - When: the browser panel is shown.
+  - Then: a "Browser panel requires the desktop app" placeholder is shown with controls disabled.
+
+## Panel state persistence
+
+- **PANEL-056 — Panel state persists**
+  - Given: the user has set folder-expansion, scroll position, active tab, view mode, diff view type, line-wrapping, and diff scope.
+  - When: switching tabs/files and returning.
+  - Then: each of these states is restored.
+
+---
+
+# CMDP — Command palette
+
+## Opening, closing, search
+
+- **CMDP-001 — Open the palette**
+  - Given: the app is open on any page.
+  - When: the user presses `Cmd+K` (or clicks the command icon).
+  - Then: the palette opens with the input focused, commands grouped (Workspaces → Navigation → Theme & Layout → Chat → Terminal → Help), and the first row selected.
+
+- **CMDP-002 — Open directly to the workspace switcher**
+  - Given: the app is open.
+  - When: the user presses `Cmd+P`.
+  - Then: the palette opens on the "Go to workspace" sub-page with placeholder "Find a workspace…".
+
+- **CMDP-003 — Toggle closed**
+  - Given: the palette is open.
+  - When: the user presses `Cmd+K` again.
+  - Then: the palette closes without running a command.
+
+- **CMDP-004 — Filter commands**
+  - Given: the palette is open at root.
+  - When: the user types a query (e.g., "theme").
+  - Then: matching commands are shown (fuzzy/keyword, case-insensitive), non-matching rows and empty groups hide, and groups reorder by best match.
+
+- **CMDP-005 — No matches**
+  - Given: the palette is open.
+  - When: the user types a query with no matches.
+  - Then: an empty state "No matches for '{query}'" is shown.
+
+- **CMDP-006 — Clear search restores all**
+  - Given: the palette has a query.
+  - When: the user clears the input.
+  - Then: all commands reappear in group order with the first row selected.
+
+- **CMDP-007 — Escape behavior**
+  - Given: the palette is open.
+  - When: the user presses Escape.
+  - Then: a non-empty search clears first; an empty search at root closes the palette; on a sub-page it returns to root without closing.
+
+- **CMDP-008 — Click outside closes**
+  - Given: the palette is open with no pending command.
+  - When: the user clicks the overlay.
+  - Then: the palette closes.
+
+## Keyboard navigation & pages
+
+- **CMDP-009 — Arrow navigation with wrap**
+  - Given: results are showing.
+  - When: the user presses Down/Up.
+  - Then: the selection moves and scrolls into view, wrapping at the ends.
+
+- **CMDP-010 — Run a command**
+  - Given: a command is selected.
+  - When: the user presses Enter (or clicks it).
+  - Then: it runs and the palette closes (unless the command keeps the palette open).
+
+- **CMDP-011 — Run and keep open**
+  - Given: a command is selected.
+  - When: the user presses `Cmd+Enter`.
+  - Then: it runs, the palette stays open, and focus returns to the input.
+
+- **CMDP-012 — Enter / exit a sub-page**
+  - Given: a page-opener command is selected (chevron shown).
+  - When: the user presses Tab / ArrowRight (caret at input end) to enter, or Shift+Tab / ArrowLeft (caret at start) / Backspace (empty) to exit.
+  - Then: the sub-page opens with a breadcrumb and updated placeholder / it returns to root; the search clears on navigation.
+
+- **CMDP-013 — Breadcrumb on sub-pages**
+  - Given: a sub-page is open.
+  - When: viewing the header.
+  - Then: a breadcrumb shows the page title with an X to return to root (no breadcrumb at root).
+
+- **CMDP-014 — Disabled rows & tooltips**
+  - Given: a command is unavailable in the current context.
+  - When: viewing/hovering the row.
+  - Then: it is greyed out and shows a reason (as a subtitle or hover tooltip), e.g., "Only one agent in this workspace", "No uncommitted changes".
+
+- **CMDP-015 — Shortcut hints & chevrons**
+  - Given: rows with a keybinding or sub-page.
+  - When: viewing them.
+  - Then: a key-badge shortcut and/or a right chevron appears in the trailing area (group label shown during search when no shortcut).
+
+- **CMDP-016 — Async command spinner & close-block**
+  - Given: a command performs async work.
+  - When: it runs.
+  - Then: the row shows a spinner; the palette refuses to close until it completes (or times out after ~30s).
+
+## Built-in commands
+
+- **CMDP-017 — Navigation commands**
+  - Given: the palette is open.
+  - When: the user runs Open home / Open settings / New workspace / New agent.
+  - Then: the app navigates home / to settings / to new-workspace / creates and opens a new agent (New agent is disabled off a workspace).
+
+- **CMDP-018 — Theme commands**
+  - Given: the palette is open.
+  - When: the user runs "Toggle theme" or opens "Switch theme…" and picks Light/Dark/System.
+  - Then: the theme flips or is set accordingly.
+
+- **CMDP-019 — Layout & panel commands**
+  - Given: the palette is open on a workspace.
+  - When: the user opens "Toggle layout…" / "Toggle panel visibility…" and runs toggle-left/right/bottom-panel, focus mode, zen mode, or a specific panel toggle.
+  - Then: the corresponding panel/mode toggles (panel toggles keep the palette open; focus/zen close it).
+
+- **CMDP-020 — Chat commands**
+  - Given: the palette is open on a workspace with a chat panel.
+  - When: the user runs Focus chat input / Search within chat / Jump to bottom / Toggle tool-call density.
+  - Then: the input focuses / chat search opens / chat scrolls to bottom / tool rows expand or compact (the row label reflects the next action); chat commands are hidden without a chat panel.
+
+- **CMDP-021 — Terminal & help commands**
+  - Given: the palette is open.
+  - When: the user runs Clear terminal / Show keyboard shortcuts / Report a problem.
+  - Then: the terminal clears (hidden without a terminal panel) / the shortcuts dialog opens / the feedback form opens.
+
+## Workspace & agent commands
+
+- **CMDP-022 — Go to workspace switcher**
+  - Given: 2+ workspaces.
+  - When: the user opens "Go to workspace…" and selects one.
+  - Then: a list with status dots is shown (the current workspace disabled as "Current workspace"); selecting another navigates to it.
+
+- **CMDP-023 — Workspace tab navigation**
+  - Given: 2+ workspace tabs.
+  - When: the user runs Next/Previous workspace tab.
+  - Then: focus moves to the next/previous tab.
+
+- **CMDP-024 — Workspace actions sub-page**
+  - Given: a workspace.
+  - When: the user opens "Workspace actions…" and runs Commit changes / Create PR (or MR) / Open PR / Rename / Close / Close others / Close all / Delete.
+  - Then: each performs its action (Commit disabled without changes; Open PR disabled without an open PR; Delete and others as labeled), and the label reflects PR vs MR by provider.
+
+- **CMDP-025 — Open-in sub-page**
+  - Given: external apps are available and the backend is local.
+  - When: the user opens "Open in…" and selects Finder / VS Code / Terminal / etc.
+  - Then: the repo opens in the chosen app (the preferred app ranks first); the entry is disabled on a remote backend.
+
+- **CMDP-026 — Go to agent switcher**
+  - Given: 2+ agents in a workspace.
+  - When: the user opens "Go to agent…" and selects one.
+  - Then: a list is shown (current agent disabled); selecting another navigates to it; the opener is disabled with only one agent.
+
+- **CMDP-027 — Agent actions sub-page**
+  - Given: an active agent.
+  - When: the user opens "Agent actions…" and runs Rename / Mark unread / Delete.
+  - Then: the rename dialog opens / the agent is marked unread / a delete confirmation appears.
+
+- **CMDP-028 — Settings sub-page**
+  - Given: the palette is open.
+  - When: the user opens "Go to settings…" and selects a section (Appearance, Keybindings, Experimental, …).
+  - Then: the app navigates to that settings section.
+
+- **CMDP-029 — Pointer & open-time behavior**
+  - Given: the palette opens while the cursor is over a row.
+  - When: the first pointer move occurs / the user later hovers a row.
+  - Then: the first move is ignored (keyboard selection stays); subsequent hovers select the hovered row.
+
+- **CMDP-030 — List resets on open & on search change**
+  - Given: the palette opens or the query changes.
+  - When: it happens.
+  - Then: the list scrolls to the top and the first row is selected.
+
+- **CMDP-031 — Long titles truncate**
+  - Given: an agent/workspace with a very long title.
+  - When: listed in the palette.
+  - Then: the title truncates with "…".
+
+---
+
+# SET — Settings page
+
+## Navigation & common behaviors
+
+- **SET-001 — Section navigation**
+  - Given: the settings page.
+  - When: the user clicks a sidebar item (or selects from the mobile dropdown).
+  - Then: the active section changes and its content is shown; sections include General, Agent, Keybindings, Panels, Dependencies, Pi, Repositories, Git, CI, File Browser, Environment Variables, Privacy, Experimental, Actions, Theme Builder.
+
+- **SET-002 — Deep-link to a section**
+  - Given: a URL with a section parameter.
+  - When: the settings page loads.
+  - Then: it opens directly to that section.
+
+- **SET-003 — Active section remembered**
+  - Given: the user viewed a section.
+  - When: they reopen settings.
+  - Then: the last-viewed section is shown.
+
+- **SET-004 — Save feedback toast**
+  - Given: the user changes a setting.
+  - When: it saves successfully / fails.
+  - Then: a "Setting updated" success toast / a "Failed to update setting" error toast appears.
+
+## General
+
+- **SET-005 — Theme appearance**
+  - Given: the General section.
+  - When: the user picks Light / Dark / System.
+  - Then: the app appearance changes immediately.
+
+- **SET-006 — Update channel & check/install**
+  - Given: the General section.
+  - When: the user picks an update channel, clicks "Check for updates", or "Install and restart".
+  - Then: a toast confirms the channel change, the check shows a spinner, and install restarts the app (button shows "Restarting…").
+
+## Agent
+
+- **SET-007 — Default model / fast mode / effort**
+  - Given: the Agent section.
+  - When: the user changes the default model, toggles fast mode, or selects an effort level.
+  - Then: each shows "Setting updated" and applies to new agents.
+
+## Keybindings
+
+- **SET-008 — Search keybindings**
+  - Given: the Keybindings section.
+  - When: the user types in the search field.
+  - Then: the list filters by name/description.
+
+- **SET-009 — Assign a hotkey**
+  - Given: a keybinding row.
+  - When: the user clicks "Click to set" and presses a combination.
+  - Then: it shows "Press keys… Esc to cancel" then records and displays the formatted hotkey.
+
+- **SET-010 — Conflict detection**
+  - Given: the user assigns a hotkey already in use.
+  - When: the conflict is detected.
+  - Then: a warning names the conflicting action with Reassign / Cancel options.
+
+- **SET-011 — Clear / reset keybindings**
+  - Given: a keybinding (or all).
+  - When: the user clicks the X on a chip / "Reset all to defaults".
+  - Then: that binding / all bindings revert to default.
+
+## Panels
+
+- **SET-012 — Panel zone assignment & hotkey**
+  - Given: the Panels section.
+  - When: the user changes a panel's zone or assigns a panel hotkey.
+  - Then: the panel moves zones / the hotkey is set (with conflict checking); disabled where rules/enabled-state prevent it.
+
+- **SET-013 — Enable/disable & reset panels**
+  - Given: the Panels section.
+  - When: the user toggles a non-builtin panel or clicks "Reset to defaults".
+  - Then: the panel appears/disappears / all panel layout settings reset.
+
+## Dependencies
+
+- **SET-014 — Claude CLI source mode & status**
+  - Given: the Dependencies section.
+  - When: the user switches Managed/Custom.
+  - Then: the mode switches (brief settling spinner) and the status shows version/health (up to date, in/out of range, not installed, no path).
+
+- **SET-015 — Claude managed install / custom path**
+  - Given: the Dependencies section.
+  - When: the user clicks Install/Retry (managed) or enters a path and clicks Apply (custom).
+  - Then: a progress bar runs and the version updates / the path is validated and applied; active version and path are displayed.
+
+- **SET-016 — Git status**
+  - Given: the Dependencies section.
+  - When: viewing the Git row.
+  - Then: it shows "v{version} — Installed" or a not-installed message.
+
+## Pi (experimental)
+
+- **SET-017 — Pi disabled banner**
+  - Given: pi is not enabled.
+  - When: viewing the Pi section.
+  - Then: a banner links to the Experimental section to enable it.
+
+- **SET-018 — Pi source mode, install, path, versions**
+  - Given: the Pi section.
+  - When: the user switches Managed/Custom, installs, or sets a custom path.
+  - Then: the status (pinned/outside-pinned/not-installed/no-path), pinned & detected versions, active path, and install progress are shown; a custom-mode warning with an install command appears.
+
+- **SET-019 — Pi API-key env vars**
+  - Given: the Pi section.
+  - When: the user adds or removes an env-var name.
+  - Then: the variable list updates with a "Setting updated" toast.
+
+## Repositories
+
+- **SET-020 — Add / list repositories**
+  - Given: the Repositories section.
+  - When: the user clicks "Add repository".
+  - Then: the add-repo dialog opens; the list shows each repo's name, path, agent count, and an accessibility warning when the path is missing.
+
+- **SET-021 — Configure a repository**
+  - Given: a repo row.
+  - When: the user clicks Configure and edits the setup command or branch-naming pattern.
+  - Then: the section expands; values save on blur, with "Using default"/"Reset to default" affordances for the setup command.
+
+- **SET-022 — Remove a repository**
+  - Given: a repo row.
+  - When: the user clicks "Remove repo & agents" and confirms.
+  - Then: a confirmation dialog (showing the agent count) deletes the repo on confirm (with a success/error toast).
+
+## Git
+
+- **SET-023 — Git settings**
+  - Given: the Git section.
+  - When: the user edits the PR-creation prompt, toggles PR status polling, sets poll interval (10–300s) and closed-workspace multiplier (1–120×), or sets the default target branch.
+  - Then: each saves with a toast; polling fields disable when polling is off; values are validated to their ranges; the PR prompt has a reset-to-default.
+
+- **SET-024 — Global defaults**
+  - Given: the Git section.
+  - When: the user edits the default branch-naming pattern or branch-deletion policy (Never / Delete if safe / Always).
+  - Then: each saves with a toast.
+
+## CI babysitter
+
+- **SET-025 — CI babysitter settings**
+  - Given: the CI section.
+  - When: the user toggles the babysitter, sets the retry cap (1–10), or edits the pipeline-failed / merge-conflict prompts.
+  - Then: each saves with a toast; the dependent fields disable when the babysitter is off; prompts have reset-to-default.
+
+## File browser
+
+- **SET-026 — File-browser settings**
+  - Given: the File Browser section.
+  - When: the user sets the default split ratio (20–80%), tab-close behavior, line-wrapping, default diff view, or the commit prompt.
+  - Then: each saves with a toast (commit prompt has reset-to-default).
+
+## Environment variables
+
+- **SET-027 — Env-var settings**
+  - Given: the Environment Variables section.
+  - When: the user toggles "override existing variables" or clicks refresh.
+  - Then: the toggle saves with a toast; the list of loaded variables (global and repo-specific) refreshes.
+
+## Privacy
+
+- **SET-028 — Email & telemetry**
+  - Given: the Privacy section.
+  - When: the user views the email (read-only) and toggles telemetry.
+  - Then: enabling telemetry saves immediately; disabling opens a confirmation ("Turn telemetry off?") with a "Disabling Telemetry…" spinner, then a toast (or an error toast on failure).
+
+## Experimental
+
+- **SET-029 — Experimental toggles**
+  - Given: the Experimental section.
+  - When: the user toggles any feature (Always interrupt and send, Smooth streaming, Per-workspace panel layout, In-place workspaces, Clone workspaces, Review all, Entity mentions, Rich markdown rendering, Pi agent).
+  - Then: each shows "Setting updated".
+
+- **SET-030 — Custom backend command & timeout**
+  - Given: the Experimental/Advanced section.
+  - When: the user sets a custom backend command or readiness timeout.
+  - Then: each saves with a "restart required" toast.
+
+## Actions
+
+- **SET-031 — Manage actions**
+  - Given: the Actions section.
+  - When: the user adds an action/group, edits, deletes, exports (downloads JSON), or imports (file picker).
+  - Then: dialogs handle add/edit/delete with confirmations; export downloads "sculptor-actions.json" (disabled when empty); import validates and merges with a count toast.
+
+- **SET-032 — Action dialog fields**
+  - Given: the action dialog (add/edit).
+  - When: the user fills Name, Prompt, Group, and the Auto-submit toggle and clicks Save.
+  - Then: Save is disabled until valid; `Cmd+Enter` submits; the action is created/updated.
+
+- **SET-033 — Reorder & regroup actions**
+  - Given: custom actions/groups.
+  - When: the user drags to reorder or rename a group inline.
+  - Then: the order updates and the group renames with a success toast.
+
+## Theme builder
+
+- **SET-034 — Appearance / fonts / code theme**
+  - Given: the Theme Builder section.
+  - When: the user changes appearance mode, primary font, code font, or code theme.
+  - Then: the UI updates to reflect each choice.
+
+- **SET-035 — Color pickers**
+  - Given: a color setting (Accent, Gray, Danger, Success, Warning, Info).
+  - When: the user clicks a swatch or enters a custom hex (with a light/dark hex override toggle).
+  - Then: the color applies; an invalid hex is shown in red.
+
+- **SET-036 — Radius / scaling / panel background**
+  - Given: the Theme Builder section.
+  - When: the user picks a radius, scaling, or panel-background option.
+  - Then: borders / overall UI size / panel translucency update accordingly.
+
+- **SET-037 — Component gallery & reset theme**
+  - Given: the Theme Builder section.
+  - When: the user clicks the component-gallery button or "Reset to defaults".
+  - Then: the component gallery opens / theme settings reset (with a toast).
+
+---
+
+# ACT — Actions feature components
+
+- **ACT-001 — Action chip appearance & trigger**
+  - Given: an action chip.
+  - When: viewing/clicking it.
+  - Then: it shows a play icon (auto-submit) or text-cursor icon (draft), a tooltip with the prompt on hover, and clicking executes (send or append); disabled chips ignore clicks.
+
+- **ACT-002 — Action context menu**
+  - Given: an action chip.
+  - When: the user right-clicks it.
+  - Then: a menu offers "Queue message" (only while the agent runs), "Edit action", a "Move to group…" submenu (current group disabled), and "Delete action" (red).
+
+- **ACT-003 — Action dialog validation & submit**
+  - Given: the action dialog (Add/Edit).
+  - When: the user fills Name and Prompt, optionally picks/creates a group, toggles Auto-submit, and saves.
+  - Then: Save is disabled until Name and Prompt are non-empty; `Cmd+Enter` submits when valid; fields pre-populate when editing.
+
+- **ACT-004 — Delete action / group confirmations**
+  - Given: a delete action/group request.
+  - When: the dialog appears.
+  - Then: it names the target (and, for a group, lists its actions and count); confirming shows a spinner and disables buttons while deleting.
+
+- **ACT-005 — Group header rename & collapse**
+  - Given: a custom group header.
+  - When: the user uses its context menu to rename (inline; Enter/blur confirms, Escape cancels) or clicks the header to collapse/expand.
+  - Then: the name updates / the group collapses (chevron flips, count badge shows when collapsed); renaming does not toggle collapse.
+
+- **ACT-006 — Drag to reorder / regroup**
+  - Given: custom actions/groups (built-ins are not draggable).
+  - When: the user drags an action or group.
+  - Then: drop indicators show before/after positions; dropping into a group moves the action there; dropping outside removes it from the group.
+
+---
+
+# SKILL — Skills UI components
+
+- **SKILL-001 — Skill chip**
+  - Given: a skill chip.
+  - When: viewing/clicking it (or pressing Enter/Space when focused).
+  - Then: it shows `/skill-name`; clicking inserts it into the editor; an optional "Open in Sculptor" button appears for custom/sculptor skills; disabled chips are not interactive; the keyboard-target chip is highlighted.
+
+- **SKILL-002 — Skill hover content**
+  - Given: a skill chip.
+  - When: the user hovers/focuses it.
+  - Then: a popover shows the type badge (Built-in/Sculptor/Custom), the skill id, and description; hovering another chip in the group swaps content instantly; scrolling suppresses flapping.
+
+- **SKILL-003 — Skills search navigation**
+  - Given: the skills search input (placeholder "Search skills…").
+  - When: the user types, arrows, presses Enter, or clears.
+  - Then: the list filters in real time, arrows move the selection, Enter inserts the selected skill, Escape/clear closes search.
+
+---
+
+# MENT — Mentions, pickers, path autocomplete, mention chips
+
+## Mention chips
+
+- **MENT-001 — File/folder mention chip**
+  - Given: a file/folder mention chip in a message.
+  - When: viewing/clicking/hovering it.
+  - Then: it shows the icon and basename (start-truncated for long paths); clicking opens the file or reveals the folder; hovering shows a popover with the full path and an action hint ("Click to open" / "Click to reveal in file browser").
+
+- **MENT-002 — Skill mention chip**
+  - Given: a skill mention chip.
+  - When: hovering it.
+  - Then: a popover shows the type badge, skill id, and description; it is not clickable.
+
+- **MENT-003 — Entity mention chip**
+  - Given: an entity (repository/workspace/agent) mention chip.
+  - When: viewing/clicking/hovering it.
+  - Then: it shows a type-colored icon and name; clicking a workspace/agent navigates to it (repositories and deleted entities are not clickable, shown strike-through); hovering shows an entity detail popover.
+
+- **MENT-004 — Mention detail panes**
+  - Given: an agent / workspace / repository mention.
+  - When: its detail popover opens.
+  - Then: it shows the entity's icon, title, optional badge, body lines, and a meta footer (e.g., agent count); deleted entities show a gray icon, strike-through title, and a "no longer exists" note.
+
+## Mention pickers
+
+- **MENT-005 — Category picker (+ trigger)**
+  - Given: the chat input.
+  - When: the user types `+`.
+  - Then: a category list appears (Files, Commands, Repositories, Workspaces, and Images if image upload is supported); Tab/Enter/click drills into a category.
+
+- **MENT-006 — File picker (@ trigger)**
+  - Given: a file mention session.
+  - When: the user types `@` and a name.
+  - Then: a list of files/folders with highlighted matches and parent paths is shown; Tab/ArrowRight/Enter drills into folders, Enter/click on a file inserts it, Shift+Tab/Escape steps back or closes; empty states show "Type to search files" / "No matching files or folders".
+
+- **MENT-007 — Skill picker (/ trigger)**
+  - Given: a skill mention session.
+  - When: the user types `/` and a name.
+  - Then: a list of skills with a detail pane (type badge, id, description) is shown; Tab/Enter/click inserts the skill; the detail pane hides while typing; "No matching skills" when empty.
+
+- **MENT-008 — Entity picker**
+  - Given: an entity mention session.
+  - When: the user selects a type and drills in.
+  - Then: sectioned lists (Repositories/Workspaces/Agents) are shown; workspaces are drillable to their agents (chevron), agents/repositories insert on Enter/click; Shift+Tab pops one level.
+
+- **MENT-009 — Image upload from picker**
+  - Given: the harness supports image upload.
+  - When: the user selects the Images category.
+  - Then: an image-upload dialog is triggered (the Images row is hidden when unsupported).
+
+## Path autocomplete
+
+- **MENT-010 — Path autocomplete dropdown & submit**
+  - Given: a path input (e.g., add-repo).
+  - When: the user types a path with "/" or "~", navigates directories, and submits.
+  - Then: after a debounce a spinner then matching directories appear (or "No matching directories"); clicking a directory drills in; Enter (dropdown closed) or `Cmd+Enter` submits the trimmed path; Escape/Tab close the dropdown.
+
+---
+
+# DEV — Dev/debug panels & markdown-diff anchors
+
+- **DEV-001 — TanStack devtools panel modes**
+  - Given: the devtools panel is enabled (via the version popover).
+  - When: it is shown.
+  - Then: a floating or docked-bottom panel appears with a header offering Dock/Float and Close; the floating panel can be dragged and resized within the viewport; the docked panel can be resized from its top edge and pushes app content up; closing hides it.
+
+- **DEV-002 — Markdown external links**
+  - Given: a markdown link with an external protocol.
+  - When: the user clicks it.
+  - Then: it opens in the OS browser and shows an external-link icon.
+
+- **DEV-003 — Markdown fragment links**
+  - Given: a `#anchor` markdown link.
+  - When: the user clicks it.
+  - Then: navigation is prevented; a dashed-underline style and a tooltip ("In-page anchor links aren't supported yet") are shown.
+
+- **DEV-004 — Markdown relative/unsupported links**
+  - Given: a relative or unsupported-scheme markdown link.
+  - When: the user clicks it.
+  - Then: navigation is prevented; a broken-link icon and a tooltip ("Linked-file navigation isn't supported yet") are shown.
+
+---
+
+## Coverage notes
+
+- Some behaviors are gated by feature flags / capabilities and only appear when enabled:
+  entity mentions, rich markdown rendering, clone/in-place workspaces, Review-all,
+  Pi agent, image upload, CI babysitter, and the dev/devtools panels. Tests should set
+  the relevant flag (or assert the gated UI is absent when off).
+- The home-page rows and the workspace banner reuse the same PR/MR button component, so
+  the WS-PR scenarios (WS-022…WS-032) also describe the home-row PR behavior (HOME-020).
+- Status dots (running / waiting / error / ready / read / unread, plus the two-dot mixed
+  state) use one shared component across tab strips, home rows, agent tabs, peek popovers,
+  and the command palette; verify the same color/animation mapping in each surface.
+- Animations (status-pill and subagent-pill "thinking" variants) are randomized per
+  appearance; tests should assert that *an* animation is present rather than a specific one.


### PR DESCRIPTION
## What

Adds the Sculptor **product specification set** to the maintained docs tree at `docs/specs/`:

- **`SPEC.md`** — narrative product spec: what Sculptor is and how each feature behaves.
- **`requirements.md`** — measurable targets, version/platform bars, persistence/migration guarantees, integration contracts, and open questions.
- **`scenarios.md`** — ~446 user-facing Given/When/Then scenarios (UI acceptance layer).
- **`scenario_coverage.md`** — maps each scenario to the integration test that demonstrates it.
- **`README.md`** — index explaining each file and how they relate.

Also adds a **Specification** link to `docs/README.md`, beside the user guide (`docs/help/`) and developer docs (`docs/development/`).

## Why

These documents previously lived in the scratch `agent_docs/` tree. Moving them to `docs/specs/` makes them long-lived, discoverable, and maintained alongside the rest of the documentation.

## Notes

- Documentation only — no code, config, or generated types change.
- All files pass file-hygiene (trailing whitespace / EOF newline); normalized a pre-existing multiple-trailing-newline in `scenarios.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)