### PR TITLE
[SCU-1543] Fix out-of-workspace Edit tool calls vanishing from chat

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/__tests__/renderToolSegments.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/__tests__/renderToolSegments.test.ts
@@ -4,13 +4,19 @@ import type { ToolResultBlock, ToolUseBlock } from "~/api";
 
 import { segmentToolBlocks } from "../chipRowUtils.ts";
 
+const DIFF_TOOL_NAMES = new Set(["Edit", "Write", "MultiEdit"]);
+
 let idCounter = 0;
+// Diff-tool fixtures carry a derivable file path (input.file_path for a
+// tool_use, diff content with filePath for a tool_result) because real
+// file-change tools always do. segmentToolBlocks only routes a diff tool to a
+// chip when a path is derivable; path-less cases are covered explicitly below.
 const makeToolUse = (name: string, id = `tu-${name}-${idCounter++}`): ToolUseBlock => ({
   type: "tool_use",
   objectType: "ToolUseBlock",
   id,
   name,
-  input: {},
+  input: DIFF_TOOL_NAMES.has(name) ? { file_path: `/repo/${name}.ts` } : {},
   invocationString: "",
 });
 
@@ -20,7 +26,35 @@ const makeToolResult = (toolName: string, toolUseId = `tu-${toolName}`): ToolRes
   toolUseId,
   toolName,
   invocationString: "",
-  content: { contentType: "generic", text: "ok" } as ToolResultBlock["content"],
+  content: DIFF_TOOL_NAMES.has(toolName)
+    ? ({
+        contentType: "diff",
+        diff: "diff --git a/x b/x\n",
+        filePath: `/repo/${toolName}.ts`,
+      } as ToolResultBlock["content"])
+    : ({ contentType: "generic", text: "ok" } as ToolResultBlock["content"]),
+  isError: false,
+});
+
+// A diff-tool block with no derivable file path: a tool_use whose file_path
+// hasn't streamed in yet, or a completed tool_result that fell back to generic
+// content (e.g. a failed edit, or an edit to a file outside the workspace).
+const makePathlessDiffToolUse = (name: string, id = `tu-${name}-${idCounter++}`): ToolUseBlock => ({
+  type: "tool_use",
+  objectType: "ToolUseBlock",
+  id,
+  name,
+  input: {},
+  invocationString: "",
+});
+
+const makeGenericDiffToolResult = (toolName: string, toolUseId = `tu-${toolName}`): ToolResultBlock => ({
+  type: "tool_result",
+  objectType: "ToolResultBlock",
+  toolUseId,
+  toolName,
+  invocationString: "",
+  content: { contentType: "generic", text: "File edited successfully." } as ToolResultBlock["content"],
   isError: false,
 });
 
@@ -183,6 +217,34 @@ describe("segmentToolBlocks", () => {
       expect(segments).toHaveLength(1);
       expect(segments[0].kind).toBe("tools");
       expect(segments[0].blocks).toHaveLength(2);
+    });
+  });
+
+  describe("path-less diff tools fall back to tool pills", () => {
+    // A chip requires a derivable file path; without one buildChipData would
+    // silently drop the block, making the tool call vanish. These blocks must
+    // fall back to a tool pill instead.
+    it("routes a diff tool_result with generic content into a tools segment", () => {
+      const segments = segmentToolBlocks([makeGenericDiffToolResult("Edit", "tu-1")]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0].kind).toBe("tools");
+      expect(segments[0].blocks).toHaveLength(1);
+    });
+
+    it("routes a diff tool_use without a file_path into a tools segment", () => {
+      const segments = segmentToolBlocks([makePathlessDiffToolUse("Edit", "tu-1")]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0].kind).toBe("tools");
+      expect(segments[0].blocks).toHaveLength(1);
+    });
+
+    it("still routes a diff tool with a derivable path into a chip segment", () => {
+      const segments = segmentToolBlocks([makeToolResult("Edit", "tu-1")]);
+
+      expect(segments).toHaveLength(1);
+      expect(segments[0].kind).toBe("chip");
     });
   });
 });

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/chipRowUtils.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/chipRowUtils.ts
@@ -280,19 +280,36 @@ export const segmentToolBlocks = (blocks: ReadonlyArray<ToolUseBlock | ToolResul
   for (const block of blocks) {
     const name = getToolName(block);
 
-    if (block.type === "tool_use" && isDiffTool(name)) {
-      flushTools();
-      currentChipBlocks.push(block);
-    } else if (block.type === "tool_result" && isDiffTool(name)) {
-      // The backend replaces tool_use with tool_result in completed messages.
-      // Convert back to a ToolUseBlock shim so the chip row can render it.
-      flushTools();
-      currentChipBlocks.push(resultToToolUseShim(block as ToolResultBlock));
-    } else {
-      // Everything else (including Bash) goes into a tool pill segment.
-      flushChip();
-      currentToolBlocks.push(block);
+    if (isDiffTool(name)) {
+      // Diff tools normally render as file chips, but a chip requires a
+      // derivable file path — without one buildChipData would silently drop the
+      // block, making the tool call vanish. Fall back to a tool pill so the
+      // call still appears (e.g. an Edit to a file outside the workspace whose
+      // result carries no path).
+      if (block.type === "tool_use" && getFilePathFromToolBlock(block) !== null) {
+        flushTools();
+        currentChipBlocks.push(block);
+        continue;
+      }
+
+      if (block.type === "tool_result") {
+        // The backend replaces tool_use with tool_result in completed messages.
+        // Convert back to a ToolUseBlock shim so the chip row can render it.
+        const result = block as ToolResultBlock;
+        const shim = resultToToolUseShim(result);
+        if (getFilePathFromToolBlock(shim, result) !== null) {
+          flushTools();
+          currentChipBlocks.push(shim);
+          continue;
+        }
+      }
+      // No derivable file path — fall through to the tool pill segment below.
     }
+
+    // Everything else (including Bash and path-less diff tools) goes into a
+    // tool pill segment.
+    flushChip();
+    currentToolBlocks.push(block);
   }
 
   flushChip();

--- a/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils.py
@@ -463,6 +463,7 @@ def _create_tool_content(
     tool_input: ToolInput,
     tool_content: Any,
     diff_tracker: DiffTracker | None,
+    is_error: bool = False,
 ) -> GenericToolContent | DiffToolContent:
     """Create appropriate tool content based on tool type."""
     if tool_name in [AgentToolName.WRITE, AgentToolName.EDIT, AgentToolName.MULTI_EDIT]:
@@ -479,15 +480,96 @@ def _create_tool_content(
         if diff:
             return DiffToolContent(diff=diff, file_path=file_path)
 
-        # DiffTracker unavailable or returned None (e.g. file outside workspace).
-        # Create a synthetic diff from the tool input so the UI still shows file contents.
-        if tool_name == AgentToolName.WRITE:
-            content = tool_input.get("content")
-            if isinstance(content, str) and content:
-                diff = _create_synthetic_write_diff(file_path, content)
-                return DiffToolContent(diff=diff, file_path=file_path)
+        # DiffTracker unavailable or returned None (e.g. file outside the
+        # workspace, like the global Claude memory dir). Synthesize a diff from
+        # the tool input so the UI still shows the change. Crucially, this keeps
+        # the result a DiffToolContent so it carries ``file_path`` — without it
+        # the frontend cannot derive a path for the file chip and silently drops
+        # the tool call (see ``chipRowUtils.ts``). This applies to every
+        # file-change tool, not just Write.
+        #
+        # Only do this for a SUCCESSFUL call. On error the file is typically
+        # unchanged and the result carries the error text, which must be
+        # preserved as generic content rather than replaced by a phantom diff
+        # (see test_failed_edit_on_unchanged_file_preserves_error_text).
+        if not is_error:
+            synthetic_diff = _create_synthetic_diff_from_tool_input(tool_name, file_path, tool_input)
+            if synthetic_diff is not None:
+                return DiffToolContent(diff=synthetic_diff, file_path=file_path)
 
     return GenericToolContent(text=str(tool_content))
+
+
+def _create_synthetic_diff_from_tool_input(tool_name: str, file_path: str, tool_input: ToolInput) -> str | None:
+    """Build a best-effort git-format diff from a file-change tool's input.
+
+    Used when the DiffTracker cannot produce a real diff (e.g. the file is
+    outside the workspace). Returns None when the input lacks the fields needed
+    to synthesize a diff, in which case the caller falls back to generic content.
+    """
+    if tool_name == AgentToolName.WRITE:
+        content = tool_input.get("content")
+        if isinstance(content, str) and content:
+            return _create_synthetic_write_diff(file_path, content)
+        return None
+
+    if tool_name in (AgentToolName.EDIT, AgentToolName.MULTI_EDIT):
+        edits = _extract_edits(tool_input)
+        if edits:
+            return _create_synthetic_edit_diff(file_path, edits)
+
+    return None
+
+
+def _extract_edits(tool_input: ToolInput) -> list[tuple[str, str]]:
+    """Extract (old_string, new_string) pairs from an Edit or MultiEdit input.
+
+    MultiEdit carries a list under ``edits``; Edit carries a single
+    ``old_string``/``new_string`` pair at the top level.
+    """
+    edits = tool_input.get("edits")
+    if isinstance(edits, list):
+        pairs: list[tuple[str, str]] = []
+        for edit in edits:
+            if isinstance(edit, dict):
+                old_string = edit.get("old_string")
+                new_string = edit.get("new_string")
+                if isinstance(old_string, str) and isinstance(new_string, str):
+                    pairs.append((old_string, new_string))
+        return pairs
+
+    old_string = tool_input.get("old_string")
+    new_string = tool_input.get("new_string")
+    if isinstance(old_string, str) and isinstance(new_string, str):
+        return [(old_string, new_string)]
+
+    return []
+
+
+def _create_synthetic_edit_diff(file_path: str, edits: list[tuple[str, str]]) -> str:
+    """Create a synthetic git-format diff for Edit/MultiEdit when DiffTracker is unavailable.
+
+    We don't know the file's real line numbers without its contents, so each
+    edit becomes a hunk showing the replaced text as removals and the new text
+    as additions. The frontend's ``getLineCounts`` skips the 5-line header and
+    counts ``+``/``-`` lines, so the chip's stats stay accurate even though the
+    hunk offsets are placeholders. This same string is also rendered in the chip
+    diff popover, so the user sees the change anchored at line 1 (the placeholder
+    offset) — matching the existing ``_create_synthetic_write_diff`` behavior.
+    """
+    lines: list[str] = [
+        f"diff --git a/{file_path} b/{file_path}",
+        "index 0000000..0000000 100644",
+        f"--- a/{file_path}",
+        f"+++ b/{file_path}",
+    ]
+    for old_string, new_string in edits:
+        old_lines = old_string.split("\n")
+        new_lines = new_string.split("\n")
+        lines.append(f"@@ -1,{len(old_lines)} +1,{len(new_lines)} @@")
+        lines.extend("-" + line for line in old_lines)
+        lines.extend("+" + line for line in new_lines)
+    return "\n".join(lines) + "\n"
 
 
 def _create_synthetic_write_diff(file_path: str, content: str) -> str:
@@ -523,7 +605,11 @@ def _load_content_for_tool_result_message_no_error_checking(
 
     assert isinstance(simple_block.content, SimpleToolContent)
     tool_content = _create_tool_content(
-        simple_block.tool_name, simple_block.content.tool_input, simple_block.content.tool_content, diff_tracker
+        simple_block.tool_name,
+        simple_block.content.tool_input,
+        simple_block.content.tool_content,
+        diff_tracker,
+        is_error=simple_block.is_error,
     )
 
     return ParsedToolResultResponse(

--- a/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils_test.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock
 
 from sculptor.agents.default.claude_code_sdk.diff_tracker import DiffTracker
 from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
+from sculptor.agents.default.claude_code_sdk.process_manager_utils import _create_synthetic_diff_from_tool_input
+from sculptor.agents.default.claude_code_sdk.process_manager_utils import _create_tool_content
+from sculptor.agents.default.claude_code_sdk.process_manager_utils import _extract_edits
 from sculptor.agents.default.claude_code_sdk.process_manager_utils import get_claude_command
 from sculptor.agents.default.claude_code_sdk.process_manager_utils import get_user_instructions
 from sculptor.agents.default.claude_code_sdk.process_manager_utils import parse_claude_code_json_lines
@@ -13,6 +16,7 @@ from sculptor.agents.testing.fake_claude_jsonl import make_tool_use_block
 from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
 from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
+from sculptor.interfaces.agents.tool_names import AgentToolName
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import LocalEnvironmentID
 from sculptor.primitives.ids import ProjectID
@@ -25,6 +29,7 @@ from sculptor.services.workspace_service.environment_manager.environments.local_
 from sculptor.services.workspace_service.setup_command_runner import FailedSetup
 from sculptor.services.workspace_service.setup_command_runner import RunningSetup
 from sculptor.state.chat_state import AskUserQuestionData
+from sculptor.state.chat_state import DiffToolContent
 from sculptor.state.chat_state import GenericToolContent
 from sculptor.state.chat_state import QuestionOption
 from sculptor.state.chat_state import UserQuestion
@@ -586,3 +591,99 @@ def test_failed_edit_on_unchanged_file_preserves_error_text(
         f"Failed Edit on unchanged file must not synthesize a DiffToolContent; got {type(block.content).__name__}: {block.content!r}"
     )
     assert "File has not been read yet" in block.content.text
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-diff fallback for file-change tools whose DiffTracker diff is None
+# (e.g. files outside the workspace, like the global Claude memory dir).
+# ---------------------------------------------------------------------------
+
+
+def _count_diff_line_changes(diff: str) -> tuple[int, int]:
+    """Mirror the frontend's getLineCounts: skip the 5-line header, then count
+    ``+``/``-`` lines (ignoring ``@@``/``+++``/``---``)."""
+    added = removed = 0
+    for line in diff.split("\n")[5:]:
+        if line.startswith(("@@", "+++", "---")):
+            continue
+        if line.startswith("+"):
+            added += 1
+        elif line.startswith("-"):
+            removed += 1
+    return added, removed
+
+
+def test_extract_edits_handles_single_edit() -> None:
+    pairs = _extract_edits({"old_string": "a", "new_string": "b"})
+    assert pairs == [("a", "b")]
+
+
+def test_extract_edits_handles_multi_edit() -> None:
+    pairs = _extract_edits({"edits": [{"old_string": "a", "new_string": "b"}, {"old_string": "c", "new_string": "d"}]})
+    assert pairs == [("a", "b"), ("c", "d")]
+
+
+def test_extract_edits_returns_empty_when_fields_missing() -> None:
+    assert _extract_edits({}) == []
+    assert _extract_edits({"old_string": "a"}) == []
+
+
+def test_synthetic_diff_for_edit_carries_path_and_counts() -> None:
+    """An Edit synthesizes a diff naming the file, with accurate +/- counts."""
+    diff = _create_synthetic_diff_from_tool_input(
+        AgentToolName.EDIT, "/outside/memory/notes.md", {"old_string": "old", "new_string": "new\nline"}
+    )
+    assert diff is not None
+    assert diff.startswith("diff --git a//outside/memory/notes.md b//outside/memory/notes.md")
+    # getLineCounts slices off the 5-line header, then counts changes.
+    assert _count_diff_line_changes(diff) == (2, 1)
+
+
+def test_synthetic_diff_for_multi_edit_sums_all_hunks() -> None:
+    diff = _create_synthetic_diff_from_tool_input(
+        AgentToolName.MULTI_EDIT,
+        "/outside/memory/notes.md",
+        {"edits": [{"old_string": "a", "new_string": "b"}, {"old_string": "c\nd", "new_string": "e"}]},
+    )
+    assert diff is not None
+    # 3 removals (a, c, d) and 2 additions (b, e) across both hunks.
+    assert _count_diff_line_changes(diff) == (2, 3)
+
+
+def test_synthetic_diff_for_write_uses_content() -> None:
+    diff = _create_synthetic_diff_from_tool_input(
+        AgentToolName.WRITE, "/outside/memory/notes.md", {"content": "line1\nline2"}
+    )
+    assert diff is not None
+    assert "+line1" in diff and "+line2" in diff
+
+
+def test_synthetic_diff_returns_none_without_usable_input() -> None:
+    assert _create_synthetic_diff_from_tool_input(AgentToolName.EDIT, "/x", {}) is None
+    assert _create_synthetic_diff_from_tool_input(AgentToolName.WRITE, "/x", {"content": ""}) is None
+
+
+def test_create_tool_content_synthesizes_diff_for_successful_edit_without_tracker() -> None:
+    """A successful Edit with no DiffTracker diff still yields a path-bearing DiffToolContent."""
+    content = _create_tool_content(
+        AgentToolName.EDIT,
+        {"file_path": "/outside/notes.md", "old_string": "a", "new_string": "b"},
+        "File edited successfully.",
+        diff_tracker=None,
+        is_error=False,
+    )
+    assert isinstance(content, DiffToolContent)
+    assert content.file_path == "/outside/notes.md"
+
+
+def test_create_tool_content_preserves_error_text_for_failed_edit() -> None:
+    """A failed Edit must keep its error text as GenericToolContent, not a phantom diff."""
+    content = _create_tool_content(
+        AgentToolName.EDIT,
+        {"file_path": "/outside/notes.md", "old_string": "a", "new_string": "b"},
+        "<tool_use_error>File has not been read yet.</tool_use_error>",
+        diff_tracker=None,
+        is_error=True,
+    )
+    assert isinstance(content, GenericToolContent)
+    assert "File has not been read yet" in content.text

--- a/sculptor/tests/integration/frontend/test_alpha_chat_chip_row_advanced.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_chip_row_advanced.py
@@ -15,7 +15,14 @@ from sculptor.testing.user_stories import user_story
 
 @user_story("to see edit tool calls rendered as chips in the alpha view")
 def test_chip_row_renders_for_edit_tool(sculptor_instance_: SculptorInstance) -> None:
-    """edit_file tool calls render as a chip row with a file chip."""
+    """An edit_file tool call renders as its own file chip.
+
+    Regression guard: an in-workspace edit often produces no diff from the diff
+    tracker. The backend used to fall back to generic content (no file path) for
+    such an edit, and the frontend silently dropped the chip — so the write and
+    edit here are separate turns (separate chip rows), and the edit's chip is the
+    one that used to vanish. Both must now render: two file chips, one per turn.
+    """
     page = sculptor_instance_.page
 
     # First create the file so the edit has something to work with
@@ -35,12 +42,15 @@ fake_claude:multi_step `{
     alpha_view = get_alpha_chat_view(page)
     expect(alpha_view).to_be_visible()
 
-    # Write + edit on the same file are merged into a single chip
+    # The write and the edit are separate turns, so each renders its own chip.
+    # The edit's chip is the one that previously disappeared when the edit had no
+    # diff; it must now be present.
     file_chips = alpha_view.get_file_chips()
-    expect(file_chips).to_have_count(1)
+    expect(file_chips).to_have_count(2)
 
-    # The chip should reference the edited file
+    # Both chips reference the same target file.
     expect(file_chips.first).to_contain_text("edit_target.txt")
+    expect(file_chips.last).to_contain_text("edit_target.txt")
 
 
 @user_story("to preview the diff by hovering over a file chip")
@@ -133,7 +143,13 @@ fake_claude:write_file `{
 def test_chip_row_edit_after_write_same_file(
     sculptor_instance_: SculptorInstance,
 ) -> None:
-    """Writing then editing the same file merges into a single chip."""
+    """Writing a file in one turn then editing it in the next renders both chips.
+
+    The write and the edit arrive as separate assistant turns, so each renders
+    in its own chip row. The edit produces no diff from the diff tracker, so its
+    chip used to be silently dropped — leaving only the write chip. Both must now
+    render: one chip per turn, each referencing the file.
+    """
     page = sculptor_instance_.page
 
     task_page = start_task_and_wait_for_ready(
@@ -149,11 +165,13 @@ fake_claude:multi_step `{
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Write + edit on the same file are merged into a single chip
+    # Separate turns render separate chips; the edit's chip is the one that used
+    # to vanish when the edit had no diff.
     alpha_view = get_alpha_chat_view(page)
     file_chips = alpha_view.get_file_chips()
-    expect(file_chips).to_have_count(1)
+    expect(file_chips).to_have_count(2)
     expect(file_chips.first).to_contain_text("write_edit.txt")
+    expect(file_chips.last).to_contain_text("write_edit.txt")
 
 
 @user_story("to see separate chip rows when a bash tool appears between file tools")

--- a/sculptor/tests/integration/frontend/test_alpha_chat_edit_outside_workspace_chip.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_edit_outside_workspace_chip.py
@@ -1,0 +1,75 @@
+"""Integration test: Edit tool calls to files OUTSIDE the workspace must still render.
+
+Regression test for a bug where ``Edit`` / ``MultiEdit`` tool calls targeting a
+file outside the agent's code directory (e.g. the global Claude memory dir under
+``~/.claude/.../memory/``) silently vanished from the alpha chat UI, even though
+they appeared in the transcript.
+
+Root cause: the diff tracker returns ``None`` for files outside the code
+directory, and the backend's synthetic-diff fallback only covered ``Write`` --
+so out-of-workspace ``Edit`` calls fell back to ``GenericToolContent`` (which
+carries no ``file_path``). The frontend routes diff tools into the file-chip
+path, then drops any chip whose path it cannot derive -- so the edit disappeared.
+
+A ``Write`` to the same location renders fine (it has a synthetic-diff fallback),
+which is what made the behaviour look inconsistent.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# An absolute path outside the agent's workspace/code directory, mirroring how
+# the global Claude memory dir lives outside the repo. A leading-slash path makes
+# fake_claude's ``Path(cwd) / file_path`` resolve to exactly this location.
+_OUTSIDE_DIR = "/tmp/sculptor_outside_ws_edit_test"
+_OUTSIDE_FILE = f"{_OUTSIDE_DIR}/memory_notes.md"
+
+# bash creates the out-of-workspace file (rendered as a bash block, not a chip),
+# then edit_file edits it. The edit is the tool call that used to disappear.
+EDIT_OUTSIDE_WORKSPACE_PROMPT = f"""\
+fake_claude:multi_step `{{
+  "steps": [
+    {{
+      "command": "bash",
+      "args": {{
+        "command": "mkdir -p {_OUTSIDE_DIR} && printf 'original line\\\\n' > {_OUTSIDE_FILE}"
+      }}
+    }},
+    {{
+      "command": "edit_file",
+      "args": {{
+        "file_path": "{_OUTSIDE_FILE}",
+        "old_string": "original line",
+        "new_string": "updated line"
+      }}
+    }}
+  ]
+}}`"""
+
+
+@user_story("to see Edit tool calls to files outside the workspace rendered as chips")
+def test_edit_outside_workspace_renders_file_chip(sculptor_instance_: SculptorInstance) -> None:
+    """An Edit to a file outside the code directory still shows a file chip."""
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=EDIT_OUTSIDE_WORKSPACE_PROMPT,
+    )
+    chat_panel = task_page.get_chat_panel()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    alpha_view = get_alpha_chat_view(page)
+    expect(alpha_view).to_be_visible()
+
+    # The out-of-workspace Edit must render as a file chip naming the edited file.
+    # Before the fix this chip was silently dropped (count 0).
+    file_chips = alpha_view.get_file_chips()
+    expect(file_chips).to_have_count(1)
+    expect(file_chips.first).to_be_visible()
+    expect(file_chips.first).to_contain_text("memory_notes.md")

--- a/sculptor/tests/integration/frontend/test_alpha_chat_edit_outside_workspace_chip.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_edit_outside_workspace_chip.py
@@ -23,10 +23,12 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# An absolute path outside the agent's workspace/code directory, mirroring how
-# the global Claude memory dir lives outside the repo. A leading-slash path makes
-# fake_claude's ``Path(cwd) / file_path`` resolve to exactly this location.
-_OUTSIDE_DIR = "/tmp/sculptor_outside_ws_edit_test"
+# A path outside the agent's workspace/code directory, mirroring how the global
+# Claude memory dir lives outside the repo. It is expressed relative to the
+# agent's cwd (the workspace) with a leading ``..`` so it resolves to a sibling
+# of the workspace, which is still inside the harness's per-test temp tree (and
+# therefore cleaned up) but outside the DiffTracker's code directory.
+_OUTSIDE_DIR = "../sculptor_outside_ws_edit_test"
 _OUTSIDE_FILE = f"{_OUTSIDE_DIR}/memory_notes.md"
 
 # bash creates the out-of-workspace file (rendered as a bash block, not a chip),


### PR DESCRIPTION
## Original bug
> some tool calls are not showing up when agent uses them, one example is a memory edit tool, i saw them in the transcripts but not in the UX (Sculptor v0.37.0rc2)

`Edit`/`MultiEdit` tool calls to a file **outside the agent's workspace/code directory** (e.g. the global Claude memory dir `~/.claude/.../memory/`) were silently dropped from the alpha chat UI, even though they appeared in the transcript. `Write` calls to the same location rendered fine, which made the behaviour look inconsistent.

Linear: SCU-1543

## Reproduction
1. Have the agent edit a file that lives **outside** its workspace (e.g. a memory file under the global Claude config dir) with the `Edit` tool.
2. Observe the alpha chat: the edit produces no file chip and no tool pill — the call is absent entirely.
3. The same call is present in the Claude transcript, and a `Write` to the same path *does* render.

The e2e test reproduces this deterministically with `fake_claude`: a `bash` step creates a file outside the workspace, then an `edit_file` step edits it.

## Root cause
- **Backend** (`process_manager_utils.py`): for files outside the code directory the `DiffTracker` produces no diff, and `_create_tool_content` only had a synthetic-diff fallback for `Write`. Out-of-workspace `Edit`/`MultiEdit` therefore fell through to `GenericToolContent`, which carries no `file_path`.
- **Frontend** (`chipRowUtils.ts`): the completed edit is routed into the file-chip path (its tool name is a diff tool), but a chip needs a derivable file path. With none, `buildChipData` silently dropped the chip — so the call vanished, with no tool-pill fallback. (This also affected *failed* edits, which likewise produce path-less generic content.)

## Fix
- Backend now synthesizes a `DiffToolContent` carrying `file_path` (plus a best-effort diff from the tool input) for any **successful** file-change tool when the `DiffTracker` can't compute a real diff — not just `Write`. Gated on `is_error` so a failed edit keeps its error text as generic content instead of a phantom diff.
- Frontend `segmentToolBlocks` now routes a diff-tool block with no derivable file path to the tool-pill segment instead of dropping it, so such calls (including failed edits) always remain visible.

## Proof the fix works
This is a UI-rendering bug about Sculptor's own output (not dependent on real Claude responses), so it is verified with a deterministic e2e Playwright test that asserts the exact UI element, rather than screenshots.

**Failing test commit:** `5065f470d22` (`Add failing test for out-of-workspace Edit chips vanishing in alpha chat`)
**Fix commit:** `4e881b73ba0`

Before the fix (e2e asserts the edit chip is present):
```
E   AssertionError: Locator expected to have count '1'
E   Actual value: 0
E     - waiting for get_by_test_id("ALPHA_CHAT_VIEW").get_by_test_id("ALPHA_CHAT_FILE_CHIP")
E       34 × locator resolved to 0 elements
FAILED .../test_alpha_chat_edit_outside_workspace_chip.py::test_edit_outside_workspace_renders_file_chip
```

After the fix:
```
============================== 1 passed in 12.43s ==============================
```

Also added: backend unit tests for the new synthetic-diff helpers and the `is_error` gate (`process_manager_utils_test.py`), and frontend unit tests for the path-less fallback (`renderToolSegments.test.ts`). Full `just test-unit` and `just check` pass.

## Review notes
Self-reviewed with `/code-review-checklist`; no outstanding findings (test isolation, an `is_error`-gate unit test, and a docstring clarification were all addressed).

(Sent by Claude)