### PR TITLE
[SCU-1542] Inject frontend telemetry keys into desktop release builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -221,6 +221,29 @@ jobs:
           set -euo pipefail
           eval "$(./scripts/export-vault-env shared/aws/AWS_ACCESS_KEY_ID shared/aws/AWS_SECRET_ACCESS_KEY)"
 
+          # Frontend telemetry client keys for the renderer bundle. Without
+          # these the shipped app has an empty Sentry DSN and can't report bugs.
+          # Tag builds use the production Sentry/PostHog projects; other builds
+          # use the dev projects. Both Vault roles can read sculptor-release.
+          if [ -n "${CI_COMMIT_TAG:-}" ]; then
+            export SCULPTOR_BUILD_ENV=production
+            eval "$(./scripts/export-vault-env \
+              sculptor-release/SCULPTOR_PRODUCTION_FRONTEND_SENTRY_DSN \
+              sculptor-release/SCULPTOR_PRODUCTION_FRONTEND_POSTHOG_TOKEN)"
+            # The eval above swallows a missing-key failure and leaves the var
+            # empty; assert so a release never ships an app that can't report bugs.
+            if [ -z "${SCULPTOR_PRODUCTION_FRONTEND_SENTRY_DSN:-}" ] \
+               || [ -z "${SCULPTOR_PRODUCTION_FRONTEND_POSTHOG_TOKEN:-}" ]; then
+              echo "::error::Release build is missing the production frontend Sentry DSN / PostHog token from Vault (sculptor-release)."
+              exit 1
+            fi
+          else
+            export SCULPTOR_BUILD_ENV=dev
+            eval "$(./scripts/export-vault-env \
+              sculptor-release/SCULPTOR_DEV_FRONTEND_SENTRY_DSN \
+              sculptor-release/SCULPTOR_DEV_FRONTEND_POSTHOG_TOKEN)"
+          fi
+
           # A tag build keeps the pyproject version; otherwise stamp a .dev version.
           if [ -z "${CI_COMMIT_TAG:-}" ]; then
             just create-version-file --annotate-dev

--- a/justfile
+++ b/justfile
@@ -1084,8 +1084,10 @@ package-desktop-installer:
     just unmount-dmg
     {{ nvm_use }}
     cd "{{justfile_directory()}}/sculptor/frontend"
-    # HACK: build with production vars so the shipped installer doesn't carry a dev/testing sentry dsn
-    eval $(uv run --project sculptor builder setup-build-vars production) && npm run electron:make
+    # Telemetry env baked into the installer. Defaults to production so a bare
+    # `just pkg` never ships a dev DSN; CI sets SCULPTOR_BUILD_ENV=dev for
+    # non-release builds.
+    eval $(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}") && npm run electron:make
     mkdir -p "{{justfile_directory()}}/dist"
     cp -r out/make/zip "{{justfile_directory()}}/dist"
     cp out/make/Sculptor.dmg "{{justfile_directory()}}/dist"
@@ -1214,7 +1216,10 @@ package-desktop-installer:
       aarch64|arm64) ELECTRON_ARCH="arm64" ;;
       *)             ELECTRON_ARCH="x64" ;;
     esac
-    npm run electron:make
+    # Inject the telemetry env before packaging, like the macOS recipe; without
+    # it the renderer bakes an empty DSN. Defaults to production; CI sets
+    # SCULPTOR_BUILD_ENV=dev for non-release builds.
+    eval $(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}") && npm run electron:make
 
     # The AppImage maker includes the version in the filename.
     # Rename the file to remove the version for consistent filenames.

--- a/justfile
+++ b/justfile
@@ -1087,7 +1087,7 @@ package-desktop-installer:
     # Telemetry env baked into the installer. Defaults to production so a bare
     # `just pkg` never ships a dev DSN; CI sets SCULPTOR_BUILD_ENV=dev for
     # non-release builds.
-    eval $(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}") && npm run electron:make
+    eval "$(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}")" && npm run electron:make
     mkdir -p "{{justfile_directory()}}/dist"
     cp -r out/make/zip "{{justfile_directory()}}/dist"
     cp out/make/Sculptor.dmg "{{justfile_directory()}}/dist"
@@ -1219,7 +1219,7 @@ package-desktop-installer:
     # Inject the telemetry env before packaging, like the macOS recipe; without
     # it the renderer bakes an empty DSN. Defaults to production; CI sets
     # SCULPTOR_BUILD_ENV=dev for non-release builds.
-    eval $(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}") && npm run electron:make
+    eval "$(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}")" && npm run electron:make
 
     # The AppImage maker includes the version in the filename.
     # Rename the file to remove the version for consistent filenames.

--- a/sculptor/builder/cli.py
+++ b/sculptor/builder/cli.py
@@ -144,6 +144,16 @@ def setup_build_vars(environment: str) -> None:
         case _ as never:
             assert_never(never)
 
+    # A production build with an empty DSN ships an app that can't report bugs.
+    # Warn on stderr (stdout is eval'd by the caller); CI escalates this to a
+    # hard failure.
+    if environment == "production" and not frontend_dsn:
+        warning = (
+            "warning: SCULPTOR_PRODUCTION_FRONTEND_SENTRY_DSN is empty; "
+            + "this build will have frontend error reporting and Report-a-Problem disabled."
+        )
+        typer.secho(warning, fg=typer.colors.YELLOW, err=True)
+
     typer.echo(f"export SCULPTOR_SENTRY_RELEASE_ID='{release_id}'")
     typer.echo(f"export SCULPTOR_FRONTEND_SENTRY_DSN='{frontend_dsn}'")
     typer.echo(f"export SCULPTOR_FRONTEND_POSTHOG_TOKEN='{frontend_posthog_token}'")

--- a/sculptor/builder/package-sculptor-x86_64.sh
+++ b/sculptor/builder/package-sculptor-x86_64.sh
@@ -146,9 +146,9 @@ build_frontend_app() (
   export npm_config_target_arch="$ELECTRON_ARCH"
   export ELECTRON_ARCH="$ELECTRON_ARCH"
 
-  # Your existing "uv" environment vars step; preserve exact semantics
-  # (eval ensures npm sees the variables in this subshell)
-  eval "$(uv run --project sculptor builder setup-build-vars production)"
+  # Inject telemetry/build env vars (eval so npm sees them in this subshell).
+  # Defaults to production; CI sets SCULPTOR_BUILD_ENV=dev for non-release builds.
+  eval "$(uv run --project sculptor builder setup-build-vars "${SCULPTOR_BUILD_ENV:-production}")"
 
 
   # <REPLACEMENT> begins here. We want to run:

--- a/sculptor/frontend/src/common/state/atoms/reportProblem.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/reportProblem.test.ts
@@ -1,0 +1,49 @@
+import * as Sentry from "@sentry/react";
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { reportProblemAtom, submitReportAtom } from "./reportProblem";
+
+// Preserve the real module (Telemetry.ts and others touch it) and override only
+// the entry points the submit flow drives.
+vi.mock("@sentry/react", async () => {
+  const actual = await vi.importActual<typeof Sentry>("@sentry/react");
+  return {
+    ...actual,
+    getClient: vi.fn(),
+    captureFeedback: vi.fn(() => "evt-123"),
+    withScope: vi.fn((cb: (scope: { setContext: () => void }) => string) => cb({ setContext: vi.fn() })),
+    getReplay: vi.fn(() => undefined),
+  };
+});
+
+describe("submitReportAtom", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A build with an empty Sentry DSN has no client; the flow must surface that
+  // as an error rather than a fake "success".
+  it("fails honestly when no Sentry client is configured", async () => {
+    vi.mocked(Sentry.getClient).mockReturnValue(undefined);
+    const store = createStore();
+    store.set(reportProblemAtom, { ...store.get(reportProblemAtom), description: "something broke" });
+
+    await store.set(submitReportAtom);
+
+    expect(store.get(reportProblemAtom).submitState.type).toBe("error");
+    expect(Sentry.captureFeedback).not.toHaveBeenCalled();
+  });
+
+  it("reports success when a Sentry client exists", async () => {
+    vi.mocked(Sentry.getClient).mockReturnValue({} as ReturnType<typeof Sentry.getClient>);
+    const store = createStore();
+    store.set(reportProblemAtom, { ...store.get(reportProblemAtom), description: "something broke" });
+
+    await store.set(submitReportAtom);
+
+    const submitState = store.get(reportProblemAtom).submitState;
+    expect(submitState.type).toBe("success");
+    expect(Sentry.captureFeedback).toHaveBeenCalledOnce();
+  });
+});

--- a/sculptor/frontend/src/common/state/atoms/reportProblem.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/reportProblem.test.ts
@@ -31,7 +31,12 @@ describe("submitReportAtom", () => {
 
     await store.set(submitReportAtom);
 
-    expect(store.get(reportProblemAtom).submitState.type).toBe("error");
+    const submitState = store.get(reportProblemAtom).submitState;
+    expect(submitState.type).toBe("error");
+    // The message is shown verbatim, so it must not carry a stray "Error:" prefix.
+    if (submitState.type === "error") {
+      expect(submitState.message).not.toMatch(/^Error:/);
+    }
     expect(Sentry.captureFeedback).not.toHaveBeenCalled();
   });
 

--- a/sculptor/frontend/src/common/state/atoms/reportProblem.ts
+++ b/sculptor/frontend/src/common/state/atoms/reportProblem.ts
@@ -157,6 +157,12 @@ export const submitReportAtom: WritableAtom<null, [], Promise<void>> = atom(null
 
   set(updateReportProblemAtom, { submitState: { type: "reporting" } });
   try {
+    // With no Sentry DSN there's no client, so captureFeedback no-ops yet still
+    // returns an id — making the report look sent. Fail honestly instead.
+    if (Sentry.getClient() === undefined) {
+      throw new Error("Error reporting isn't configured in this build, so the report couldn't be sent.");
+    }
+
     const { screenshotData } = get(reportProblemAtom);
     const healthCheckData = get(healthCheckDataAtom);
     const attachments: Array<{ filename: string; data: Uint8Array; contentType: string }> = [];

--- a/sculptor/frontend/src/common/state/atoms/reportProblem.ts
+++ b/sculptor/frontend/src/common/state/atoms/reportProblem.ts
@@ -134,6 +134,19 @@ export const submitReportAtom: WritableAtom<null, [], Promise<void>> = atom(null
   const userEmail = get(userEmailAtom);
   const userFullName = get(userFullNameAtom);
 
+  // With no Sentry DSN there's no client, so captureFeedback would no-op yet
+  // still return an id — making the report look sent. Fail before uploading
+  // diagnostics for a report that can't be delivered.
+  if (Sentry.getClient() === undefined) {
+    set(updateReportProblemAtom, {
+      submitState: {
+        type: "error",
+        message: "Bug reporting isn't configured in this build, so the report couldn't be sent.",
+      },
+    });
+    return;
+  }
+
   let reportId: string | null = null;
   let s3Url: string | null = null;
   let didDiagnosticsFail = false;
@@ -157,12 +170,6 @@ export const submitReportAtom: WritableAtom<null, [], Promise<void>> = atom(null
 
   set(updateReportProblemAtom, { submitState: { type: "reporting" } });
   try {
-    // With no Sentry DSN there's no client, so captureFeedback no-ops yet still
-    // returns an id — making the report look sent. Fail honestly instead.
-    if (Sentry.getClient() === undefined) {
-      throw new Error("Error reporting isn't configured in this build, so the report couldn't be sent.");
-    }
-
     const { screenshotData } = get(reportProblemAtom);
     const healthCheckData = get(healthCheckDataAtom);
     const attachments: Array<{ filename: string; data: Uint8Array; contentType: string }> = [];


### PR DESCRIPTION
## Problem

Shipped desktop builds (0.37.x) ship with an empty frontend Sentry DSN and PostHog token. As a result **Report-a-Problem silently does nothing** — the UI shows "Thank you for your report!" but no feedback reaches Sentry — and frontend analytics are disabled.

The renderer bakes these public client keys in at build time via `builder setup-build-vars`, which reads them from the environment. The desktop build workflow never exported them from Vault, so `setup-build-vars` emitted empty values, `initializeSentry()` skipped init, and `Sentry.captureFeedback()` had no client to send through.

## Changes

- **`build-desktop.yml`** — export the frontend Sentry DSN + PostHog token from Vault before `just refresh pkg`. Tag builds use the production Sentry/PostHog projects; other (main / dispatch) builds use the dev projects, so the dev path is verifiable without cutting a release. A release build with missing production keys now **fails loudly** instead of shipping an app that can't report bugs (the `eval "$(export-vault-env …)"` wrapper swallows a missing-key error and leaves the var empty, so the assertion is explicit).
- **`justfile` / `package-sculptor-x86_64.sh`** — select the telemetry environment via `SCULPTOR_BUILD_ENV` (default `production`), and add the missing `setup-build-vars` call to the **Linux** packaging recipe, which previously ran `electron:make` with no telemetry env at all.
- **`setup-build-vars`** — warn on stderr (stdout is `eval`'d) when a production build has an empty DSN.
- **`reportProblem`** — the submit flow now surfaces an error when no Sentry client exists instead of reporting a fake success, with a unit test.

`SCULPTOR_BUILD_ENV` is intentionally separate from the justfile `MODE` (which feeds vite `--mode`) to avoid side effects on the webapp bundle.

## Testing

- `just format`, `just check`, `just test-unit` all pass.
- New unit test covers both the no-client (error) and client-present (success) paths.
- The dev export path will be exercised by a dev build off this branch once merged/triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)