### PR TITLE
Detect merge conflicts on GitHub PRs for the CI Babysitter

### DIFF
--- a/sculptor/frontend/src/pages/settings/components/CIBabysitterSettingsSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/CIBabysitterSettingsSection.tsx
@@ -96,7 +96,7 @@ export const CIBabysitterSettingsSection = ({ onSettingChange }: CIBabysitterSet
   };
 
   return (
-    <SettingsSectionLayout description="When enabled, Sculptor watches open MRs and asks an AI agent to fix CI failures and merge conflicts automatically. Currently only available for GitLab MRs. Coming soon for GitHub PRs.">
+    <SettingsSectionLayout description="When enabled, Sculptor watches open MRs and PRs and asks an AI agent to fix CI failures and merge conflicts automatically.">
       <SettingRow
         title="Enable CI Babysitter"
         description="Spawn a per-workspace babysitter agent when an MR's pipeline fails or develops a merge conflict."

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -133,6 +133,7 @@ def _build_open_pr_status(
     return PrStatusInfo(
         workspace_id=workspace_id,
         pr_state="open",
+        has_conflicts=_parse_conflict_status(pr_node),
         pr_iid=pr_node["number"],
         pr_title=pr_node.get("title"),
         pr_web_url=pr_node.get("url"),
@@ -155,6 +156,8 @@ _PR_QUERY_LIMIT = 5
 # field on the GraphQL ``PullRequest`` type, so unresolved-comment surfacing
 # actually works. Requesting ``statusCheckRollup { state }`` (one aggregate
 # enum) rather than every individual check context also lowers the point cost.
+# ``mergeable`` (MERGEABLE / CONFLICTING / UNKNOWN) surfaces merge conflicts so
+# the CI babysitter can act on a conflicted PR the same way it does for an MR.
 # ``{owner}`` / ``{repo}`` in the field args are expanded by gh from the
 # working directory's ``origin`` remote, so no repo plumbing is needed here.
 _GRAPHQL_PR_QUERY = """
@@ -167,6 +170,7 @@ query($owner: String!, $name: String!, $branch: String!, $limit: Int!) {
         url
         state
         baseRefName
+        mergeable
         commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
         latestReviews(first: 20) { nodes { state author { login } } }
         reviewThreads(first: 30) {
@@ -219,6 +223,26 @@ def _fetch_prs_with_details(working_dir: Path, source_branch: str) -> list[dict]
     if repository is None:
         return []
     return (repository.get("pullRequests") or {}).get("nodes") or []
+
+
+def _parse_conflict_status(pr_node: dict) -> bool | None:
+    """Map a PR's GitHub ``mergeable`` enum to our tri-state conflict flag.
+
+    GitHub computes mergeability asynchronously and exposes it as
+    ``MERGEABLE`` / ``CONFLICTING`` / ``UNKNOWN``. ``CONFLICTING`` means the PR
+    cannot merge cleanly into its base (a merge conflict); ``MERGEABLE`` means
+    it can. ``UNKNOWN`` (GitHub hasn't finished computing, common right after a
+    push) and any unrecognized/missing value map to None, so we neither claim a
+    conflict nor claim cleanliness until GitHub is sure. This mirrors GitLab's
+    ``has_conflicts`` (bool | None) so the CI babysitter's MERGE_CONFLICT
+    transition fires identically for PRs and MRs.
+    """
+    mergeable = pr_node.get("mergeable")
+    if mergeable == "CONFLICTING":
+        return True
+    if mergeable == "MERGEABLE":
+        return False
+    return None
 
 
 def _parse_check_status(pr_node: dict) -> Literal["running", "passed", "failed"] | None:

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -31,15 +31,18 @@ def _pr_node(
     check_state: str | None = None,
     reviews: list[dict] | None = None,
     threads: list[dict] | None = None,
+    mergeable: str | None = None,
 ) -> dict:
     """Build one graphql ``pullRequests.nodes`` entry in the given GitHub state.
 
     Mirrors the shape returned by the single ``gh api graphql`` query the
     backend now issues: identity fields alongside the check/review/comment
-    detail (``statusCheckRollup`` is null when no checks have run).
+    detail (``statusCheckRollup`` is null when no checks have run). ``mergeable``
+    is GitHub's ``MERGEABLE`` / ``CONFLICTING`` / ``UNKNOWN`` merge-conflict enum;
+    it is included only when provided so unrelated tests keep their minimal shape.
     """
     rollup = {"state": check_state} if check_state is not None else None
-    return {
+    node = {
         "number": number,
         "title": f"PR #{number}",
         "url": f"https://github.com/org/repo/pull/{number}",
@@ -49,6 +52,9 @@ def _pr_node(
         "latestReviews": {"nodes": reviews or []},
         "reviewThreads": {"nodes": threads or []},
     }
+    if mergeable is not None:
+        node["mergeable"] = mergeable
+    return node
 
 
 def _open_node(number: int, base_ref: str = "main", **kwargs) -> dict:  # noqa: ANN003
@@ -256,6 +262,43 @@ def test_status_check_rollup_state_maps_to_pipeline_status(rollup_state: str | N
 
 
 # ---------------------------------------------------------------------------
+# Open PR merge conflict → has_conflicts flows through (parity with GitLab MRs).
+# GitHub reports mergeability via the ``mergeable`` enum; CONFLICTING means the
+# PR cannot merge cleanly. Surfacing it as has_conflicts=True is what lets the
+# CI babysitter's MERGE_CONFLICT transition fire for PRs the same way it does
+# for MRs (mr_status sets has_conflicts from glab's ``has_conflicts``).
+# ---------------------------------------------------------------------------
+
+
+def test_open_pr_has_conflicts_flag_flows_through() -> None:
+    with _patch_cli(_graphql_handler([_open_node(700, mergeable="CONFLICTING")])):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.has_conflicts is True
+
+
+@pytest.mark.parametrize(
+    ("mergeable", "expected"),
+    [
+        ("CONFLICTING", True),
+        ("MERGEABLE", False),
+        # GitHub computes mergeability asynchronously; UNKNOWN (common right
+        # after a push) and any unrecognized/absent value stay None so we never
+        # claim a conflict — or claim cleanliness — before GitHub is sure.
+        ("UNKNOWN", None),
+        (None, None),
+        ("SOMETHING_NEW", None),
+    ],
+)
+def test_mergeable_state_maps_to_has_conflicts(mergeable: str | None, expected: bool | None) -> None:
+    with _patch_cli(_graphql_handler([_open_node(10, mergeable=mergeable)])):
+        result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
+
+    assert result.has_conflicts is expected
+
+
+# ---------------------------------------------------------------------------
 # The query must request the fields the parser reads, via `gh api graphql`.
 # This is the unit-level guard against regressing to the broken approach
 # (mocks can never exercise real gh field validation — see the live test below).
@@ -277,7 +320,15 @@ def test_graphql_query_requests_the_fields_the_parser_reads() -> None:
     assert cmd[:3] == ["gh", "api", "graphql"]
     query = _captured_query(cmd)
     # Every field the parser navigates must be present in the query.
-    for field in ("statusCheckRollup", "state", "baseRefName", "latestReviews", "reviewThreads", "commits"):
+    for field in (
+        "statusCheckRollup",
+        "state",
+        "baseRefName",
+        "latestReviews",
+        "reviewThreads",
+        "commits",
+        "mergeable",
+    ):
         assert field in query, f"query is missing field {field!r}"
     # `reviewThreads` is requested directly (it is a valid GraphQL PullRequest
     # field, unlike `gh pr view --json`'s curated subset that shipped the bug).

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -114,6 +114,29 @@ def _install_fake_glab(fake_bin_dir: Path, script: str) -> None:
     script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
 
 
+_FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
+
+# Fake `gh` returning one OPEN PR that GitHub reports as CONFLICTING. The
+# backend issues a single `gh api graphql` query; this node carries
+# "mergeable":"CONFLICTING", so a backend that surfaces PR merge conflicts maps
+# it to has_conflicts=True and the babysitter fires on the very first poll (a
+# merge conflict needs no baseline change, unlike a pipeline failure -- see
+# transitions.classify_transitions). A backend that ignores the mergeable field
+# (the SCU-1529 bug) leaves has_conflicts=None and no babysitter tab appears.
+_FAKE_GH_CONFLICTING_PR_SCRIPT = """\
+#!/bin/bash
+if [[ "$*" == *"graphql"* ]]; then
+    echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","mergeable":"CONFLICTING","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
+fi
+"""
+
+
+def _install_fake_gh(fake_bin_dir: Path, script: str) -> None:
+    script_path = fake_bin_dir / "gh"
+    script_path.write_text(textwrap.dedent(script))
+    script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
+
+
 def _install_state_driven_glab(instance: SculptorInstance, state_file: Path, pipeline_id_file: Path) -> None:
     _install_fake_glab(
         instance.fake_bin_dir,
@@ -160,6 +183,10 @@ def _enable_babysitter(instance: SculptorInstance) -> None:
 
 
 _PIPELINE_PROMPT_FRAGMENT = "Investigate the failing pipeline for this MR"
+
+# Fragment of the default merge-conflict prompt (user_config.CIBabysitterConfig).
+# Chosen to be provider-neutral so the assertion survives the "MR"/"PR" wording.
+_MERGE_CONFLICT_PROMPT_FRAGMENT = "merge conflict with its base branch"
 
 
 def _bump_pipeline_id_after_baseline(page, pipeline_id_file: Path, new_id: str) -> None:
@@ -451,3 +478,32 @@ def test_restart_reuses_existing_babysitter_tab(
 
         expect(pipeline_prompts).to_have_count(2, timeout=60_000)
         expect(agent_tabs.get_agent_tab_by_name("CI Babysitter")).to_have_count(1)
+
+
+@user_story("to have the CI Babysitter automatically resolve a merge conflict on a GitHub PR")
+def test_github_pr_merge_conflict_creates_babysitter(sculptor_instance_: SculptorInstance) -> None:
+    """When a GitHub PR opened from a workspace has a merge conflict, the
+    coordinator spawns a 'CI Babysitter' agent tab and delivers the configured
+    merge-conflict prompt -- at parity with GitLab MR conflict handling.
+
+    Regression for SCU-1529: the GitHub PR status path never surfaced
+    has_conflicts (the `gh api graphql` query didn't request `mergeable`, and
+    the parser didn't map it), so the coordinator's MERGE_CONFLICT transition
+    never fired for PRs and no babysitter tab ever appeared. A merge conflict
+    surfaces on the first poll, so -- unlike the pipeline-failure scenarios --
+    no baseline bump is needed.
+    """
+    _enable_babysitter(sculptor_instance_)
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_CONFLICTING_PR_SCRIPT)
+    _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
+
+    start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
+
+    agent_tabs = PlaywrightAgentTabBarElement(sculptor_instance_.page)
+    babysitter_tab = agent_tabs.get_agent_tab_by_name("CI Babysitter")
+    expect(babysitter_tab.first).to_be_visible(timeout=60_000)
+
+    babysitter_tab.first.click()
+    alpha_chat = get_alpha_chat_view(sculptor_instance_.page)
+    conflict_prompt_messages = alpha_chat.get_messages().filter(has_text=_MERGE_CONFLICT_PROMPT_FRAGMENT)
+    expect(conflict_prompt_messages.first).to_be_visible()


### PR DESCRIPTION
## Original bug

> PR status doesn't detect merge conflicts, so the CI Babysitter never fixes them
>
> GitHub PR status detection doesn't surface merge conflicts, so the CI Babysitter is never triggered to resolve them. GitLab MR status already detects merge conflicts and triggers the babysitter correctly. Bring PR merge-conflict detection to parity with MR detection so a conflicted PR is flagged and the babysitter kicks in to fix it, the same way it does for MRs.

Linear: [SCU-1529](https://linear.app/imbue/issue/SCU-1529/pr-status-doesnt-detect-merge-conflicts-so-the-ci-babysitter-never)

## Hypotheses considered

1. **GitHub PR status never surfaces `has_conflicts`** — REPRODUCED. The `gh api graphql` query in `pr_status.py` never requested a mergeability field and `_build_open_pr_status` never set `has_conflicts`, so it stayed `None` for every PR. The CI babysitter's `MERGE_CONFLICT` transition only fires when `has_conflicts is True`, so it could never fire for a GitHub PR — whereas GitLab's `_build_open_mr_status` sets `has_conflicts` from `glab`'s JSON. This is the whole bug; no other independent hypotheses were needed.

## For each reproduced bug

### CI Babysitter never fires for a conflicted GitHub PR

**Repro steps**

The bug lives in backend PR-status polling and surfaces in the UI as a missing "CI Babysitter" agent tab. It is reproduced deterministically by an end-to-end Playwright test (`test_github_pr_merge_conflict_creates_babysitter`) that drives the real Sculptor UI:

1. Install a fake `gh` CLI that returns one OPEN pull request whose GitHub `mergeable` field is `CONFLICTING` (a merge conflict).
2. Point the workspace's `origin` remote at a GitHub URL so the poller uses the `gh`/PR path.
3. Enable the CI Babysitter in settings.
4. Start a workspace agent (the most-recently-used, driveable agent the babysitter can spawn from).
5. Wait for the backend to poll PR status and for the coordinator to react.

A merge conflict surfaces on the very first poll (`transitions.classify_transitions` fires `MERGE_CONFLICT` even when `prev is None`), so — unlike the pipeline-failure scenarios — no baseline bump is needed.

**Expected vs actual**
- Expected: a "CI Babysitter" agent tab appears with the configured merge-conflict prompt, exactly as it does for a conflicted GitLab MR.
- Actual: no babysitter tab ever appears. The conflict is invisible to the coordinator, so it never acts.

**Before**

The e2e test drives the real UI and asserts on the (absent) "CI Babysitter" tab. Against the pre-fix code it fails because the tab never appears — the right evidence for a presence/absence bug is the deterministic 60s wait, not a static screenshot of a missing element. This is a backend-detection fix (no frontend rendering change beyond a settings copy line), so per `.sculptor/code.md`'s Proof of Work the evidence is the failing-then-passing `/run-integration-test` output.

```
>       expect(babysitter_tab.first).to_be_visible(timeout=60_000)
E       AssertionError: Locator expected to be visible
E       Actual value: <element(s) not found>
E       Call log:
E         - Expect "to_be_visible" with timeout 60000ms
E         - waiting for get_by_test_id("AGENT_TAB").filter(has_text="CI Babysitter").first

sculptor/tests/integration/frontend/test_ci_babysitter.py:437: AssertionError
======================== 1 failed in 117.11s (0:01:57) =========================
```

Unit-level (pre-fix), in `pr_status_test.py`:
```
FAILED ...::test_open_pr_has_conflicts_flag_flows_through
FAILED ...::test_mergeable_state_maps_to_has_conflicts[CONFLICTING-True]
FAILED ...::test_mergeable_state_maps_to_has_conflicts[MERGEABLE-False]
FAILED ...::test_graphql_query_requests_the_fields_the_parser_reads  (query is missing field 'mergeable')
```

**Root cause**

`sculptor/sculptor/web/pr_status.py` builds an open PR's status from a single `gh api graphql` query. That query (`_GRAPHQL_PR_QUERY`) requested `number`, `title`, `url`, `state`, `baseRefName`, the status-check rollup, reviews, and review threads — but **no mergeability field** — and `_build_open_pr_status` never populated `PrStatusInfo.has_conflicts`. As a result every GitHub PR reported `has_conflicts=None`. The CI babysitter's `MERGE_CONFLICT` transition (`services/ci_babysitter_service/transitions.py`) only appends when `new.has_conflicts is True`, so it was unreachable for PRs. GitLab's path (`mr_status.py::_build_open_mr_status`) sets `has_conflicts=mr_data.get("has_conflicts")` from `glab`'s JSON, which is why MRs already worked.

**Fix**

In `pr_status.py`: add `mergeable` to `_GRAPHQL_PR_QUERY`, add `_parse_conflict_status` that maps GitHub's `mergeable` enum (`CONFLICTING` → `True`, `MERGEABLE` → `False`, `UNKNOWN`/missing → `None`), and pass `has_conflicts=_parse_conflict_status(pr_node)` into the `PrStatusInfo` built by `_build_open_pr_status`. `mergeable` is a stable, non-preview field on the GraphQL `PullRequest` type, so no special Accept header is needed; mapping `UNKNOWN` to `None` matches GitLab's tri-state semantics (GitHub computes mergeability asynchronously, so `UNKNOWN` is common right after a push and must not be read as "no conflict"). The downstream transition/coordinator logic was already correct and provider-agnostic, so surfacing the flag is the entire fix. The settings copy that claimed merge-conflict babysitting was "Currently only available for GitLab MRs. Coming soon for GitHub PRs." was updated, since it now contradicts the shipped behavior.

**Test**
- Path: `sculptor/tests/integration/frontend/test_ci_babysitter.py::test_github_pr_merge_conflict_creates_babysitter` (e2e) plus unit coverage in `sculptor/sculptor/web/pr_status_test.py` (`test_open_pr_has_conflicts_flag_flows_through`, `test_mergeable_state_maps_to_has_conflicts`, and the `mergeable` field added to `test_graphql_query_requests_the_fields_the_parser_reads`).
- Kind: e2e (Playwright). Per `.sculptor/testing.md` an integration test is required and was used; the bug is reproducible through the UI (the babysitter tab), so no unit-only fallback was taken. The unit tests are supplementary regression coverage — in particular the query-field guard, since a fake `gh` can't validate the real GraphQL field name (the same class of gap that shipped the historical `reviewThreads` bug; the opt-in live-schema test covers it when run).
- Failing-test commit: `e57251c562`
- Fix commit: `be91c54dbc`

**After**

The same e2e test passes against the fixed code — the "CI Babysitter" tab now appears with the merge-conflict prompt within the first poll cycle (Call phase 20.71s):

```
…ntend/test_ci_babysitter.py::test_github_pr_merge_conflict_creates_babysitter     20.95s   20.71s    5.32s   46.98s
============================== 1 passed in 57.67s ==============================
```

Unit-level (post-fix), `pr_status_test.py`: `29 passed, 1 skipped` (the skip is the opt-in live-GitHub schema check). The four previously-failing assertions now pass.

A UI screenshot of the fixed behavior was captured from the passing e2e run and saved to the workspace at `attachments/bug-scu-1529-after.png`. It shows the workspace on **PR #42** with a **CI Babysitter** agent tab spawned next to "Claude 1" and the merge-conflict prompt delivered into it ("This MR has a merge conflict with its base branch. Fetch the latest, then rebase against the base branch, resolve all conflicts, and force-push the result."). GitHub PR descriptions can't render a local image path (there's no `gh` attachment-upload API), so the embedded evidence here is the failing→passing test output above — which, being a Playwright test, drives the real browser UI and asserts on the actual rendered tab and message. The fix surface is backend (`pr_status.py`); the only frontend change is the one-line settings copy correction.

## Deferred follow-ups

- **Generalize the CI Babysitter's MR-centric copy/prompt wording to cover PRs.** The default merge-conflict prompt ("This MR has a merge conflict…") and the "Enable CI Babysitter" `SettingRow` description ("when an MR's pipeline fails…") are now also delivered for GitHub PRs but still say "MR". This is cosmetic and the prompt is user-configurable, so it was kept out of this fix to avoid changing a behavior-affecting default string; the top-level settings description was updated here because it explicitly claimed PRs were unsupported. Tracked in [SCU-1537](https://linear.app/imbue/issue/SCU-1537/generalize-ci-babysitter-mr-centric-copyprompt-wording-to-cover-github).

## Review notes

The Phase A4.5 self-review (`/code-review-checklist`) ran against `d43a64e6c8...HEAD`. Findings I did not act on:

- **Proof-of-work / screenshot rule (declined as written, mitigated):** the checklist flags any diff touching a frontend file (`.tsx`) as requiring an embedded before/after screenshot rather than test output. I captured an after-screenshot (referenced above) rather than skip it, but GitHub PR bodies can't embed a local image path, so the embedded proof is the failing→passing test output. This is the `.sculptor/code.md` non-UI proof path, which fits since the fix is backend and the single `.tsx` change is a copy string a reviewer verifies by reading the diff.
- **MR-centric wording (declined for scope):** see Deferred follow-ups above.


---
(Sent by Claude)
