### PR TITLE
Expand ~ in the file viewer and fix out-of-repo path display

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChipDiffPopover.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChipDiffPopover.module.scss
@@ -37,11 +37,20 @@
 
 .filePathDir {
   color: var(--gray-a9);
+  // `direction: rtl` left-truncates long paths (ellipsis on the leading dirs,
+  // keeping the segment nearest the file visible). On its own it makes the bidi
+  // algorithm treat an absolute path's leading "/" as a neutral at the start of
+  // an RTL run and reorder it to the visual end — so "/Users/x" renders as
+  // "Users/x/" and collides with the separator slash ("Users/x//file").
+  // `unicode-bidi: plaintext` pins the base direction to the first strong
+  // character (a letter), keeping the slash in place. Mirrors `.itemPathDim` in
+  // path-autocomplete/PathAutocomplete.module.scss.
   direction: rtl;
   flex-shrink: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  unicode-bidi: plaintext;
   white-space: nowrap;
 }
 

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/DiffFileHeader.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/DiffFileHeader.module.scss
@@ -12,8 +12,11 @@
 }
 
 .dirPath {
-  // stylelint-disable-next-line sculptor/no-hardcoded-values -- enough room for the ellipsis character
-  min-width: 2ch;
+  // Size to content and shrink/ellipsize under pressure. A fixed floor (e.g.
+  // `min-width: 2ch`, meant to reserve room for the ellipsis) padded a
+  // single-character directory — a home-dir `~` — out to two characters,
+  // leaving a visible gap between the `~` and the `/` separator.
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -1351,7 +1351,17 @@ def workspace_read_file(
             raise HTTPException(status_code=400, detail="Workspace environment not found")
 
         task_repo_path = environment.get_working_directory()
-        file_path = task_repo_path / read_file_request.file_path
+        requested_path = read_file_request.file_path
+        if requested_path == "~" or requested_path.startswith("~/"):
+            # A leading ~ addresses the environment's home directory, not a
+            # literal "~" entry under the workspace. Expand it against the
+            # environment's home (which may differ from the host process's
+            # $HOME) so a chip like ~/notes.txt opens the home file instead of
+            # <workspace>/~/notes.txt. The absolute result then flows through
+            # the host-readable direct-read path below.
+            file_path = environment.get_user_home_directory() / requested_path[2:]
+        else:
+            file_path = task_repo_path / requested_path
 
         # Try the workspace environment first (handles workspace-relative files).
         # Fall back to reading directly from the host filesystem for any

--- a/sculptor/tests/integration/frontend/test_file_chip_tilde_path_opens_home_file.py
+++ b/sculptor/tests/integration/frontend/test_file_chip_tilde_path_opens_home_file.py
@@ -1,0 +1,103 @@
+"""Tests that a file @-mention chip with a ``~/`` path opens the home-dir file.
+
+Regression test for SCU-1528: the file viewer treated a leading ``~`` literally
+and resolved it against the workspace (opening ``<workspace>/~/<file>``) instead
+of expanding ``~`` to the environment's home directory.  This drives the full
+pipeline: ``@~/<file>`` path-mode mention -> committed file chip -> click on the
+rendered chip -> ``openFileViewTabAtom`` -> the ``read-file`` endpoint ->
+``ReadOnlyPreview`` showing the home file's content.
+
+Sibling to ``test_at_mention_file_chip_click_opens_tab.py`` (the workspace-relative
+branch of the same chip-click flow) and ``test_at_mention_path_mode.py`` (the
+``@~/`` path-mode picker).  The home-sentinel fixture mirrors
+``test_path_tilde_display.py``.
+"""
+
+import os
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.constants import ElementIDs
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.diff_panel import get_diff_panel_from_page
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+
+@pytest.fixture
+def _home_marker_file() -> Generator[str, None, None]:
+    """Create a uniquely-named file under HOME and yield its basename.
+
+    The file viewer resolves a ``~/`` path against the environment's home
+    directory, which for the local test environment is the real ``$HOME`` the
+    server inherits.  We need a real, readable file there to prove the fix reads
+    the home file rather than ``<workspace>/~/<file>``.  The pid-suffixed name
+    keeps parallel test workers from colliding; mirrors the home-sentinel
+    pattern in ``test_path_tilde_display.py``.
+    """
+    marker = Path.home() / f"scu1528_home_marker_{os.getpid()}.txt"
+    marker.write_text("SCU-1528 home file contents\n")
+    try:
+        yield marker.name
+    finally:
+        marker.unlink(missing_ok=True)
+
+
+@user_story("to open a ~/ file chip and read the file from my home directory")
+def test_file_chip_with_tilde_path_opens_home_file(
+    sculptor_instance_: SculptorInstance,
+    _home_marker_file: str,
+) -> None:
+    page = sculptor_instance_.page
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt='fake_claude:text `{"text": "Ready"}`',
+    )
+    chat_panel = task_page.get_chat_panel()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    chat_input = chat_panel.get_chat_input()
+    mention_list = chat_panel.get_mention_list()
+
+    # Typing ``@~/<name>`` switches the picker into path mode (a live filesystem
+    # listing of $HOME) and filters to the marker file.  Enter commits a file
+    # chip whose id carries the literal ``~/`` path.
+    chat_input.press_sequentially(f"@~/{_home_marker_file}")
+    expect(mention_list).to_be_visible()
+    # Wait for the filtered entry to render before pressing Enter, otherwise the
+    # keypress no-ops against an empty list.
+    expect(chat_panel.get_mention_items().first).to_be_visible()
+    page.keyboard.press("Enter")
+    expect(mention_list).not_to_be_visible()
+
+    editor_chip = chat_panel.get_mention_spans()
+    expect(editor_chip).to_be_visible()
+
+    send_button = chat_panel.get_send_button()
+    expect(send_button).to_be_enabled()
+    send_button.click()
+    expect(chat_input).to_have_text("")
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
+
+    alpha_view = get_alpha_chat_view(page)
+    expect(alpha_view).to_be_visible()
+    latest_user_message = alpha_view.get_user_messages().last
+    rendered_chip = latest_user_message.get_by_test_id(ElementIDs.MENTION_SPAN)
+    expect(rendered_chip).to_be_visible()
+
+    # Clicking the rendered ``~/`` chip must open the file viewer on the home
+    # file.  Before the fix the viewer resolved ``<workspace>/~/<file>`` -> 404
+    # -> "Could not load file content"; after the fix ``~`` expands to $HOME and
+    # the read-only preview renders the file.
+    rendered_chip.click()
+
+    diff_panel = get_diff_panel_from_page(page)
+    expect(diff_panel).to_be_visible()
+    expect(diff_panel.get_tab_by_name(_home_marker_file).first).to_be_visible()
+    expect(diff_panel.get_read_only_preview()).to_be_visible()
+    expect(diff_panel).not_to_contain_text("Could not load file content")


### PR DESCRIPTION
## Original bug

> **File viewer doesn't expand `~` to the workspace home when opening a file chip** ([SCU-1528](https://linear.app/imbue/issue/SCU-1528/file-viewer-doesnt-expand-to-the-workspace-home-when-opening-a-file))
>
> When the chat shows a file chip, hovering lets the user open the file in the file viewer. If the file path is something like `~/<file>`, the file viewer treats `~` literally and resolves it relative to the workspace — opening `<workspace>/~/<file>` instead of the file under the home directory. The viewer needs to expand a leading `~` (and `~/`) to the **workspace's home directory** rather than joining it onto the workspace path.

## Hypotheses considered

1. **The `read-file` endpoint joins a `~/` path onto the working directory instead of expanding it** — **REPRODUCED**. `workspace_read_file` builds the path as `task_repo_path / read_file_request.file_path`, so `~/<file>` resolves to `<workspace>/~/<file>`. Reproduced end-to-end and fixed (see below).
2. **The `ui/open-file` endpoint (`_resolve_open_file_target`) rejects `~/` paths** — **DISCARDED**. That endpoint serves the `sculpt` CLI "open file in UI" feature ("Resolve a *CLI-provided* absolute path"), where the shell expands `~` before the CLI ever sees it, so a literal `~/` rarely reaches it. It is a separate code path from the in-app file viewer this ticket describes, so it is intentionally out of scope here.

## For each reproduced bug

### File viewer shows "Could not load file content" for a `~/` file chip

**Repro steps**

1. Open Sculptor and create a workspace/agent on any repo.
2. Ensure a file exists in the home directory the backend runs as, e.g. `~/notes.txt` with some contents.
3. In the chat input, type `@~/notes.txt`. The leading `~` switches the `@`-mention picker into **path mode**, which lists the home directory live and surfaces `notes.txt`.
4. Press <kbd>Enter</kbd> to commit the file chip, then send the message.
5. In the sent message, click the rendered `notes.txt` file chip.

**Expected vs actual**

- Expected: the file viewer opens and shows the contents of `~/notes.txt` (the file under the home directory).
- Actual (before fix): the file viewer opens a tab labelled `notes.txt`, but the preview shows **"Could not load file content"** — the backend resolved `<workspace>/~/notes.txt`, which does not exist, and returned 404.

**Before**

Captured with the manual QA harness (`/auto-qa-changes`) against the unfixed code: clicking the `~/`-path file chip opens the viewer tab, but the read-only preview region renders **"Could not load file content"** instead of the file. Screenshot saved at `attachments/screenshots/scu1528-before-file-viewer-tilde.png`. (Not embedded inline: the capture includes a terminal strip showing the developer's local username/hostname, which this repo's public-visibility policy treats as PII to keep out of a world-readable PR. The deterministic failing-test output below is the embedded, reproducible before-evidence.)

The corresponding integration assertion fails on the unfixed code (failing-test commit `91bee538ec`):

```
>       expect(diff_panel.get_read_only_preview()).to_be_visible()
E       AssertionError: Locator expected to be visible
E       Actual value: <element(s) not found>
E       Call log:
E         - Expect "to_be_visible" with timeout 30000ms
E         - waiting for get_by_test_id("DIFF_PANEL").get_by_test_id("READ_ONLY_PREVIEW")
```

**Root cause**

`workspace_read_file` in `sculptor/sculptor/web/app.py` built the target path as `file_path = task_repo_path / read_file_request.file_path`, where `task_repo_path` is `environment.get_working_directory()`. Python's `Path` join treats `~/<file>` as a relative segment, so the result was `<workspace>/~/<file>` — a literal `~` directory under the workspace. `environment.exists()` returns false for that path and it is not an existing absolute file, so the endpoint raised 404, and the frontend `ReadOnlyPreview` rendered "Could not load file content". The endpoint never expanded `~` to the home directory.

**Fix**

Before joining, detect a leading `~` or `~/` and expand it against `environment.get_user_home_directory()` — the home directory *inside* the environment, which can differ from the backend host process's `$HOME` — rather than joining it onto the workspace path. The resulting absolute path then flows unchanged through the endpoint's existing host-readable direct-read fallback, so no other logic changes. `~user`-style paths and all non-tilde paths fall through to the original `task_repo_path / requested_path` branch, preserving prior behavior. Using the environment's own home (rather than `Path.expanduser()`, which reads the host process `$HOME`) keeps the resolution correct for environments whose home differs from the host.

**Test**

- Path: `sculptor/tests/integration/frontend/test_file_chip_tilde_path_opens_home_file.py`
- Kind: e2e (Playwright). Drives the full user flow — `@~/<file>` path-mode mention → committed file chip → click → `read-file` → `ReadOnlyPreview` — and asserts the preview renders rather than showing "Could not load file content". A `_home_marker_file` fixture creates a uniquely-named, self-cleaning file under `Path.home()` so there is a real home-directory file to read (the local test environment's home is the real `$HOME` the server inherits; this mirrors the existing `test_path_tilde_display.py` home-sentinel pattern).
- Failing-test commit: `91bee538ec`
- Fix commit: `2dbddd7396`

**After**

Captured with the manual QA harness against the fixed code: clicking the same `~/`-path file chip opens the viewer and renders the home file's contents (`SCU-1528 home file contents` / `This file lives under ~ (the home directory).`). Screenshot saved at `attachments/screenshots/scu1528-after-file-viewer-tilde.png` (not embedded inline, same PII reason as above).

The same integration test passes on the fixed code:

```
PASSED sculptor/tests/integration/frontend/test_file_chip_tilde_path_opens_home_file.py::test_file_chip_with_tilde_path_opens_home_file
========================= 1 passed in 66.28s (0:01:06) =========================
```

## Follow-on visual fixes

Verifying the fix above exercised the file viewer and file chips with **out-of-repo / home-directory paths** for the first time — previously those files could not be opened at all — which surfaced two pre-existing, purely-cosmetic rendering bugs in the same area. Both are fixed here. Per the repo's test policy, purely-visual bugs are verified by inspection rather than automated tests: a DOM-text assertion can't see either one, because the underlying path strings are already correct and only the rendered glyph order / spacing was wrong. Both were confirmed by hand in the running app.

### File chip mangled an absolute path as `Users/<user>//file` (commit `aa52ff9b77`)

- **Symptom:** the agent tool-result file chip rendered an absolute path like `/Users/<user>/1.txt` as `Users/<user>//1.txt` — leading slash missing, doubled slash before the basename — and the displaced slash could not be selected with the mouse.
- **Root cause:** `AlphaChipDiffPopover` renders the directory segment in a span styled `direction: rtl` (to left-truncate long paths). The Unicode bidi algorithm treats an absolute path's leading `/` as a neutral at the start of an RTL run and reorders it to the visual end, where it collides with the `/` separator span. The selection oddity is the same artifact — visual order no longer matched logical order. The stored path was always correct; only the rendering was wrong (the breadcrumb and "Copy file path" both produced the right string).
- **Fix:** add `unicode-bidi: plaintext` to `.filePathDir` so the bidi base direction follows the first strong character (a letter), keeping the slash in place while preserving left-truncation. Mirrors the existing `.itemPathDim` rule in `path-autocomplete`.

### File-viewer header added a stray space after a `~` directory (commit `da13be32ad`)

- **Symptom:** opening a home-directory file (e.g. `~/1.txt`) showed a visible gap between the `~` and the `/` separator in the viewer's breadcrumb header.
- **Root cause:** the breadcrumb's directory segment is a flex item with a `min-width: 2ch` floor (intended to reserve room for the truncation ellipsis). A home-dir directory is a single `~`, so the unconditional floor stretched the 1ch content out to 2ch, leaving a ~1-character gap before the separator.
- **Fix:** change `min-width: 2ch` to `min-width: 0` (the standard flexbox-ellipsis idiom) so the segment sizes to its content and still shrinks / ellipsizes for long paths.

## Review notes

The Phase A4.5 self-review (`/code-review-checklist`) surfaced two findings, both deliberately not acted on:

- `test_file_chip_tilde_path_opens_home_file.py` — `_home_marker_file` writes to `Path.home()`, which the `isolate_from_host_filesystem` rule flags as host-filesystem dependence. Kept because the bug is *defined* as resolving `~` against the environment's home and the integration harness inherits the real `$HOME` with no override hook, so a controlled file under `Path.home()` is the only way to exercise this through the real UI. It follows the established precedent of `test_path_tilde_display.py` / `test_path_autocomplete_keyboard.py`, uses a pid-suffixed name for per-xdist-worker uniqueness, and cleans up via `try/finally`.
- `test_file_chip_tilde_path_opens_home_file.py` — `latest_user_message.get_by_test_id(ElementIDs.MENTION_SPAN)` reaches for a test id directly (`use_pom_hierarchy`). Kept because it is scoped to a POM-derived locator and mirrors the sibling `test_at_mention_file_chip_click_opens_tab.py` verbatim.

The two follow-on visual fixes have no automated tests by policy (purely visual; see that section); they are CSS-only and were verified by inspection in the running app.

No work was deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
