### PR TITLE
Enable fast mode toggle for Opus 4.8

### DIFF
--- a/sculptor/frontend/src/common/modelCapabilities.ts
+++ b/sculptor/frontend/src/common/modelCapabilities.ts
@@ -17,15 +17,20 @@ const MODEL_CAPABILITIES: Partial<Record<LlmModel, ModelCapabilities>> = {
     supportsFileAttachments: true,
     supportsFastMode: true,
   },
+  // CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K are the current-generation Opus
+  // ("Claude 4.8 Opus" — see modelConstants.ts). Newer Opus generations are
+  // bound to these enum values by bumping the display label there, so the
+  // capabilities below must be kept in sync with that label. Fast mode is
+  // supported, matching Opus 4.7 and 4.6 (SCU-1541).
   [LlmModel.CLAUDE_4_OPUS]: {
     supportsSystemPrompt: true,
     supportsFileAttachments: true,
-    supportsFastMode: false,
+    supportsFastMode: true,
   },
   [LlmModel.CLAUDE_4_OPUS_200K]: {
     supportsSystemPrompt: true,
     supportsFileAttachments: true,
-    supportsFastMode: false,
+    supportsFastMode: true,
   },
   [LlmModel.CLAUDE_4_6_OPUS]: {
     supportsSystemPrompt: true,

--- a/sculptor/tests/integration/frontend/test_model_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_model_capability_gating.py
@@ -16,6 +16,8 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
 # Long display names as they appear in the model selector dropdown (ModelSelectOptions uses getModelLongName).
+_OPUS_48_1M_MODEL_NAME = "Claude 4.8 Opus (1M)"
+_OPUS_48_MODEL_NAME = "Claude 4.8 Opus"
 _OPUS_46_MODEL_NAME = "Claude 4.6 Opus (1M)"
 _SONNET_MODEL_NAME = "Claude 4.6 Sonnet"
 
@@ -48,6 +50,48 @@ def test_fast_mode_toggle_gated_by_model(sculptor_instance_: SculptorInstance) -
 
     # Switch to Opus 4.6 — fast mode is supported, toggle must reappear.
     select_model_by_name(chat_panel, _OPUS_46_MODEL_NAME)
+    expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
+
+
+@user_story("to see the fast mode toggle when Opus 4.8 is selected")
+def test_fast_mode_toggle_visible_for_opus_48(sculptor_instance_: SculptorInstance) -> None:
+    """Fast mode toggle must be present for Opus 4.8, just like 4.7 and 4.6 (SCU-1541).
+
+    Opus 4.8 reuses the generic CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K enum values
+    (only the display label in modelConstants.ts was bumped to "Claude 4.8
+    Opus"); the matching entries in modelCapabilities.ts were left at
+    supportsFastMode: false. As a result the toggle was hidden for 4.8 even
+    though it appears for 4.7/4.6.
+
+    Steps:
+    1. Start with Fake Claude (supports fast mode) — toggle visible.
+    2. Switch to Sonnet — toggle must disappear (clean baseline).
+    3. Switch to Opus 4.8 (1M) — toggle must reappear.
+    4. Switch to Opus 4.8 (200K) — toggle must remain visible.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        page,
+        prompt='fake_claude:text `{"text": "ready"}`',
+        workspace_name="Opus 4.8 Fast Mode WS",
+    )
+    chat_panel = task_page.get_chat_panel()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    # Fake Claude supports fast mode — toggle should be visible.
+    expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
+
+    # Switch to Sonnet — fast mode is not supported, toggle must disappear.
+    select_model_by_name(chat_panel, _SONNET_MODEL_NAME)
+    expect(chat_panel.get_fast_mode_toggle()).not_to_be_visible()
+
+    # Switch to Opus 4.8 (1M) — fast mode is supported, toggle must reappear.
+    select_model_by_name(chat_panel, _OPUS_48_1M_MODEL_NAME)
+    expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
+
+    # Switch to Opus 4.8 (200K) — fast mode is supported, toggle must stay visible.
+    select_model_by_name(chat_panel, _OPUS_48_MODEL_NAME)
     expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
 
 


### PR DESCRIPTION
## Original bug

> Fast mode is expected to be configured per workspace with the rest of the model settings, but the toggle is not enabled for Opus 4.8 even though it appears for Opus 4.7 and 4.6.
>
> Also evaluate how and why this was missed and how to prevent the same gap for future model updates.

Linear: [SCU-1541](https://linear.app/imbue/issue/SCU-1541/enable-fast-mode-toggle-for-opus-48)

This was an autonomous `/sculptor-workflow:fix-bug` run.

## Hypotheses considered

1. **`modelCapabilities.ts` marks the Opus 4.8 enum values as `supportsFastMode: false`, so the toolbar gate hides the toggle.** — **REPRODUCED.**
2. **The backend harness reports `supports_fast_mode=false` for Opus 4.8 (per-model harness gating).** — **DISCARDED.** `ClaudeCodeHarness.capabilities()` returns `supports_fast_mode=True` unconditionally for every Claude model, and the frontend gate `canUseFastMode = useTaskSupportsFastMode(...) ?? true` is therefore true. The harness is not model-aware; the per-model decision lives entirely on the frontend.
3. **Opus 4.8 is a brand-new `LlmModel` value that is missing from the capabilities map and falls through to `DEFAULT_CAPABILITIES` (`supportsFastMode: false`).** — **DISCARDED.** Opus 4.8 does not have its own enum value; it reuses the existing `CLAUDE_4_OPUS` / `CLAUDE_4_OPUS_200K` values, which have explicit (but stale) entries in the map — so this is a wrong value, not a missing one.

## For each reproduced bug

### Fast mode toggle hidden for Opus 4.8

**Repro steps**
1. Launch Sculptor and create a workspace.
2. In the chat input toolbar, open the model selector (it defaults to whatever the MRU/default is — e.g. "Fable").
3. Select **"Claude 4.8 Opus"** (or "Claude 4.8 Opus (1M)").
4. Look at the chat input toolbar next to the model selector.

**Expected vs actual**
- Expected: a lightning-bolt (Zap) fast-mode toggle appears next to the model selector, exactly as it does when "Claude 4.7 Opus" or "Claude 4.6 Opus" is selected.
- Actual: no toggle appears for Opus 4.8. (`locate [data-testid=FAST_MODE_TOGGLE]` returns 0 elements.) The toggle is present for 4.7, 4.6, and Fake Claude.

**Before**
The toggle is absent. The failing regression test pinpoints it — the first two steps (Fake Claude → visible, Sonnet → hidden) pass, then the Opus 4.8 step fails:

```
138         # Switch to Opus 4.8 (1M) — fast mode is supported, toggle must reappear.
139         select_model_by_name(chat_panel, _OPUS_48_1M_MODEL_NAME)
140 >       expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
141 E       AssertionError: Locator expected to be visible
142 E       Actual value: <element(s) not found>
143 E       Call log:
144 E         - Expect "to_be_visible" with timeout 30000ms
145 E         - waiting for get_by_test_id("CHAT_PANEL").get_by_test_id("FAST_MODE_TOGGLE")

============================== 1 failed in 49.95s ==============================
```

(Before/after screenshots from the manual test server were also captured during the run and shown in the workflow output; see Review notes for why they are not embedded inline here.)

**Root cause**
The chat toolbar renders the toggle only when `modelCapabilities.supportsFastMode && canUseFastMode` is true (`sculptor/frontend/src/pages/workspace/components/ChatInput.tsx:698`). `canUseFastMode` comes from the harness and is true for all Claude models, so the deciding factor is the per-model `supportsFastMode` flag in `sculptor/frontend/src/common/modelCapabilities.ts`. Opus 4.8 was shipped by *rebinding* the generic `CLAUDE_4_OPUS` / `CLAUDE_4_OPUS_200K` enum values to the new model — only the display label in `modelConstants.ts` was bumped to "Claude 4.8 Opus". The capabilities map is keyed by the same enum values, and those entries still carried `supportsFastMode: false` from when the enum meant the older Opus 4.0 (which did not support fast mode). Because the enum name did not change, nothing forced a corresponding update to the capabilities map, and the two facts about "the current Opus" — its label and its capabilities — live in separate files keyed by a stable enum.

**Fix**
Set `supportsFastMode: true` for both `CLAUDE_4_OPUS` and `CLAUDE_4_OPUS_200K`, matching Opus 4.7 and 4.6. The harness already advertises fast mode and the backend applies it per-message regardless of model (`process_manager_utils.py` appends `--settings {"fastMode": true}`), so the toggle is now both visible and functional. A comment was added above the entries tying the capabilities to the display label in `modelConstants.ts`, so the next time the Opus generation is rebound the capabilities are reviewed alongside the label.

**Test**
- Path: `sculptor/tests/integration/frontend/test_model_capability_gating.py`
- Kind: e2e (Playwright integration test). Added `test_fast_mode_toggle_visible_for_opus_48`, which selects both 4.8 variants and asserts the toggle is visible, with Fake Claude / Sonnet steps as positive/negative baselines.
- Failing-test commit: `47d979d06a`
- Fix commit: `9d42faa9d9`

**After**
With the fix, the same test passes, and the whole file (4 tests) stays green:

```
============================== 1 passed in 27.48s ==============================
...
============================== 4 passed in 39.00s ==============================
```

Manual verification via the live UI confirmed the full flow with Opus 4.8 selected: the toggle appears, is clickable, and activates (`data-active=true`) — i.e. fast mode can actually be enabled, not just rendered.

## How this was missed and how to prevent it

- **Why missed:** new Opus generations are rolled out by relabeling the generic `CLAUDE_4_OPUS` / `CLAUDE_4_OPUS_200K` enum values (so existing per-workspace model preferences keep pointing at "the latest Opus"). Bumping the label in `modelConstants.ts` does not touch `modelCapabilities.ts`, which is keyed by the same unchanged enum — so a stale `supportsFastMode: false` survived the bump silently.
- **Prevention in this PR:** (1) the in-code comment cross-referencing the label and capabilities at the point of edit; (2) the regression test that locks in the toggle for 4.8.
- **Prevention deferred:** a lightweight "model update checklist"/guard covering every place that must change when an Opus generation is rebound (backend `LlmModel`, `modelConstants.ts` label, `modelCapabilities.ts` capabilities, `ModelSelectOptions.PRODUCTION_MODELS`). See Deferred follow-ups.

## Deferred follow-ups

- Add a model-update checklist or automated guard so capability drift is caught when the generic Opus enum is rebound to a new generation — [SCU-1544](https://linear.app/imbue/issue/SCU-1544/prevent-model-capability-drift-when-the-generic-opus-enum-is-rebound)

## Review notes

- **Before/after screenshots not embedded inline (MEDIUM, deliberate).** This is a UI-visible bug, so the proof-of-work standard prefers embedded before/after screenshots. They were captured via the manual test server and displayed in the workflow output, but they are not embedded in this PR body: the only reference available is a local absolute path under a user home directory, which does not render on GitHub and would leak a local username path into a public repository (against the repo's public-visibility policy). The failing→passing integration-test output above is included in their place as PII-safe, GitHub-renderable evidence; the bug is behavioral and is verified end-to-end by the Playwright test that drives the same UI a user would.

(Sent by Claude)
