### PR TITLE
Clean up stale docs and dead build tooling

### DIFF
--- a/docs/help/changes.md
+++ b/docs/help/changes.md
@@ -30,7 +30,7 @@ If something looks wrong, send a follow-up message in the chat panel to ask the 
 
 ## Committing changes
 
-When you're satisfied with the changes, click the **Commit** button at the bottom of the Changes tab. The button label reflects the change count — for example, **Commit 2 changes**.
+When you're satisfied with the changes, click the **Commit** button in the header of the Changes tab. The button label reflects the change count — for example, **Commit 2 changes**.
 
 ![Commit button in the Changes tab showing the pending change count](images/commit_button.png)
 

--- a/docs/help/workspaces.md
+++ b/docs/help/workspaces.md
@@ -37,8 +37,11 @@ agent sessions.
 The default mode is **worktree** (above). Two other modes are available under
 **Settings > Experimental**:
 
-- **Clone** — a full, separate clone of the repo with its own `local` remote that
-  you sync back explicitly.
+- **Clone** — a full, separate clone of the repo with its own history and git
+  remotes that mirror your repo's (or, if your repo has no remotes, a single
+  `origin` pointing at your repo on disk). Changes stay in the clone; you bring
+  them back explicitly — push to a shared remote and pull locally, or push
+  directly to your on-disk repo.
 - **In-place** — the agent works directly in your original repository, with no
   separate copy.
 

--- a/justfile
+++ b/justfile
@@ -1029,21 +1029,6 @@ build-desktop-app:
     mkdir -p "{{justfile_directory()}}/dist/darwin-arm64"
     cp -r out/Sculptor-darwin-arm64/ "{{justfile_directory()}}/dist/darwin-arm64"
 
-# Uses electron forge to create an executable application for MacOS on x86_64. This app will not be bundled into an installer.
-[group("build")]
-[macos]
-build-desktop-app--x86_64:
-    #!/usr/bin/env arch -x86_64 /usr/local/bin/bash -l
-    {{ nvm_use }}
-    set -e
-    just refresh-assets
-    just sidecar "cpython-3.11.13-macos-x86_64-none"
-    cd "{{justfile_directory()}}/sculptor/frontend"
-    npm install --force
-    eval $(uv run --project sculptor builder setup-build-vars "${MODE:-dev}") && npm run electron:package -- --  --platform=darwin --arch=x64
-    mkdir -p "{{justfile_directory()}}/dist/Darwin-x86_64"
-    cp -r out/Sculptor-darwin-x64/ "{{justfile_directory()}}/dist/darwin-x86_64"
-
 # Uses electron forge to create an executable application for Linux. This app will not be bundled into an installer.
 [group("build")]
 [linux]

--- a/sculptor/sculptor/agents/default/constants.py
+++ b/sculptor/sculptor/agents/default/constants.py
@@ -84,7 +84,7 @@ You are working in a git worktree of the user's local repository (worktree mode)
 
 The checkout is a real git worktree, so the `.git` directory is shared with the user's repository on disk. Commits you make on this branch are immediately visible in the user's working copy — there is no separate sync step.
 
-Because the `.git` is shared, the remotes you see (e.g. `origin`) are the user's real remotes. There is no `local` remote; sync-back is automatic via the shared object store.
+Because the `.git` is shared, the remotes you see (e.g. `origin`) are the user's real remotes, and there is no `local` remote. Your commits and branch are written straight into the user's `.git`, so they show up in the user's repo automatically.
 
 You can push changes normally with `git push`, but NEVER do so without explicit permission from the user.
 </Environment mode>

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -119,7 +119,7 @@ def create(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace ID (or set SCULPT_WORKSPACE_ID)"),
     prompt: str | None = typer.Option(None, "--prompt", "-p", help="The task prompt"),
     model: str = typer.Option(
-        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m])"
+        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)"
     ),
     name: str | None = typer.Option(None, "--name", help="Agent name"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -420,7 +420,7 @@ def send(
     message: str = typer.Argument(..., help="Message to send"),
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace ID (or set SCULPT_WORKSPACE_ID)"),
     model: str = typer.Option(
-        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m])"
+        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)"
     ),
     file: list[str] | None = typer.Option(None, "--file", help="Files to include (repeatable)"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Stream the agent's response after sending"),

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -31,7 +31,7 @@ def run_cmd(
         ),
     ),
     model: str = typer.Option(
-        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m])"
+        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)"
     ),
     strategy: str = typer.Option(
         "worktree",


### PR DESCRIPTION
## Summary

Removes two holdovers left behind by removed features, and fixes a few small doc/CLI inaccuracies.

### Stale-holdover cleanup
- **`docs/help/workspaces.md`** — Rewrote the **Clone** workspace-mode bullet. The `local` remote no longer exists; the bullet now describes actual clone behavior: the clone's git remotes mirror the source repo (with a fallback `origin` pointing at the on-disk repo when the source has none), and changes are brought back by an explicit push rather than via a `local` remote. This matches the agent-facing `CLONE_MODE_PROMPT`.
- **`justfile`** — Removed the dead `build-desktop-app--x86_64` recipe. macOS Intel is not a shipped target (the `Target` enum has no `MAC_X64`), and nothing references the recipe. The shared `install-build-deps-x86_64` toolchain is intentionally kept, since the installer recipe still relies on it.

### Small accuracy fixes
- **`docs/help/changes.md`** — The Commit button is in the Changes-tab header, not at the bottom.
- **`agents/default/constants.py`** — Clarified the worktree-mode prompt's sync-back wording.
- **sculpt CLI** (`agent.py`, `run.py`) — Listed `fable` as a valid `--model` option; it was already an accepted alias.

## Testing
`just format`, `just check`, and `just test-unit` were all run. `format` and `check` pass clean. The only `test-unit` failures were two pre-existing parallelism flakes (a `btw_service` concurrency test and a PTY terminal test) in subsystems untouched by this change — both pass when re-run in isolation.

(Sent by Claude)
