### PR TITLE
Broadcast agent renames so terminal tabs update live

### DIFF
--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
@@ -162,6 +162,9 @@ class _StubTaskService(TaskService):
     def mark_unread(self, task_id: TaskID, transaction: DataModelTransaction) -> Task:
         return _stub(task_id, transaction)
 
+    def rename_task(self, task_id: TaskID, title: str, transaction: DataModelTransaction) -> Task:
+        return _stub(task_id, title, transaction)
+
     def update_available_models(
         self,
         task_id: TaskID,

--- a/sculptor/sculptor/services/task_service/api.py
+++ b/sculptor/sculptor/services/task_service/api.py
@@ -64,6 +64,16 @@ class TaskService(Service, ABC):
     def mark_unread(self, task_id: TaskID, transaction: DataModelTransaction) -> Task: ...
 
     @abstractmethod
+    def rename_task(self, task_id: TaskID, title: str, transaction: DataModelTransaction) -> Task:
+        """Set an agent task's title and publish the update.
+
+        Writes `title` onto the task's `AgentTaskStateV2` and registers the same
+        task-update publish a message write does, so live subscribers refresh
+        even though the rename created no message. Without this an idle terminal
+        agent's tab keeps its old name until a tab switch forces a re-fetch
+        (SCU-1531)."""
+
+    @abstractmethod
     def update_available_models(
         self,
         task_id: TaskID,

--- a/sculptor/sculptor/services/task_service/base_implementation.py
+++ b/sculptor/sculptor/services/task_service/base_implementation.py
@@ -218,6 +218,23 @@ class BaseTaskService(TaskService, ABC):
         transaction.add_callback(lambda: self._publish_task_update(task=updated_task))
         return updated_task
 
+    def rename_task(self, task_id: TaskID, title: str, transaction: DataModelTransaction) -> Task:
+        assert isinstance(transaction, SQLTransaction)
+        task = self.get_task(task_id, transaction)
+        if not task:
+            raise TaskNotFound(f"{task_id} not found")
+        assert isinstance(task.current_state, AgentTaskStateV2)
+        logger.debug("Renaming task {} to {!r}", task_id, title)
+        updated_state = task.current_state.evolve(task.current_state.ref().title, title)
+        updated_task = task.evolve(task.ref().current_state, updated_state)
+        updated_task = transaction.upsert_task(updated_task)
+        # Publish the same task-update a message write registers, so live
+        # subscribers refresh even though this rename created no message. Without
+        # it, an idle terminal agent (no message activity to piggyback on) keeps
+        # its old tab name until a tab switch forces a re-fetch (SCU-1531).
+        transaction.add_callback(lambda: self._publish_task_update(task=updated_task))
+        return updated_task
+
     def update_available_models(
         self,
         task_id: TaskID,

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2011,11 +2011,10 @@ def rename_workspace_agent(
         workspace = _get_workspace_or_404(workspace_id, transaction)
         task = _validate_agent_in_workspace(agent_id, workspace, transaction, services)
 
-        assert isinstance(task.current_state, AgentTaskStateV2)
-        updated_state = task.current_state.evolve(task.current_state.ref().title, rename_request.title)
-        updated_task = task.evolve(task.ref().current_state, updated_state)
-        # pyrefly: ignore [missing-attribute]
-        transaction.upsert_task(updated_task)
+        # rename_task both persists the new title and publishes a task update,
+        # so live subscribers (e.g. an idle terminal agent's tab) refresh
+        # immediately without a tab switch (SCU-1531).
+        updated_task = services.task_service.rename_task(task.object_id, rename_request.title, transaction)
 
         task_view = create_initial_task_view(updated_task, settings)
         assert isinstance(task_view, CodingAgentTaskView)

--- a/sculptor/tests/integration/frontend/test_terminal_agent_external_rename.py
+++ b/sculptor/tests/integration/frontend/test_terminal_agent_external_rename.py
@@ -1,0 +1,105 @@
+"""Integration test for live propagation of an external terminal-agent rename.
+
+Regression test for SCU-1531: renaming a terminal agent via the ``sculpt`` CLI
+(which hits ``PATCH /api/v1/workspaces/{workspace_id}/agents/{agent_id}``)
+looked like a no-op in the UI. The new name only appeared after the user
+switched tabs, which forced a re-fetch of the agent list.
+
+The cause was server-side: the rename endpoint persisted the new title but
+never broadcast a task update to live WebSocket subscribers. Coding agents
+masked the bug because their constant message activity piggybacks the fresh
+title onto the next broadcast; an idle terminal agent ("no message-queue
+subscription, no title generation") never re-broadcasts, so its tab stayed
+stale until a tab switch.
+
+This test reproduces the external rename faithfully by issuing the PATCH the
+CLI issues and asserting the tab label updates live, with NO tab switch.
+
+The terminal agent is driven to a fully idle state (a shell round-trip) BEFORE
+the rename: its one startup task message (``EnvironmentAcquiredRunnerMessage``)
+has already been published by then, so an idle terminal produces no further
+broadcast that could accidentally carry the new title and mask the bug.
+"""
+
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+from sculptor.foundation.itertools import only
+from sculptor.testing.elements.agent_tab import PlaywrightAgentTabBarElement
+from sculptor.testing.elements.terminal import get_agent_terminal_textarea
+from sculptor.testing.elements.terminal import run_command_in_agent_terminal
+from sculptor.testing.elements.terminal import wait_for_xterm_substring
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+
+def _create_terminal_agent(agent_tab_bar: PlaywrightAgentTabBarElement) -> None:
+    agent_tab_bar.open_agent_type_menu()
+    agent_tab_bar.get_agent_type_menu_item_terminal().click()
+
+
+def _drive_terminal_to_idle(page: Page) -> None:
+    """Wait until the terminal's shell is up and responsive, then idle.
+
+    A successful shell round-trip proves the backend acquired the environment
+    (so the one-shot ``EnvironmentAcquiredRunnerMessage`` task publish has
+    already happened) and the PTY is live. After this the terminal agent emits
+    no further task updates, so a later rename's broadcast — or its absence —
+    is observed in isolation.
+    """
+    expect(get_agent_terminal_textarea(page)).to_be_attached()
+    page.wait_for_timeout(3_000)
+    run_command_in_agent_terminal(page, "echo terminal-ready-marker")
+    wait_for_xterm_substring(page, "terminal-ready-marker")
+
+
+@user_story("to see a terminal agent's tab update live when it is renamed via sculpt")
+def test_terminal_agent_external_rename_updates_tab_live(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """An external (sculpt/API) rename of a terminal agent updates its tab live.
+
+    Steps:
+    1. Create a workspace with a chat agent, then add a terminal agent and
+       drive it to a fully idle state.
+    2. Resolve the workspace and terminal-agent IDs via the backend API.
+    3. Rename the terminal agent with a direct PATCH (as `sculpt agent rename`
+       does), without switching tabs.
+    4. Verify the terminal tab's label updates live to the new name.
+    """
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="External Rename WS")
+    agent_tab_bar = PlaywrightAgentTabBarElement(page)
+    agent_tabs = agent_tab_bar.get_agent_tabs()
+    expect(agent_tabs).to_have_count(1)
+
+    # Step 1: Add a terminal agent. It is created second, so it is the tab at
+    # index 1 and is labeled "Terminal 1". Drive it to idle so its startup
+    # task message can't mask the rename broadcast.
+    _create_terminal_agent(agent_tab_bar)
+    expect(agent_tabs).to_have_count(2)
+    terminal_tab = agent_tabs.nth(1)
+    expect(terminal_tab).to_have_text("Terminal 1")
+    _drive_terminal_to_idle(page)
+
+    # Step 2: Resolve the workspace and terminal-agent IDs via the backend API,
+    # exactly as the sculpt CLI does (list workspaces, then list agents).
+    base_url = sculptor_instance_.backend_api_url.rstrip("/")
+    workspaces = page.request.get(f"{base_url}/api/v1/workspaces/recent").json()["workspaces"]
+    workspace_id = only(ws["objectId"] for ws in workspaces if not ws.get("isDeleted"))
+    agents = page.request.get(f"{base_url}/api/v1/workspaces/{workspace_id}/agents").json()
+    terminal_agent_id = only(agent["id"] for agent in agents if agent["title"] == "Terminal 1")
+
+    # Step 3: Rename the terminal agent with the same PATCH `sculpt agent
+    # rename` issues. We deliberately do NOT switch tabs afterward: the only way
+    # the UI can learn the new name is a live broadcast from the server.
+    response = page.request.patch(
+        f"{base_url}/api/v1/workspaces/{workspace_id}/agents/{terminal_agent_id}",
+        data={"title": "Renamed By Sculpt"},
+    )
+    assert response.ok, f"rename request failed: {response.status} {response.text()}"
+
+    # Step 4: The tab label must update live, without a tab switch forcing a
+    # re-fetch.
+    expect(terminal_tab).to_have_text("Renamed By Sculpt")


### PR DESCRIPTION
## Original bug

> Renaming a terminal agent via `sculpt` doesn't update the UI until a tab switch ([SCU-1531](https://linear.app/imbue/issue/SCU-1531))
>
> Using `sculpt` to rename a terminal agent looks like a no-op in the UI — the new name doesn't appear until the user switches workspace or agent tabs (forcing a re-render). The rename should propagate live so the tab/label updates immediately without needing a tab switch.

## Hypotheses considered

1. **The rename endpoint never broadcasts the change to live subscribers, and terminal agents (unlike coding agents) never re-broadcast on their own.** — **REPRODUCED.**
2. *Frontend reactivity/memoization bug in the agent-tab component* — **DISCARDED.** The tab label reads `agent.title` from the `tasksArrayAtom` Jotai store and re-renders correctly when that store changes; the UI-driven rename (context menu) already updates live because the HTTP response writes the store directly. The data simply never arrives over the live channel, so this is not a render bug.
3. *Terminal tabs read their name from a different source (terminal registry/config) than coding tabs* — **DISCARDED.** Terminal and coding tabs render through the same `AgentTabs` path and both read `agent.title`; there is no terminal-specific label source.

## For each reproduced bug

### Terminal-agent rename via the external API doesn't propagate live

**Repro steps**
1. Create a workspace with a chat agent ("Claude 1").
2. Add a Terminal agent (it appears as the "Terminal 1" tab) and let its shell come up.
3. From the terminal agent's own shell, run the external rename exactly as the CLI does:
   `sculpt agent rename "$SCULPT_AGENT_ID" "Renamed By Sculpt"` (equivalently, `PATCH /api/v1/workspaces/{workspace_id}/agents/{agent_id}` with `{"title": "Renamed By Sculpt"}`).
4. Do **not** switch tabs.

**Expected vs actual**
- Expected: the "Terminal 1" tab updates to "Renamed By Sculpt" immediately.
- Actual: the tab keeps showing "Terminal 1"; the new name only appears after switching tabs (which forces a re-fetch of the agent list).

**Before**

`sculpt` reports the rename succeeded (`Agent tsk_… renamed to 'Renamed By Sculpt'.`) but the agent tab is unchanged. The committed e2e test reproduces this deterministically — on `main` it fails at the live-update assertion:

```
E   AssertionError: Locator expected to have text 'Renamed By Sculpt'
E   Actual value: Terminal 1
E   Call log:
E     - Expect "to_have_text" with timeout 30000ms
E     - waiting for get_by_test_id("AGENT_TAB").nth(1)
E       34 × locator resolved to <div role="tab" ... aria-selected="true" data-testid="AGENT_TAB">…</div>
E          - unexpected value "Terminal 1"
```

A manual before-screenshot (`attachments/screenshots/scu-1531-before-terminal-rename-stale.png`) shows the same: the terminal prints the success line, yet the tab still reads "Terminal 1".

**Root cause**

`rename_workspace_agent` in `sculptor/sculptor/web/app.py` persisted the new title with `transaction.upsert_task(...)` but never registered a `_publish_task_update` callback. Every other live-affecting task mutation in `task_service/base_implementation.py` (`mark_read`, `mark_unread`, `update_available_models`, `delete_task`) registers that callback so a `TaskMessageContainer` is broadcast to the WebSocket subscribers that feed the frontend's `tasksArrayAtom`. Without it, an external rename produced no broadcast. The reason it surfaced specifically for **terminal** agents: a coding agent constantly emits messages (status, title prediction), and each `create_message` re-publishes the freshly-read task row — piggybacking the new title onto the next broadcast. A terminal agent is silent by design ("no message-queue subscription, no title generation"), so nothing ever re-broadcast its task, and the tab stayed stale until a tab switch forced a re-fetch.

**Fix**

Move the rename into a new `TaskService.rename_task(task_id, title, transaction)` method that, exactly like `mark_read`/`mark_unread`/`update_available_models`, writes the title onto the task's `AgentTaskStateV2` and registers a `_publish_task_update` callback after the upsert. The endpoint now calls `services.task_service.rename_task(...)`. Every connected client refreshes the tab label live, regardless of agent type. The UI-driven rename path does not double-render: the frontend's `updateTasksAtom` skips equal task data, so the added broadcast is deduped against the optimistic store update.

**Test**
- Path: `sculptor/tests/integration/frontend/test_terminal_agent_external_rename.py`
- Kind: e2e (Playwright). It creates a terminal agent, drives it to a fully idle state (so its one startup message can't accidentally carry the rename), renames it through the real PATCH endpoint, and asserts the tab updates live with **no** tab switch.
- Failing-test commit: `5cdfcd1138`
- Fix commit: `2f3d54a131`

**After**

With the fix, the same test passes:

```
[gw0] [100%] PASSED sculptor/tests/integration/frontend/test_terminal_agent_external_rename.py::test_terminal_agent_external_rename_updates_tab_live
============================ 1 passed in 91.44s (0:01:31) ============================
```

Manual after-verification (`attachments/screenshots/scu-1531-after-terminal-rename-live.png`): running the same `sculpt agent rename` from inside the terminal flips the tab from "Terminal 1" to "Renamed By Sculpt" within ~2s, with no tab switch.

## Visual verification

Before/after screenshots were captured through the manual-test harness (the workspace's `attachments/screenshots/` directory):
- `scu-1531-before-terminal-rename-stale.png` — `sculpt` reports the rename succeeded, but the agent tab still reads "Terminal 1".
- `scu-1531-after-terminal-rename-live.png` — after the fix, the agent tab reads "Renamed By Sculpt" live, with no tab switch.

## Review notes

- **LOW** — `sculptor/tests/integration/frontend/test_terminal_agent_external_rename.py` (`_drive_terminal_to_idle`): the helper uses a fixed `page.wait_for_timeout(3_000)`, but it is followed by a retrying readiness check (`run_command_in_agent_terminal` + `wait_for_xterm_substring`), so it is not the flaky `sleep-then-snapshot` pattern. It mirrors the established `_wait_for_terminal_ready` helper in `test_terminal_agent_basic.py`. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
