### PR TITLE
Make Stop terminate a running workspace setup command

### DIFF
--- a/sculptor/frontend/src/common/state/hooks/useInterruptAgent.ts
+++ b/sculptor/frontend/src/common/state/hooks/useInterruptAgent.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { interruptWorkspaceAgent } from "../../../api";
 import { type ToastContent, ToastType } from "../../../components/Toast.tsx";
 import { isInterruptingAtomFamily } from "../atoms/interruptState.ts";
+import { workspaceSetupStatusAtomFamily } from "../atoms/workspaceSetupStatus.ts";
 
 type UseInterruptAgentResult = {
   isInterrupting: boolean;
@@ -37,6 +38,21 @@ export function useInterruptAgent(
     const interruptingAtom = isInterruptingAtomFamily(taskID);
     if (store.get(interruptingAtom)) return;
     store.set(interruptingAtom, true);
+    // A workspace setup command runs as its own process (the backend
+    // SetupCommandRunner), independent of the agent. While it's still running
+    // alongside the agent's turn, interrupting the agent alone leaves it
+    // running — so cancel it too, mirroring the setup card's own Cancel button.
+    // The backend streams the resulting terminal state back, which updates the
+    // setup card in the UI (SCU-1527). Best-effort: a no-op if setup already
+    // finished, and a failure here must not block the agent interrupt below.
+    if (store.get(workspaceSetupStatusAtomFamily(workspaceID))?.status === "running") {
+      try {
+        await fetch(`/api/v1/workspaces/${workspaceID}/setup/cancel`, { method: "POST" });
+      } catch (error) {
+        console.error("Failed to cancel workspace setup:", error);
+      }
+    }
+
     try {
       await interruptWorkspaceAgent({ path: { workspace_id: workspaceID, agent_id: taskID } });
       setToast({ title: "Agent stopped successfully", type: ToastType.SUCCESS });

--- a/sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py
+++ b/sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py
@@ -12,14 +12,17 @@ from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.setup_status import PlaywrightSetupStatusElement
+from sculptor.testing.fake_claude_pause import FakeClaudePause
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# A prompt that just sleeps — the agent stays busy with no output, so the chat
-# status pill keeps showing its Stop button while setup runs concurrently.
-_SLEEP_PROMPT = 'fake_claude:sleep `{"seconds": 120}`'
+# A setup command that runs effectively forever, so it can never finish on its
+# own within the test window — the only way the card leaves its running state
+# is the Stop button (the behaviour under test) or the cleanup cancel. A short
+# sleep could complete naturally on a slow runner and mask the bug.
+_LONG_SETUP_COMMAND = "sleep 600"
 
 
 def _configure_setup_command(page: Page, command: str) -> None:
@@ -30,7 +33,7 @@ def _configure_setup_command(page: Page, command: str) -> None:
 
 
 def _best_effort_cancel_setup(setup_status: PlaywrightSetupStatusElement) -> None:
-    """Cancel a still-running setup so a lingering ``sleep`` doesn't race the
+    """Cancel a still-running setup so the long-lived ``sleep`` doesn't race the
     Playwright trace teardown (mirrors the setup-reminder tests). Best-effort:
     if setup already terminated, the cancel button is gone and there's nothing
     to do."""
@@ -45,46 +48,50 @@ def test_stop_button_cancels_running_setup_command(sculptor_instance_: SculptorI
     terminate the setup command and surface the stopped state in the setup
     card.
 
-    Repro shape: configure a long-running setup command (``sleep 60``) and
-    start a turn that keeps the agent busy (``fake_claude:sleep``). Both run
-    concurrently, so the chat status pill shows its Stop button while the setup
-    card shows its running-only Cancel affordance. Clicking the chat Stop
-    button must drive the setup command to a terminal state — the running-only
-    Cancel affordance disappears and the terminal Rerun affordance appears.
+    Repro shape: configure a long-running setup command and start a turn that
+    keeps the agent busy (a ``FakeClaudePause`` sentinel, so the agent stays
+    mid-turn with no wall-clock race). Both run concurrently, so the chat
+    status pill shows its Stop button while the setup card shows its
+    running-only Cancel affordance. Clicking the chat Stop button must drive
+    the setup command to a terminal state — the running-only Cancel affordance
+    disappears and the terminal Rerun affordance appears.
 
     With the bug present, the Stop button only interrupts the agent: the setup
     subprocess keeps running, the card stays in its running state, and the
     Rerun affordance never appears.
     """
     page = sculptor_instance_.page
-    _configure_setup_command(page, "sleep 60")
+    _configure_setup_command(page, _LONG_SETUP_COMMAND)
 
     setup_status = PlaywrightSetupStatusElement(page)
+    pause = FakeClaudePause()
     try:
         task_page = start_task_and_wait_for_ready(
             sculptor_page=page,
-            prompt=_SLEEP_PROMPT,
+            prompt=pause.prompt,
             wait_for_agent_to_finish=False,
         )
         chat_panel = task_page.get_chat_panel()
 
         # Precondition 1: the agent is mid-turn, so the chat Stop button is up.
-        expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=15_000)
+        expect(chat_panel.get_thinking_indicator()).to_be_visible()
         stop_button = chat_panel.get_stop_button()
         expect(stop_button).to_be_visible()
 
         # Precondition 2: the setup command is running concurrently — the
         # running-only Cancel affordance proves it.
-        expect(setup_status.get_cancel_button()).to_be_visible(timeout=30_000)
+        expect(setup_status.get_cancel_button()).to_be_visible()
 
         # Act: click the chat Stop button.
         stop_button.click()
 
         # The setup command must terminate and the card must reflect the
         # stopped state: the running-only Cancel affordance disappears and the
-        # terminal Rerun affordance appears. ``sleep 60`` would otherwise keep
-        # the card in its running state well past this timeout.
-        expect(setup_status.get_rerun_button()).to_be_visible(timeout=20_000)
+        # terminal Rerun affordance appears.
+        expect(setup_status.get_rerun_button()).to_be_visible()
         expect(setup_status.get_cancel_button()).to_have_count(0)
     finally:
+        # Let the paused agent turn end naturally (Stop already killed it; this
+        # is belt-and-suspenders) and kill any setup left running on failure.
+        pause.release()
         _best_effort_cancel_setup(setup_status)

--- a/sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py
+++ b/sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py
@@ -1,0 +1,90 @@
+"""Test that the chat Stop button terminates a running workspace setup command.
+
+When a workspace setup command is still running while the agent is mid-turn,
+the chat status pill shows a Stop button. Clicking it must terminate the
+in-progress setup command (not just interrupt the agent) and the setup card
+must reflect the stopped/terminal state.
+
+See SCU-1527.
+"""
+
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.setup_status import PlaywrightSetupStatusElement
+from sculptor.testing.playwright_utils import navigate_to_settings_page
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# A prompt that just sleeps — the agent stays busy with no output, so the chat
+# status pill keeps showing its Stop button while setup runs concurrently.
+_SLEEP_PROMPT = 'fake_claude:sleep `{"seconds": 120}`'
+
+
+def _configure_setup_command(page: Page, command: str) -> None:
+    settings_page = navigate_to_settings_page(page=page)
+    repos = settings_page.click_on_repositories()
+    repos.expand_repo_config()
+    repos.set_setup_command(command)
+
+
+def _best_effort_cancel_setup(setup_status: PlaywrightSetupStatusElement) -> None:
+    """Cancel a still-running setup so a lingering ``sleep`` doesn't race the
+    Playwright trace teardown (mirrors the setup-reminder tests). Best-effort:
+    if setup already terminated, the cancel button is gone and there's nothing
+    to do."""
+    cancel_button = setup_status.get_cancel_button()
+    if cancel_button.count() > 0 and cancel_button.is_visible():
+        cancel_button.click()
+
+
+@user_story("to terminate a running workspace setup command by clicking the chat Stop button")
+def test_stop_button_cancels_running_setup_command(sculptor_instance_: SculptorInstance) -> None:
+    """Clicking the chat Stop button while a setup command is running must
+    terminate the setup command and surface the stopped state in the setup
+    card.
+
+    Repro shape: configure a long-running setup command (``sleep 60``) and
+    start a turn that keeps the agent busy (``fake_claude:sleep``). Both run
+    concurrently, so the chat status pill shows its Stop button while the setup
+    card shows its running-only Cancel affordance. Clicking the chat Stop
+    button must drive the setup command to a terminal state — the running-only
+    Cancel affordance disappears and the terminal Rerun affordance appears.
+
+    With the bug present, the Stop button only interrupts the agent: the setup
+    subprocess keeps running, the card stays in its running state, and the
+    Rerun affordance never appears.
+    """
+    page = sculptor_instance_.page
+    _configure_setup_command(page, "sleep 60")
+
+    setup_status = PlaywrightSetupStatusElement(page)
+    try:
+        task_page = start_task_and_wait_for_ready(
+            sculptor_page=page,
+            prompt=_SLEEP_PROMPT,
+            wait_for_agent_to_finish=False,
+        )
+        chat_panel = task_page.get_chat_panel()
+
+        # Precondition 1: the agent is mid-turn, so the chat Stop button is up.
+        expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=15_000)
+        stop_button = chat_panel.get_stop_button()
+        expect(stop_button).to_be_visible()
+
+        # Precondition 2: the setup command is running concurrently — the
+        # running-only Cancel affordance proves it.
+        expect(setup_status.get_cancel_button()).to_be_visible(timeout=30_000)
+
+        # Act: click the chat Stop button.
+        stop_button.click()
+
+        # The setup command must terminate and the card must reflect the
+        # stopped state: the running-only Cancel affordance disappears and the
+        # terminal Rerun affordance appears. ``sleep 60`` would otherwise keep
+        # the card in its running state well past this timeout.
+        expect(setup_status.get_rerun_button()).to_be_visible(timeout=20_000)
+        expect(setup_status.get_cancel_button()).to_have_count(0)
+    finally:
+        _best_effort_cancel_setup(setup_status)


### PR DESCRIPTION
## Original bug

> In a rich chat pane, while a workspace setup command is running we show a Stop button, but clicking it does nothing — the setup command keeps running. Wire the Stop button up so it actually terminates the in-progress setup command (and reflects the stopped state in the UI).

Linear: [SCU-1527](https://linear.app/imbue/issue/SCU-1527/stop-button-does-nothing-while-a-workspace-setup-command-is-running)

## Hypotheses considered

1. **The chat Stop button only interrupts the agent and never cancels a running setup command** — REPRODUCED. The status pill's Stop button (and the Esc keybinding) route through `useInterruptAgent.interrupt()`, which called only `interruptWorkspaceAgent`. A workspace setup command runs as its own backend process (`SetupCommandRunner`), so interrupting the agent left it running.

## For each reproduced bug

### Chat Stop button does not terminate a running workspace setup command

**Repro steps**

1. Configure a project workspace setup command that runs long enough to observe (e.g. `sleep 600`): Settings → Repositories → expand the repo config → set the setup command.
2. Create a new workspace and start a turn that keeps the agent busy while setup runs. In the test this is a `FakeClaudePause` sentinel (the agent stays mid-turn with no wall-clock); in real use it is any first turn that is still in progress while setup runs.
3. While the setup command is still running, the chat status pill shows a **Stop** button and the setup card shows its running-only **Cancel** affordance.
4. Click the chat **Stop** button.

**Expected vs actual**

- Expected: clicking Stop terminates the in-progress setup command, and the setup card moves to its terminal state (the running-only Cancel affordance disappears and the Rerun affordance appears).
- Actual (before fix): Stop only interrupts the agent. The setup subprocess keeps running, the setup card stays in its running state, and the Rerun affordance never appears.

**Before**

The e2e test fails on the pre-fix code because the setup card never leaves its running state after Stop is clicked. Both preconditions pass first (the chat Stop button is visible, and the setup card's Cancel affordance is visible), so the failure is specifically that Stop did not terminate setup:

```
>           expect(setup_status.get_rerun_button()).to_be_visible(timeout=20_000)
E           AssertionError: Locator expected to be visible
E             - waiting for get_by_test_id("setup-rerun-button")

sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py:89: AssertionError
========================= 1 failed in 64.07s (0:01:04) =========================
```

Deterministic before/after screenshots were also captured via the Playwright harness (FakeClaude). On the buggy build, after clicking Stop the agent's "Thinking…" pill clears but the setup card stays **running** (`sleep` still executing, Cancel affordance present, no Rerun). On the fixed build the same click drives the card to its terminal state (red, exited, **Rerun** affordance present). GitHub PR bodies can't embed local image files via the CLI, so the failing-then-passing e2e output above is the embedded evidence; the screenshots are saved in the originating workspace's attachments directory and were reviewed in that session.

**Root cause**

The status pill Stop button's `onClick` calls `interrupt()` from `useInterruptAgent` (`sculptor/frontend/src/common/state/hooks/useInterruptAgent.ts`), the single "stop the agent" entry point shared by the Stop button and the Esc keybinding. That function called only `interruptWorkspaceAgent`, which sends an `InterruptProcessUserMessage` to the agent harness. The workspace setup command, however, runs in a completely separate backend component — `SetupCommandRunner` (`sculptor/sculptor/services/workspace_service/setup_command_runner.py`) — kicked off in `DefaultWorkspaceService` before the agent's turn and cancelled only via the dedicated `POST /api/v1/workspaces/{id}/setup/cancel` endpoint. Interrupting the agent therefore had no effect on the setup subprocess, so it kept running and the setup card stayed in its running state. The setup card's own Cancel button hit the cancel endpoint correctly, but the chat Stop button — the primary stop affordance — did not.

**Fix**

`useInterruptAgent.interrupt()` now reads the workspace's setup status from the shared `workspaceSetupStatusAtomFamily` and, when it is `"running"`, POSTs to `/api/v1/workspaces/{id}/setup/cancel` (the same endpoint the setup card's Cancel button uses) in addition to interrupting the agent. The cancel runs best-effort in its own try/catch so it never blocks the agent interrupt, and it is a no-op when no setup is running. The backend's cancel path drives the runner to a terminal state and streams the new `SetupStateChanged` back, which updates the setup card — so the UI reflects the stopped state with no extra frontend wiring. Putting the change in the shared hook means both the Stop button and the Esc keybinding now terminate a running setup; the queued-message "interrupt and send" path is intentionally left agent-only.

**Test**

- Path: `sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py`
- Kind: e2e (Playwright + FakeClaude). The bug is about Sculptor's own Stop→setup wiring and does not depend on Claude's responses, so per `.sculptor/testing.md` FakeClaude is the correct stand-in; no unit-test fallback was needed.
- Failing-test commit: `ff7f380660`
- Fix commit: `f2a376201c`
- Test-hardening commit (self-review follow-up): `897b3981e9`

**After**

After the fix the test passes — clicking Stop terminates the setup command and the setup card reaches its terminal Rerun state:

```
[gw0] [100%] PASSED sculptor/tests/integration/frontend/test_stop_cancels_running_setup.py::test_stop_button_cancels_running_setup_command
============================== 1 passed in 33.85s ==============================
```

## Review notes

The self-review (`/code-review-checklist`) flagged two issues in the new integration test; both were acted on in the test-hardening follow-up commit, so there are no outstanding review notes:

- `no_wall_clock_in_fake_claude` — the test originally used `fake_claude:sleep` to keep the agent busy. Switched to the `FakeClaudePause` sentinel so the agent stays mid-turn without a wall-clock race.
- `no_lowered_timeouts` — removed the below-default `expect(...)` timeouts and switched the setup command to one that can't finish on its own within the test window (so a slow runner can't mask the bug via natural setup completion).

_(no outstanding review notes)_


(Sent by Claude)
