### PR TITLE
Fix white-on-white terminal text in light mode (SCU-1535)

### DIFF
--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
@@ -168,6 +168,15 @@ const buildTerminalTheme = (panelBg: string, appTheme: string): ITheme => {
     cursor: "#3B352B",
     cursorAccent: panelBg,
     selectionBackground: "#D4D0C8",
+    // xterm.js's built-in ANSI palette is tuned for a dark background — its
+    // "white" (#d3d7cf) and "brightWhite" (#eeeeec) are near-white. Programs
+    // that paint default/secondary text with ANSI white (e.g. Claude Code's
+    // diff context lines) therefore rendered white-on-white on the light panel
+    // background. Remap the white-family entries to the dark foreground tones
+    // so that text stays legible. Dark mode keeps xterm's defaults, which
+    // already read correctly against the dark background.
+    white: "#3B352B",
+    brightWhite: "#1C1813",
   };
 };
 

--- a/sculptor/sculptor/testing/elements/terminal.py
+++ b/sculptor/sculptor/testing/elements/terminal.py
@@ -346,6 +346,25 @@ def get_xterm_theme_foreground(page: Page) -> str:
     )
 
 
+def get_xterm_theme_color(page: Page, key: str) -> str:
+    """Return an arbitrary color from the xterm theme options by key.
+
+    Reads ``xterm.options.theme[key]`` (e.g. ``"white"``, ``"brightWhite"``,
+    one of the 16 ANSI palette entries) — the theme *config object* our code
+    builds, not a rendered/computed style. Returns ``""`` when the entry is
+    unset, which is exactly the buggy state for the ANSI palette in light mode
+    (an unset entry falls back to xterm.js's dark-tuned default).
+    """
+    return page.evaluate(
+        """(key) => {
+        const xterm = window.__xterm;
+        if (!xterm || !xterm.options.theme) return '';
+        return xterm.options.theme[key] || '';
+    }""",
+        key,
+    )
+
+
 def wait_for_xterm_theme_ready(page: Page) -> None:
     """Wait until the xterm theme has non-empty background and foreground colors."""
     try:

--- a/sculptor/tests/integration/regression/test_regression_terminal_light_mode_contrast.py
+++ b/sculptor/tests/integration/regression/test_regression_terminal_light_mode_contrast.py
@@ -90,10 +90,10 @@ def test_terminal_text_is_legible_in_light_mode(sculptor_instance_: SculptorInst
         color = get_xterm_theme_color(page, entry)
         assert color, (
             f"light-mode theme.{entry} is not set — it falls back to xterm.js's "
-            f"dark-tuned default, which is white-on-white against {background!r}"
+            + f"dark-tuned default, which is white-on-white against {background!r}"
         )
         ratio = _contrast_ratio(color, background)
         assert ratio >= _MIN_CONTRAST_RATIO, (
             f"light-mode theme.{entry} ({color}) has contrast {ratio:.2f}:1 against "
-            f"background {background} — below the {_MIN_CONTRAST_RATIO}:1 legibility floor"
+            + f"background {background} — below the {_MIN_CONTRAST_RATIO}:1 legibility floor"
         )

--- a/sculptor/tests/integration/regression/test_regression_terminal_light_mode_contrast.py
+++ b/sculptor/tests/integration/regression/test_regression_terminal_light_mode_contrast.py
@@ -1,0 +1,99 @@
+"""Regression test: terminal text must stay legible in light mode.
+
+In light mode, terminal output that uses the ANSI "white" / "bright white"
+palette entries — e.g. the *context* (unmodified) lines in a Claude Code
+file-write update block — rendered white-on-white and was impossible to read.
+The cause: ``buildTerminalTheme`` set only ``foreground``/``background``/etc.
+and never overrode the 16 ANSI palette colors, so xterm.js fell back to its
+built-in palette, which is tuned for a dark background (``white`` ≈ #d3d7cf,
+``brightWhite`` ≈ #eeeeec). Against the light-mode panel background those two
+entries have almost no contrast.
+
+This asserts the light-mode theme defines an ANSI palette whose white-family
+entries have real contrast against the background. It reads the xterm theme
+*config object* (``xterm.options.theme.white`` etc.), the same behavioural
+signal the sibling ``test_regression_terminal_theme_toggle.py`` reads for the
+background color — not a rendered/computed style.
+
+Distinct from ``test_regression_terminal_theme_toggle.py`` (which covers the
+terminal *background* updating on theme toggle); both live in the same xterm
+theme/palette code.
+"""
+
+from sculptor.testing.elements.terminal import get_xterm_theme_background
+from sculptor.testing.elements.terminal import get_xterm_theme_color
+from sculptor.testing.elements.terminal import get_xterm_theme_foreground
+from sculptor.testing.elements.terminal import open_terminal_and_wait
+from sculptor.testing.elements.terminal import wait_for_xterm_theme_change
+from sculptor.testing.elements.terminal import wait_for_xterm_theme_ready
+from sculptor.testing.pages.task_page import PlaywrightTaskPage
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# WCAG AA contrast ratio for normal-size text. The bug rendered white-on-white
+# (ratio ≈ 1.0:1); a correct light-mode palette clears this comfortably.
+_MIN_CONTRAST_RATIO = 4.5
+
+
+def _relative_luminance(hex_color: str) -> float:
+    """WCAG relative luminance of a ``#rrggbb`` color."""
+    value = hex_color.lstrip("#")
+    r, g, b = (int(value[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
+
+    def _channel(c: float) -> float:
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * _channel(r) + 0.7152 * _channel(g) + 0.0722 * _channel(b)
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    """WCAG contrast ratio between two ``#rrggbb`` colors (1.0 .. 21.0)."""
+    lighter = max(_relative_luminance(foreground), _relative_luminance(background))
+    darker = min(_relative_luminance(foreground), _relative_luminance(background))
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _switch_to_light_mode(page, task_page: PlaywrightTaskPage) -> None:
+    """Ensure the terminal theme is in light mode, toggling if needed.
+
+    The app defaults to dark mode, so one toggle normally suffices, but we
+    detect by background luminance rather than assuming the starting mode.
+    """
+    if _relative_luminance(get_xterm_theme_background(page)) <= 0.5:
+        old_bg = get_xterm_theme_background(page)
+        old_fg = get_xterm_theme_foreground(page)
+        task_page.toggle_theme()
+        wait_for_xterm_theme_change(page, old_bg, old_fg)
+    assert _relative_luminance(get_xterm_theme_background(page)) > 0.5, (
+        f"expected a light terminal background after switching to light mode, got {get_xterm_theme_background(page)!r}"
+    )
+
+
+@user_story("to read terminal output in light mode without it being white-on-white")
+def test_terminal_text_is_legible_in_light_mode(sculptor_instance_: SculptorInstance) -> None:
+    """The light-mode terminal theme must give ANSI white-family text real contrast."""
+    page = sculptor_instance_.page
+    task_page = PlaywrightTaskPage(page=page)
+
+    start_task_and_wait_for_ready(sculptor_page=page, prompt="Hello")
+    open_terminal_and_wait(page)
+    wait_for_xterm_theme_ready(page)
+
+    _switch_to_light_mode(page, task_page)
+
+    background = get_xterm_theme_background(page)
+    # ANSI "white" (index 7) and "brightWhite" (index 15) are what programs use
+    # for light-on-dark "default" / context text; these are the entries that
+    # rendered white-on-white before the fix.
+    for entry in ("white", "brightWhite"):
+        color = get_xterm_theme_color(page, entry)
+        assert color, (
+            f"light-mode theme.{entry} is not set — it falls back to xterm.js's "
+            f"dark-tuned default, which is white-on-white against {background!r}"
+        )
+        ratio = _contrast_ratio(color, background)
+        assert ratio >= _MIN_CONTRAST_RATIO, (
+            f"light-mode theme.{entry} ({color}) has contrast {ratio:.2f}:1 against "
+            f"background {background} — below the {_MIN_CONTRAST_RATIO}:1 legibility floor"
+        )


### PR DESCRIPTION
## Original bug

> Terminal agent text renders white-on-white in light mode
>
> In light mode, terminal agent output doesn't always render legibly. Example:
> when Claude writes to a file, it shows an update block — newly-added text
> (highlighted green) renders correctly, but unmodified/context lines render as
> white-on-white and are impossible to read. In dark mode the same content
> renders correctly as white-on-black. Fix the light-mode color handling so
> unhighlighted terminal text uses a foreground color with proper contrast
> against the light background (likely the ANSI "default foreground" palette
> entry for light mode).
>
> Note: this is a *distinct* symptom from the already-fixed terminal-theme-toggle
> bug (guarded by `test_regression_terminal_theme_toggle.py`), which was about
> the terminal *background* color. They live in the same xterm theme/palette
> code — reuse it, don't reopen that fix.

Linear: SCU-1535

## Hypotheses considered

1. **The xterm theme never sets the 16 ANSI palette colors, so light-mode
   "white" ANSI text falls back to xterm.js's dark-tuned defaults and renders
   white-on-white** — REPRODUCED.
2. Context lines use the SGR *default foreground* (which our theme already sets
   to a dark color in light mode) — DISCARDED: if that were the cause the text
   would already be legible in light mode (our light foreground is `#3B352B`),
   which contradicts the bug. Cell inspection (below) confirmed the context
   lines use ANSI palette indices 7/15, not the default foreground.
3. Context lines use 24-bit truecolor white (which a palette remap could not
   fix) — DISCARDED: cell inspection showed the cells are `palette:7` /
   `palette:15`, i.e. true ANSI palette entries, so a palette remap is the
   correct lever.

## For each reproduced bug

### Terminal ANSI white/brightWhite text is white-on-white in light mode

**Repro steps**
1. Open Sculptor (default theme is dark) and create a workspace.
2. Add a **Terminal** agent (its main panel is a PTY rendered by xterm.js).
3. In the shell, print a Claude-style file-write update block where the
   *context* lines use ANSI white / bright-white and the *added* line uses ANSI
   green, e.g.:
   ```
   printf '\033[1m== Update(demo.py) ==\033[0m\n\033[37m  1    def greet(name):\033[0m\n\033[97m  2        return hello name\033[0m\n\033[32m  3 +      print(greeting)\033[0m\n\033[37m  4    trailing context line\033[0m\n'
   ```
4. Toggle to light mode (Cmd/Ctrl+Shift+D).

**Expected vs actual**
- Expected: every line in the block is legible against the light background.
- Actual: the context lines (ANSI white `\033[37m` / bright-white `\033[97m`)
  render white-on-white and are invisible; only the bold header and the green
  added line are readable. In dark mode all lines are legible.

**Before**
Captured via `/auto-qa-changes` (real PTY terminal agent, light mode). The
context lines are washed out to near-invisible while the green added line stays
legible — the exact ticket symptom. Cell inspection of the xterm buffer
confirmed the foreground modes: context lines = `palette:7` (white) and
`palette:15` (brightWhite); added line = `palette:2` (green). In that state
`xterm.options.theme.white` / `.brightWhite` are unset (light bg `#f9f9f9`).
Screenshot: `scu1535-before-light-mode.png` (attached in the Sculptor session).

**Root cause**
`buildTerminalTheme` in `sculptor/frontend/src/pages/workspace/panels/useTerminal.ts`
built the xterm `ITheme` with only `background` / `foreground` / `cursor` /
`cursorAccent` / `selectionBackground`. It never overrode the 16 ANSI palette
colors, so xterm.js used its built-in palette, which is tuned for a dark
background: ANSI `white` is `#d3d7cf` and `brightWhite` is `#eeeeec` — both
near-white. Programs that paint default/secondary text with ANSI white — notably
Claude Code's diff *context* lines — therefore rendered at ~1.1–1.4:1 contrast
against the light-mode panel background (effectively white-on-white), while the
green additions (a different palette entry) stayed legible. Dark mode looked
correct only because near-white text reads fine on the dark background.

**Fix**
Remap the light-mode theme's `white` / `brightWhite` ANSI entries to the dark
foreground tones (`#3B352B` / `#1C1813`) so that ANSI-white-painted terminal
text has real contrast (≈11:1 / ≈17:1) on the light panel background. The change
is confined to the light-mode branch of `buildTerminalTheme`; dark mode is
untouched and keeps xterm's defaults, which already read correctly against the
dark background. This reuses the existing theme/palette code rather than
reopening the separate terminal-background fix.

**Test**
- Path: `sculptor/tests/integration/regression/test_regression_terminal_light_mode_contrast.py`
- Kind: e2e (Playwright integration). It opens a terminal, toggles to light
  mode, and asserts the theme's `white` / `brightWhite` ANSI entries clear a
  WCAG legibility floor (4.5:1) against the background — reading the xterm theme
  *config object*, the same behavioural signal the sibling
  `test_regression_terminal_theme_toggle.py` reads for the background color (not
  a rendered/computed style, so it is not a layout-only test).
- Failing-test commit: `197d747ecb`
- Fix commit: `daf8062315`

Failing run (before the fix):
```
E   AssertionError: light-mode theme.white is not set — it falls back to
    xterm.js's dark-tuned default, which is white-on-white against '#f9f9f9'
======================== 1 failed in 106.03s =========================
```
Passing run (after the fix):
```
============================== 1 passed in 56.65s ==============================
```

**After**
Captured via `/auto-qa-changes` (same flow, after the fix). The context lines
now render in the dark foreground tone (`#3B352B`, sampled), the green added
line is unchanged, and no white-on-white remains. Dark mode was re-checked and
is unchanged (context lines still light-on-dark and legible). Screenshots:
`scu1535-after-light-mode.png` and `scu1535-dark-mode-unchanged.png` (attached
in the Sculptor session).

> Note on screenshots: this PR was produced by an autonomous agent driving a
> headless browser; the before/after PNGs are attached in the originating
> Sculptor session. GitHub PR bodies can't host local images via the CLI, so
> the visual evidence is summarized above and backed by the failing→passing
> integration-test output and the xterm cell-color inspection.

## Deferred follow-ups

- **[SCU-1540](https://linear.app/imbue/issue/SCU-1540/light-mode-terminal-remap-remaining-low-contrast-bright-ansi-colors)** —
  the other light-on-dark ANSI defaults (`brightYellow` `#fce94f`, `brightGreen`
  `#8ae234`, `brightCyan` `#34e2e2`) are also low-contrast on the light
  background. They were out of scope here (the ticket reports only the
  white/brightWhite context-line case, and the green additions render
  correctly), so they were intentionally left alone to keep the change minimal
  and avoid altering colors the ticket confirms work. SCU-1540 tracks providing
  a full light-mode ANSI palette if broader light-mode terminal legibility
  becomes a goal.

## Review notes

The Phase A4.5 self-review (`/code-review-checklist`) ran against `main...HEAD`.
Findings I did not act on, with rationale:

- **Proof-of-work (HIGH per the checklist):
Before:
<img width="1618" height="1041" alt="CleanShot 2026-06-18 at 13 36 12" src="https://github.com/user-attachments/assets/621f1e4a-74a3-4b19-b0ad-b1f36c7bc47e" />
After:
<img width="1616" height="1040" alt="CleanShot 2026-06-18 at 13 36 27" src="https://github.com/user-attachments/assets/f0f72e51-83e9-47f4-9c03-7531531e21e7" />

- **assert-vs-expect (LOW): the contrast checks use Python `assert`, not
  Playwright `expect()`.** The asserted values are `page.evaluate` reads of the
  xterm theme config taken after an auto-retrying `wait_for_xterm_theme_change`
  settle, and `expect()` cannot target a computed contrast ratio. This matches
  the sibling `test_regression_terminal_theme_toggle.py`; not a flake risk.
- **untyped `page` param (LOW): `_switch_to_light_mode(page, ...)` leaves `page`
  untyped.** Consistent with how the existing terminal helpers are called; the
  `no-untyped-args-kwargs` ratchet still passes. Left as-is to avoid further
  churn on the locked test file.

(Sent by Claude)
