### PR TITLE
Draft non-auto-send actions into the PTY for terminal agents

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/useTerminalChatActions.ts
+++ b/sculptor/frontend/src/pages/workspace/components/useTerminalChatActions.ts
@@ -12,8 +12,9 @@ import { useTaskAcceptsAutomatedPrompts, useTaskStatus } from "~/common/state/ho
  * custom actions) work for automated-prompt-capable terminal agents.
  *
  * When the agent's registration opted in (`acceptsAutomatedPrompts`),
- * `sendMessage` routes the prompt through the terminal-input endpoint so it
- * arrives as typed input; otherwise nothing is registered and every consumer
+ * `sendMessage` (auto-send) and `appendText` (non-auto-send draft) both route
+ * the prompt through the terminal-input endpoint, differing only in whether
+ * the submit Enter is sent; otherwise nothing is registered and every consumer
  * stays disabled by default. Consumers are untouched — the routing decision
  * lives entirely in which hook registered the actions.
  */
@@ -29,20 +30,32 @@ export const useTerminalChatActions = (taskId: string): void => {
       // disabled state registered.
       return;
     }
+
+    // Both prompt seams write through the same terminal-input endpoint and
+    // differ only in whether the submit Enter is sent. `submit: true`
+    // (auto-send actions, Commit, Create PR) types the prompt and submits it;
+    // `submit: false` (non-auto-send "draft" actions) types it into the PTY
+    // and leaves it unsubmitted for the user to edit/send — the terminal
+    // counterpart of appendText populating a rich-chat composer.
+    const writePrompt = async (text: string, submit: boolean): Promise<void> => {
+      try {
+        await postAgentTerminalInput({ path: { agent_id: taskId }, body: { text, submit } });
+      } catch {
+        // The endpoint's authoritative guard fired: the program went busy
+        // (or its hooks are silent) between the click and the write.
+        // Surface it; do not retry.
+        setPromptRejectedToast({ title: "Agent is busy", description: "Try again when it's at its prompt." });
+      }
+    };
     setChatActions((prev) => ({
       ...prev,
-      // No editor exists for terminal agents — appendText/insertSkill stay
-      // null and consumers already null-check them.
-      sendMessage: async (message: string): Promise<void> => {
-        try {
-          await postAgentTerminalInput({ path: { agent_id: taskId }, body: { text: message, submit: true } });
-        } catch {
-          // The endpoint's authoritative guard fired: the program went busy
-          // (or its hooks are silent) between the click and the write.
-          // Surface it; do not retry.
-          setPromptRejectedToast({ title: "Agent is busy", description: "Try again when it's at its prompt." });
-        }
+      // No rich-text editor exists for terminal agents, so insertSkill stays
+      // null (consumers already null-check it). appendText drafts the prompt
+      // into the PTY without submitting (submit: false).
+      appendText: (text: string): void => {
+        void writePrompt(text, false);
       },
+      sendMessage: (message: string): Promise<void> => writePrompt(message, true),
     }));
   }, [setChatActions, setPromptRejectedToast, doesAcceptAutomatedPrompts, taskId]);
 

--- a/sculptor/tests/integration/frontend/test_terminal_agent_automated_prompts.py
+++ b/sculptor/tests/integration/frontend/test_terminal_agent_automated_prompts.py
@@ -12,6 +12,7 @@ import re
 
 from playwright.sync_api import expect
 
+from sculptor.testing.elements.action_dialog import get_action_dialog
 from sculptor.testing.elements.agent_tab import PlaywrightAgentTabBarElement
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.elements.terminal import get_agent_terminal_panel
@@ -119,3 +120,95 @@ def test_prompt_features_route_to_capable_terminal_agent(sculptor_instance_: Scu
     finally:
         (registrations_dir / "fake-prompts.toml").unlink(missing_ok=True)
         (registrations_dir / "fake-noprompt.toml").unlink(missing_ok=True)
+
+
+@user_story("to draft a non-auto-send action into a capable terminal agent without submitting it")
+def test_non_auto_send_action_drafts_into_terminal_without_submitting(sculptor_instance_: SculptorInstance) -> None:
+    """A non-auto-submit ("draft") action must insert its text into a capable
+    terminal agent's PTY *without* submitting it — mirroring how the same action
+    populates a rich-chat composer for the user to edit/send. Before the fix,
+    terminal agents registered only ``sendMessage`` and left ``appendText`` null,
+    so clicking a draft action was a silent no-op.
+
+    Proof strategy: a draft insert (``submit=false``) writes a bracketed-paste
+    body with no trailing Enter, so the program's ``read`` stays blocked and the
+    drafted text sits in the line buffer (echoed, but unsubmitted). A later
+    auto-submit action sends the Enter, completing that same line — so the
+    program receives BOTH prompts concatenated in a single ``RECEIVED:`` line.
+    That single line proves the draft was inserted (it is present) AND that it
+    was not submitted on its own (it only surfaced once the second action sent
+    the Enter). With the bug present, the draft never reaches the PTY, so only
+    the second prompt appears.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        page, prompt="Draft action terminal test", workspace_name="Draft Action WS"
+    )
+
+    registrations_dir = sculptor_instance_.sculptor_folder / "terminal_agents"
+    registrations_dir.mkdir(parents=True, exist_ok=True)
+    (registrations_dir / "fake-prompts.toml").write_text(
+        f'display_name = "Fake Prompts"\nlaunch_command = "{_FAKE_PROMPTS_COMMAND}"\naccepts_automated_prompts = true\n'
+    )
+    try:
+        # Create a draft action (auto-submit OFF) and an auto-submit action.
+        # No spaces in the prompts so they land on a single xterm line and the
+        # concatenated RECEIVED line is matched exactly.
+        actions_panel = task_page.get_actions_panel()
+        actions_panel.get_add_button().click()
+        draft_dialog = get_action_dialog(page)
+        expect(draft_dialog).to_be_visible()
+        draft_dialog.fill_name("Draft Insert")
+        draft_dialog.fill_prompt("DRAFT-INSERT-PART")
+        # The auto-submit switch defaults ON; toggle it OFF so the chip drafts.
+        draft_dialog.get_auto_submit_switch().click()
+        draft_dialog.click_save()
+        expect(draft_dialog).not_to_be_visible()
+
+        actions_panel.get_add_button().click()
+        send_dialog = get_action_dialog(page)
+        expect(send_dialog).to_be_visible()
+        send_dialog.fill_name("Send Now")
+        send_dialog.fill_prompt("SEND-NOW-PART")
+        send_dialog.click_save()  # auto-submit stays ON
+        expect(send_dialog).not_to_be_visible()
+
+        # Launch the capable terminal agent and wait until it is at its prompt.
+        agent_tab_bar = PlaywrightAgentTabBarElement(page)
+        agent_tab_bar.open_agent_type_menu()
+        registered_item = agent_tab_bar.get_agent_type_menu_item_registered("fake-prompts")
+        expect(registered_item).to_be_visible()
+        registered_item.click()
+        prompts_tab = agent_tab_bar.get_agent_tab_by_name("Fake Prompts 1").first
+        expect(prompts_tab).to_be_visible()
+        expect(get_agent_terminal_panel(page)).to_be_visible()
+        wait_for_xterm_substring(page, "FAKE-PROMPTS-BANNER")
+        wait_for_xterm_substring(page, "IDLE-DONE")
+        expect(prompts_tab).to_have_attribute("data-dot-status", _NEUTRAL_DOT)
+
+        # Click the DRAFT action: its text must reach the PTY (visible via the
+        # line-discipline echo) WITHOUT being submitted. The echo is both the
+        # core regression assertion (a null appendText writes nothing) and the
+        # sync point that the write landed before the submit below.
+        actions_panel = task_page.get_actions_panel()
+        draft_chip = actions_panel.get_action_chip_by_name("Draft Insert")
+        expect(draft_chip).to_be_enabled()
+        draft_chip.click()
+        wait_for_xterm_substring(page, "DRAFT-INSERT-PART")
+
+        # A draft does not submit: no line was read, so the program never went
+        # busy and the tab dot stays neutral.
+        expect(prompts_tab).to_have_attribute("data-dot-status", _NEUTRAL_DOT)
+
+        # Click the AUTO-SUBMIT action: it sends the Enter that completes the
+        # single line already holding the drafted text.
+        send_chip = actions_panel.get_action_chip_by_name("Send Now")
+        expect(send_chip).to_be_enabled()
+        send_chip.click()
+
+        # One RECEIVED line carries BOTH prompts — proof the draft was inserted
+        # but held until the auto-submit action sent the Enter.
+        wait_for_xterm_substring(page, "RECEIVED:DRAFT-INSERT-PARTSEND-NOW-PART")
+    finally:
+        (registrations_dir / "fake-prompts.toml").unlink(missing_ok=True)


### PR DESCRIPTION
## Original bug

> For terminal agents, action buttons that auto-send work correctly, but action buttons that *don't* auto-send do nothing when clicked. They should insert their text into the PTY (without sending), matching the behavior of rich-chat agents where a non-auto-send action populates the input for the user to edit/send.

Ticket: [SCU-1533](https://linear.app/imbue/issue/SCU-1533/non-auto-send-action-buttons-are-a-no-op-for-terminal-agents)

## Hypotheses considered

1. **Non-auto-send actions route to `chatActions.appendText`, which `useTerminalChatActions` left `null` for terminal agents, so the click is a silent no-op** — **REPRODUCED**.

## For each reproduced bug

### Non-auto-send ("draft") action buttons are a no-op for terminal agents

**Repro steps**

1. Open a workspace and register a terminal agent that accepts automated prompts (a TOML under `<sculptor folder>/terminal_agents/` with `accepts_automated_prompts = true`).
2. Launch that terminal agent from the agent-type menu and wait until it signals idle (sitting at its prompt).
3. Open the **Actions** panel. The built-in Sculptor group's `/help` and `/fix-bug` chips are non-auto-submit ("draft") actions (`autoSubmit: false`); a user-created action with auto-submit toggled off behaves the same.
4. Click the `/help` chip (any non-auto-submit action).
5. Observe the terminal.

**Expected vs actual**

- **Expected:** the action's prompt text is typed into the terminal's PTY *without* being submitted, leaving it in the program's input line for the user to edit and press Enter — mirroring how a non-auto-send action populates a rich-chat composer.
- **Actual (before fix):** clicking the action does nothing at all — no text reaches the terminal. (Auto-submit actions and the Commit / Create PR buttons worked, because those route through `sendMessage`, which *was* wired.)

**Before**

Failing integration test (drives the real UI: creates a draft action, launches a capable terminal agent, clicks the draft chip, reads the real xterm buffer). The drafted text never reaches the PTY:

```
FAILED test_non_auto_send_action_drafts_into_terminal_without_submitting
AssertionError: Expected xterm buffer to contain 'DRAFT-INSERT-PART', but timed out. Buffer:
<user>@<host> code % echo FAKE-PROMPTS-BANNER; sculpt signal idle; printf %sDONE IDLE-; echo; while read -r _line; do echo RECEIVED:$_line; sculpt signal busy; done
FAKE-PROMPTS-BANNER
IDLE-DONE
========================= 1 failed in 71.69s =========================
```

Also verified visually with `/auto-qa-changes`: with a capable terminal agent at its prompt, clicking the built-in `/help` draft action left the terminal prompt empty (no-op). _(The before/after screenshots are not embedded here: the terminal captures include a local shell prompt of the form `<user>@<host>`, which must not be published to this public repo. They were captured and reviewed during the autonomous run.)_

**Root cause**

`ActionsPanel.handleActionClick` routes auto-submit actions to `chatActions.sendMessage` and non-auto-submit ("draft") actions to `chatActions.appendText` (`sculptor/frontend/src/pages/workspace/panels/ActionsPanel.tsx`). For terminal agents, `useTerminalChatActions` registered only `sendMessage` and left `appendText` (and `insertSkill`) `null`. Because the consumer calls `chatActions.appendText?.(...)`, the optional chaining turns a `null` `appendText` into a silent no-op — so auto-submit actions worked while every non-auto-submit action did nothing.

**Fix**

Register `appendText` for opted-in terminal agents in `useTerminalChatActions`. It writes the prompt through the same `/terminal/input` endpoint as `sendMessage`, but with `submit: false` — the endpoint already supports this and writes the prompt as a bracketed paste into the PTY *without* the trailing Enter, leaving it unsubmitted in the program's input line for the user to edit and send. `sendMessage` and `appendText` now share a single `writePrompt(text, submit)` helper that differs only in the submit flag (and shares the existing "Agent is busy" rejection toast). `insertSkill` stays `null` because terminal agents have no rich-text editor; the analogous SkillsPanel gap is tracked as a follow-up (see below).

**Test**

- Path: `sculptor/tests/integration/frontend/test_terminal_agent_automated_prompts.py::test_non_auto_send_action_drafts_into_terminal_without_submitting`
- Kind: e2e (Playwright integration). No fallback — the bug reproduces fully through the UI; this is exactly the right harness per the repo's test strategy (the bug is in Sculptor's own UI routing and does not depend on Claude's responses).
- Failing-test commit: `da593f8b2c`
- Fix commit: `4fc9a580de`

The test proves both halves of the desired behavior: a draft insert (`submit: false`) leaves the prompt unsubmitted, so the program's `read` stays blocked and the drafted text only surfaces — concatenated with a later auto-submit action — in a single `RECEIVED:` line.

**After**

Same test passes after the fix:

```
========================= 1 passed in 48.45s =========================
```

Visually (`/auto-qa-changes`): after the fix, clicking the `/help` draft action drafts `/sculptor:help` into the terminal's PTY and leaves it unsubmitted (no `RECEIVED:` line appears, i.e. it was not sent).

## Deferred follow-ups

- **Skill insertion is also a no-op for terminal agents.** `SkillsPanel` clicks call `chatActions.insertSkill`, which this change still leaves `null` for terminal agents. Out of scope for SCU-1533 (which is specifically about action buttons), and it likely warrants its own small design decision (draft `/skill-name` into the PTY vs. the full invocation). Tracked separately: [SCU-1538](https://linear.app/imbue/issue/SCU-1538/skill-insertion-is-a-no-op-for-terminal-agents-skillspanel-insertskill)

## Review notes

- **Proof-of-work screenshots not embedded (intentional).** Before/after screenshots were captured via `/auto-qa-changes` and reviewed during the autonomous run (before: clicking the built-in `/help` draft action on a capable terminal agent left the prompt empty; after: it drafts `/sculptor:help` into the PTY unsubmitted). They are not embedded in this body because the terminal captures show a local shell prompt (`<user>@<host>`) — PII that must not be published to this public repo — and GitHub PR bodies can't embed local image files via the CLI. The failing→passing integration test, which drives the real UI and reads the real xterm buffer, is the embedded proof instead.


---

*(Sent by Claude)*
