### PR TITLE
Reword skills to use capability-based ask-tool language

### DIFF
--- a/sculptor/sculptor-experimental/skills/handoff/SKILL.md
+++ b/sculptor/sculptor-experimental/skills/handoff/SKILL.md
@@ -34,8 +34,9 @@ The handoff can land in one of two places:
 
 If `$ARGUMENTS` already makes the choice clear (e.g. it mentions "new agent",
 "same workspace", or "new workspace"), use that. **Otherwise, ask the user which
-one** using the AskUserQuestion tool (`mcp__sculptor__ask_user_question`) and
-wait for the answer before creating anything.
+one with your question tool** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — and
+wait for the answer before creating anything. (The tool call raises the
+"waiting for input" status that alerts the user; don't ask in plain text.)
 
 ## Step 2 — Pre-flight: commit uncommitted work (new-workspace mode only)
 
@@ -55,8 +56,7 @@ git status --porcelain
 ```
 
 If the output is non-empty, list the affected paths (just the paths, not the
-diffs) and ask via the AskUserQuestion tool
-(`mcp__sculptor__ask_user_question`):
+diffs) and ask with your question tool:
 
 > You have N uncommitted change(s). Commit them before handing off?
 > - **Yes, commit them** — write a concise commit message inferred from the

--- a/sculptor/sculptor-workflow/skills/architect/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/architect/SKILL.md
@@ -32,22 +32,21 @@ rename command.
 The architect runs a multi-turn Q&A loop with the user. The rules
 below apply to every Q&A turn.
 
-### Every turn ends with mcp__sculptor__ask_user_question
+### Every turn ends by asking the user a question with your question tool
 
-**Every turn in a Q&A loop MUST end with an
-`mcp__sculptor__ask_user_question` tool call.** This is the single
+**Every turn in a Q&A loop MUST end by asking the user a question with your question tool.**
+This is the single
 rule that determines whether the turn succeeded. If you end a turn
 without it, you have stopped silently and the user has nothing to
 respond to.
 
 The ritual holds regardless of what happened earlier in the turn —
 research, answering the user's question, long discussion, a
-back-and-forth. Every one of those ends with
-`mcp__sculptor__ask_user_question`.
+back-and-forth. Every one of those ends by asking the user a question with your question tool.
 
 **One narrow exception: spawning the Plan agent.** When you spawn
 `/sculptor-workflow:plan` at finalize, the spawning turn ends with
-**text instructions** rather than `mcp__sculptor__ask_user_question`.
+**text instructions** rather than a question.
 The workspace's "waiting for input" state must belong to the Plan
 agent, not to this one. The exception applies only to the spawn turn.
 
@@ -56,8 +55,8 @@ agent, not to this one. The exception applies only to the spawn turn.
 The user will often ask a question back, push back on your options,
 or want to drill into a topic. This is a feature, not a problem — but
 it's the moment the skill fails most often: the agent goes into
-"answer the user" mode and forgets to close with
-`mcp__sculptor__ask_user_question`.
+"answer the user" mode and forgets to close by asking the user a
+question with your question tool.
 
 Handle it like this:
 
@@ -65,7 +64,7 @@ Handle it like this:
    (Grep, Read) if needed.
 2. Update `architecture.md` to reflect anything new the conversation
    surfaced.
-3. End the turn with `mcp__sculptor__ask_user_question` — usually a
+3. End the turn by asking the user a question with your question tool — usually a
    follow-up that builds on the discussion, or a "keep drilling or
    move on?" pacing question.
 
@@ -73,7 +72,7 @@ Research does not excuse skipping the ritual.
 
 ### Do not announce upcoming tool calls
 
-When you're about to call `mcp__sculptor__ask_user_question`, do
+When you're about to ask the user a question, do
 **not** announce it in text first. Just make the call.
 
 Any sentence that announces an upcoming tool call ("Here are the
@@ -120,8 +119,8 @@ structure* section below. Don't look for it in `.sculptor/docs.md`.
 
 Resolve:
 
-- **Slug** — from the input, or ask via
-  `mcp__sculptor__ask_user_question` if the input is empty. When you
+- **Slug** — from the input, or use your question tool to ask the user if the input is empty.
+  When you
   ask, glob the configured spec location for existing slugs and offer
   them as options.
 - **Spec path** — from the seed if provided, otherwise derive from
@@ -132,8 +131,8 @@ Resolve:
 - **Mocks path** — from seed, or `<spec-dir>/mocks.html` (or
   `<slug>.mocks.html` in flat mode) if it exists, else none.
 
-If the spec doesn't exist at the resolved path, stop and ask the user
-via `mcp__sculptor__ask_user_question` what to do — write the spec
+If the spec doesn't exist at the resolved path, stop and ask with your question tool
+what to do — write the spec
 first (invoke `/sculptor-workflow:spec`), or use a different slug.
 
 ## Step 3: Read upstream artifacts
@@ -328,7 +327,7 @@ When the design is clear enough:
    in the *Alternatives considered* section with the trade-offs you
    evaluated, add a *Risks and mitigations* section.
 2. Show the path in a code block.
-3. Emit the finalize `mcp__sculptor__ask_user_question` on its own
+3. Emit the finalizing question on its own
    turn (never bundled with substantive questions) with these
    options:
    - **Proceed to Plan** — spawn the Plan agent, hand off
@@ -370,12 +369,12 @@ is not yet final.
    - `Mocks path:` (only if mocks exist)
 2. Rename the new agent to `Plan` via `/sculptor:sculpt-cli`.
 3. End this turn with **text instructions** pointing the user to the
-   new tab — do NOT call `mcp__sculptor__ask_user_question`. See the
+   new tab — do not ask the user. See the
    spawn-turn exception in the Q&A ritual at the top of this skill.
 
 ### If the user picks "Revise"
 
-Use `mcp__sculptor__ask_user_question` to ask what to change, then
+Use your question tool to ask what to change, then
 iterate on `architecture.md`.
 
 ### If the user picks "Stop"
@@ -394,18 +393,18 @@ path. The user can resume the pipeline later by invoking
   spec issue, capture it in `architecture.md`'s *Open Questions*
   section and flag it to the user — they can return to the Spec tab
   to resolve it.
-- **Use `mcp__sculptor__ask_user_question` for every question.** The
-  built-in `AskUserQuestion` tool is blocked in Sculptor.
+- **Ask every question with your question tool** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion`. Never ask in plain text: only the tool call puts the
+  workspace into the "waiting for input" state that alerts the user.
 - **Follow the Q&A ritual in every step that asks the user a
-  question.** Ending a Q&A turn without
-  `mcp__sculptor__ask_user_question` is the primary failure mode of
+  question.** Ending a Q&A turn without asking the user a question is
+  the primary failure mode of
   this skill.
 - After every user answer, update `architecture.md` before asking the
   next question.
-- The finalize question is always its own
-  `mcp__sculptor__ask_user_question` call on its own turn.
+- The finalizing question is always its own
+  question on its own turn.
 - When spawning the Plan agent, end the spawning turn with **text
-  instructions** rather than `mcp__sculptor__ask_user_question`. The
+  instructions** rather than a question. The
   workspace's "waiting for input" state must belong to the Plan
   agent.
 - Reference `REQ-*` IDs from the spec wherever possible so traceability

--- a/sculptor/sculptor-workflow/skills/build/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/build/SKILL.md
@@ -47,11 +47,10 @@ Check for `.sculptor/docs.md` (for spec / plan paths). Same rule.
 - `Architecture path:` absolute or repo-relative
 - `Plan folder:` absolute or repo-relative path to the `plan/` folder
 
-If no slug is provided, ask via `mcp__sculptor__ask_user_question`,
-offering glob-discovered slugs.
+If no slug is provided, ask with your question tool — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — offering glob-discovered slugs. (The tool call raises the "waiting for input" status that alerts the user; don't ask in plain text.)
 
 Verify the plan folder exists at the resolved path. If not, stop and
-ask the user how to proceed.
+ask the user how to proceed with your question tool.
 
 ## Step 3: Read the overview and implement_task.md
 
@@ -98,8 +97,7 @@ For each TODO entry, in order:
 5. Mark the TODO as `completed`.
 6. Move to the next TODO.
 
-If a task hard-fails with a blocker you cannot resolve, stop and use
-`mcp__sculptor__ask_user_question` to ask the user how to proceed.
+If a task hard-fails with a blocker you cannot resolve, stop and ask the user how to proceed with your question tool.
 Do NOT skip the task.
 
 ## When the TODO list is empty
@@ -123,8 +121,7 @@ skip it), report that clearly so the user can spawn Review manually.
 - Do NOT make empty commits — `implement_task.md` covers when to
   skip the commit step.
 - Do NOT make architectural decisions that contradict the task
-  file — if something seems wrong, surface it via
-  `mcp__sculptor__ask_user_question` rather than improvising.
+  file — if something seems wrong, surface it to the user with your question tool rather than improvising.
 - Do NOT read task files ahead of time — only read each task file
   when you start working on it.
 - Do NOT proceed past a failed task without asking the user.

--- a/sculptor/sculptor-workflow/skills/build/implement_task.md
+++ b/sculptor/sculptor-workflow/skills/build/implement_task.md
@@ -93,7 +93,7 @@ When you're done with the task, report one of:
 
 - **Success (committed):** `Task <X.Y> completed. Commit: <hash>. All verification passed.`
 - **Success (no commit):** `Task <X.Y> completed. No changes to commit. All verification passed.` — use this when the task was about spawning an agent, running verification, or otherwise didn't produce code changes.
-- **Failure:** Use `mcp__sculptor__ask_user_question` to surface the failure: what went wrong, what you tried, and options for the user.
+- **Failure:** Use your question tool — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — to surface the failure (it raises the "waiting for input" status that alerts the user): what went wrong, what you tried, and options for the user.
 
 Do not include full test output in your report — just summarize the
 result.
@@ -106,5 +106,4 @@ result.
 - **Make an empty commit.** If `git diff --cached` is empty after
   staging, do not commit.
 - Make architectural decisions that contradict the task file — if
-  something seems wrong, surface it via
-  `mcp__sculptor__ask_user_question` rather than improvising.
+  something seems wrong, surface it to the user with your question tool rather than improvising.

--- a/sculptor/sculptor-workflow/skills/fix-bug/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/fix-bug/SKILL.md
@@ -69,7 +69,7 @@ Check the current branch with `git branch --show-current`.
 - If the current branch **is** the default branch, create a new branch using
   the code config's **Branch Naming** convention. If the config has no
   branch naming section:
-  - **Interactive mode:** use `mcp__sculptor__ask_user_question` to ask the user.
+  - **Interactive mode:** ask with your question tool.
   - **Autonomous mode:** generate a reasonable slug from the bug description
     (lowercased, kebab-case, ticket ID prefix if present), e.g.
     `auto/bugs/SCU-123-login-crash` or `auto/bugs/login-crash`.
@@ -93,8 +93,7 @@ description, and comments, and use that context as the bug description for the
 rest of the workflow.
 
 If the config says a ticket is always required but no ticket ID was provided:
-- **Interactive mode:** use `mcp__sculptor__ask_user_question` to ask for the
-  ticket ID or whether they want to proceed without one.
+- **Interactive mode:** use your question tool to ask for the ticket ID or whether they want to proceed without one.
 - **Autonomous mode:** proceed without a ticket. Note in the final MR/PR body
   that no ticket was provided.
 
@@ -109,7 +108,7 @@ Before writing any code, get full clarity on what is broken.
 
 ### Gather information
 
-1. **Ask the user questions** using `mcp__sculptor__ask_user_question` if the description is
+1. **Ask the user questions with your question tool** if the description is
    vague or incomplete. Don't guess — ask about:
    - Exact steps to reproduce
    - What the user expected to happen
@@ -151,14 +150,14 @@ Write out your understanding as a summary:
 `<img>` tags. Walk the user through each screenshot, explaining what you did
 and what you observed.
 
-**You MUST use the `mcp__sculptor__ask_user_question` tool here** — do NOT use a plain text
+**You MUST ask with your question tool here** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — do NOT use a plain text
 message. The tool triggers a UI notification that grabs the user's attention.
 Ask:
 > "Does this match your understanding? Is the test location correct? Please
 > confirm so I can proceed."
 
 Then **STOP. Do not proceed to Phase 2. Do not write any code.** Wait for the
-user's explicit response via the `mcp__sculptor__ask_user_question` tool result.
+user's explicit response.
 
 ## Phase 2: Write a Failing Test
 
@@ -180,8 +179,7 @@ this skill — do not do it.
 ### If you hit an obstacle that seems to require deviating
 
 If, while writing the test, you believe you need to change the test kind (e.g.
-fall back from an end-to-end test to a unit test), you MUST stop and use
-`mcp__sculptor__ask_user_question` before writing anything different. In the question:
+fall back from an end-to-end test to a unit test), you MUST stop and ask with your question tool before writing anything different. In the question:
 
 - Name the **specific obstacle** you hit (e.g. "the bug only reproduces when
   \<X\>, and the end-to-end test framework cannot do \<Y\>"). "Difficult,"
@@ -332,7 +330,7 @@ Enter this workflow only when the input began with `--autonomous` (or
 
 ### Forbidden in autonomous mode
 
-- **No `mcp__sculptor__ask_user_question` calls.** Not for clarification, not
+- **No asking the user.** Not for clarification, not
   for confirmation, not for fallback approval, not ever.
 - **No waiting on the user.** Don't ask "should I proceed?" — proceed.
 - **No fabricated bugs.** If you cannot reproduce any plausible interpretation

--- a/sculptor/sculptor-workflow/skills/mock/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/mock/SKILL.md
@@ -77,17 +77,16 @@ another agent, may include these markers:
   exploration mode (no spec exists yet).
 
 If the feature description is missing or too vague (1-3 words like
-"settings page"), use `mcp__sculptor__ask_user_question` to ask the user
+"settings page"), use your question tool to ask the user
 to describe the feature in a sentence or two before continuing.
 
 If mode is **confirmation** and `Associated spec:` is missing, stop and
-ask the user via `mcp__sculptor__ask_user_question` for the spec path
+ask with your question tool for the spec path
 before proceeding — confirmation mocks without a spec are meaningless.
 
 ## Step 3: Determine mode
 
-If `Mode:` is in the input, use it. Otherwise ask via
-`mcp__sculptor__ask_user_question`:
+If `Mode:` is in the input, use it. Otherwise ask with your question tool:
 
 - **Exploration** — "I'll generate 3+ end-to-end variants to help you
   explore ideas before you commit to a direction."
@@ -102,8 +101,7 @@ spec.
 1. **Slug.** If a slug was provided, use it. Otherwise derive one from
    the feature description: kebab-case, 2-5 words, lowercase,
    alphanumeric + hyphens only. If the derived slug is not obvious from
-   the feature description, confirm it with
-   `mcp__sculptor__ask_user_question`.
+   the feature description, confirm it with your question tool.
 2. **Paths.** If a `Target path:` was provided, use it. Otherwise derive
    from the **Spec Location** pattern in `.sculptor/docs.md`:
    - **Directory-per-spec** pattern (e.g. `specs/<slug>/spec.md`) →
@@ -111,8 +109,8 @@ spec.
      `specs/<slug>/mocks.context.md`.
    - **Flat** pattern (e.g. `docs/<slug>.md`) → mocks live at
      `docs/<slug>.mocks.html` and `docs/<slug>.mocks.context.md`.
-3. If `mocks.html` already exists at the target location, ask the user
-   via `mcp__sculptor__ask_user_question` whether to extend it, replace
+3. If `mocks.html` already exists at the target location, use your question tool to ask
+   whether to extend it, replace
    it, or pick a new slug.
 
 ## Step 5: Resolve the visual anchor
@@ -125,8 +123,7 @@ Look at the **UI Reference** section of `.sculptor/docs.md`:
   Look for a component library, design tokens, or existing pages you
   can imitate.
 - If the UI Reference is empty **and** the repo has no discoverable
-  frontend code (brand-new project, pure backend), STOP and ask the
-  user via `mcp__sculptor__ask_user_question`:
+  frontend code (brand-new project, pure backend), STOP and ask with your question tool:
   - What visual style the mocks should follow (e.g. clean minimal,
     dashboard, mobile-first)
   - Any reference sites or apps to imitate
@@ -207,8 +204,7 @@ match the visual style from Step 5's resolution, realistic sample
 data — no `foo`/`bar`/`lorem ipsum`.
 
 After generating, show the user both file paths in code blocks so they
-can open them, then immediately enter Step 8's iteration loop by asking
-what they want to change (via `mcp__sculptor__ask_user_question`) and
+can open them, then immediately enter Step 8's iteration loop by asking — with your question tool — what they want to change, and
 emitting the checklist footer.
 
 ## Step 8: Iterate
@@ -225,12 +221,12 @@ Every turn in Step 8 MUST end with both:
    Logged tweak in mocks.context.md: yes/no
    Summary: <one line describing what you did this turn>
    ```
-2. A call to `mcp__sculptor__ask_user_question` (asking what to tweak
+2. A question via your question tool (asking what to tweak
    next, or offering to wrap up — see below).
 
 The text-output footer comes first, then the tool call closes the turn.
 Ending a turn without the footer is the primary failure mode of this
-skill. Ending without `mcp__sculptor__ask_user_question` is the second.
+skill. Ending without a question to the user is the second.
 
 ### On every user answer
 
@@ -251,8 +247,7 @@ skill. Ending without `mcp__sculptor__ask_user_question` is the second.
 ### When to offer to wrap up
 
 When the user seems satisfied (no new tweaks landing, they say they're
-happy, or the conversation is clearly winding down), use
-`mcp__sculptor__ask_user_question` to offer:
+happy, or the conversation is clearly winding down), ask with your question tool, offering:
 
 - **I'm done** — wrap up the mock session
 - **Keep iterating** — stay in Step 8
@@ -283,11 +278,9 @@ the spec using Decisions and Rejected Alternatives as input.
 
 ## Rules
 
-- **Use `mcp__sculptor__ask_user_question` for every question.** The
-  built-in `AskUserQuestion` tool is blocked in Sculptor. Always use
-  `mcp__sculptor__ask_user_question`.
+- **Ask every question with your question tool** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion`. Never ask in plain text: only the tool call puts the workspace into the "waiting for input" state that alerts the user.
 - **Every turn in Step 8 MUST end with the checklist footer AND
-  `mcp__sculptor__ask_user_question`.** The footer is the drift-prevention
+  a question to the user via your question tool.** The footer is the drift-prevention
   anchor; the tool call keeps the ritual intact. Missing either is a
   failure.
 - **Do NOT commit.** The mock skill never runs `git commit`. Users

--- a/sculptor/sculptor-workflow/skills/plan/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/plan/SKILL.md
@@ -29,22 +29,20 @@ Before doing anything else, rename this agent to "Plan" via the
 The plan agent runs a multi-turn Q&A loop with the user. The rules
 below apply to every Q&A turn.
 
-### Every turn ends with mcp__sculptor__ask_user_question
+### Every turn ends by asking the user a question
 
-**Every turn in a Q&A loop MUST end with an
-`mcp__sculptor__ask_user_question` tool call.** This is the single
+**Every turn in a Q&A loop MUST end with a question to the user via your question tool.** This is the single
 rule that determines whether the turn succeeded. If you end a turn
 without it, you have stopped silently and the user has nothing to
 respond to.
 
 The ritual holds regardless of what happened earlier in the turn —
 research, answering the user's question, long discussion, a
-back-and-forth. Every one of those ends with
-`mcp__sculptor__ask_user_question`.
+back-and-forth. Every one of those ends by asking the user a question with your question tool.
 
 **One narrow exception: spawning the Build agent.** When you spawn
 `/sculptor-workflow:build` at finalize, the spawning turn ends with
-**text instructions** rather than `mcp__sculptor__ask_user_question`.
+**text instructions** rather than a question.
 The workspace's "waiting for input" state must belong to the Build
 agent, not to this one. The exception applies only to the spawn turn.
 
@@ -53,8 +51,8 @@ agent, not to this one. The exception applies only to the spawn turn.
 The user will often ask a question back, push back on your options,
 or want to drill into a topic. This is a feature, not a problem — but
 it's the moment the skill fails most often: the agent goes into
-"answer the user" mode and forgets to close with
-`mcp__sculptor__ask_user_question`.
+"answer the user" mode and forgets to close by asking the user a
+question with your question tool.
 
 Handle it like this:
 
@@ -62,15 +60,15 @@ Handle it like this:
    (Grep, Read) if needed.
 2. Update the relevant task file (or `00_overview.md`) to reflect
    anything new the conversation surfaced.
-3. End the turn with `mcp__sculptor__ask_user_question` — usually a
-   follow-up that builds on the discussion, or a "keep drilling or
-   move on?" pacing question.
+3. End the turn by asking the user a question with your question tool —
+   usually a follow-up that builds on the discussion, or a "keep
+   drilling or move on?" pacing question.
 
 Research does not excuse skipping the ritual.
 
 ### Do not announce upcoming tool calls
 
-When you're about to call `mcp__sculptor__ask_user_question`, do
+When you're about to ask the user a question, do
 **not** announce it in text first. Just make the call.
 
 Any sentence that announces an upcoming tool call ("Here are the
@@ -119,8 +117,8 @@ The plan folder path:
 - **Directory-per-spec:** `<spec-dir>/plan/`
 - **Flat:** `<spec-dir>/<slug>.plan/`
 
-If the plan folder already exists, ask the user via
-`mcp__sculptor__ask_user_question` whether to extend it, replace it,
+If the plan folder already exists, use your question tool to ask
+whether to extend it, replace it,
 or pick a new slug.
 
 ## Step 3: Read upstream artifacts
@@ -336,8 +334,7 @@ do. Include:>
   section).
 - **Confirm end-to-end tests with the user.** After writing the plan,
   present the user with a summary of which end-to-end tests you've
-  identified for each task. Use `mcp__sculptor__ask_user_question` to
-  ask the user to confirm these are the right tests, or suggest
+  identified for each task. Use your question tool to ask the user to confirm these are the right tests, or suggest
   additional ones.
 
 ### Mandatory final tasks (every plan)
@@ -444,8 +441,8 @@ None. This task spawns an agent; it does not edit code.
 3. The Review agent self-renames on entry; you do not need to
    rename it.
 4. End this turn with **text instructions** pointing the user to
-   the new Review tab. Do NOT call
-   `mcp__sculptor__ask_user_question` (the workspace's "waiting for
+   the new Review tab. Do NOT ask the user a question (the
+   workspace's "waiting for
    input" state must belong to the Review agent now).
 
 ## Verification checklist
@@ -473,7 +470,7 @@ After writing all task files:
    verify-all-tests and launch-review tasks at the end of the Task
    Index). If they're missing, write them now.
 3. Show the plan folder path in a code block.
-4. Emit the finalize `mcp__sculptor__ask_user_question` on its own
+4. Emit the finalizing question on its own
    turn:
    - **Proceed to Build** — spawn the Build agent, hand off
    - **Revise** — keep iterating on the plan
@@ -515,11 +512,11 @@ yet final.
      folder
 2. Rename the new agent to `Build` via `/sculptor:sculpt-cli`.
 3. End this turn with **text instructions** pointing the user to the
-   new tab — no `mcp__sculptor__ask_user_question`.
+   new tab — without asking the user a question.
 
 ### If the user picks "Revise" or "Stop"
 
-Revise: ask via `mcp__sculptor__ask_user_question` what to change,
+Revise: use your question tool to ask what to change,
 then edit task files in place. Stop: end cleanly with a short text
 note pointing at the plan folder.
 
@@ -578,7 +575,7 @@ verified them in the codebase.
 - Do NOT reference other task files for context — repeat the context
   instead.
 - Do NOT omit end-to-end tests for user-facing features.
-- **Use `mcp__sculptor__ask_user_question` for every question.**
+- **Ask every question with your question tool** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion`. Never ask in plain text: only the tool call puts the workspace into the "waiting for input" state that alerts the user.
 - The finalize question is its own turn.
 - When spawning the Build agent, end the spawning turn with **text
-  instructions** rather than `mcp__sculptor__ask_user_question`.
+  instructions** rather than a question.

--- a/sculptor/sculptor-workflow/skills/review/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/review/SKILL.md
@@ -29,26 +29,25 @@ Before doing anything else, rename this agent to "Review" via the
 Most of this skill runs autonomously (Steps 1-8). A Q&A loop only
 kicks in if the user picks **Address findings in this tab** at
 Step 9's finalize. The rules below apply to that loop and to any
-other turn where you call `mcp__sculptor__ask_user_question`
+other turn where you ask the user a question with your question tool
 (including the finalize question itself).
 
-### Every turn ends with mcp__sculptor__ask_user_question
+### Every turn ends by asking the user a question
 
-**Every turn in a Q&A loop MUST end with an
-`mcp__sculptor__ask_user_question` tool call.** This is the single
+**Every turn in a Q&A loop MUST end by asking the user a question with your question tool.**
+This is the single
 rule that determines whether the turn succeeded. If you end a turn
 without it, you have stopped silently and the user has nothing to
 respond to.
 
 The ritual holds regardless of what happened earlier in the turn —
 research, fixing a finding, answering the user's question, long
-discussion. Every one of those ends with
-`mcp__sculptor__ask_user_question`.
+discussion. Every one of those ends by asking the user a question with your question tool.
 
 **One narrow exception: spawning a fixer agent.** When the user
 picks "Spawn a fixer agent" at finalize and you spawn it, the
 spawning turn ends with **text instructions** rather than
-`mcp__sculptor__ask_user_question`. The workspace's "waiting for
+by asking the user a question. The workspace's "waiting for
 input" state must belong to the fixer agent, not to this one. The
 exception applies only to the spawn turn.
 
@@ -57,8 +56,8 @@ exception applies only to the spawn turn.
 The user will often ask a question back, push back on a finding, or
 want to drill into a topic. This is a feature, not a problem — but
 it's the moment the skill fails most often: the agent goes into
-"answer the user" mode and forgets to close with
-`mcp__sculptor__ask_user_question`.
+"answer the user" mode and forgets to close by asking the user a
+question with your question tool.
 
 Handle it like this:
 
@@ -67,7 +66,7 @@ Handle it like this:
 2. Update `review.md` to reflect anything new the conversation
    surfaced — mark findings as resolved with commit references when
    a fix has landed.
-3. End the turn with `mcp__sculptor__ask_user_question` — usually a
+3. End the turn by asking the user a question with your question tool — usually a
    follow-up that builds on the discussion, or a "address the next
    finding or stop?" pacing question.
 
@@ -75,7 +74,7 @@ Research does not excuse skipping the ritual.
 
 ### Do not announce upcoming tool calls
 
-When you're about to call `mcp__sculptor__ask_user_question`, do
+When you're about to ask the user a question, do
 **not** announce it in text first. Just make the call.
 
 Any sentence that announces an upcoming tool call ("Here are the
@@ -122,15 +121,13 @@ Read them. Key sections:
 - `Plan folder:` absolute or repo-relative
 - `Diff range:` git diff range, defaults to `origin/main...HEAD`
 
-If no slug is provided, ask via `mcp__sculptor__ask_user_question`,
-offering glob-discovered slugs.
+If no slug is provided, ask with your question tool, offering glob-discovered slugs.
 
 Resolve all paths from the slug + docs config if any are missing
 from the seed.
 
 If `origin/main` doesn't exist, or no commits are ahead of it, use
-`mcp__sculptor__ask_user_question` to ask the user what base
-reference to compare against.
+your question tool to ask the user what base reference to compare against.
 
 ## Step 3: Read upstream artifacts
 
@@ -255,7 +252,7 @@ Show the path in a code block.
 
 ## Step 9: Finalize
 
-Emit the finalize `mcp__sculptor__ask_user_question` on its own turn
+Emit the finalizing question on its own turn
 with these options:
 
 - **Address findings in this tab** — switch into a Q&A loop where
@@ -265,7 +262,7 @@ with these options:
 - **Spawn a fixer agent** — spawn a fresh agent (renamed `Fix`)
   seeded with `review.md` and the list of findings to address. Use
   `/sculptor:sculpt-cli` to spawn; end the spawn turn with text
-  instructions (no `mcp__sculptor__ask_user_question`).
+  instructions (no question).
 - **Done** — stop cleanly.
 
 Act on the user's choice.
@@ -281,9 +278,8 @@ Each turn:
    logical change).
 3. Update `review.md` to mark the finding as **Resolved** with a
    reference to the commit hash.
-4. End the turn with `mcp__sculptor__ask_user_question` asking
-   whether to address the next finding, hand off to a fixer agent,
-   or stop.
+4. End the turn by asking the user, with your question tool, whether to
+   address the next finding, hand off to a fixer agent, or stop.
 
 ## Rules
 
@@ -293,10 +289,10 @@ Each turn:
   even if the diff looks clean.
 - Do NOT block on a failing test by halting Review. Capture the
   failure in `review.md`, continue, and surface it in the Summary.
-- **Use `mcp__sculptor__ask_user_question` for every question.**
+- **Ask every question with your question tool** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion`. Never ask in plain text: only the tool call puts the workspace into the "waiting for input" state that alerts the user.
 - The finalize question is its own turn.
 - When spawning a fixer agent, end the spawn turn with **text
-  instructions** rather than `mcp__sculptor__ask_user_question`.
+  instructions** rather than by asking the user a question.
 - Re-run the test suite even if Build already did — Review is the
   one phase that re-verifies; other phases trust prior phases'
   verification.

--- a/sculptor/sculptor-workflow/skills/setup-repo/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/setup-repo/SKILL.md
@@ -45,7 +45,7 @@ from the repo root.
 
 ## Step 2: Ask the user how to proceed
 
-Use `mcp__sculptor__ask_user_question`:
+Ask with your question tool:
 
 > I'd like to set up Sculptor configs for this repo so I can build, test, and
 > fix bugs effectively. This is a one-time setup — the configs will be saved
@@ -415,13 +415,13 @@ Write all three files to `.sculptor/code.md`, `.sculptor/testing.md`, and
 
 ### Ask the user to review
 
-Use the `mcp__sculptor__ask_user_question` tool to ask the user to review the files:
+Use your question tool to ask the user to review the files:
 
 > I've written the config files to `.sculptor/code.md`,
 > `.sculptor/testing.md`, and `.sculptor/docs.md`. Please review them and
 > let me know if anything needs to be adjusted.
 
-**You MUST use the `mcp__sculptor__ask_user_question` tool here**, not a plain text message.
+**You MUST ask with your question tool here** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — not a plain text message. The tool call is what raises the "waiting for input" status that alerts the user.
 The tool triggers a UI notification in Sculptor that grabs the user's attention
 — without it, the user may not notice the question.
 

--- a/sculptor/sculptor-workflow/skills/spec/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/spec/SKILL.md
@@ -33,31 +33,28 @@ rename command if you don't already know it.
 
 Several steps below involve multi-turn conversation with the user —
 most obviously **Step 4** (goals) and **Step 7** (fill the spec), but
-also any step that asks the user a question via
-`mcp__sculptor__ask_user_question`. The rules in this section apply
+also any step that asks the user a question. The rules in this section apply
 whenever you're in a Q&A loop. Later steps add step-specific content
 (what to ask, how to update the file) on top of these.
 
-### Every turn ends with mcp__sculptor__ask_user_question
+### Every turn ends by asking the user a question with your question tool
 
-**Every turn in a Q&A loop MUST end with an
-`mcp__sculptor__ask_user_question` tool call.** This is the single
+**Every turn in a Q&A loop MUST end by asking the user a question with your question tool.** This is the single
 rule that determines whether the turn succeeded. If you end a turn
 without it, you have stopped silently — the user has nothing to
 respond to and the skill is stuck.
 
-Before ending any turn, verify: *did this turn emit an
-`mcp__sculptor__ask_user_question` call?* If not, emit one now.
+Before ending any turn, verify: *did this turn end by asking the user
+a question with your question tool?* If not, do so now.
 
 The ritual holds regardless of what happened earlier in the turn —
 research, answering the user's question, long discussion, a
-back-and-forth. Every one of those ends with
-`mcp__sculptor__ask_user_question`.
+back-and-forth. Every one of those ends by asking the user a question with your question tool.
 
 **One narrow exception: spawning a Mock agent.** When you spawn a
 mock-creator agent in Step 6, Step 7's escape hatch, or Step 9, the
 spawning turn ends with **text instructions** rather than
-`mcp__sculptor__ask_user_question`. This is deliberate: the
+asking the user a question. This is deliberate: the
 workspace's "waiting for input" state must belong to the Mock agent
 while the user is iterating on mocks, not to the Spec agent —
 otherwise the Mock agent's attention signals are masked. The
@@ -75,8 +72,8 @@ The user will often:
 This is a feature, not a problem. When it happens, the conversational
 frame shifts: you owe the user a response before asking anything new.
 **This is the moment the skill fails most often** — the agent goes
-into "answer the user" mode and forgets to close the turn with
-`mcp__sculptor__ask_user_question`.
+into "answer the user" mode and forgets to close the turn by asking
+the user a question with your question tool.
 
 Handle it like this:
 
@@ -85,8 +82,8 @@ Handle it like this:
    answer concretely.
 2. **Update the spec file** to reflect anything new the conversation
    surfaced.
-3. **End the turn with `mcp__sculptor__ask_user_question`.** Usually
-   this is a follow-up that builds on what you just discussed
+3. **End the turn by asking the user a question with your question tool.**
+   Usually this is a follow-up that builds on what you just discussed
    ("Given what I found in `foo.py`, which of these do you prefer?"),
    but it can also be "do you want to keep drilling into this, or
    move on?" — so the user stays in control of the pace.
@@ -99,16 +96,16 @@ you drive the spec forward.
 The silent-stop failure is especially likely when a user's answer
 prompts more exploration (Grep, Read, or another round of codebase
 digging) before the next question. Research output eats your output
-budget, and the final synthesis step — including the
-`mcp__sculptor__ask_user_question` call — gets skipped.
+budget, and the final synthesis step — including asking the user a
+question — gets skipped.
 
-Do the research. Then still update the spec file and still emit
-`mcp__sculptor__ask_user_question` in the same turn. Research does
+Do the research. Then still update the spec file and still ask the
+user a question with your question tool in the same turn. Research does
 not excuse skipping the ritual.
 
 ### Do not announce upcoming tool calls in text
 
-When you're about to call `mcp__sculptor__ask_user_question`, do
+When you're about to ask the user a question, do
 **not** announce the call in text first. Just make the call.
 
 Any sentence that announces an upcoming tool call — whether it ends
@@ -125,10 +122,9 @@ call. Examples of announcement preambles that trigger this:
 - "A few more questions."
 - "Next I'll ask about X."
 
-Delete any such sentence and emit the tool call directly. Options,
-questions, and choices go INSIDE the
-`mcp__sculptor__ask_user_question` call, not as preamble describing
-what you're about to do.
+Delete any such sentence and ask the user directly. Options,
+questions, and choices go INSIDE the question you ask, not as
+preamble describing what you're about to do.
 
 **Context about the prior state is fine** (e.g. "I updated the User
 Scenarios section with that flow.", "Grepping turned up one related
@@ -138,7 +134,7 @@ do it.
 
 ### How to ask
 
-Use the `mcp__sculptor__ask_user_question` tool for every question.
+For every question, ask with your question tool — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion`. Never ask in plain text: only the tool call puts the workspace into the "waiting for input" state that alerts the user.
 Provide concrete, distinct options grounded in what you found in the
 codebase. Sculptor's UI always shows a free-text field alongside the
 options, so you do not need to include an explicit "Other" option.
@@ -170,8 +166,7 @@ for the writing guidance. Don't look for those in `.sculptor/docs.md`.
 ## Step 2: Parse the input
 
 `$ARGUMENTS` is the feature description. If it's empty or too vague
-(1-3 words like "add caching"), use `mcp__sculptor__ask_user_question`
-to ask the user to describe the feature in one or two sentences before
+(1-3 words like "add caching"), use your question tool to ask the user to describe the feature in one or two sentences before
 continuing. Follow the Q&A ritual above.
 
 ## Step 3: Scaffold the spec
@@ -247,8 +242,7 @@ Focus on:
 - **Audience** — whose experience changes, and how?
 - **Non-goals** — what are they explicitly NOT trying to do?
 
-Pick 1 to 3 that are genuinely missing from `$ARGUMENTS` and ask via
-`mcp__sculptor__ask_user_question`. Skip anything the input already
+Pick 1 to 3 that are genuinely missing from `$ARGUMENTS` and ask with your question tool. Skip anything the input already
 covers.
 
 **Skip this step entirely if `$ARGUMENTS` already covers problem,
@@ -313,7 +307,7 @@ mocks come first.
 
 ### The three options
 
-Use `mcp__sculptor__ask_user_question` with:
+Ask with your question tool, with:
 
 1. **Mock first (exploration)** — "I'll spawn a mock-creator agent to
    build 3+ HTML variants so you can see options before we fill out
@@ -337,8 +331,8 @@ Use `mcp__sculptor__ask_user_question` with:
    Do NOT pass `Associated spec:` — the spec only has Overview at
    this point. The mock agent's handoff artifact `mocks.context.md`
    feeds the rest of the spec, not the other way around.
-2. End this turn with **text instructions** — do NOT call
-   `mcp__sculptor__ask_user_question`. Briefly tell the user what
+2. End this turn with **text instructions** — do NOT ask the user
+   a question. Briefly tell the user what
    you spawned, point them at the new "Mock" tab, and let them
    know they can come back to this tab whenever they're ready,
    whether that's because mocking is done, they have questions
@@ -347,9 +341,9 @@ Use `mcp__sculptor__ask_user_question` with:
    prescribe specific reply phrases. Then end the turn with no
    tool call.
 
-   Why no `ask_user_question` here: that tool puts the workspace
-   into "waiting for input" state, which would mask the Mock
-   agent's own attention signals. The Spec agent should be quiet
+   Why no question here: asking the user a question puts the
+   workspace into "waiting for input" state, which would mask the
+   Mock agent's own attention signals. The Spec agent should be quiet
    until the user returns.
 
 3. When the user comes back, infer from their message which path
@@ -375,8 +369,7 @@ Use `mcp__sculptor__ask_user_question` with:
        mock files — leave them as-is.
 
    If their message is genuinely ambiguous between these paths, ask
-   a clarifying question — this is a normal Q&A turn now, so use
-   `mcp__sculptor__ask_user_question`.
+   a clarifying question with your question tool — this is a normal Q&A turn now.
 
 ### If the user picks "Spec first, mock at the end"
 
@@ -495,12 +488,12 @@ session is already in progress or has produced mocks, don't re-offer.
 Also do not offer if the user previously selected "stop offering"
 (see below).
 
-Use `mcp__sculptor__ask_user_question`:
+Ask with your question tool:
 
 - **Yes, spawn a mock agent now** — treat this as if the user picked
   "Mock first" in Step 6. Spawn the agent (see Step 6 for the
   invocation), end this turn with text instructions per Step 6 (no
-  `ask_user_question` — see the exception in the Q&A ritual), and
+  question — see the exception in the Q&A ritual), and
   when the user returns integrate the mocks into the spec and resume
   Q&A.
 - **No, keep going in Q&A** — continue with your next substantive
@@ -524,7 +517,7 @@ the spec?
   final call.
 
 **The finalize question must always be its own
-`mcp__sculptor__ask_user_question` call, on a turn of its own.**
+question, on a turn of its own.**
 Never bundle it with substantive questions in the same call. The user
 cannot decide whether to finalize until they have seen every
 preceding answer reflected in the spec file.
@@ -533,12 +526,11 @@ The correct sequence is:
 
 1. User answers the previous round of substantive questions.
 2. You update the spec file to integrate every one of those answers.
-3. Only then, on a new turn, emit a standalone
-   `mcp__sculptor__ask_user_question` with the single finalize
-   question — no other questions attached.
+3. Only then, on a new turn, ask the user the single
+   finalize question on its own — no other questions attached.
 
 If you still have substantive questions you want to ask, ask those
-instead (in their own `mcp__sculptor__ask_user_question` call) — the
+instead (as a separate question) — the
 finalize offer can wait for the next round.
 
 ## Step 8: Finalize
@@ -578,8 +570,7 @@ Stay in conversation to refine the spec:
   list.
 
 **Do NOT begin implementation** until the user explicitly says so.
-When they signal they're done refining, use
-`mcp__sculptor__ask_user_question` to offer:
+When they signal they're done refining, ask with your question tool, offering:
 
 - **Create / revise HTML mocks** — spawn a mock-creator agent via
   `/sculptor:sculpt-cli`, invoking `/sculptor-workflow:mock` in `Mode: confirmation`.
@@ -594,7 +585,7 @@ When they signal they're done refining, use
   If mocks already exist at the target path, note that in the
   invocation so the agent revises rather than overwrites. End this
   turn with the same text instructions as Step 6 — no
-  `mcp__sculptor__ask_user_question` (see the exception in the Q&A
+  question (see the exception in the Q&A
   ritual). The Mock agent self-renames on entry, so you don't need
   to rename it here. Let the user know they can come back when
   mocking is done, when they have questions, or if they want to
@@ -618,7 +609,7 @@ When they signal they're done refining, use
 
   Rename the new agent to `Architect` via `/sculptor:sculpt-cli`,
   then end this turn with text instructions pointing the user to
-  the new tab — no `mcp__sculptor__ask_user_question` (same
+  the new tab — no question (same
   spawn-turn exception as Mocks). The Architect will take it from
   there.
 - **Leave as a spec** — stop here
@@ -666,14 +657,12 @@ Act on the user's choice.
   a separately-spawned mock-creator agent, not by you.
 - Do NOT skip the docs config. If `.sculptor/docs.md` is missing,
   invoke `/sculptor-workflow:setup-repo` first.
-- **Use `mcp__sculptor__ask_user_question` for every question.** The
-  built-in `AskUserQuestion` tool is blocked in Sculptor.
+- **Ask every question with your question tool** (see *How to ask*) — never a plain-text question.
 - **Follow the Q&A ritual (see above) in every step that asks the
   user a question** — Step 2 (if `$ARGUMENTS` is vague), Step 4
   (goals), Step 6 (mock choice), Step 7 (spec Q&A), Step 9
-  (refine). Ending a Q&A turn without
-  `mcp__sculptor__ask_user_question` is the primary failure mode of
-  this skill.
+  (refine). Ending a Q&A turn without asking the user a question is
+  the primary failure mode of this skill.
 - **Every question in Step 4 must be about goals, outcomes,
   audience, or scope — never implementation.** If you're about to
   ask an implementation question, stop and move on to Step 5
@@ -681,7 +670,7 @@ Act on the user's choice.
 - After every user answer, update the spec file before asking the
   next question.
 - The finalize question (Step 7) is always its own
-  `mcp__sculptor__ask_user_question` call on its own turn, after the
+  question on its own turn, after the
   spec has been updated with all prior answers. Never bundle it with
   substantive questions.
 - When mocks exist next to the spec at Step 8, auto-add the Mocks
@@ -689,7 +678,7 @@ Act on the user's choice.
 - When spawning another agent (a Mock agent in Step 6 / Step 7
   escape hatch / Step 9, or an Architect agent in Step 9), end the
   spawning turn with **text instructions** rather than
-  `mcp__sculptor__ask_user_question`. This is the one deliberate
+  asking the user a question. This is the one deliberate
   exception to the Q&A ritual: the workspace's "waiting for input"
   state must belong to the spawned agent until the user returns, so
   the Spec agent stays quiet. When the user replies, infer their


### PR DESCRIPTION
## Original bug

> **Workflow skills name MCP ask/plan tools that don't exist for terminal agents**
>
> The workflow skills reference Sculptor's MCP ask/plan tools by name, but those tools don't exist for terminal agents — so the instructions don't apply. Update the skills to tell the agent to use these capabilities *without* being prescriptive about the specific MCP tool. E.g. say "Use your ask tool" rather than naming a specific MCP tool, so the guidance works for both rich-chat and terminal agents.

Ticket: [SCU-1534](https://linear.app/imbue/issue/SCU-1534/workflow-skills-name-mcp-askplan-tools-that-dont-exist-for-terminal)

## Hypotheses considered

1. **Bundled-plugin skills named only the Sculptor MCP ask tool** — the workflow skills (and the experimental `handoff` skill) instructed the agent to use `mcp__sculptor__ask_user_question`. A terminal agent doesn't have that tool, so the instruction didn't apply to it. **REPRODUCED.**

(The plan-mode identifiers `mcp__sculptor__exit_plan_mode` / `ExitPlanMode` never appeared in any bundled skill, despite the ticket title saying "ask/plan" — only the ask tool was named.)

## Reproduced bug

### Skills named an ask tool that only one agent type has

**Repro steps**

1. Check out `main` (merge base `d43a64e6c8`).
2. From the repo root, run:
   ```
   grep -rnE "mcp__sculptor__ask_user_question|AskUserQuestion" \
     sculptor/sculptor-workflow sculptor/sculptor-experimental
   ```
3. Observe 112 matches across 10 skill files (`spec`, `architect`, `plan`, `review`, `mock`, `build/SKILL.md`, `build/implement_task.md`, `fix-bug`, `setup-repo`, `handoff`). Each prescribes `mcp__sculptor__ask_user_question` — e.g. `architect/SKILL.md`: "**Every turn in a Q&A loop MUST end with an `mcp__sculptor__ask_user_question` tool call.**"
4. A terminal agent (plain Claude Code, not Sculptor rich chat) running one of these skills has no `mcp__sculptor__ask_user_question` tool, so the instruction is inapplicable for that agent type.

**Expected vs actual**

- Expected: skill instructions point at an ask tool that the running agent actually has, in a way that works for every agent type.
- Actual: skills named only `mcp__sculptor__ask_user_question`, which exists for Sculptor rich-chat agents but not for terminal agents.

**Before** (skill prose on `main`)

```
### Every turn ends with mcp__sculptor__ask_user_question

**Every turn in a Q&A loop MUST end with an
`mcp__sculptor__ask_user_question` tool call.** ...

- **Use `mcp__sculptor__ask_user_question` for every question.** The
  built-in `AskUserQuestion` tool is blocked in Sculptor.
```

**Root cause**

The bundled skills were authored for Sculptor's rich-chat agent. That agent has the `mcp__sculptor__ask_user_question` MCP tool (injected by the backend harness system prompt, `sculptor/sculptor/agents/default/claude_code_sdk/harness.py`) and has the built-in `AskUserQuestion` blocked, so the skills hard-coded the MCP identifier. Terminal agents run the *same* bundled skill markdown as plain Claude Code, where that MCP tool doesn't exist (they have the built-in `AskUserQuestion` instead), so the prescriptive instruction didn't apply.

**Fix**

Make every "ask the user" instruction point at a structured *question tool* — which is the whole point, because the tool call is what raises the workspace's "waiting for input" status that alerts the user; a plain-text question does not. Each skill names both options exactly once, keyed on *availability*: "`mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion`" — so the guidance is correct for every agent type (terminal agents fall back to the built-in; agents that have the MCP tool prefer it). Inline mentions use the shorthand "your question tool" so it stays unambiguous that asking goes through the tool, never plain text. The rich-chat-specific "the built-in `AskUserQuestion` tool is blocked in Sculptor" explanations are dropped. Behavioral intent is preserved: interactive Q&A turns still end with a structured question, and the spawn-turn exceptions (turn ends with text instructions and deliberately does *not* ask) are unchanged.

**After** (skill prose on this branch)

```
### Every turn ends by asking the user a question with your question tool

**Every turn in a Q&A loop MUST end by asking the user a question with your question tool.** ...

- For every question, ask with your question tool — `mcp__sculptor__ask_user_question`
  if it's available, otherwise the built-in `AskUserQuestion`. Never ask in plain
  text: only the tool call puts the workspace into the "waiting for input" state
  that alerts the user.
```

## Notes

This is a wording/guidance change to skill markdown — there is no code path and no UI surface, so the proof of work is the before/after prose above rather than a test or screenshots. (An earlier iteration prototyped a unit test that scanned the skills for these identifiers; it was dropped, because now that the skills intentionally name the tools, a test forbidding those names is the wrong invariant and a prose-policy test is brittle.)

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
