### PR TITLE
Prune low-value comments in backend integration tests

### DIFF
--- a/sculptor/tests/acceptance/conftest.py
+++ b/sculptor/tests/acceptance/conftest.py
@@ -45,10 +45,8 @@ def test_user_org_project(
     test_user_email: str,
 ) -> tuple[UserReference, OrganizationReference, Project]:
     with test_service_collection.data_model_service.open_transaction(RequestID()) as transaction:
-        user_reference = UserReference("test_user")  # Using UserReference for consistency
-        organization_reference = OrganizationReference(
-            "test_organization"
-        )  # Using OrganizationReference for consistency
+        user_reference = UserReference("test_user")
+        organization_reference = OrganizationReference("test_organization")
         project_id = ProjectID()
         project = Project(
             object_id=project_id,

--- a/sculptor/tests/integration/conftest.py
+++ b/sculptor/tests/integration/conftest.py
@@ -45,10 +45,8 @@ def test_user_org_project(
     test_user_email: str,  # noqa: ARG001
 ) -> tuple[UserReference, OrganizationReference, Project]:
     with test_service_collection.data_model_service.open_transaction(RequestID()) as transaction:
-        user_reference = UserReference("test_user")  # Using UserReference for consistency
-        organization_reference = OrganizationReference(
-            "test_organization"
-        )  # Using OrganizationReference for consistency
+        user_reference = UserReference("test_user")
+        organization_reference = OrganizationReference("test_organization")
         project_id = ProjectID()
         project = Project(
             object_id=project_id,

--- a/sculptor/tests/integration/frontend/test_add_workspace_agent_type.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_agent_type.py
@@ -1,10 +1,9 @@
 """Add Workspace form's first-agent type picker.
 
-Replaces the old workspace-harness picker tests: agent type is per-agent,
-so the form's picker chooses the type of the workspace's *first agent* via
-createWorkspaceAgent. The select is always visible (Terminal is available to
-everyone); only the pi option is gated behind the experimental pi-agent
-flag.
+Agent type is per-agent, so the form's picker chooses the type of the
+workspace's *first agent* via createWorkspaceAgent. The select is always
+visible (Terminal is available to everyone); only the pi option is gated
+behind the experimental pi-agent flag.
 """
 
 from playwright.sync_api import expect

--- a/sculptor/tests/integration/frontend/test_add_workspace_page.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_page.py
@@ -213,7 +213,7 @@ def test_multiple_new_workspace_tabs_with_independent_drafts(
 
     all_tabs = add_ws_page.get_add_workspace_tabs()
     initial_tab_count = all_tabs.count()
-    first_tab_index = initial_tab_count - 1  # the current (last) tab
+    first_tab_index = initial_tab_count - 1
 
     first_workspace_name = "First Draft Workspace"
 
@@ -351,11 +351,6 @@ def test_create_workspace_without_prompt(
 
     # Step 5: Verify the agent responds (1 user message + 1 assistant response).
     wait_for_completed_message_count(chat_panel, expected_message_count=2)
-
-
-# ---------------------------------------------------------------------------
-# Focus management tests
-# ---------------------------------------------------------------------------
 
 
 @user_story("to start typing immediately after creating a workspace")
@@ -563,11 +558,6 @@ def test_cmd_enter_in_repo_autocomplete_does_not_create_workspace(
 
     # Confirm we are still on the New Workspace page (no navigation happened).
     expect(chat_panel).not_to_be_visible()
-
-
-# ---------------------------------------------------------------------------
-# Workspace cleanup on project deletion
-# ---------------------------------------------------------------------------
 
 
 def _extract_workspace_id(url: str) -> str:

--- a/sculptor/tests/integration/frontend/test_alpha_chat_intro.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_intro.py
@@ -91,7 +91,6 @@ def test_intro_text_renders_above_first_message(sculptor_instance_: SculptorInst
     # Send the very first message.
     send_chat_message(chat_panel, 'fake_claude:text `{"text": "Hello"}`')
 
-    # Wait for messages to fully render (replaces wait_for_function + sleep).
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
     # Scroll to the very top so both the intro and the first message are

--- a/sculptor/tests/integration/frontend/test_alpha_chat_tool_block_file_chips.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_tool_block_file_chips.py
@@ -19,9 +19,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ---------------------------------------------------------------------------
-# Prompt for test 1: multiple sequential Read + Glob calls
-# ---------------------------------------------------------------------------
 MULTI_READ_AND_GLOB_PROMPT = """\
 fake_claude:multi_step `{
   "steps": [
@@ -84,9 +81,6 @@ fake_claude:multi_step `{
 }`"""
 
 
-# ---------------------------------------------------------------------------
-# Prompt for test 2: background bash then read the output file
-# ---------------------------------------------------------------------------
 BACKGROUND_BASH_THEN_READ_PROMPT = """\
 fake_claude:multi_step `{
   "steps": [

--- a/sculptor/tests/integration/frontend/test_alpha_chat_view.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_view.py
@@ -23,10 +23,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ---------------------------------------------------------------------------
-# Plan-mode prompt used by ExitPlanMode tests
-# ---------------------------------------------------------------------------
-
 PLAN_MODE_PROMPT = """\
 fake_claude:multi_step `{
   "steps": [
@@ -35,11 +31,6 @@ fake_claude:multi_step `{
     {"command": "exit_plan_mode", "args": {"allowedPrompts": []}}
   ]
 }`"""
-
-
-# ---------------------------------------------------------------------------
-# Alpha chat view feature tests (ported from classic view)
-# ---------------------------------------------------------------------------
 
 
 @user_story("to see ask-user-question blocks rendered in the new chat view")

--- a/sculptor/tests/integration/frontend/test_alpha_prompt_navigator_interactions.py
+++ b/sculptor/tests/integration/frontend/test_alpha_prompt_navigator_interactions.py
@@ -2,9 +2,7 @@
 
 Focuses on interactions with ``AlphaPromptNavigator``: dot clicks, active
 highlight tracking the scroll position, keyboard nav continuing from a
-clicked dot, and popover tooltip on hover.  The non-alpha dot rail
-(``PromptNavigator.tsx``) is covered separately by
-``test_prompt_navigator.py``.
+clicked dot, and popover tooltip on hover.
 """
 
 import json
@@ -151,7 +149,6 @@ def test_hovering_dot_shows_popover(sculptor_instance_: SculptorInstance) -> Non
 
     tooltip = navigator.get_tooltip()
     expect(tooltip).to_be_visible()
-    # Should include the prompt label text.
     expect(tooltip).to_contain_text("First prompt")
 
 
@@ -171,7 +168,6 @@ def test_popover_swaps_content_between_dots(sculptor_instance_: SculptorInstance
     # content swaps instantly (no additional open delay).
     navigator.get_dot(2).hover()
     expect(tooltip).to_contain_text("Prompt 3")
-    # And the old prompt's label is gone.
     expect(tooltip).not_to_contain_text("First prompt")
 
 

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_search.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_search.py
@@ -45,7 +45,6 @@ def test_alpha_search_flow(sculptor_instance_: SculptorInstance) -> None:
     search_input = search_bar.get_search_input()
     expect(search_input).to_be_visible()
 
-    # Type search query
     search_input.fill("zymurgy")
 
     # Verify match counter shows matches
@@ -56,11 +55,9 @@ def test_alpha_search_flow(sculptor_instance_: SculptorInstance) -> None:
     # Navigate to next match with Enter
     search_input.press("Enter")
 
-    # Verify counter updated
     expect(counter).to_contain_text("2/")
 
     # Close search with Escape
     search_input.press("Escape")
 
-    # Search bar should be hidden
     expect(search_input).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_task_switch.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_task_switch.py
@@ -51,7 +51,6 @@ def test_scroll_position_restored_on_task_switch(sculptor_instance_: SculptorIns
         }}"""
     )
 
-    # Record position
     pos_a = get_alpha_scroll_position(page)
 
     # Switch to task B via workspace tab (no reload)

--- a/sculptor/tests/integration/frontend/test_alpha_tool_pill_popover.py
+++ b/sculptor/tests/integration/frontend/test_alpha_tool_pill_popover.py
@@ -44,8 +44,8 @@ fake_claude:multi_step `{
     expect(pills).to_have_count(2)
 
     # Click the first pill (Read) — its popover should show the file path.
-    # (The popover no longer prints the tool name as a header for single-entry
-    # pills; it shows the per-tool details directly.)
+    # (For single-entry pills the popover shows the per-tool details directly,
+    # with no tool-name header.)
     pills.nth(0).click()
     popover = chat_panel.get_tool_pill_popover()
     expect(popover).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_ask_user_question.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question.py
@@ -73,11 +73,9 @@ fake_claude:ask_user_question `{
     ask_tool_blocks = get_ask_user_question_tool_blocks(page)
     expect(ask_tool_blocks).to_have_count(1)
 
-    # Verify the question is displayed in the panel
     question_text = ask_panel.get_question_text()
     expect(question_text).to_contain_text("programming language")
 
-    # Verify at least one option is rendered
     options = ask_panel.get_options()
     expect(options.first).to_be_visible()
 
@@ -85,24 +83,17 @@ fake_claude:ask_user_question `{
     submit_button = ask_panel.get_submit_button()
     expect(submit_button).to_be_disabled()
 
-    # Select the first option (likely Python)
     options.first.click()
 
-    # The submit button should now be enabled
     expect(submit_button).to_be_enabled()
 
-    # Submit the answer
     submit_button.click()
 
-    # After submission, the Q&A panel should disappear
     expect(ask_panel).not_to_be_visible(timeout=30_000)
 
-    # The chat input should reappear (back to normal mode)
     chat_input = chat_panel.get_chat_input()
     expect(chat_input).to_be_visible()
 
-    # The agent should continue processing after receiving the answer.
-    # Wait for the agent to finish streaming.
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
 
     # After the agent finishes, we should have completed messages:
@@ -116,12 +107,10 @@ fake_claude:ask_user_question `{
     # tool block — no duplicates should appear from persistence or page state.
     expect(ask_tool_blocks).to_have_count(1)
 
-    # Verify the tool block shows the submitted state with the question and answer
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_question_visible("programming language")
-    # The answer should be one of the options (Python, JavaScript, or Rust)
-    # We know the first option was selected, which is likely Python
+    # The first option was selected, which is likely Python.
     tool_block.expect_answer_visible("Python")
 
 
@@ -180,38 +169,30 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Verify we're on question 1
     question_text = ask_panel.get_question_text()
     expect(question_text).to_contain_text("programming language")
 
-    # Button should say "Next" (haven't answered all questions yet)
+    # Button says "Next" because not all questions are answered yet.
     submit_button = ask_panel.get_submit_button()
     expect(submit_button).to_have_text("Next")
 
-    # Select an answer for question 1
     options = ask_panel.get_options()
     options.first.click()
 
-    # Navigate to question 2
     ask_panel.navigate_next()
 
-    # Verify we're on question 2
     expect(question_text).to_contain_text("experience level")
 
-    # Button should still say "Next"
     expect(submit_button).to_have_text("Next")
 
-    # Select an answer for question 2
     options = ask_panel.get_options()
     options.first.click()
 
-    # Navigate to question 3
     ask_panel.navigate_next()
 
-    # Verify we're on question 3
     expect(question_text).to_contain_text("type of project")
 
-    # Q3 is the only unanswered question, so button says "Submit" (disabled)
+    # Q3 is the only unanswered question, so button says "Submit" (disabled).
     expect(submit_button).to_have_text("Submit")
     expect(submit_button).to_be_disabled()
 
@@ -223,22 +204,18 @@ fake_claude:ask_user_question `{
     ask_panel.navigate_next()
     expect(question_text).to_contain_text("type of project")
 
-    # Select an answer for question 3
     options = ask_panel.get_options()
     options.first.click()
 
-    # Now all questions are answered, button should say "Submit"
+    # Now all questions are answered, button should say "Submit".
     expect(submit_button).to_have_text("Submit")
 
-    # Submit the answers
     submit_button.click()
 
-    # Wait for the agent to finish
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify the tool block shows all three questions and answers
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_question_visible("programming language")
@@ -282,20 +259,16 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Select multiple options
     ask_panel.select_option("Python")
     ask_panel.select_option("JavaScript")
     ask_panel.select_option("Rust")
 
-    # Submit
     ask_panel.submit()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify the tool block shows all selected answers
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_answers_visible(["Python", "JavaScript", "Rust"])
@@ -337,10 +310,8 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Select 'Other' option
     ask_panel.select_option("Other")
 
-    # Verify text input appears and is focused
     other_input = ask_panel.get_other_input()
     expect(other_input).to_be_visible()
     expect(other_input).to_be_focused()
@@ -349,21 +320,16 @@ fake_claude:ask_user_question `{
     submit_button = ask_panel.get_submit_button()
     expect(submit_button).to_be_disabled()
 
-    # Type custom text
     ask_panel.type_other_text("Haskell")
 
-    # Now submit should be enabled
     expect(submit_button).to_be_enabled()
 
-    # Submit
     submit_button.click()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify the tool block shows the custom answer
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_answer_visible("Haskell")
@@ -404,23 +370,18 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Select some predefined options
     ask_panel.select_option("Python")
     ask_panel.select_option("JavaScript")
 
-    # Select Other and type custom text
     ask_panel.select_option("Other")
     ask_panel.type_other_text("Elixir")
 
-    # Submit
     ask_panel.submit()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify the tool block shows all answers including custom text
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_answers_visible(["Python", "JavaScript", "Elixir"])
@@ -462,21 +423,17 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Click Dismiss instead of answering
     ask_panel.dismiss()
 
-    # Q&A panel should disappear
     expect(ask_panel).not_to_be_visible(timeout=30_000)
 
-    # Wait for agent to finish (agent should continue despite dismissal)
+    # The agent should continue despite the dismissal.
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify the tool block shows dismissed state
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_dismissed_state()
 
-    # Verify the question text is still visible when expanded
     tool_block.expect_question_visible("programming language")
 
 
@@ -548,7 +505,6 @@ fake_claude:ask_user_question `{
 }`""",
     )
 
-    # Second question should appear
     expect(ask_panel).to_be_visible(timeout=30_000)
     expect(ask_panel.get_question_text()).to_contain_text("framework")
 
@@ -559,17 +515,14 @@ fake_claude:ask_user_question `{
 
     expect(ask_panel).not_to_be_visible(timeout=30_000)
 
-    # Wait for agent to finish
     expect(chat_panel.get_thinking_indicator(), "agent to finish after Q2").not_to_be_visible()
 
     # Messages: user Q1, assistant Q1, assistant default, user Q2, assistant Q2, assistant default
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=6)
 
-    # Verify two separate tool blocks exist
     ask_tool_blocks = get_ask_user_question_tool_blocks(page)
     expect(ask_tool_blocks).to_have_count(2)
 
-    # Verify each tool block shows its respective question
     first_block = PlaywrightAskUserQuestionBlockElement(locator=ask_tool_blocks.nth(0), page=page)
     first_block.expect_submitted_state()
     first_block.expect_question_visible("programming language")
@@ -610,7 +563,6 @@ fake_claude:ask_user_question `{
         wait_for_agent_to_finish=False,
     )
 
-    # Wait for Q&A panel to appear
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
     expect(ask_panel.get_question_text()).to_contain_text("programming language")
@@ -618,12 +570,10 @@ fake_claude:ask_user_question `{
     # Navigate away from the workspace and back to force Jotai store reinitialization.
     navigate_away_and_back(page)
 
-    # Question should still be pending and visible
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible()
     expect(ask_panel.get_question_text()).to_contain_text("programming language")
 
-    # Should be able to answer normally
     options = ask_panel.get_options()
     options.first.click()
     ask_panel.submit()
@@ -685,7 +635,6 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).not_to_be_visible()
 
-    # Tool block should show submitted state with answers
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_question_visible("programming language")
@@ -888,15 +837,12 @@ fake_claude:ask_user_question `{
     expect(submit_button).to_have_text("Submit")
     expect(submit_button).to_be_enabled()
 
-    # Submit
     submit_button.click()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify tool block
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_answer_visible("Red")
@@ -941,17 +887,14 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Verify the long question text is visible (at least part of it)
     expect(ask_panel.get_question_text()).to_contain_text("preferred programming language")
 
-    # Should be able to interact normally
     options = ask_panel.get_options()
     expect(options.first).to_be_visible()
     options.first.click()
 
     ask_panel.submit()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
@@ -998,21 +941,17 @@ fake_claude:ask_user_question `{
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Verify special characters appear correctly
     expect(ask_panel.get_question_text()).to_contain_text("favorite programming language")
 
-    # Select an option with special characters (e.g., C++)
     options = ask_panel.get_options()
     options.first.click()
 
     ask_panel.submit()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify tool block shows the question and answer with special characters
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
     tool_block.expect_question_visible("favorite programming language")
@@ -1079,20 +1018,17 @@ fake_claude:ask_user_question `{
         page = instance.page
 
         # The workspace still exists after restart.
-        # Wait for the workspace tab to be visible, then click it.
         workspace_tab = page.get_by_test_id(ElementIDs.WORKSPACE_TAB).first
         expect(workspace_tab).to_be_visible()
         workspace_tab.click()
 
-        # Wait for messages to fully load from persistence before checking tool blocks.
-        # Previously we only waited for the chat panel to be visible, which doesn't
-        # guarantee messages have finished loading from the backend.  Waiting for the
-        # expected message count (3 from Phase 1) ensures the chat is fully populated.
+        # Wait for messages to fully load from persistence before checking tool blocks:
+        # a visible chat panel does not guarantee messages have finished loading from the
+        # backend, so wait for the expected count to ensure the chat is fully populated.
         task_page_after = PlaywrightTaskPage(page=page)
         chat_panel_after = task_page_after.get_chat_panel()
         wait_for_completed_message_count(chat_panel=chat_panel_after, expected_message_count=3)
 
-        # After messages are loaded, verify only one tool block exists
         ask_tool_blocks_after_restart = get_ask_user_question_tool_blocks(page)
         expect(ask_tool_blocks_after_restart).to_have_count(1)
 
@@ -1140,16 +1076,13 @@ fake_claude:ask_user_question `{
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the Q&A panel to appear
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Select an answer and submit
     options = ask_panel.get_options()
     options.first.click()
     ask_panel.submit()
 
-    # After submission, the Q&A panel should disappear
     expect(ask_panel).not_to_be_visible(timeout=30_000)
 
     # REGRESSION: After answering, the task status must transition to RUNNING while
@@ -1157,7 +1090,6 @@ fake_claude:ask_user_question `{
     # should be visible while the agent processes the answer.
     expect(chat_panel.get_thinking_indicator(), "task should be RUNNING while processing answer").to_be_visible()
 
-    # Wait for the agent to finish processing the answer
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
@@ -1192,7 +1124,6 @@ fake_claude:ask_user_question `{
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the Q&A panel to appear
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
@@ -1201,7 +1132,6 @@ fake_claude:ask_user_question `{
     options.first.click()
     ask_panel.submit()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
@@ -1241,7 +1171,6 @@ fake_claude:ask_user_question `{
         wait_for_agent_to_finish=False,
     )
 
-    # Wait for the Q&A panel to appear
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
@@ -1249,7 +1178,6 @@ fake_claude:ask_user_question `{
     ask_panel.select_option("Other")
     ask_panel.type_other_text("Haskell is my favorite")
 
-    # The submit button should be enabled (answer provided)
     submit_button = ask_panel.get_submit_button()
     expect(submit_button).to_be_enabled()
 
@@ -1259,12 +1187,10 @@ fake_claude:ask_user_question `{
     # The Q&A panel should reappear (pendingUserQuestion persists in Jotai)
     expect(ask_panel).to_be_visible()
 
-    # The "Other" input should still be visible with the typed text preserved
     other_input = ask_panel.get_other_input()
     expect(other_input).to_be_visible()
     expect(other_input).to_have_value("Haskell is my favorite")
 
-    # The submit button should still be enabled
     expect(submit_button).to_be_enabled()
 
 
@@ -1299,24 +1225,19 @@ fake_claude:ask_user_question `{
         wait_for_agent_to_finish=False,
     )
 
-    # Wait for the Q&A panel to appear
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
-    # Select the first predefined option ("React")
     ask_panel.select_option("React")
 
-    # The submit button should be enabled
     submit_button = ask_panel.get_submit_button()
     expect(submit_button).to_be_enabled()
 
     # Navigate away and back
     navigate_away_and_back(page)
 
-    # The Q&A panel should reappear
     expect(ask_panel).to_be_visible()
 
-    # The submit button should still be enabled (option still selected)
     expect(submit_button).to_be_enabled()
 
     # Verify the selection was preserved by submitting and checking the answer
@@ -1372,7 +1293,6 @@ fake_claude:ask_user_question `{
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for Q&A panel
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
@@ -1391,7 +1311,6 @@ fake_claude:ask_user_question `{
     ask_panel.submit()
     expect(ask_panel).not_to_be_visible(timeout=30_000)
 
-    # Wait for agent to finish
     expect(chat_panel.get_thinking_indicator(), "agent to finish after batch 1").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
@@ -1419,7 +1338,6 @@ fake_claude:ask_user_question `{
     expect(ask_panel).to_be_visible(timeout=30_000)
     expect(ask_panel.get_question_text()).to_contain_text("framework")
 
-    # Should be able to answer and submit normally
     options = ask_panel.get_options()
     options.first.click()
     ask_panel.submit()
@@ -1479,12 +1397,10 @@ fake_claude:multi_step `{
     # Queue a message while the agent is busy
     send_chat_message(chat_panel=chat_panel, message="this should stay queued")
 
-    # The queued message bar should be visible while the agent is sleeping
     queued_bar = chat_panel.get_queued_message_bar()
     expect(queued_bar).to_have_count(1)
     expect(queued_bar).to_contain_text("this should stay queued")
 
-    # Wait for the Q&A panel to appear (after the sleep finishes)
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=30_000)
 
@@ -1509,7 +1425,6 @@ fake_claude:multi_step `{
     options.first.click()
     ask_panel.submit()
 
-    # After submission, the Q&A panel should disappear
     expect(ask_panel).not_to_be_visible(timeout=30_000)
 
     # Wait for the agent to finish processing the answer AND the queued message.
@@ -1562,12 +1477,10 @@ fake_claude:ask_user_question `{
     ask_panel.type_other_text(long_text)
     ask_panel.submit()
 
-    # Wait for completion
     expect(ask_panel).not_to_be_visible(timeout=30_000)
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
 
-    # Verify the tool block shows the full custom answer as a single element
     tool_block = get_first_ask_user_question_tool_block(page)
     tool_block.expect_submitted_state()
 
@@ -1685,7 +1598,6 @@ fake_claude:ask_user_question `{
     ask_panel.select_option("Other")
     ask_panel.type_other_text("Emacs")
 
-    # Verify we're on question 3 of 3.
     expect(ask_panel).to_contain_text("Question 3 of 3")
 
     # Now both agents have pending AUQs. Switch to agent 2.

--- a/sculptor/tests/integration/frontend/test_ask_user_question_continue.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question_continue.py
@@ -84,7 +84,6 @@ fake_claude:ask_user_question_and_continue `{
     # Now answer the question — this triggers a follow-up invocation
     auq_panel.select_first_option_and_submit()
 
-    # Q&A panel should disappear after submission
     expect(auq_panel).not_to_be_visible()
 
     # Wait for the follow-up invocation to finish

--- a/sculptor/tests/integration/frontend/test_at_mention_completion.py
+++ b/sculptor/tests/integration/frontend/test_at_mention_completion.py
@@ -38,14 +38,11 @@ def test_at_mention_opens_suggestion_popup(sculptor_instance_: SculptorInstance)
     chat_input = chat_panel.get_chat_input()
     expect(chat_input).to_be_visible()
 
-    # Type '@' to trigger the mention suggestion
     chat_input.press_sequentially("@")
 
-    # The mention list should appear with file suggestions
     mention_list = chat_panel.get_mention_list()
     expect(mention_list).to_be_visible()
 
-    # Should have at least one suggestion item
     items = chat_panel.get_mention_items()
     expect(items.first).to_be_visible()
 
@@ -59,13 +56,12 @@ def test_at_mention_filters_by_query(sculptor_instance_: SculptorInstance) -> No
     chat_input = chat_panel.get_chat_input()
     expect(chat_input).to_be_visible()
 
-    # Type '@stuff' — the test repo has a root-level 'stuff.txt' file
+    # The test repo has a root-level 'stuff.txt' file.
     chat_input.press_sequentially("@stuff")
 
     mention_list = chat_panel.get_mention_list()
     expect(mention_list).to_be_visible()
 
-    # At least one item should match 'stuff'
     items = chat_panel.get_mention_items()
     expect(items.first).to_be_visible()
     expect(items.first).to_contain_text("stuff")
@@ -87,13 +83,10 @@ def test_at_mention_select_with_enter(sculptor_instance_: SculptorInstance) -> N
     expect(mention_list).to_be_visible()
     expect(chat_panel.get_mention_items().first).to_be_visible()
 
-    # Press Enter to select the first suggestion
     chat_input.press("Enter")
 
-    # The mention list should disappear after selection
     expect(mention_list).not_to_be_visible()
 
-    # The editor should now contain a mention span with the file name
     mention_span = chat_panel.get_mention_spans()
     expect(mention_span).to_be_visible()
     expect(mention_span).to_contain_text("stuff")
@@ -121,13 +114,10 @@ def test_at_mention_select_with_click(sculptor_instance_: SculptorInstance) -> N
     # Remember the text of the first suggestion
     first_item_text = items.first.inner_text()
 
-    # Click the first suggestion
     items.first.click()
 
-    # The mention list should disappear
     expect(mention_list).not_to_be_visible()
 
-    # The editor should contain a mention span with the selected file name.
     mention_span = chat_panel.get_mention_spans()
     expect(mention_span).to_be_visible()
     expect(mention_span).to_contain_text(first_item_text)
@@ -142,16 +132,13 @@ def test_at_mention_escape_closes_popup(sculptor_instance_: SculptorInstance) ->
     chat_input = chat_panel.get_chat_input()
     expect(chat_input).to_be_visible()
 
-    # Type '@' to open suggestions
     chat_input.press_sequentially("@")
 
     mention_list = chat_panel.get_mention_list()
     expect(mention_list).to_be_visible()
 
-    # Press Escape to dismiss
     chat_input.press("Escape")
 
-    # The mention list should disappear
     expect(mention_list).not_to_be_visible()
 
     # No mention should have been inserted
@@ -195,7 +182,6 @@ def test_at_mention_persists_as_styled_span_after_workspace_switch(
     chat_input = chat_panel.get_chat_input()
     expect(chat_input).to_be_visible()
 
-    # Type '@stuff' to bring up the suggestion list then select with Enter
     chat_input.press_sequentially("@stuff")
     mention_list = chat_panel.get_mention_list()
     expect(mention_list).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_at_mention_path_mode.py
+++ b/sculptor/tests/integration/frontend/test_at_mention_path_mode.py
@@ -43,7 +43,6 @@ def test_path_mode_workspace_root_lists_tracked_files(sculptor_instance_: Sculpt
     expect(mention_list).to_be_visible()
     expect(chat_panel.get_mention_items().first).to_be_visible()
 
-    # Every known root-level fixture entry is present.
     expect(mention_list).to_contain_text("README")
     expect(mention_list).to_contain_text("stuff")
     # The src/ folder lists under a row with text "src". There may be other
@@ -59,10 +58,8 @@ def test_path_mode_surfaces_dotgit_folder(sculptor_instance_: SculptorInstance) 
 
     The fuzzy file cache is backed by ``git ls-files``, which never lists
     ``.git/`` itself.  Path mode hits ``getFilesAndFolders`` which reads the
-    disk directly.  This is the regression protection for commit
-    ``78956b055de`` (surface entries the fuzzy corpus excludes) — we use
-    ``.git/`` as the canary instead of a custom gitignored file because it
-    reliably exists in any workspace clone.
+    disk directly.  We use ``.git/`` as the canary instead of a custom
+    gitignored file because it reliably exists in any workspace clone.
     """
     task_page = _navigate_to_task_chat(sculptor_instance_)
     chat_panel = task_page.get_chat_panel()

--- a/sculptor/tests/integration/frontend/test_at_mention_tab_drill_and_shift_tab.py
+++ b/sculptor/tests/integration/frontend/test_at_mention_tab_drill_and_shift_tab.py
@@ -1,7 +1,6 @@
 """Integration tests for Tab-drill (into a folder) and Shift+Tab (up a folder).
 
-Recent changes introduced a distinction between Enter and Tab in the @-mention
-picker:
+Enter and Tab have distinct behaviors in the @-mention picker:
 - Enter on a folder commits it as a mention chip (for folder reveal).
 - Tab on a folder drills *into* it, switching the picker to path-mode on the
   selected directory — including gitignored entries that fuzzy search hides.

--- a/sculptor/tests/integration/frontend/test_auto_collapse_combined_diff.py
+++ b/sculptor/tests/integration/frontend/test_auto_collapse_combined_diff.py
@@ -115,7 +115,6 @@ def test_many_files_start_collapsed_in_review_all(sculptor_instance_: SculptorIn
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Open the Changes panel and click Review All
     task_page.activate_changes_panel()
     task_page.click_review_all()
 
@@ -138,14 +137,12 @@ def test_few_files_start_expanded_in_review_all(sculptor_instance_: SculptorInst
     start expanded (not collapsed)."""
     page = sculptor_instance_.page
 
-    # Enable Review All via Settings UI
     _enable_review_all_via_settings(page)
 
     task_page = start_task_and_wait_for_ready(page, prompt=_THREE_FILES_PROMPT, wait_for_agent_to_finish=False)
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Open the Changes panel and click Review All
     task_page.activate_changes_panel()
     task_page.click_review_all()
 

--- a/sculptor/tests/integration/frontend/test_auto_update_browser.py
+++ b/sculptor/tests/integration/frontend/test_auto_update_browser.py
@@ -23,10 +23,6 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 
 pytestmark = pytest.mark.release
 
-# ---------------------------------------------------------------------------
-# B1: Null initial state — no flicker
-# ---------------------------------------------------------------------------
-
 
 def test_null_initial_state_version_popover(
     sculptor_instance_: SculptorInstance,
@@ -54,11 +50,6 @@ def test_null_initial_state_settings_page(
 
     update_controls = PlaywrightSettingsUpdateElement(page=page)
     expect(update_controls.get_channel_select()).to_be_disabled()
-
-
-# ---------------------------------------------------------------------------
-# B2: Each status variant renders correctly
-# ---------------------------------------------------------------------------
 
 
 def test_idle_status_shows_up_to_date(
@@ -195,11 +186,6 @@ def test_update_dot_appears_when_downloading(
     expect(version_popover.get_update_dot()).to_be_visible()
 
 
-# ---------------------------------------------------------------------------
-# B3: Toast dismiss + re-show logic
-# ---------------------------------------------------------------------------
-
-
 def test_dismissed_download_toast_stays_dismissed(
     sculptor_instance_: SculptorInstance,
     mock_electron_api: MockSculptorElectronAPI,
@@ -223,11 +209,6 @@ def test_dismissed_download_toast_stays_dismissed(
     mock_electron_api.push_status({"type": "ready", "channel": "STABLE", "version": "2.0.0"})
     ready_toast = toast.filter_by_text("Update ready (v2.0.0)")
     expect(ready_toast).to_be_visible()
-
-
-# ---------------------------------------------------------------------------
-# B4: Channel switch flow via Settings
-# ---------------------------------------------------------------------------
 
 
 def test_channel_switch_calls_ipc_and_shows_pending(
@@ -318,11 +299,6 @@ def test_check_for_updates_button(
 
     calls = mock_electron_api.get_ipc_calls(method="checkForUpdate")
     assert len(calls) == 1
-
-
-# ---------------------------------------------------------------------------
-# B5: Disabled state — auto-update feature gate is off
-# ---------------------------------------------------------------------------
 
 
 def test_disabled_status_grays_out_settings_controls(

--- a/sculptor/tests/integration/frontend/test_auto_update_electron.py
+++ b/sculptor/tests/integration/frontend/test_auto_update_electron.py
@@ -39,10 +39,6 @@ from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.resources import invalidate_shared_instance
 from sculptor.testing.sculptor_instance import SculptorInstance
 
-# ---------------------------------------------------------------------------
-# Session-scoped fixture: set env vars before the Electron process starts
-# ---------------------------------------------------------------------------
-
 
 @pytest.fixture(scope="session", autouse=True)
 def _auto_update_electron_env(
@@ -128,11 +124,6 @@ def _reset_auto_update_state(
     auto_update_server.set_no_update()
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _open_version_popover(page: Page) -> PlaywrightVersionPopoverElement:
     """Open the version popover by clicking the version trigger."""
     popover = PlaywrightVersionPopoverElement(page)
@@ -147,11 +138,6 @@ def _click_check_for_updates(page: Page) -> None:
     button = update.get_check_button()
     expect(button).to_be_visible()
     button.click()
-
-
-# ---------------------------------------------------------------------------
-# E1: Happy path — update available → download → ready
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.release
@@ -188,11 +174,6 @@ def test_update_available_and_ready(
     expect(version_popover.get_update_dot()).to_be_visible()
 
 
-# ---------------------------------------------------------------------------
-# E2: No update available
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.release
 @pytest.mark.electron
 def test_no_update_available_shows_up_to_date(
@@ -214,11 +195,6 @@ def test_no_update_available_shows_up_to_date(
         "Up to date",
         timeout=30_000,
     )
-
-
-# ---------------------------------------------------------------------------
-# E3: Download failure — artifact missing → error
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.release
@@ -244,11 +220,6 @@ def test_download_failure_shows_error(
     )
 
 
-# ---------------------------------------------------------------------------
-# E4: Network failure — server unreachable → error
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.release
 @pytest.mark.electron
 def test_network_failure_shows_error(
@@ -270,11 +241,6 @@ def test_network_failure_shows_error(
         )
     finally:
         auto_update_server.set_online()
-
-
-# ---------------------------------------------------------------------------
-# E5a: Channel switch — STABLE → RC (verify RC feed path)
-# ---------------------------------------------------------------------------
 
 
 def _enable_channel_select(page: Page, auto_update_server: AutoUpdateTestServer) -> None:  # noqa: F811
@@ -317,11 +283,6 @@ def test_channel_switch_stable_to_rc(
     # Verify the server saw a request on the RC path (/slim-rc/...).
     paths = auto_update_server.get_request_paths()
     assert any("/slim-rc/" in p for p in paths), f"Expected RC feed path in {paths}"
-
-
-# ---------------------------------------------------------------------------
-# E5b: Channel switch — RC → STABLE after RC download
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.release
@@ -389,11 +350,6 @@ def test_channel_switch_rc_to_stable_after_download(
     # Verify the server saw requests on the STABLE path (/slim/, not /slim-rc/).
     paths = auto_update_server.get_request_paths()
     assert any("/slim/" in p and "/slim-rc/" not in p for p in paths), f"Expected STABLE feed path in {paths}"
-
-
-# ---------------------------------------------------------------------------
-# E9: User-Agent identifies Sculptor
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.electron

--- a/sculptor/tests/integration/frontend/test_branch_name_collisions.py
+++ b/sculptor/tests/integration/frontend/test_branch_name_collisions.py
@@ -84,7 +84,7 @@ def test_clone_mode_collision_blocks_creation(sculptor_instance_: SculptorInstan
     page = sculptor_instance_.page
     add_ws_page = PlaywrightAddWorkspacePage(page=page)
 
-    # Clone is now opt-in; enable the flag and pick clone mode explicitly.
+    # Clone is opt-in; enable the flag and pick clone mode explicitly.
     enable_clone_workspaces(page)
 
     navigate_to_add_workspace_page(page)

--- a/sculptor/tests/integration/frontend/test_branch_switching_integration.py
+++ b/sculptor/tests/integration/frontend/test_branch_switching_integration.py
@@ -22,17 +22,14 @@ def test_branch_switching_with_untracked_file(sculptor_instance_: SculptorInstan
     """
     page = sculptor_instance_.page
 
-    # Set up test branches
     branch_a = "branch_a"
     branch_b = "branch_b"
 
-    # Create and set up branch A
     sculptor_instance_.repo.create_reset_and_checkout_branch(branch_a)
     sculptor_instance_.repo.write_file("src/file_a.py", "print('Hello from branch A!')")
     sculptor_instance_.repo.stage_all_changes()
     sculptor_instance_.repo.commit("Add file A", commit_time="2025-01-01T00:00:01")
 
-    # Create and set up branch B
     sculptor_instance_.repo.create_reset_and_checkout_branch(branch_b)
     sculptor_instance_.repo.write_file("src/file_b.py", "print('Hello from branch B!')")
     sculptor_instance_.repo.stage_all_changes()
@@ -41,14 +38,11 @@ def test_branch_switching_with_untracked_file(sculptor_instance_: SculptorInstan
     # Switch back to branch A (this is our current branch when Sculptor starts)
     sculptor_instance_.repo.checkout_branch(branch_a)
 
-    # Create an untracked file
     sculptor_instance_.repo.write_file("untracked_file.txt", "This is an untracked file")
 
-    # Verify initial state
     current_branch = sculptor_instance_.repo.get_current_branch_name()
     assert current_branch == branch_a, f"Expected to be on {branch_a}, but on {current_branch}"
 
-    # Verify both branches exist
     all_branches = sculptor_instance_.repo.get_branches()
     assert branch_a in all_branches, f"Branch {branch_a} not found in repo. Available branches: {all_branches}"
     assert branch_b in all_branches, f"Branch {branch_b} not found in repo. Available branches: {all_branches}"

--- a/sculptor/tests/integration/frontend/test_browser_panel.py
+++ b/sculptor/tests/integration/frontend/test_browser_panel.py
@@ -144,7 +144,7 @@ def test_browser_panel_navigation_tour(
 ) -> None:
     """End-to-end tour of the navigation contract on a single panel.
 
-    Combines Task 2.5's navigate / address-bar / back-forward / refresh /
+    Combines the navigate / address-bar / back-forward / refresh /
     target=_blank / fresh-state / invalid-URL cases into one long-running
     test on a single Sculptor instance.
     """

--- a/sculptor/tests/integration/frontend/test_claude_binary_installation.py
+++ b/sculptor/tests/integration/frontend/test_claude_binary_installation.py
@@ -24,10 +24,6 @@ from sculptor.testing.user_stories import user_story
 # Mark for tests that hit external services (download from the internet, etc.)
 external_deps = pytest.mark.external_deps
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _populate_with_custom_mode(path: Path) -> None:
     """Write a config with dependency_paths.claude=claude so the instance uses custom mode.
@@ -68,11 +64,6 @@ def _delete_managed_claude_cache(sculptor_folder: Path) -> None:
     claude_dir = sculptor_folder / "internal" / DEPENDENCIES_DIR_NAME / "claude"
     if claude_dir.exists():
         shutil.rmtree(claude_dir)
-
-
-# ---------------------------------------------------------------------------
-# Settings section tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.release
@@ -208,11 +199,6 @@ def test_settings_git_section_visible(sculptor_instance_: SculptorInstance) -> N
     expect(git_status).to_contain_text("Installed")
 
 
-# ---------------------------------------------------------------------------
-# Onboarding tests
-# ---------------------------------------------------------------------------
-
-
 @user_story("to see that Claude is not found during onboarding and can use a custom path")
 @custom_sculptor_folder_populator.with_args(_populate_with_custom_mode)
 @stub_dependency("claude", state=DependencyState.NOT_INSTALLED)
@@ -299,10 +285,6 @@ def test_onboarding_claude_override_invalid_path(sculptor_instance_factory_: Scu
         expect(error).to_be_visible()
         expect(error).to_contain_text("No executable found")
 
-
-# ---------------------------------------------------------------------------
-# Real installation tests (require internet access)
-# ---------------------------------------------------------------------------
 
 INSTALL_TIMEOUT_MS = 120_000
 

--- a/sculptor/tests/integration/frontend/test_claude_errors.py
+++ b/sculptor/tests/integration/frontend/test_claude_errors.py
@@ -23,10 +23,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _stop_agent(chat_panel: PlaywrightChatPanelElement) -> None:
     """Click the stop button and wait for the agent to stop."""
@@ -34,11 +30,6 @@ def _stop_agent(chat_panel: PlaywrightChatPanelElement) -> None:
     expect(stop_button).to_be_visible()
     stop_button.click()
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
-
-
-# ---------------------------------------------------------------------------
-# 1. Non-JSON output
-# ---------------------------------------------------------------------------
 
 
 @user_story("to see the agent recover gracefully when the Anthropic API returns garbage")
@@ -65,11 +56,6 @@ def test_garbage_output_does_not_crash_ui(sculptor_instance_: SculptorInstance) 
     send_chat_message(chat_panel, 'fake_claude:text `{"text": "Recovery after garbage"}`')
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
     expect(chat_panel.get_messages().last).to_contain_text("Recovery after garbage")
-
-
-# ---------------------------------------------------------------------------
-# 2. Hung / non-responsive process
-# ---------------------------------------------------------------------------
 
 
 @user_story("to stop a non-responsive agent via the Stop button")
@@ -101,11 +87,6 @@ def test_stop_kills_hung_process(sculptor_instance_: SculptorInstance) -> None:
     expect(messages.last).to_contain_text("Recovery after hang")
 
 
-# ---------------------------------------------------------------------------
-# 3. Stdin backpressure
-# ---------------------------------------------------------------------------
-
-
 @user_story("to stop an agent that ignores stdin without the UI freezing")
 def test_stdin_backpressure_does_not_block_stop(sculptor_instance_: SculptorInstance) -> None:
     """When the CLI never reads stdin, writing a follow-up message or interrupt
@@ -135,11 +116,6 @@ def test_stdin_backpressure_does_not_block_stop(sculptor_instance_: SculptorInst
     send_chat_message(chat_panel, 'fake_claude:text `{"text": "Recovery after backpressure"}`')
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
     expect(chat_panel.get_messages().last).to_contain_text("Recovery after backpressure")
-
-
-# ---------------------------------------------------------------------------
-# 4. Process leak after error response
-# ---------------------------------------------------------------------------
 
 
 def _read_pid_file(pid_path: Path, page: Page, timeout: float = 10.0) -> int:
@@ -217,11 +193,6 @@ def test_error_response_terminates_process(sculptor_instance_: SculptorInstance)
         if leaked_pid is not None:
             _kill_process(leaked_pid)
         pid_path.unlink(missing_ok=True)
-
-
-# ---------------------------------------------------------------------------
-# 5. Successful response + slow-to-exit process
-# ---------------------------------------------------------------------------
 
 
 @user_story("to see a successful response even when the CLI process is slow to exit")

--- a/sculptor/tests/integration/frontend/test_closed_workspaces_dropdown.py
+++ b/sculptor/tests/integration/frontend/test_closed_workspaces_dropdown.py
@@ -31,7 +31,6 @@ def test_pill_visibility_toggles_with_closed_workspace_count(
     pill = layout.get_closed_workspaces_pill()
     expect(pill).not_to_be_visible()
 
-    # Close the first workspace tab
     layout.close_workspace_tab(workspace_tab_index=0)
 
     expect(pill).to_be_visible()
@@ -99,7 +98,6 @@ def test_reopen_workspace_from_dropdown(
     expect(row).to_be_visible()
     row.click()
 
-    # Workspace tab should reappear and pill should disappear
     expect(workspace_tabs).to_have_count(2)
     expect(pill).not_to_be_visible()
 
@@ -134,7 +132,6 @@ def test_delete_workspace_from_dropdown(
     expect(delete_button).to_be_visible()
     delete_button.click()
 
-    # Confirmation dialog should appear
     confirm_dialog = dropdown_element.get_delete_confirmation_dialog()
     expect(confirm_dialog).to_be_visible()
 
@@ -164,7 +161,6 @@ def test_pill_visible_on_add_workspace_page(
     expect(pill).to_be_visible()
     expect(pill).to_contain_text("1")
 
-    # Navigate to the add workspace page
     layout.get_add_workspace_button().click()
 
     # Pill should still be visible on the new workspace page
@@ -210,7 +206,6 @@ def test_open_all_reopens_all_closed_workspaces(
     expect(open_all_button).to_be_visible()
     open_all_button.click()
 
-    # Both closed workspace tabs should reappear and pill should disappear
     expect(workspace_tabs).to_have_count(3)
     expect(pill).not_to_be_visible()
     expect(dropdown_element).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_command_palette.py
+++ b/sculptor/tests/integration/frontend/test_command_palette.py
@@ -80,9 +80,7 @@ def test_command_palette_navigates_to_settings(sculptor_instance_: SculptorInsta
     palette.type_query("Open Settings")
     palette.select_by_command_id("nav.settings")
 
-    # The palette should auto-close after the navigation.
     expect(palette).not_to_be_visible()
-    # And the Settings page should be visible.
     expect(layout.get_settings_page_locator()).to_be_visible()
 
 
@@ -123,7 +121,6 @@ def test_command_palette_keep_open_command(sculptor_instance_: SculptorInstance)
     palette.type_query("Toggle Theme")
     palette.select_by_command_id("theme.toggle")
 
-    # Palette is still visible.
     expect(palette).to_be_visible()
 
     # Flip the theme back so the test doesn't leave a lasting side effect

--- a/sculptor/tests/integration/frontend/test_commit_from_changes_tab.py
+++ b/sculptor/tests/integration/frontend/test_commit_from_changes_tab.py
@@ -35,14 +35,12 @@ def test_commit_button_sends_commit_message(sculptor_instance_: SculptorInstance
     # Open Changes tab (Uncommitted scope — commit only applies to uncommitted changes)
     task_page.activate_changes_panel(scope="uncommitted")
 
-    # Verify there's a file in the changes tree
     changes_tree = get_changes_tree(page)
     expect(changes_tree).to_be_visible()
     tree_rows = changes_tree.get_tree_rows()
     expect(tree_rows).to_have_count(1)
     expect(tree_rows.first).to_contain_text("hello.py")
 
-    # The commit button should be visible and clickable
     commit_btn = task_page.get_commit_button()
     expect(commit_btn).to_be_visible()
     expect(commit_btn).to_contain_text("Commit 1 change")

--- a/sculptor/tests/integration/frontend/test_component_gallery_tab.py
+++ b/sculptor/tests/integration/frontend/test_component_gallery_tab.py
@@ -44,18 +44,14 @@ def test_component_gallery_opens_as_tab(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create a workspace.
     start_task_and_wait_for_ready(page, prompt="Gallery test", workspace_name="Gallery WS")
 
-    # Step 2: Open Component Gallery via Theme Builder.
     _open_component_gallery_tab(sculptor_instance_)
 
-    # Step 3: Verify a Component Gallery tab appears.
     layout = PlaywrightProjectLayoutPage(page=page)
     gallery_tab = layout.get_component_gallery_tab()
     expect(gallery_tab).to_be_visible()
 
-    # Step 4: Verify the Component Gallery tab is active.
     expect(gallery_tab).to_have_attribute("aria-selected", "true")
 
 
@@ -74,24 +70,19 @@ def test_component_gallery_tab_is_closeable(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create a workspace.
     start_task_and_wait_for_ready(page, prompt="Close gallery test", workspace_name="Close Gallery WS")
 
-    # Step 2: Open Component Gallery tab.
     _open_component_gallery_tab(sculptor_instance_)
 
     layout = PlaywrightProjectLayoutPage(page=page)
     gallery_tab = layout.get_component_gallery_tab()
     expect(gallery_tab).to_be_visible()
 
-    # Step 3: Click the close button on the Component Gallery tab.
     close_button = gallery_tab.get_by_test_id(ElementIDs.TAB_CLOSE_BUTTON)
     close_button.click()
 
-    # Step 4: Verify the Component Gallery tab disappears.
     expect(gallery_tab).to_have_count(0)
 
-    # Step 5: Verify a workspace tab is active.
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(1)
 
@@ -111,25 +102,20 @@ def test_component_gallery_tab_context_menu_no_rename_or_delete(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create a workspace and open Component Gallery.
     start_task_and_wait_for_ready(page, prompt="Menu test", workspace_name="Menu Gallery WS")
     _open_component_gallery_tab(sculptor_instance_)
 
-    # Step 2: Right-click the Component Gallery tab.
     layout = PlaywrightProjectLayoutPage(page=page)
     tab_bar = PlaywrightAgentTabBarElement(page)
     gallery_tab = layout.get_component_gallery_tab()
     expect(gallery_tab).to_be_visible()
     tab_bar.open_context_menu(gallery_tab)
 
-    # Step 3: Verify Close is visible.
     close_item = tab_bar.get_context_menu_close_item()
     expect(close_item).to_be_visible()
 
-    # Step 4: Verify Rename is not present.
     rename_item = tab_bar.get_context_menu_rename_item()
     expect(rename_item).to_have_count(0)
 
-    # Step 5: Verify Delete is not present.
     delete_item = tab_bar.get_context_menu_delete_item()
     expect(delete_item).to_have_count(0)

--- a/sculptor/tests/integration/frontend/test_custom_actions.py
+++ b/sculptor/tests/integration/frontend/test_custom_actions.py
@@ -17,10 +17,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _create_task_and_navigate(sculptor_instance: SculptorInstance):
     """Create a TestingAgent task via API and navigate to its workspace page.
@@ -32,11 +28,6 @@ def _create_task_and_navigate(sculptor_instance: SculptorInstance):
         prompt="Test task for custom actions",
     )
     return task_page
-
-
-# ---------------------------------------------------------------------------
-# Tests: Actions Panel (workspace)
-# ---------------------------------------------------------------------------
 
 
 @user_story("to create a custom action from the actions panel and see it appear as a chip")
@@ -55,7 +46,6 @@ def test_create_action_from_panel(sculptor_instance_: SculptorInstance) -> None:
 
     expect(dialog).not_to_be_visible()
 
-    # Verify the chip appears in the panel
     chip = actions_panel.get_action_chip_by_name("Run Tests")
     expect(chip).to_be_visible()
 
@@ -80,31 +70,21 @@ def test_edit_action_from_settings(sculptor_instance_: SculptorInstance) -> None
     # stable" failures under parallel execution).
     settings_page.dismiss_toast()
 
-    # Find the action row and click the edit icon
     edit_button = actions_section.get_action_edit_button("Old Name")
     edit_button.click()
 
-    # Edit the action name
     edit_dialog = get_action_dialog(sculptor_instance_.page)
     expect(edit_dialog).to_be_visible()
     edit_dialog.fill_name("New Name")
     edit_dialog.click_save()
     expect(edit_dialog).not_to_be_visible()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # Verify the updated name appears in settings
     updated_row = actions_section.get_action_row_by_name("New Name")
     expect(updated_row).to_be_visible()
 
-    # Old name should be gone
     expect(actions_section.get_action_row_by_name("Old Name")).to_have_count(0)
-
-
-# ---------------------------------------------------------------------------
-# Tests: Settings page
-# ---------------------------------------------------------------------------
 
 
 @user_story("to create a custom action from the settings page")
@@ -113,7 +93,6 @@ def test_create_action_from_settings(sculptor_instance_: SculptorInstance) -> No
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     actions_section = settings_page.click_on_actions()
 
-    # Click "Add Action"
     actions_section.get_add_action_button().click()
 
     dialog = get_action_dialog(sculptor_instance_.page)
@@ -124,10 +103,8 @@ def test_create_action_from_settings(sculptor_instance_: SculptorInstance) -> No
 
     expect(dialog).not_to_be_visible()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # Verify the action row appears
     action_row = actions_section.get_action_row_by_name("Lint Code")
     expect(action_row).to_be_visible()
 
@@ -147,19 +124,14 @@ def test_delete_action_from_settings(sculptor_instance_: SculptorInstance) -> No
     dialog.click_save()
     expect(dialog).not_to_be_visible()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # Find the action row and click the delete icon
     actions_section.get_action_delete_button("To Remove").click()
 
-    # Confirm deletion
     actions_section.confirm_delete_action()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # Verify the action row is gone
     expect(actions_section.get_action_row_by_name("To Remove")).to_have_count(0)
 
 
@@ -169,21 +141,16 @@ def test_create_group_from_settings(sculptor_instance_: SculptorInstance) -> Non
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     actions_section = settings_page.click_on_actions()
 
-    # Click "Add Group"
     actions_section.get_add_group_button().click()
 
-    # Fill in the group name in the dialog that appears
     group_name_input = actions_section.get_group_name_input()
     expect(group_name_input).to_be_visible()
     group_name_input.fill("My Group")
 
-    # Click "Create Group"
     actions_section.get_create_group_button().click()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # Verify the group appears in the settings section
     group_heading = actions_section.get_group_headings().filter(has_text="My Group")
     expect(group_heading).to_be_visible()
 
@@ -203,7 +170,6 @@ def test_action_persists_across_page_reload(sculptor_instance_: SculptorInstance
     dialog.click_save()
     expect(dialog).not_to_be_visible()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
     # Soft-reload to verify persistence (direct reload causes ERR_INSUFFICIENT_RESOURCES on CI)
@@ -214,14 +180,8 @@ def test_action_persists_across_page_reload(sculptor_instance_: SculptorInstance
     reloaded_settings = PlaywrightSettingsPage(page=sculptor_instance_.page)
     actions_section = reloaded_settings.click_on_actions()
 
-    # Verify the action still exists
     action_row = actions_section.get_action_row_by_name("Persistent Action")
     expect(action_row).to_be_visible()
-
-
-# ---------------------------------------------------------------------------
-# Tests: Skill mentions in action prompts
-# ---------------------------------------------------------------------------
 
 
 @user_story("to see clean prompt text in settings when an action contains a skill mention")
@@ -235,7 +195,6 @@ def test_action_with_skill_mention_displays_cleanly_in_settings(sculptor_instanc
     """
     page = sculptor_instance_.page
 
-    # Open the action dialog from the settings page
     settings_page = navigate_to_settings_page(page=page)
     actions_section = settings_page.click_on_actions()
     actions_section.get_add_action_button().click()
@@ -250,17 +209,13 @@ def test_action_with_skill_mention_displays_cleanly_in_settings(sculptor_instanc
     expect(prompt_input).to_be_visible()
     insert_mention_into_tiptap(prompt_input, "/fix-bug", "/")
 
-    # Verify the mention span was inserted into the editor
     expect(dialog.get_mention_span()).to_be_visible()
 
-    # Save the action
     dialog.click_save()
     expect(dialog).not_to_be_visible()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # Find the action row in settings and verify the prompt preview is clean text.
     # The prompt preview must NOT contain raw HTML attributes — if it does,
     # the tiptap-markdown serializer is leaking HTML into the stored prompt.
     action_row = actions_section.get_action_row_by_name("Skill Action")
@@ -269,11 +224,7 @@ def test_action_with_skill_mention_displays_cleanly_in_settings(sculptor_instanc
     expect(action_row).not_to_contain_text("data-label")
 
 
-# ---------------------------------------------------------------------------
 # Tests: Delete group also deletes actions (SCU-308)
-# ---------------------------------------------------------------------------
-
-
 @user_story("to delete a group from settings and have its actions deleted too")
 def test_delete_group_deletes_actions_from_settings(sculptor_instance_: SculptorInstance) -> None:
     """Delete a group from the settings page and verify its actions are also removed."""
@@ -281,7 +232,6 @@ def test_delete_group_deletes_actions_from_settings(sculptor_instance_: Sculptor
     settings_page = navigate_to_settings_page(page=page)
     actions_section = settings_page.click_on_actions()
 
-    # 1. Create a group
     actions_section.get_add_group_button().click()
     group_name_input = actions_section.get_group_name_input()
     expect(group_name_input).to_be_visible()
@@ -290,7 +240,6 @@ def test_delete_group_deletes_actions_from_settings(sculptor_instance_: Sculptor
 
     settings_page.dismiss_toast()
 
-    # 2. Create an action in that group
     actions_section.get_add_action_button().click()
     dialog = get_action_dialog(page)
     expect(dialog).to_be_visible()
@@ -303,27 +252,17 @@ def test_delete_group_deletes_actions_from_settings(sculptor_instance_: Sculptor
 
     settings_page.dismiss_toast()
 
-    # Verify action appears under the group
     action_row = actions_section.get_action_row_by_name("Doomed Action")
     expect(action_row).to_be_visible()
 
-    # 3. Delete the group via the trash icon on the group header
     actions_section.click_delete_group("Doomed Group")
 
-    # 4. Confirm in the delete group dialog
     actions_section.confirm_delete_group()
 
-    # Wait for success toast
     expect(settings_page.get_toast()).to_be_visible()
 
-    # 5. Verify both group and action are gone
     expect(actions_section.get_group_headings().filter(has_text="Doomed Group")).to_have_count(0)
     expect(actions_section.get_action_row_by_name("Doomed Action")).to_have_count(0)
-
-
-# ---------------------------------------------------------------------------
-# Tests: Built-in Sculptor group
-# ---------------------------------------------------------------------------
 
 
 @user_story("to see the built-in Sculptor group with its un-deletable skill chips")
@@ -339,7 +278,6 @@ def test_builtin_chips(sculptor_instance_: SculptorInstance) -> None:
     page = sculptor_instance_.page
     actions_panel = task_page.get_actions_panel()
 
-    # Sculptor header + both built-in chips are visible.
     sculptor_header = actions_panel.get_group_header_by_name("Sculptor")
     expect(sculptor_header).to_be_visible()
     expect(actions_panel.get_action_chip_by_name("/help")).to_be_visible()
@@ -406,7 +344,6 @@ def test_draft_action_populates_and_focuses_chat_input(sculptor_instance_: Sculp
     dialog.click_save()
     expect(dialog).not_to_be_visible()
 
-    # Click the chip.
     actions_panel.get_action_chip_by_name("My Draft Action").click()
 
     chat_input = task_page.get_chat_panel().get_chat_input()
@@ -420,7 +357,6 @@ def test_delete_group_deletes_actions_from_panel(sculptor_instance_: SculptorIns
     and verify its actions are also removed."""
     page = sculptor_instance_.page
 
-    # 1. Create an action with a new group from the workspace panel
     task_page = _create_task_and_navigate(sculptor_instance_)
     actions_panel = task_page.get_actions_panel()
 
@@ -434,15 +370,11 @@ def test_delete_group_deletes_actions_from_panel(sculptor_instance_: SculptorIns
     dialog.click_save()
     expect(dialog).not_to_be_visible()
 
-    # Verify the action chip appears in the panel
     chip = actions_panel.get_action_chip_by_name("Panel Action")
     expect(chip).to_be_visible()
 
-    # 2. Right-click the group header to open context menu, then click "Delete group"
     actions_panel.delete_group_via_context_menu("Panel Group")
 
-    # 3. Confirm in the delete group dialog
     actions_panel.confirm_delete_group()
 
-    # 4. Verify the action chip is gone
     expect(actions_panel.get_action_chip_by_name("Panel Action")).to_have_count(0)

--- a/sculptor/tests/integration/frontend/test_delete_last_repo.py
+++ b/sculptor/tests/integration/frontend/test_delete_last_repo.py
@@ -28,18 +28,14 @@ def test_deleting_last_repo_shows_onboarding_add_repo_step(
     with sculptor_instance_factory_.spawn_instance() as sculptor_instance:
         page = sculptor_instance.page
 
-        # Step 1: Navigate to Settings > Repositories
         settings_page = navigate_to_settings_page(page=page)
         repos_settings = settings_page.click_on_repositories()
 
-        # Step 2: The remove button on the only repo should be enabled (not disabled)
         remove_button = repos_settings.get_first_repo_remove_button()
         expect(remove_button).to_be_enabled()
 
-        # Step 3: Click remove and confirm
         repos_settings.remove_first_repo()
 
-        # Step 4: The onboarding wizard should appear at the ADD_REPO step
         onboarding_page = PlaywrightOnboardingPage(page)
         add_repo_step = onboarding_page.get_add_repo_step()
         expect(add_repo_step).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_diff_scope_and_fullscreen.py
+++ b/sculptor/tests/integration/frontend/test_diff_scope_and_fullscreen.py
@@ -42,7 +42,6 @@ def test_scope_picker_defaults_to_all(sculptor_instance_: SculptorInstance) -> N
     task_page.activate_changes_panel()
     task_page.click_review_all()
 
-    # Verify the scope picker inside the diff panel is visible and shows "All".
     # The Changes tab also renders its own DiffScopePicker, so we scope to the
     # diff panel to avoid a strict-mode violation from two matching elements.
     diff_panel = task_page.get_diff_panel()
@@ -65,7 +64,6 @@ def test_expand_toggle_expands_and_collapses(sculptor_instance_: SculptorInstanc
     task_page.activate_changes_panel()
     task_page.click_review_all()
 
-    # Click the expand toggle
     diff_panel = task_page.get_diff_panel()
     expand_toggle = diff_panel.get_expand_toggle()
     expect(expand_toggle).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_discard_file.py
+++ b/sculptor/tests/integration/frontend/test_discard_file.py
@@ -60,7 +60,6 @@ def test_discard_file_removes_from_changes(sculptor_instance_: SculptorInstance)
     expect(discard_row).to_have_count(1)
     discard_row.hover()
 
-    # Click the discard button
     discard_button = changes_panel.get_discard_button(discard_row)
     expect(discard_button).to_be_visible()
     discard_button.click()
@@ -71,7 +70,6 @@ def test_discard_file_removes_from_changes(sculptor_instance_: SculptorInstance)
     expect(dialog).to_contain_text("discard_me.py")
     expect(dialog).to_contain_text("cannot be undone")
 
-    # Confirm the discard
     changes_panel.get_discard_dialog_confirm().click()
 
     # Dialog should close and the file should be removed from the list
@@ -103,7 +101,6 @@ def test_discard_cancel_preserves_file(sculptor_instance_: SculptorInstance) -> 
     discard_row.hover()
     changes_panel.get_discard_button(discard_row).click()
 
-    # Cancel the dialog
     dialog = changes_panel.get_discard_dialog()
     expect(dialog).to_be_visible()
     changes_panel.get_discard_dialog_cancel().click()

--- a/sculptor/tests/integration/frontend/test_entity_mention_persistence.py
+++ b/sculptor/tests/integration/frontend/test_entity_mention_persistence.py
@@ -9,7 +9,7 @@ Two tests:
   1. Single-mention round-trip — the draft re-renders as a chip, not as
      literal ``+[type:id|display_name]`` text.
   2. Multi-paragraph round-trip — both mentions hydrate after the cross-
-     paragraph hydration fix (commit ``e0fa91faa9c``), not just the first.
+     paragraph hydration fix, not just the first.
      The hydration walk scans every text node and applies replacements in
      descending position order so earlier indices stay valid.
 """

--- a/sculptor/tests/integration/frontend/test_file_browser_tabs.py
+++ b/sculptor/tests/integration/frontend/test_file_browser_tabs.py
@@ -61,7 +61,6 @@ def test_tab_switching_shows_correct_content(sculptor_instance_: SculptorInstanc
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Ensure the File Browser panel is visible
     task_page.activate_file_browser()
     file_browser = task_page.get_file_browser()
 

--- a/sculptor/tests/integration/frontend/test_history_panel.py
+++ b/sculptor/tests/integration/frontend/test_history_panel.py
@@ -187,7 +187,6 @@ def test_history_panel_refreshes_on_target_branch_change(sculptor_instance_: Scu
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open the History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -259,7 +258,6 @@ def test_terminus_shows_fork_point_hash(sculptor_instance_: SculptorInstance) ->
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -285,7 +283,6 @@ def test_terminus_visible_with_no_commits(sculptor_instance_: SculptorInstance) 
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -375,7 +372,6 @@ def test_merge_commit_shows_spur(sculptor_instance_: SculptorInstance) -> None:
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -407,7 +403,6 @@ def test_commit_entry_shows_metadata_line(sculptor_instance_: SculptorInstance) 
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -435,7 +430,6 @@ def test_commit_hover_popover_shows_details(sculptor_instance_: SculptorInstance
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -466,7 +460,6 @@ def test_click_dismisses_popover(sculptor_instance_: SculptorInstance) -> None:
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=60_000)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -520,7 +513,6 @@ def test_folder_rename_shows_correct_paths(sculptor_instance_: SculptorInstance)
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()
@@ -572,7 +564,6 @@ def test_clicking_renamed_file_in_commits_shows_rename_banner(sculptor_instance_
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Open History tab
     task_page.activate_history_panel()
     history_panel = task_page.get_history_panel()
     expect(history_panel).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_history_panel_diffs.py
+++ b/sculptor/tests/integration/frontend/test_history_panel_diffs.py
@@ -15,10 +15,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ---------------------------------------------------------------------------
-# Prompts
-# ---------------------------------------------------------------------------
-
 # Creates a branch with a single commit that touches TWO files.
 _MULTI_FILE_COMMIT_PROMPT = """\
 fake_claude:multi_step `{
@@ -165,11 +161,6 @@ fake_claude:multi_step `{
 }`"""
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _open_history_and_expand_first_commit(
     task_page: PlaywrightTaskPage,
 ) -> tuple[PlaywrightHistoryPanelElement, Locator]:
@@ -187,9 +178,7 @@ def _open_history_and_expand_first_commit(
     return history_panel, first_commit
 
 
-# ---------------------------------------------------------------------------
 # Bug 1: clicking a file in a multi-file commit crashes
-# ---------------------------------------------------------------------------
 
 
 @user_story("to view a single file's diff from a multi-file commit without the diff viewer crashing")
@@ -224,9 +213,7 @@ def test_click_file_in_multi_file_commit(
     expect(diff_panel).to_contain_text("a = 1")
 
 
-# ---------------------------------------------------------------------------
 # Bug 2: commit-diff tab not re-selectable after opening same file from Changes
-# ---------------------------------------------------------------------------
 
 
 @user_story("to switch between a commit-diff tab and an uncommitted-diff tab for the same file")
@@ -277,9 +264,7 @@ def test_commit_diff_tab_selectable_alongside_regular_tab(
     expect(commit_tab).to_have_attribute("aria-selected", "true")
 
 
-# ---------------------------------------------------------------------------
 # Additional bug exploration: clicking files from two different commits
-# ---------------------------------------------------------------------------
 
 
 @user_story("to open diffs from two different commits and switch between them")
@@ -340,9 +325,7 @@ def test_open_files_from_different_commits(
     expect(first_tab).to_have_attribute("aria-selected", "true")
 
 
-# ---------------------------------------------------------------------------
 # Additional: closing a commit-diff tab should not affect regular tabs
-# ---------------------------------------------------------------------------
 
 
 @user_story("to close a commit-diff tab without losing the regular diff tab for the same file")
@@ -398,9 +381,7 @@ def test_close_commit_diff_tab_keeps_regular_tab(
     expect(diff_panel).to_contain_text("x = 2")
 
 
-# ---------------------------------------------------------------------------
 # Edge case: same file modified in two commits shows correct diff per tab
-# ---------------------------------------------------------------------------
 
 
 @user_story("to view the correct diff content when the same file is modified across two commits")
@@ -467,9 +448,7 @@ def test_same_file_two_commits_shows_correct_content(
     expect(diff_panel).to_contain_text("version_two")
 
 
-# ---------------------------------------------------------------------------
 # Edge case: switching between files within a single multi-file commit
-# ---------------------------------------------------------------------------
 
 
 @user_story("to switch between different file diffs within the same commit")
@@ -513,9 +492,7 @@ def test_switch_files_within_same_commit(
     expect(diff_panel).to_contain_text("a = 1")
 
 
-# ---------------------------------------------------------------------------
 # Bug 3: DiffFileHeader shows +0 -0 for commit-diff tabs
-# ---------------------------------------------------------------------------
 
 
 @user_story("to see correct line count stats in the file header for a commit-scoped diff")
@@ -547,9 +524,7 @@ def test_commit_diff_file_header_shows_line_counts(
     expect(diff_panel.get_file_header()).to_contain_text("+1")
 
 
-# ---------------------------------------------------------------------------
 # Edge case: commit-diff tab shows only its commit's content
-# ---------------------------------------------------------------------------
 
 
 @user_story("to verify that a commit-diff tab shows the commit's changes, not uncommitted edits")
@@ -605,9 +580,7 @@ def test_commit_diff_shows_committed_content_not_uncommitted(
     expect(diff_panel).not_to_contain_text("x = 2")
 
 
-# ---------------------------------------------------------------------------
 # Bug 4: split-view handle rendered for an added file inside a commit diff
-# ---------------------------------------------------------------------------
 
 
 @user_story("to not see a useless splitter when viewing a newly added file inside a commit diff")

--- a/sculptor/tests/integration/frontend/test_home_page.py
+++ b/sculptor/tests/integration/frontend/test_home_page.py
@@ -26,14 +26,12 @@ def test_recent_workspaces_shown_on_home_page(
     """After creating a workspace, navigating to /home should show it in the recent list."""
     page = sculptor_instance_.page
 
-    # Create a workspace
     start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt="Build the feature",
         workspace_name="My Feature Workspace",
     )
 
-    # Navigate to Home page
     navigate_to_home_page(page)
 
     # Wait for the recent workspaces to load and verify the workspace appears
@@ -49,7 +47,6 @@ def test_empty_state_shown_for_new_user(
     """When a user has zero workspaces, the empty state should be shown on the home page."""
     page = sculptor_instance_.page
 
-    # Navigate to the home page
     navigate_to_home_page(page)
 
     # The empty state heading should be visible
@@ -80,7 +77,6 @@ def test_workspace_search_filters_list(
         workspace_name="Dark Mode Feature",
     )
 
-    # Navigate to Home page
     navigate_to_home_page(page)
 
     # Wait for recent workspaces to load
@@ -105,14 +101,12 @@ def test_clicking_workspace_row_navigates_to_workspace(
     """Clicking a workspace row should navigate to that workspace."""
     page = sculptor_instance_.page
 
-    # Create a workspace
     start_task_and_wait_for_ready(
         sculptor_page=page,
         prompt="Build feature",
         workspace_name="Navigation Test",
     )
 
-    # Navigate to Home page
     navigate_to_home_page(page)
 
     # Wait for and click the workspace row

--- a/sculptor/tests/integration/frontend/test_image_thumbnail_strip.py
+++ b/sculptor/tests/integration/frontend/test_image_thumbnail_strip.py
@@ -272,14 +272,12 @@ def test_thumbnails_use_object_fit_cover(
     expect(thumbnails.nth(0)).to_have_css("object-fit", "cover")
 
 
-# ---------------------------------------------------------------------------
 # Alpha chat view tests
 #
 # Strategy: attach files and send in classic view (where _attach_and_send
 # works with ASSISTANT_MESSAGE/USER_MESSAGE selectors), then switch to
 # alpha view for layout assertions.  This verifies that AlphaUserMessage
 # renders existing file blocks correctly.
-# ---------------------------------------------------------------------------
 
 
 def _get_alpha_preview_list(page: Page) -> Locator:

--- a/sculptor/tests/integration/frontend/test_image_upload.py
+++ b/sculptor/tests/integration/frontend/test_image_upload.py
@@ -153,13 +153,11 @@ def test_image_upload_from_second_agent(sculptor_instance_: SculptorInstance, te
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Add a second agent to the workspace
     agent_tab_bar = task_page.get_agent_tab_bar()
     agent_tab_bar.get_add_agent_button().click()
 
     expect(agent_tab_bar.get_agent_tabs()).to_have_count(2)
 
-    # The new agent's chat panel should be visible
     new_task_page = PlaywrightTaskPage(page=page)
     new_chat_panel = new_task_page.get_chat_panel()
 
@@ -209,13 +207,11 @@ def test_images_deleted_when_task_deleted(
 
     images = _verify_image_in_message(chat_panel, message_index=0, expected_image_count=2)
 
-    # Extract image paths from data-path attributes
     image_paths = []
     for i in range(2):
         image_path = images.nth(i).get_attribute("data-path")
         image_paths.append(Path(image_path))
 
-    # Verify images exist on disk before deletion
     assert len(image_paths) == 2, "Should have extracted 2 image paths"
     for image_path in image_paths:
         assert image_path.exists(), f"Image should exist at {image_path}"
@@ -233,6 +229,5 @@ def test_images_deleted_when_task_deleted(
     delete_resp = page.request.delete(f"{base_url}/api/v1/workspaces/{ws_id}")
     assert delete_resp.ok, f"Failed to delete workspace: {delete_resp.status}"
 
-    # Verify images no longer exist on disk
     for image_path in image_paths:
         assert not image_path.exists(), f"Image should be deleted at {image_path}"

--- a/sculptor/tests/integration/frontend/test_inline_media_display.py
+++ b/sculptor/tests/integration/frontend/test_inline_media_display.py
@@ -65,11 +65,9 @@ def test_assistant_img_tag_renders_file_preview(
 
     messages = chat_panel.get_messages()
 
-    # The assistant message (index 1) should contain the rendered file preview
     assistant_message = messages.nth(1)
     expect_message_to_have_role(message=assistant_message, role=ElementIDs.ASSISTANT_MESSAGE)
 
-    # The FileBlock should have been delivered and rendered as a FILE_PREVIEW_CONTAINER
     file_preview_container = assistant_message.get_by_test_id(ElementIDs.FILE_PREVIEW_CONTAINER)
     expect(file_preview_container).to_have_count(1)
 
@@ -192,7 +190,6 @@ def test_assistant_img_tag_persists_after_tool_call(
     file_preview_container = assistant_message.get_by_test_id(ElementIDs.FILE_PREVIEW_CONTAINER)
     expect(file_preview_container).to_have_count(1)
 
-    # The text content should also be visible
     expect(assistant_message).to_contain_text("Here is a screenshot")
     expect(assistant_message).to_contain_text("Done.")
 
@@ -292,13 +289,11 @@ def test_assistant_img_tag_persists_after_restart(
 
     # Phase 2: Restart and verify the image persisted
     with sculptor_instance_factory_.spawn_instance() as instance:
-        # Navigate to the workspace
         new_task_page = PlaywrightTaskPage(page=instance.page)
         workspace_tab = new_task_page.get_workspace_tabs().first
         expect(workspace_tab).to_be_visible()
         workspace_tab.click()
 
-        # Wait for the chat to load with the persisted messages
         chat_panel = new_task_page.get_chat_panel()
         wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
@@ -310,7 +305,6 @@ def test_assistant_img_tag_persists_after_restart(
         file_preview_container = assistant_message.get_by_test_id(ElementIDs.FILE_PREVIEW_CONTAINER)
         expect(file_preview_container).to_have_count(1)
 
-        # The surrounding text should also be visible
         expect(assistant_message).to_contain_text("Here is a screenshot")
         expect(assistant_message).to_contain_text("Done.")
 
@@ -325,7 +319,6 @@ def test_assistant_multiple_images_render_as_thumbnail_strip(
     The FILE_PREVIEW_LIST container should use flex-direction: row so images appear
     side by side, matching the layout used in user messages.
     """
-    # Create a second test image for the strip
     temp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
     second_image_path = temp_file.name
     temp_file.close()
@@ -413,13 +406,11 @@ def test_assistant_img_tag_persists_after_tool_call_and_restart(
 
     # Phase 2: Restart and verify the image persisted
     with sculptor_instance_factory_.spawn_instance() as instance:
-        # Navigate to the workspace
         new_task_page = PlaywrightTaskPage(page=instance.page)
         workspace_tab = new_task_page.get_workspace_tabs().first
         expect(workspace_tab).to_be_visible()
         workspace_tab.click()
 
-        # Wait for the chat to load with the persisted messages
         chat_panel = new_task_page.get_chat_panel()
         wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
@@ -431,6 +422,5 @@ def test_assistant_img_tag_persists_after_tool_call_and_restart(
         file_preview_container = assistant_message.get_by_test_id(ElementIDs.FILE_PREVIEW_CONTAINER)
         expect(file_preview_container).to_have_count(1)
 
-        # The surrounding text should also be visible
         expect(assistant_message).to_contain_text("Here is a screenshot")
         expect(assistant_message).to_contain_text("Done.")

--- a/sculptor/tests/integration/frontend/test_interrupt_and_continue.py
+++ b/sculptor/tests/integration/frontend/test_interrupt_and_continue.py
@@ -55,7 +55,6 @@ def test_interrupt_initial_message_immediately(sculptor_instance_: SculptorInsta
 
     _interrupt_agent_before_any_output(chat_panel=chat_panel)
 
-    # Verify no InterruptFailure warning is shown to the user.
     expect(chat_panel.get_messages().filter(has_text="InterruptFailure")).to_have_count(0)
     expect(chat_panel.get_messages().filter(has_text="Failed to interrupt")).to_have_count(0)
 
@@ -72,10 +71,8 @@ def test_interrupt_shows_stopped_indicator(sculptor_instance_: SculptorInstance)
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Verify initial text appeared
     expect(chat_panel.get_messages().nth(1)).to_contain_text("Here is some content.")
 
-    # Send a slow message and interrupt it
     send_chat_message(chat_panel=chat_panel, message=_SLEEP_PROMPT)
     _interrupt_agent_before_any_output(chat_panel=chat_panel)
 
@@ -198,14 +195,11 @@ def test_interrupt_and_continue(sculptor_instance_: SculptorInstance) -> None:
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Send a slow message and interrupt it
     send_chat_message(chat_panel=chat_panel, message=_SLEEP_PROMPT)
     _interrupt_agent_before_any_output(chat_panel=chat_panel)
 
-    # Verify the Stopped marker is present
     expect(chat_panel.get_messages().last).to_contain_text("Stopped")
 
-    # Send a follow-up message and verify the agent can still respond
     send_chat_message(
         chat_panel=chat_panel,
         message='fake_claude:text `{"text": "Follow-up response."}`',

--- a/sculptor/tests/integration/frontend/test_keybindings.py
+++ b/sculptor/tests/integration/frontend/test_keybindings.py
@@ -47,7 +47,6 @@ def test_search_filters_keybindings(sculptor_instance_: SculptorInstance) -> Non
     """Searching should filter keybindings by name or description."""
     keybindings = _navigate_to_keybindings(sculptor_instance_)
 
-    # Search for "search"
     keybindings.search("search")
 
     # "Command palette" and "Chat search" should be visible
@@ -57,7 +56,6 @@ def test_search_filters_keybindings(sculptor_instance_: SculptorInstance) -> Non
     # Unrelated bindings should be hidden
     expect(keybindings.get_keybinding_row("new_workspace")).to_have_count(0)
 
-    # Clear search, all should be visible again
     keybindings.clear_search()
     expect(keybindings.get_keybinding_row("new_workspace")).to_be_visible()
 
@@ -76,7 +74,6 @@ def test_record_new_keybinding(sculptor_instance_: SculptorInstance) -> None:
     # in test_duplicate_detection_reassign.
     keybindings.set_keybinding("command_palette", f"{mod}+j")
 
-    # Verify the display updates
     display = keybindings.get_keybinding_display_text("command_palette")
     expect(display).to_contain_text("J")
 
@@ -90,10 +87,8 @@ def test_clear_keybinding(sculptor_instance_: SculptorInstance) -> None:
     """Clearing a keybinding should show 'Click to set'."""
     keybindings = _navigate_to_keybindings(sculptor_instance_)
 
-    # Clear the "Help" keybinding
     keybindings.clear_keybinding("help")
 
-    # Verify it shows "Click to set"
     display = keybindings.get_keybinding_display_text("help")
     expect(display).to_contain_text("Click to set")
 
@@ -115,7 +110,6 @@ def test_reset_all_to_defaults(sculptor_instance_: SculptorInstance) -> None:
     display = keybindings.get_keybinding_display_text("command_palette")
     expect(display).to_contain_text("J")
 
-    # Reset all
     keybindings.reset_all_to_defaults()
 
     # Verify it reverts (default is Meta+K -> displays as ⌘K or Ctrl+K)
@@ -141,7 +135,6 @@ def test_duplicate_detection_reassign(sculptor_instance_: SculptorInstance) -> N
     expect(warning).to_be_visible()
     expect(warning).to_contain_text("Command palette")
 
-    # Click Reassign
     keybindings.click_reassign()
 
     # "Help" should now show the new binding
@@ -173,7 +166,6 @@ def test_duplicate_detection_cancel(sculptor_instance_: SculptorInstance) -> Non
     warning = keybindings.get_conflict_warning()
     expect(warning).to_be_visible()
 
-    # Click Cancel
     keybindings.click_cancel_conflict()
 
     # Warning should disappear
@@ -321,9 +313,7 @@ def test_help_dialog_hides_unbound(sculptor_instance_: SculptorInstance) -> None
     keybindings.reset_all_to_defaults()
 
 
-# ---------------------------------------------------------------------------
 # Functional tests — verify keybindings trigger the correct actions
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.release
@@ -338,7 +328,6 @@ def test_keybindings_suppressed_when_overlay_open(sculptor_instance_: SculptorIn
     keybindings.reset_all_to_defaults()
     blur_active_element(page)
 
-    # Count workspace tabs before
     layout = PlaywrightProjectLayoutPage(page=page)
     initial_tab_count = layout.get_workspace_tabs().count()
 
@@ -378,11 +367,9 @@ def test_default_command_palette_keybinding_works(sculptor_instance_: SculptorIn
     blur_active_element(page)
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Press the default binding for command_palette
     mod = get_playwright_modifier_key()
     layout.press_keyboard_shortcut(f"{mod}+k")
 
-    # Search modal should open
     palette = layout.get_command_palette()
     expect(palette).to_be_visible()
 
@@ -407,11 +394,9 @@ def test_customized_keybinding_is_honored(sculptor_instance_: SculptorInstance) 
     # keybindings row in Settings now displays the new binding. The same
     # `userConfigAtom -> keybindingsAtom` chain feeds both the settings
     # UI and the global keyboard-shortcut handler, so once the row
-    # reflects "J" the global handler has the new binding too. Replaces
-    # a fixed `wait_for_timeout(1000)` that was race-prone in CI.
+    # reflects "J" the global handler has the new binding too.
     expect(keybindings.get_keybinding_display_text("command_palette")).to_contain_text("J")
 
-    # Navigate away from settings.
     blur_active_element(page)
     layout = PlaywrightProjectLayoutPage(page=page)
 

--- a/sculptor/tests/integration/frontend/test_multi_agent_workspace.py
+++ b/sculptor/tests/integration/frontend/test_multi_agent_workspace.py
@@ -58,8 +58,7 @@ def test_multiple_agent_tabs_shown_for_shared_workspace(
 ) -> None:
     """Create a workspace and add a second agent. Verify 2 agent tabs exist.
 
-    This is the workspace-tabs equivalent of the old workspace badge test:
-    instead of badges, the number of agent tabs indicates workspace sharing.
+    The number of agent tabs indicates workspace sharing.
     """
     page = sculptor_instance_.page
     task_page = PlaywrightTaskPage(page=page)
@@ -81,10 +80,7 @@ def test_multiple_agent_tabs_shown_for_shared_workspace(
 def test_single_agent_shows_one_agent_tab(
     sculptor_instance_: SculptorInstance,
 ) -> None:
-    """Create a workspace with a single agent. Verify exactly 1 agent tab.
-
-    This is the workspace-tabs equivalent of the old "no badge for single task" test.
-    """
+    """Create a workspace with a single agent. Verify exactly 1 agent tab."""
     page = sculptor_instance_.page
     task_page = PlaywrightTaskPage(page=page)
     agent_tab_bar = task_page.get_agent_tab_bar()

--- a/sculptor/tests/integration/frontend/test_multi_repo.py
+++ b/sculptor/tests/integration/frontend/test_multi_repo.py
@@ -34,11 +34,6 @@ def _add_repo_via_settings(page: Page, repo_path: Path) -> None:
     repos_section.add_repo(str(repo_path.resolve()))
 
 
-# ============================================================================
-# Project Creation Tests
-# ============================================================================
-
-
 @user_story("to create new projects and use them in workspaces")
 def test_create_new_project_from_add_workspace_page(
     sculptor_instance_: SculptorInstance, test_repo_factory_: TestRepoFactory
@@ -125,11 +120,6 @@ def test_git_init_dialog_for_non_git_directories(sculptor_instance_: SculptorIns
     project_option = add_ws_page.get_project_options().filter(has_text=project_name)
     expect(project_option).to_be_visible()
     page.keyboard.press("Escape")
-
-
-# ============================================================================
-# Multi-Project Workspace Tests
-# ============================================================================
 
 
 @user_story("to create workspaces in different projects and switch between them")
@@ -259,11 +249,6 @@ def test_send_messages_across_multiple_project_workspaces(
     expect(chat_panel_b.get_messages()).to_have_count(4)
 
 
-# ============================================================================
-# MRU Project Selection Tests
-# ============================================================================
-
-
 @user_story("to have the most recently used project pre-selected when creating a new workspace")
 def test_mru_project_updates_after_creating_workspace(
     sculptor_instance_: SculptorInstance, test_repo_factory_: TestRepoFactory
@@ -305,20 +290,10 @@ def test_mru_project_updates_after_creating_workspace(
     expect(add_ws_page.get_project_selector()).to_contain_text(project_a_name)
 
 
-# ============================================================================
-# Duplicate Project Name Tests
-# ============================================================================
-
-
 @pytest.mark.skip(reason="Duplicate project name disambiguation requires redesign for workspace-tabs UI")
 @user_story("to distinguish between projects with the same folder name")
 def test_duplicate_project_names() -> None:
     """Test handling of projects with same leaf folder names but different paths."""
-
-
-# ============================================================================
-# Repo Validation Tests
-# ============================================================================
 
 
 @user_story("to create an initial commit when adding an empty git repo")

--- a/sculptor/tests/integration/frontend/test_open_in_viewer.py
+++ b/sculptor/tests/integration/frontend/test_open_in_viewer.py
@@ -15,8 +15,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ========== Constants ==========
-
 WRITE_FILE_PROMPT = """\
 fake_claude:write_file `{
   "file_path": "greeting.txt",
@@ -29,9 +27,6 @@ fake_claude:edit_file `{
   "old_string": "Hello, world!",
   "new_string": "Hi, everyone!"
 }`"""
-
-
-# ========== Helper Functions ==========
 
 
 def open_diff_via_alpha_chip(chat_panel: PlaywrightChatPanelElement, file_path: str) -> None:
@@ -67,9 +62,6 @@ def assert_diff_panel_shows_diff_view(diff_panel: PlaywrightDiffPanelElement, ta
     expect(unified.or_(split)).to_be_visible(timeout=30_000)
 
     expect(diff_panel.get_read_only_preview()).to_have_count(0)
-
-
-# ========== Tests ==========
 
 
 @user_story("to open a created repo file in the diff viewer from the chat panel")

--- a/sculptor/tests/integration/frontend/test_optimistic_deletion.py
+++ b/sculptor/tests/integration/frontend/test_optimistic_deletion.py
@@ -21,8 +21,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# --- Happy-path: agent deletion ---
-
 
 @user_story("to have agent tabs disappear instantly when deleted")
 def test_optimistic_agent_deletion_removes_tab_immediately(
@@ -79,9 +77,6 @@ def test_optimistic_agent_deletion_last_agent_creates_new_one(
     expect(layout.get_workspace_tabs()).to_have_count(1)
 
 
-# --- Happy-path: workspace deletion ---
-
-
 @user_story("to have workspace tabs disappear instantly when deleted")
 def test_optimistic_workspace_deletion_removes_tab_immediately(
     sculptor_instance_: SculptorInstance,
@@ -106,9 +101,6 @@ def test_optimistic_workspace_deletion_removes_tab_immediately(
     # Optimistic delete removes the tab immediately, but on slower runners
     # the DOM update may lag behind the dialog dismissal.
     expect(workspace_tabs).to_have_count(1)
-
-
-# --- Failure / rollback: agent deletion ---
 
 
 @user_story("to see an agent restored when deletion fails")
@@ -209,9 +201,6 @@ def test_agent_deletion_failure_retry_succeeds(
     expect(agent_tabs).to_have_count(1)
 
 
-# --- Failure / rollback: workspace deletion ---
-
-
 @user_story("to see a workspace restored when deletion fails")
 def test_workspace_deletion_failure_rolls_back_and_shows_error_toast(
     sculptor_instance_: SculptorInstance,
@@ -256,9 +245,6 @@ def test_workspace_deletion_failure_rolls_back_and_shows_error_toast(
         expect(toast).to_contain_text("Retry")
     finally:
         page.unroute(workspace_delete_pattern, fail_workspace_delete)
-
-
-# --- activeIndex clamping on workspace deletion ---
 
 
 def _read_tabs_state(page: Page) -> dict:

--- a/sculptor/tests/integration/frontend/test_panel_zones.py
+++ b/sculptor/tests/integration/frontend/test_panel_zones.py
@@ -21,8 +21,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ── Zone auto-hide ────────────────────────────────────────────────────
-
 
 @user_story("to have empty panel zones auto-hide when the last panel is moved out")
 def test_zone_hides_when_last_panel_moved_out(sculptor_instance_: SculptorInstance) -> None:
@@ -157,9 +155,6 @@ def test_zone_with_no_panels_is_hidden_on_load(sculptor_instance_: SculptorInsta
     page.evaluate("localStorage.clear()")
 
 
-# ── Stale panel pruning ───────────────────────────────────────────────
-
-
 @user_story("to not see empty zones after a panel is removed in a new release")
 def test_stale_panel_id_pruned_from_persisted_layout(sculptor_instance_: SculptorInstance) -> None:
     """A removed panel's ID lingering in localStorage should be pruned on startup.
@@ -252,9 +247,6 @@ def test_stale_panel_id_pruned_from_persisted_layout(sculptor_instance_: Sculpto
     expect(bottom_right).to_be_visible()
 
 
-# ── New panel reconciliation ──────────────────────────────────────────
-
-
 @user_story("to see newly added panels after updating Sculptor")
 def test_new_panel_visible_after_loading_with_old_layout(sculptor_instance_: SculptorInstance) -> None:
     """A newly registered panel should be accessible even when the user has pre-existing panel state.
@@ -332,9 +324,6 @@ def test_new_panel_visible_after_loading_with_old_layout(sculptor_instance_: Scu
     # Cleanup: clear injected localStorage so subsequent tests on this
     # xdist worker start with default panel state.
     page.evaluate("localStorage.clear()")
-
-
-# ── Panel height persistence ──────────────────────────────────────────
 
 
 @user_story("to have sidebar panel heights persist after resizing them")

--- a/sculptor/tests/integration/frontend/test_panels_settings.py
+++ b/sculptor/tests/integration/frontend/test_panels_settings.py
@@ -1,6 +1,6 @@
 """Integration tests for the Settings → Panels page.
 
-Covers the user-facing flows added in the panel-registry-settings work:
+Covers the user-facing flows:
 1.  Toggle off / on a panel via the Settings switch.
 2.  Move a panel to a different zone via the Zone select.
 3.  Drag a panel icon in the layout diagram to a different zone.

--- a/sculptor/tests/integration/frontend/test_pi_basic.py
+++ b/sculptor/tests/integration/frontend/test_pi_basic.py
@@ -4,9 +4,8 @@ Creates a workspace with ``agent_type=pi``, sends a user message, and asserts th
 FakePi assistant response renders. Spot-checks that the most prominent
 Claude-only affordances (sub-agent pill, fast-mode toggle) are suppressed and
 the skills panel renders its empty state. The plan-mode toggle is NOT here: pi
-now supports the interactive backchannel, so that toggle is available — its
-gating is covered by test_pi_capability_gating.py. Per-capability parity is the
-responsibility of test_pi_capability_gating.py.
+supports the interactive backchannel, so that toggle is available — its
+gating is covered by test_pi_capability_gating.py.
 """
 
 from playwright.sync_api import expect
@@ -109,7 +108,7 @@ def test_pi_workspace_suppresses_claude_only_surfaces(
     expect(chat_panel.get_chat_input()).to_be_visible()
     expect(chat_panel.get_send_button()).to_be_visible()
 
-    # The plan-mode toggle is intentionally NOT asserted absent here: pi now
+    # The plan-mode toggle is intentionally NOT asserted absent here: pi
     # supports the interactive backchannel, so the toggle renders (its gating is
     # covered by test_pi_capability_gating.py).
     expect(page.get_by_test_id(ElementIDs.FAST_MODE_TOGGLE)).to_have_count(0)

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -128,7 +128,7 @@ def test_sub_agent_pill_renders_under_both_harnesses(
     as the AlphaSubagentPill (the parent entry with nested, attributed child
     activity) under Claude AND pi.
 
-    This is the two-sided assertion for `supports_sub_agents` (REQ-TEST-4): pi
+    This is the two-sided assertion for `supports_sub_agents`: pi
     spawns sub-agents through the pinned `sculptor_subagent` extension, whose
     structured per-child progress the adapter maps onto the same
     `parent_tool_use_id` grouping Claude uses. Pi's `fake_pi:subagent` directive

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -128,8 +128,7 @@ def test_sub_agent_pill_renders_under_both_harnesses(
     as the AlphaSubagentPill (the parent entry with nested, attributed child
     activity) under Claude AND pi.
 
-    This is the two-sided assertion for `supports_sub_agents` (REQ-TEST-4): the
-    render path was previously suppressed for pi (the gate hid the pill); pi now
+    This is the two-sided assertion for `supports_sub_agents` (REQ-TEST-4): pi
     spawns sub-agents through the pinned `sculptor_subagent` extension, whose
     structured per-child progress the adapter maps onto the same
     `parent_tool_use_id` grouping Claude uses. Pi's `fake_pi:subagent` directive
@@ -147,8 +146,7 @@ def test_sub_agent_pill_renders_under_both_harnesses(
         )
     send_chat_message(chat_panel=chat_panel, message=prompt)
 
-    # The sub-agent activity renders as the pill under both harnesses (the gate
-    # no longer suppresses it for pi).
+    # The sub-agent activity renders as the pill under both harnesses.
     expect(sculptor_instance_.page.get_by_test_id(ElementIDs.ALPHA_CHAT_SUBAGENT_PILL).first).to_be_visible(
         timeout=30000
     )
@@ -330,12 +328,11 @@ def test_uploads_usable_and_deliver_under_pi(sculptor_instance_: SculptorInstanc
     expect(page.get_by_test_id(ElementIDs.CHAT_INPUT)).to_be_visible()
     expect(page.get_by_test_id(ElementIDs.FILE_UPLOAD)).to_be_attached()
     if harness.first_agent_type != "pi":
-        # Claude branch unchanged: the upload affordance has always been live.
+        # The Claude upload affordance is live; nothing further to assert here.
         return
-    # Flipped pi branch: attachments are no longer dropped. Deliver one image
-    # and one non-image file through the upload transport, then assert FakePi
-    # received the image on `images[]` (one image, image/png) and the text file
-    # as a path in the prompt text — the exclusive split prompt assembly does.
+    # Deliver one image and one non-image file through the upload transport, then
+    # assert FakePi received the image on `images[]` (one image, image/png) and the
+    # text file as a path in the prompt text — the exclusive split prompt assembly does.
     image_id = upload_file_via_api(page, name="pic.png", mime_type="image/png", content=_png_bytes())
     text_id = upload_file_via_api(page, name="notes.txt", mime_type="text/plain", content=b"sentinel-99")
     send_message_via_api(page, message="fake_pi:report_inputs", files=[image_id, text_id])

--- a/sculptor/tests/integration/frontend/test_plan_mode.py
+++ b/sculptor/tests/integration/frontend/test_plan_mode.py
@@ -22,8 +22,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# ========== Constants ==========
-
 PLAN_MODE_MULTI_STEP_PROMPT = """\
 fake_claude:multi_step `{
   "steps": [
@@ -32,9 +30,6 @@ fake_claude:multi_step `{
     {"command": "exit_plan_mode"}
   ]
 }`"""
-
-
-# ========== Group A: Agent-Initiated Plan Mode (EnterPlanMode lights up toggle) ==========
 
 
 @user_story("to see the plan toggle light up when the agent enters plan mode")
@@ -193,9 +188,6 @@ def test_enter_plan_mode_not_hidden_in_collapsed_called_tools(sculptor_instance_
     expect(tool_names.first).to_be_visible()
 
 
-# ========== Group B: ExitPlanMode Approval Flow ==========
-
-
 @user_story("to approve a plan proposed by the agent")
 def test_exit_plan_mode_shows_approval_prompt(sculptor_instance_: SculptorInstance) -> None:
     """Test the full ExitPlanMode -> approval prompt -> approve flow."""
@@ -208,31 +200,24 @@ def test_exit_plan_mode_shows_approval_prompt(sculptor_instance_: SculptorInstan
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the approval prompt
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # Verify the question text
     question_text = auq_panel.get_question_text()
     expect(question_text).to_contain_text("How would you like to proceed")
 
-    # Verify "Approve plan" option and "Revise" other-option are visible
     options = auq_panel.get_options()
     expect(options.filter(has_text="Approve plan").first).to_be_visible()
     revise_option = auq_panel.get_other_option()
     expect(revise_option).to_contain_text("Revise")
 
-    # Select "Approve plan" and submit
     auq_panel.select_option("Approve plan")
     auq_panel.submit()
 
-    # Q&A panel should disappear
     expect(auq_panel).not_to_be_visible()
 
-    # Wait for the agent to finish
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
 
-    # Verify the ExitPlanMode tool block shows approved state
     exit_plan_block = chat_panel.get_exit_plan_mode_block()
     expect(exit_plan_block).to_be_visible()
     expect(exit_plan_block).to_contain_text("Plan approved")
@@ -251,26 +236,20 @@ def test_exit_plan_mode_revision_flow(sculptor_instance_: SculptorInstance) -> N
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the approval prompt
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
     # Select the "Revise" option (the "other" slot, relabeled for plan approval)
     auq_panel.get_other_option().click()
 
-    # Type revision feedback
     auq_panel.type_other_text("Please also consider edge cases")
 
-    # Submit
     auq_panel.submit()
 
-    # Q&A panel should disappear
     expect(auq_panel).not_to_be_visible()
 
-    # Wait for the agent to finish
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
 
-    # Verify the ExitPlanMode tool block shows revision state
     exit_plan_block = chat_panel.get_exit_plan_mode_block()
     expect(exit_plan_block).to_be_visible()
     expect(exit_plan_block).to_contain_text("Plan revision requested")
@@ -301,16 +280,13 @@ def test_exit_plan_mode_revision_auto_expands(sculptor_instance_: SculptorInstan
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the approval prompt
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # Select "Revise" and type feedback
     auq_panel.get_other_option().click()
     auq_panel.type_other_text("Please also handle error cases")
     auq_panel.submit()
 
-    # Wait for the agent to finish
     expect(auq_panel).not_to_be_visible()
 
     # The revision feedback should be visible without clicking to expand
@@ -335,30 +311,24 @@ def test_exit_plan_mode_revision_preserves_text_after_navigation(sculptor_instan
         wait_for_agent_to_finish=False,
     )
 
-    # Wait for the approval prompt
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # Select "Revise" and type feedback
     auq_panel.get_other_option().click()
     auq_panel.type_other_text("Add better error handling")
 
-    # The submit button should be enabled
     submit_button = auq_panel.get_submit_button()
     expect(submit_button).to_be_enabled()
 
-    # Navigate away and back
     navigate_away_and_back(page)
 
     # The approval prompt should reappear with state preserved
     expect(auq_panel).to_be_visible()
 
-    # The "Other" input (revision feedback) should still be visible with the typed text
     other_input = auq_panel.get_other_input()
     expect(other_input).to_be_visible()
     expect(other_input).to_have_value("Add better error handling")
 
-    # The submit button should still be enabled
     expect(submit_button).to_be_enabled()
 
 
@@ -374,17 +344,13 @@ def test_exit_plan_mode_dismiss_flow(sculptor_instance_: SculptorInstance) -> No
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the approval prompt
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # Click dismiss
     auq_panel.dismiss()
 
-    # Q&A panel should disappear
     expect(auq_panel).not_to_be_visible()
 
-    # Wait for the agent to finish
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
 
     # Verify the most recent ExitPlanMode tool block shows dismissed state.
@@ -408,30 +374,22 @@ def test_exit_plan_mode_survives_page_reload(sculptor_instance_: SculptorInstanc
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the approval prompt to appear
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # Soft reload the page
     soft_reload_page(page)
 
     # Approval prompt should re-appear after reload
     expect(auq_panel).to_be_visible()
 
-    # ExitPlanMode tool block should still be visible
     exit_plan_block = chat_panel.get_exit_plan_mode_block()
     expect(exit_plan_block).to_be_visible()
 
-    # Submit an approval answer
     auq_panel.select_option("Approve plan")
     auq_panel.submit()
 
-    # Wait for the agent to finish
     expect(auq_panel).not_to_be_visible()
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
-
-
-# ========== Group C: User-Initiated Plan Mode ("Plan First" Toggle) ==========
 
 
 @user_story("to see a plan-first toggle button in the chat input")
@@ -448,7 +406,6 @@ def test_plan_first_toggle_is_visible(sculptor_instance_: SculptorInstance) -> N
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Assert the plan-first toggle is visible
     toggle = chat_panel.get_plan_mode_toggle()
     expect(toggle).to_be_visible()
 
@@ -468,19 +425,14 @@ def test_plan_first_toggle_activates_and_deactivates(sculptor_instance_: Sculpto
 
     toggle = chat_panel.get_plan_mode_toggle()
 
-    # Initially the toggle should not have the active primary styling
     expect(toggle).to_have_attribute("data-active", "false")
 
-    # Click to activate
     toggle.click()
 
-    # The toggle should now have the active primary styling (inline style with primary color)
     expect(toggle).to_have_attribute("data-active", "true")
 
-    # Click again to deactivate
     toggle.click()
 
-    # The primary styling should be gone
     expect(toggle).to_have_attribute("data-active", "false")
 
 
@@ -499,18 +451,13 @@ def test_plan_first_toggle_persists_after_send(sculptor_instance_: SculptorInsta
 
     toggle = chat_panel.get_plan_mode_toggle()
 
-    # Activate the toggle
     toggle.click()
     expect(toggle).to_have_attribute("data-active", "true")
 
-    # Send a message
     send_chat_message(chat_panel=chat_panel, message="Implement feature Y")
 
     # The toggle should remain on after send (persistent mode toggle)
     expect(toggle).to_have_attribute("data-active", "true")
-
-
-# ========== Group D: Write + ExitPlanMode in Same Message ==========
 
 
 WRITE_AND_EXIT_PLAN_PROMPT = """\
@@ -558,7 +505,6 @@ def test_write_tool_shows_created_file_with_exit_plan_mode(sculptor_instance_: S
     exit_plan_block = chat_panel.get_exit_plan_mode_block()
     expect(exit_plan_block).to_be_visible()
 
-    # Dismiss the approval prompt
     auq_panel.dismiss()
     expect(auq_panel).not_to_be_visible()
 
@@ -613,12 +559,9 @@ def test_plan_file_write_with_other_tools_shows_exit_plan_mode_block(
     exit_plan_block = chat_panel.get_exit_plan_mode_block()
     expect(exit_plan_block).to_be_visible()
 
-    # Dismiss the approval prompt
     auq_panel.dismiss()
     expect(auq_panel).not_to_be_visible()
 
-
-# ========== Group E: Open Plan File in Document Viewer ==========
 
 # Writes the plan file to .claude/plans/ in the same parallel batch as
 # ExitPlanMode (mcp-namespaced — what real Claude emits, and what the live
@@ -675,9 +618,6 @@ def test_plan_file_opens_in_document_viewer(sculptor_instance_: SculptorInstance
     task_page.get_diff_panel().expect_shows_file_view("plan.md")
 
 
-# ========== Group F: Clicking ExitPlanMode Block Opens Plan File ==========
-
-
 @user_story("to see the plan file auto-open when the plan approval UI appears")
 def test_plan_file_auto_opens_on_exit_plan_mode(sculptor_instance_: SculptorInstance) -> None:
     """Test that the plan file automatically opens in the document viewer when ExitPlanMode is pending.
@@ -704,7 +644,6 @@ def test_plan_file_auto_opens_on_exit_plan_mode(sculptor_instance_: SculptorInst
     plan_tab = diff_panel.get_tab_by_name("plan.md")
     expect(plan_tab.first).to_be_visible()
 
-    # Verify the file content is displayed
     preview = diff_panel.get_read_only_preview()
     expect(preview).to_be_visible()
 
@@ -735,17 +674,14 @@ def test_exit_plan_mode_block_click_opens_plan_file(sculptor_instance_: Sculptor
     expect(exit_plan_block).to_be_visible()
     expect(exit_plan_block).to_contain_text("Plan ready for review")
 
-    # Click on the ExitPlanMode block to open the plan file
     exit_plan_block.click()
 
-    # Verify the diff panel opens with a tab for the plan file
     diff_panel = task_page.get_diff_panel()
     expect(diff_panel).to_be_visible()
 
     plan_tab = diff_panel.get_tab_by_name("plan.md")
     expect(plan_tab.first).to_be_visible()
 
-    # Verify the file content is displayed
     preview = diff_panel.get_read_only_preview()
     expect(preview).to_be_visible()
 
@@ -818,9 +754,6 @@ def test_plan_file_view_refreshes_when_rewritten(sculptor_instance_: SculptorIns
     expect(preview).to_contain_text("PLAN_TOKEN_VERSION_TWO")
 
 
-# ========== Group G: AskUserQuestion During Plan Mode ==========
-
-
 ASK_DURING_PLAN_MODE_PROMPT = """\
 fake_claude:enter_plan_mode_and_ask `{
   "questions": [
@@ -854,20 +787,15 @@ def test_ask_user_question_during_plan_mode(sculptor_instance_: SculptorInstance
     )
     chat_panel = task_page.get_chat_panel()
 
-    # The AUQ panel should appear with the question
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # Verify the question text is displayed
     question_text = auq_panel.get_question_text()
     expect(question_text).to_contain_text("Which language")
 
-    # Select an option and submit
     auq_panel.get_options().first.click()
     auq_panel.submit()
 
-    # Q&A panel should disappear
     expect(auq_panel).not_to_be_visible()
 
-    # Agent should finish
     expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_pr_button_errors.py
+++ b/sculptor/tests/integration/frontend/test_pr_button_errors.py
@@ -124,11 +124,6 @@ def _assert_error_button_with_popover(
     _expand_details_and_verify(task_page, details_text)
 
 
-# ---------------------------------------------------------------------------
-# Group 1: CLI missing (no gh/glab on PATH) — one spawn, two scenarios
-# ---------------------------------------------------------------------------
-
-
 @user_story("to see an error when gh/glab CLI is not installed")
 def test_cli_missing_shows_error_for_github_and_gitlab(
     sculptor_instance_factory_: SculptorInstanceFactory, tmp_path: Path
@@ -168,10 +163,6 @@ def test_cli_missing_shows_error_for_github_and_gitlab(
         popover = task_page.get_pr_button_error_popover()
         expect(popover).to_contain_text("brew install glab")
 
-
-# ---------------------------------------------------------------------------
-# Group 2: GitHub error variants — one spawn, mode-switching fake gh
-# ---------------------------------------------------------------------------
 
 _FAKE_GH_SCRIPT = """\
 #!/bin/bash
@@ -246,10 +237,6 @@ def test_github_cli_error_variants(sculptor_instance_: SculptorInstance, tmp_pat
     )
 
 
-# ---------------------------------------------------------------------------
-# Group 3: GitHub happy paths — one spawn, mode-switching fake gh
-# ---------------------------------------------------------------------------
-
 # The backend issues a single `gh api graphql` query for PR status, so each
 # mode emits the GraphQL response envelope: no_pr returns an empty node list,
 # open_pr returns one node tagged "state": "OPEN". The mode-file path is
@@ -300,10 +287,6 @@ def test_github_happy_paths(sculptor_instance_: SculptorInstance, tmp_path: Path
     expect(open_button).to_be_visible()
     expect(open_button).to_contain_text("PR #42")
 
-
-# ---------------------------------------------------------------------------
-# Group 4: GitLab error variants — one spawn, mode-switching fake glab
-# ---------------------------------------------------------------------------
 
 _FAKE_GLAB_SCRIPT = """\
 #!/bin/bash

--- a/sculptor/tests/integration/frontend/test_pr_management.py
+++ b/sculptor/tests/integration/frontend/test_pr_management.py
@@ -30,18 +30,14 @@ def test_settings_git_section(sculptor_instance_: SculptorInstance) -> None:
     settings_page = navigate_to_settings_page(page=page)
     git_section = settings_page.click_on_git()
 
-    # Verify the three settings fields are visible
     expect(git_section.get_creation_prompt_textarea()).to_be_visible()
     expect(git_section.get_poll_interval_input()).to_be_visible()
     expect(git_section.get_default_target_branch_input()).to_be_visible()
 
-    # Edit default target branch and verify persistence
     git_section.set_default_target_branch("develop")
 
-    # Wait for toast to confirm the change was saved
     toast = settings_page.get_toast()
     expect(toast).to_be_visible()
 
-    # Read config file and verify the setting was persisted
     config = load_config(config_path)
     assert config.pr_default_target_branch == "develop"

--- a/sculptor/tests/integration/frontend/test_project_path_monitoring.py
+++ b/sculptor/tests/integration/frontend/test_project_path_monitoring.py
@@ -23,31 +23,23 @@ def test_project_path_monitoring(sculptor_instance_: SculptorInstance) -> None:
     task_starter = home_page.get_task_starter()  # type: ignore[attr-defined]
     task_starter.get_task_input().fill("Hello, world!")
 
-    # Store the original project path
     original_path = sculptor_instance_.repo.base_path
 
     with create_temp_dir(root_dir=get_temp_dir()) as temp_dir:
-        # Step 1: Move the project directory
         moved_path = temp_dir / original_path.name
         shutil.move(str(original_path), str(moved_path))
 
-        # Step 3: Verify the banner contains expected message
         warning_banner_element = home_page.get_warning_banner()
         expect(warning_banner_element).to_be_visible()
 
-        # Step 4: Click the "Learn more" link
         warning_banner_element.click_link()
 
-        # Step 5: Verify the dialog appears
         dialog = home_page.get_project_path_dialog()
         expect(dialog).to_be_visible()
 
-        # Step 6: Close the dialog
         dialog.close()
         expect(dialog).not_to_be_visible()
 
-        # Step 7: Move the project back to original location
         shutil.move(str(moved_path), str(original_path))
 
-        # Step 8: Wait for the warning banner to disappear
         expect(warning_banner_element).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_queued_messages.py
+++ b/sculptor/tests/integration/frontend/test_queued_messages.py
@@ -81,11 +81,9 @@ def test_queued_message_bar_appears_and_shows_content(sculptor_instance_: Sculpt
 
     send_chat_message(chat_panel=chat_panel, message="queued content here")
 
-    # Bar should appear with count 1
     queued_bar = chat_panel.get_queued_message_bar()
     expect(queued_bar).to_have_count(1)
 
-    # Bar should contain the queued message text
     expect(queued_bar).to_contain_text("queued content here")
 
     # Send button is always visible; edit/cancel are in the DOM but hidden via opacity
@@ -141,10 +139,8 @@ def test_interrupt_and_send_queued_message(sculptor_instance_: SculptorInstance)
     send_chat_message(chat_panel=chat_panel, message='fake_claude:text `{"text": "promoted response"}`')
     expect(chat_panel.get_queued_message_bar()).to_have_count(1)
 
-    # Click interrupt-and-send button
     chat_panel.get_queued_message_send_button().click()
 
-    # Queued message bar should disappear
     expect(chat_panel.get_queued_message_bar()).to_have_count(0)
 
     # Wait for the promoted message to be processed by the agent.
@@ -164,7 +160,6 @@ def test_interrupt_and_send_shows_spinner_while_in_flight(sculptor_instance_: Sc
     send_button = chat_panel.get_queued_message_send_button()
     expect(send_button).to_be_enabled()
 
-    # Click interrupt — button should become disabled immediately
     send_button.click()
 
     # The bar should eventually disappear (interrupt completes)
@@ -218,7 +213,6 @@ def test_edit_with_text_in_editor_shows_dialog(sculptor_instance_: SculptorInsta
     _, chat_panel = _start_busy_agent(sculptor_instance_)
     page = chat_panel._page
 
-    # Queue a message
     send_chat_message(chat_panel=chat_panel, message="queued text")
     expect(chat_panel.get_queued_message_bar()).to_have_count(1)
 
@@ -342,7 +336,6 @@ def test_queued_message_persists_across_page_refresh(sculptor_instance_: Sculpto
     send_chat_message(chat_panel=chat_panel, message="persistent message")
     expect(chat_panel.get_queued_message_bar()).to_have_count(1)
 
-    # Reload the page
     page = chat_panel._page
     soft_reload_page(page)
 
@@ -367,7 +360,6 @@ def test_always_interrupt_setting_bypasses_queue(sculptor_instance_: SculptorIns
     experimental = settings_page.click_on_experimental()
     experimental.enable_always_interrupt()
 
-    # Start a busy agent
     _, chat_panel = _start_busy_agent(sculptor_instance_)
 
     # Send a message while agent is busy — with always-interrupt enabled,

--- a/sculptor/tests/integration/frontend/test_read_unread_status.py
+++ b/sculptor/tests/integration/frontend/test_read_unread_status.py
@@ -26,15 +26,6 @@ def test_unread_indicator_when_switching_agents_within_workspace(
     """Create a workspace with two agents, verify read/unread transitions on agent tabs.
 
     Flow:
-    1. Create workspace with agent 1 (runs, finishes, user sees it → read)
-    2. Add agent 2 via "+" button (navigates to agent 2, agent 1 is still read)
-    3. Send a follow-up message to agent 2 (agent 2 becomes read with new content)
-    4. Agent 1 should still be read (no new updates since last viewed)
-    5. Navigate back to agent 1, then back to agent 2
-    6. Agent 2 should now be unread (it got a response while we were on agent 1)
-       Note: agent 2's response was seen before switching.
-
-    Revised flow:
     1. Create workspace with agent 1 (finishes, user sees it → read)
     2. Add agent 2 (auto-navigates to agent 2, both are read/unread appropriately)
     3. Send a message on agent 2 so it gets activity

--- a/sculptor/tests/integration/frontend/test_settings_tab.py
+++ b/sculptor/tests/integration/frontend/test_settings_tab.py
@@ -30,17 +30,13 @@ def test_settings_opens_as_tab(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create a workspace.
     start_task_and_wait_for_ready(page, prompt="Settings test", workspace_name="Settings WS")
 
-    # Step 2: Click the settings button.
     layout.get_settings_button().click()
 
-    # Step 3: Verify a Settings tab appears.
     settings_tab = layout.get_settings_tab()
     expect(settings_tab).to_be_visible()
 
-    # Step 4: Verify the Settings tab is active.
     expect(settings_tab).to_have_attribute("aria-selected", "true")
 
 
@@ -60,16 +56,12 @@ def test_settings_tab_is_closeable(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create a workspace.
     start_task_and_wait_for_ready(page, prompt="Close settings test", workspace_name="Close WS")
 
-    # Step 2: Open Settings tab.
     layout.open_settings_tab()
 
-    # Step 3: Click the close button on the Settings tab.
     layout.close_settings_tab()
 
-    # Step 4: Verify the Settings tab disappears.
     expect(layout.get_settings_tab()).to_have_count(0)
 
     # Step 5: Verify at least one workspace tab is active (the close action
@@ -94,16 +86,12 @@ def test_settings_tab_singleton(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create a workspace.
     start_task_and_wait_for_ready(page, prompt="Singleton test", workspace_name="Singleton WS")
 
-    # Step 2: Open Settings tab.
     layout.open_settings_tab()
 
-    # Step 3: Click the settings button again.
     layout.get_settings_button().click()
 
-    # Step 4: Verify there is still only one Settings tab.
     expect(layout.get_settings_tab()).to_have_count(1)
 
 
@@ -123,19 +111,14 @@ def test_settings_tab_context_menu_no_rename_or_delete(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create a workspace and open Settings.
     start_task_and_wait_for_ready(page, prompt="Menu test", workspace_name="Menu WS")
 
     settings_tab = layout.open_settings_tab()
 
-    # Step 2: Right-click the Settings tab.
     settings_tab.click(button="right")
 
-    # Step 3: Verify Close is visible.
     expect(layout.get_tab_context_menu_close()).to_be_visible()
 
-    # Step 4: Verify Rename is not present.
     expect(layout.get_tab_context_menu_rename()).to_have_count(0)
 
-    # Step 5: Verify Delete is not present.
     expect(layout.get_tab_context_menu_delete()).to_have_count(0)

--- a/sculptor/tests/integration/frontend/test_side_toggle.py
+++ b/sculptor/tests/integration/frontend/test_side_toggle.py
@@ -30,28 +30,23 @@ def test_right_side_toggle_hides_and_shows_panels(sculptor_instance_: SculptorIn
     page = sculptor_instance_.page
     panel_zones = PlaywrightPanelZonesElement(page)
 
-    # Step 1: Create a workspace and navigate to the agent page
     start_task_and_wait_for_ready(sculptor_page=page, prompt="Hello")
 
-    # Step 2: Ensure right side is visible — the right side may or may not
-    # have visible panels depending on the default layout.  Toggle a panel
-    # on if needed so we have something to hide/show.
+    # The right side may or may not have visible panels depending on the
+    # default layout.  Toggle a panel on if needed so we have something to
+    # hide/show.
     right_area = panel_zones.get_right_area()
     ensure_right_area_visible(page)
     expect(right_area).to_be_visible()
 
-    # Step 3: Click the right side toggle button to hide the right area
     right_toggle = panel_zones.get_side_toggle_right()
     expect(right_toggle).to_be_visible()
     right_toggle.click()
 
-    # Step 4: The right area should be hidden
     expect(right_area).not_to_be_visible()
 
-    # Step 5: Click the right side toggle again to restore
     right_toggle.click()
 
-    # Step 6: The right area should be visible again
     expect(right_area).to_be_visible()
 
 
@@ -69,27 +64,22 @@ def test_bottom_toggle_hides_and_shows_terminal(sculptor_instance_: SculptorInst
     page = sculptor_instance_.page
     panel_zones = PlaywrightPanelZonesElement(page)
 
-    # Step 1
     start_task_and_wait_for_ready(sculptor_page=page, prompt="Hello")
 
-    # Step 2: Ensure the terminal panel is visible (may already be open
-    # depending on the default layout).
+    # The terminal panel may already be open depending on the default layout.
     terminal_icon = panel_zones.get_terminal_icon()
     expect(terminal_icon).to_be_visible()
     ensure_terminal_visible(page)
     add_terminal_button = get_add_terminal_button(page)
 
-    # Step 3: Click the bottom toggle to hide it
     bottom_toggle = panel_zones.get_side_toggle_bottom()
     expect(bottom_toggle).to_be_visible()
     bottom_toggle.click()
 
-    # Step 4: Terminal icon should still be accessible, but the bottom zone content is gone
+    # Terminal icon should still be accessible, but the bottom zone content is gone
     expect(terminal_icon).to_be_visible()
     expect(add_terminal_button).not_to_be_visible()
 
-    # Step 5: Restore
     bottom_toggle.click()
 
-    # The bottom zone should be visible again
     expect(add_terminal_button).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_skill_autocomplete.py
+++ b/sculptor/tests/integration/frontend/test_skill_autocomplete.py
@@ -78,8 +78,6 @@ def test_workspace_skill_appears_in_autocomplete_popover(sculptor_instance_: Scu
         except AssertionError:
             if attempt == 4:
                 raise
-            # Clear the input and retry — Escape dismisses the popover,
-            # then select-all + delete clears the text.
             page.keyboard.press("Escape")
             expect(mention_list).not_to_be_visible()
             page.keyboard.press(f"{mod_key}+a")
@@ -202,7 +200,6 @@ def test_slash_command_persists_as_chip_after_reload(sculptor_instance_: Sculpto
     page.keyboard.press("Enter")
     expect(mention_list).not_to_be_visible()
 
-    # The skill chip should be rendered as a mention span.
     mention_span = chat_panel.get_mention_spans()
     expect(mention_span).to_be_visible()
     expect(mention_span).to_contain_text(skill_name)

--- a/sculptor/tests/integration/frontend/test_skills_panel.py
+++ b/sculptor/tests/integration/frontend/test_skills_panel.py
@@ -71,7 +71,6 @@ def test_skills_panel_click_inserts_mention_chip(sculptor_instance_: SculptorIns
 
     chat_panel = task_page.get_chat_panel()
 
-    # The editor starts empty — no mention chip should be visible yet.
     expect(chat_panel.get_mention_spans()).not_to_be_visible()
 
     skills_panel = task_page.open_skills_panel()
@@ -123,7 +122,6 @@ def test_skills_panel_keyboard_navigation_inserts_chip(sculptor_instance_: Sculp
     alpha_chip = skills_panel.get_skill_chip(first)
     expect(alpha_chip).to_have_attribute("data-selected", "true")
 
-    # ArrowDown moves the selection to the second chip; Enter inserts it.
     search_input.press("ArrowDown")
     beta_chip = skills_panel.get_skill_chip(second)
     expect(beta_chip).to_have_attribute("data-selected", "true")
@@ -149,7 +147,6 @@ def test_skills_panel_search_filters_list(sculptor_instance_: SculptorInstance) 
 
     skills_panel = task_page.open_skills_panel()
 
-    # Both chips visible before searching.
     expect(skills_panel.get_skill_chip(keep)).to_be_visible()
     expect(skills_panel.get_skill_chip(drop)).to_be_visible()
 

--- a/sculptor/tests/integration/frontend/test_status_pill.py
+++ b/sculptor/tests/integration/frontend/test_status_pill.py
@@ -35,16 +35,13 @@ def test_status_pill_visible_during_agent_activity(sculptor_instance_: SculptorI
     )
     chat_panel = task_page.get_chat_panel()
 
-    # The status pill should be visible while the agent is working
     status_pill = chat_panel.get_status_pill()
     expect(status_pill).to_be_visible()
 
-    # It should have a label (Thinking..., Streaming..., or Calling tools...)
     label = chat_panel.get_status_pill_label()
     expect(label).to_be_visible()
     expect(label).not_to_be_empty()
 
-    # It should show elapsed time
     elapsed = chat_panel.get_status_pill_elapsed()
     expect(elapsed).to_be_visible()
     expect(elapsed).to_contain_text("s")
@@ -62,7 +59,6 @@ def test_status_pill_disappears_after_completion(sculptor_instance_: SculptorIns
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # The status pill should NOT be visible after completion
     status_pill = chat_panel.get_status_pill()
     expect(status_pill).not_to_be_visible()
 
@@ -79,7 +75,6 @@ def test_status_pill_shows_stop_button(sculptor_instance_: SculptorInstance) -> 
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the pill to appear
     status_pill = chat_panel.get_status_pill()
     expect(status_pill).to_be_visible()
 
@@ -100,11 +95,9 @@ def test_status_pill_shows_animation(sculptor_instance_: SculptorInstance) -> No
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for the pill to appear
     status_pill = chat_panel.get_status_pill()
     expect(status_pill).to_be_visible()
 
-    # Should have an animation element
     animation = chat_panel.get_status_pill_animation()
     expect(animation).to_be_visible()
 
@@ -141,20 +134,16 @@ def test_status_pill_timer_persists_across_tab_switch(sculptor_instance_: Sculpt
         }""",
     )
 
-    # Read the elapsed value before navigating away
     elapsed_before_text = elapsed_locator.text_content()
     assert elapsed_before_text is not None
     elapsed_before = float(elapsed_before_text.rstrip("s"))
     assert elapsed_before >= 2.0, f"Expected >= 2.0s before switch, got {elapsed_before}s"
 
-    # Navigate away from the workspace
     navigate_to_add_workspace_page(page)
 
-    # Navigate back by clicking the workspace tab
     workspace_tab = task_page.get_workspace_tabs().first
     workspace_tab.click()
 
-    # Wait for the status pill to reappear
     expect(status_pill).to_be_visible()
 
     # The timer should NOT have reset. On remount the timer is restored
@@ -220,6 +209,5 @@ fake_claude:ask_user_question `{
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible()
 
-    # The status pill must NOT be visible while WAITING.
     status_pill = chat_panel.get_status_pill()
     expect(status_pill).not_to_be_visible()

--- a/sculptor/tests/integration/frontend/test_status_pill_tasks_widget.py
+++ b/sculptor/tests/integration/frontend/test_status_pill_tasks_widget.py
@@ -638,7 +638,6 @@ def test_large_dag_scale_rules(sculptor_instance_: SculptorInstance) -> None:
     expect(status_pill).to_be_visible()
     status_pill.click()
 
-    # All 60 task rows render — leading-completed collapse has been removed.
     rows = agent_tasks.get_rows()
     expect(rows).to_have_count(60)
 

--- a/sculptor/tests/integration/frontend/test_stopped_turn_footer.py
+++ b/sculptor/tests/integration/frontend/test_stopped_turn_footer.py
@@ -72,11 +72,9 @@ def test_stopped_turn_footer_shows_duration_after_content_streamed(
 
     _stop_agent_via_status_pill(chat_panel)
 
-    # The turn footer should be visible
     turn_footer = alpha_view.get_turn_footers()
     expect(turn_footer).to_be_visible()
 
-    # It must say "Stopped"
     expect(turn_footer).to_contain_text("Stopped")
 
     # It must also include duration info (contains "s" for seconds, e.g. "3.2s")
@@ -138,7 +136,6 @@ def test_turn_footer_shows_metrics_after_completed_turn(
     turn_footer = alpha_view.get_turn_footers()
     expect(turn_footer).to_be_visible()
     expect(turn_footer).to_contain_text("s")
-    # Token count should also be present
     expect(turn_footer).to_contain_text("tokens")
 
 

--- a/sculptor/tests/integration/frontend/test_tab_context_menus.py
+++ b/sculptor/tests/integration/frontend/test_tab_context_menus.py
@@ -27,7 +27,6 @@ def test_terminal_tab_context_menu_close_others(
     """
     page = sculptor_instance_.page
 
-    # Create a workspace
     start_task_and_wait_for_ready(page, prompt="Terminal test", workspace_name="Terminal WS")
 
     # Open the terminal panel (it is not visible by default)
@@ -38,7 +37,6 @@ def test_terminal_tab_context_menu_close_others(
     add_terminal_button.click()
     add_terminal_button.click()
 
-    # Verify 3 terminal tabs exist
     terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(3)
 
@@ -50,5 +48,4 @@ def test_terminal_tab_context_menu_close_others(
     expect(close_others_item).to_be_visible()
     close_others_item.click()
 
-    # Verify only 1 terminal tab remains
     expect(terminal_tabs).to_have_count(1)

--- a/sculptor/tests/integration/frontend/test_task_page_chatting.py
+++ b/sculptor/tests/integration/frontend/test_task_page_chatting.py
@@ -26,10 +26,8 @@ def test_prompt_draft_persists_from_task_page(sculptor_instance_: SculptorInstan
 
     task_page = start_task_and_wait_for_ready(sculptor_instance_.page, prompt=task_text)
 
-    # Type a follow-up message
     task_page.get_chat_panel().get_chat_input().fill(follow_up_text)
 
-    # Verify that we can reload and the prompt draft persists
     soft_reload_page(task_page)
     expect(task_page.get_chat_panel().get_chat_input()).to_have_text(follow_up_text)
 
@@ -40,23 +38,19 @@ def test_prompt_drafts_persist_on_multiple_tasks_and_home_page(sculptor_instance
     page = sculptor_instance_.page
     follow_up_text = "This is a follow-up message draft."
 
-    # Create a workspace/agent
     task_page = start_task_and_wait_for_ready(page, prompt="Hello, this is a test message!")
     chat_panel = task_page.get_chat_panel()
 
     # Type a follow-up message draft in chat input (don't send it)
     chat_panel.get_chat_input().fill(follow_up_text)
 
-    # Navigate away to Add Workspace page
     task_page.get_add_workspace_button().click()
     add_workspace_page = PlaywrightAddWorkspacePage(page=page)
     expect(add_workspace_page.get_submit_button()).to_be_visible()
 
-    # Navigate back to the first workspace tab
     task_page.get_workspace_tabs().first.click()
     expect(task_page.get_chat_panel()).to_be_visible()
 
-    # Verify the draft text is still there
     task_page = PlaywrightTaskPage(page=page)
     expect(task_page.get_chat_panel().get_chat_input()).to_have_text(follow_up_text)
 
@@ -69,7 +63,6 @@ def test_starting_text(sculptor_instance_: SculptorInstance) -> None:
     task_page = start_task_and_wait_for_ready(sculptor_instance_.page, prompt=task_text)
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for initial exchange to complete
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
     messages = chat_panel.get_messages()
@@ -92,10 +85,8 @@ def test_send_message_after_task_start(sculptor_instance_: SculptorInstance) -> 
 
     send_chat_message(chat_panel=chat_panel, message="This is a second test message! Please respond briefly!")
 
-    # Verify assistant has responded to both messages
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    # Verify both user messages appear
     messages = chat_panel.get_messages()
 
     expect_message_to_have_role(message=messages.nth(0), role=ElementIDs.USER_MESSAGE)
@@ -118,23 +109,18 @@ def test_send_multiple_messages(sculptor_instance_: SculptorInstance) -> None:
     chat_input = chat_panel.get_chat_input()
     expect(chat_input).to_have_text("")
 
-    # Send second message and verify conversation flow
     send_chat_message(
         chat_panel=chat_panel, message="Hello this is test message two of three! Please respond briefly!"
     )
 
-    # Ensure assistant has responded before continuing
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    # Send third message to test extended conversation handling
     send_chat_message(
         chat_panel=chat_panel, message="Hello this is test message three of three! Please respond briefly!"
     )
 
-    # Wait for complete conversation with all assistant responses
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=6)
 
-    # Verify all messages appear in correct order
     messages = chat_panel.get_messages()
     expect_message_to_have_role(message=messages.nth(0), role=ElementIDs.USER_MESSAGE)
     expect(messages.nth(0)).to_contain_text("Hello this is test message one of three! Please respond briefly!")
@@ -171,15 +157,12 @@ def test_remove_queued_message_and_continue(sculptor_instance_: SculptorInstance
     delete_queued_message_button = chat_panel.get_delete_queued_message_button().last
     delete_queued_message_button.click()
 
-    # Expect there to be no queued messages after all the messages have been sent and responded to
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
     expect(chat_panel.get_queued_message_bar()).to_have_count(0)
 
-    # Send a new message to verify conversation can continue normally
     chat_input.fill("Hello this is test message four of four! Please respond briefly!")
     chat_panel.get_send_button().click()
 
-    # Verify final state
     messages = chat_panel.get_messages()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=6)
     expect_message_to_have_role(message=messages.nth(0), role=ElementIDs.USER_MESSAGE)
@@ -207,34 +190,27 @@ def test_model_selection(sculptor_instance_: SculptorInstance) -> None:
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Verify we can see and interact with the model selector
     model_selector = chat_panel.get_model_selector()
     expect(model_selector).to_be_visible()
 
-    # Switch to the second fake model
     select_model_by_name(chat_panel=chat_panel, model_name=FAKE_CLAUDE_2_MODEL_NAME)
 
-    # Send a message using the second model
     send_chat_message(
         chat_panel=chat_panel,
         message='fake_claude:text `{"text": "Hello from Fake Claude 2"}`',
     )
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
 
-    # Verify the model selector still shows "Fake Claude 2" after the response
     expect(model_selector).to_contain_text("Fake Claude 2", ignore_case=True)
 
-    # Switch back to the first fake model
     select_model_by_name(chat_panel=chat_panel, model_name=FAKE_CLAUDE_MODEL_NAME)
 
-    # Send a message using the first model
     send_chat_message(
         chat_panel=chat_panel,
         message='fake_claude:text `{"text": "Hello from Fake Claude again"}`',
     )
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=6)
 
-    # Verify the model selector shows "Fake Claude" again
     expect(model_selector).to_contain_text("Fake Claude", ignore_case=True)
 
 
@@ -243,14 +219,12 @@ def test_model_selector_updates_when_switching_tasks(sculptor_instance_: Sculpto
     """Test that the model selector displays the correct model when navigating between workspace tabs."""
     page = sculptor_instance_.page
 
-    # Create first workspace with Fake Claude
     start_task_and_wait_for_ready(
         page,
         prompt='fake_claude:text `{"text": "Task 1 response"}`',
         model_name=FAKE_CLAUDE_MODEL_NAME,
     )
 
-    # Create second workspace with Fake Claude 2
     start_task_and_wait_for_ready(
         page,
         prompt='fake_claude:text `{"text": "Task 2 response"}`',
@@ -265,7 +239,6 @@ def test_model_selector_updates_when_switching_tasks(sculptor_instance_: Sculpto
     expect(model_selector).to_be_visible()
     expect(model_selector).to_contain_text("Fake Claude 2", ignore_case=True)
 
-    # Navigate to first workspace tab and verify its model
     workspace_tabs.first.click()
     first_task_page = PlaywrightTaskPage(page=page)
     first_chat_panel = first_task_page.get_chat_panel()

--- a/sculptor/tests/integration/frontend/test_task_page_plan_tab.py
+++ b/sculptor/tests/integration/frontend/test_task_page_plan_tab.py
@@ -1,9 +1,8 @@
 """Integration tests for the agent-tasks UI (StatusPill popover).
 
-The agent-tasks UI lives in the StatusPill popover (the legacy
-``TodoListPanel`` was deprecated). These tests verify that TaskCreate /
-TaskUpdate calls produced by the agent surface in the popover and update as
-the agent reports completion.
+The agent-tasks UI lives in the StatusPill popover. These tests verify that
+TaskCreate / TaskUpdate calls produced by the agent surface in the popover and
+update as the agent reports completion.
 """
 
 from playwright.sync_api import expect

--- a/sculptor/tests/integration/frontend/test_terminal.py
+++ b/sculptor/tests/integration/frontend/test_terminal.py
@@ -42,7 +42,6 @@ def test_terminal_panel_creates_single_websocket_connection(sculptor_instance_: 
     """
     page = sculptor_instance_.page
 
-    # Create a workspace and wait for it to be ready
     start_task_and_wait_for_ready(sculptor_page=page, prompt="Hello")
 
     # Wait for the workspace page to load — the terminal sidebar icon only

--- a/sculptor/tests/integration/frontend/test_terminal_tab_enhancements.py
+++ b/sculptor/tests/integration/frontend/test_terminal_tab_enhancements.py
@@ -37,25 +37,20 @@ def test_terminal_tab_double_click_rename(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create workspace and open terminal.
     start_task_and_wait_for_ready(page, prompt="Terminal test", workspace_name="Term WS")
     open_terminal_and_wait(page)
 
-    # Step 2: Double-click the terminal tab.
     terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(1)
     terminal_tabs.first.dblclick()
 
-    # Step 3: Verify inline rename input appears.
     rename_input = get_inline_rename_input(page)
     expect(rename_input).to_be_visible()
 
-    # Step 4: Type a new name and press Enter.
     rename_input.fill("My Shell")
     rename_input.press("Enter")
     expect(rename_input).not_to_be_visible()
 
-    # Step 5: Verify the terminal tab shows the new name.
     expect(terminal_tabs.first).to_have_text("My Shell")
 
 
@@ -72,7 +67,6 @@ def test_terminal_context_menu_has_close_all_and_rename(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create workspace and terminal.
     start_task_and_wait_for_ready(page, prompt="Term menu test", workspace_name="Term Menu WS")
     open_terminal_and_wait(page)
 
@@ -82,10 +76,8 @@ def test_terminal_context_menu_has_close_all_and_rename(
     terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(2)
 
-    # Step 2: Right-click a terminal tab.
     terminal_tabs.nth(0).click(button="right")
 
-    # Step 3: Verify Rename and Close others items are visible.
     rename_item = get_tab_context_menu_rename(page)
     expect(rename_item).to_be_visible()
 
@@ -106,14 +98,11 @@ def test_terminal_compact_layout_no_heading(
     """
     page = sculptor_instance_.page
 
-    # Step 1: Create workspace and open terminal.
     start_task_and_wait_for_ready(page, prompt="Layout test", workspace_name="Layout WS")
     open_terminal_and_wait(page)
 
-    # Step 2: Verify the terminal heading is not present.
     terminal_heading = get_terminal_heading(page)
     expect(terminal_heading).to_have_count(0)
 
-    # Step 3: Verify terminal tabs are rendered.
     terminal_tabs = get_terminal_tabs(page)
     expect(terminal_tabs).to_have_count(1)

--- a/sculptor/tests/integration/frontend/test_theme_builder.py
+++ b/sculptor/tests/integration/frontend/test_theme_builder.py
@@ -12,7 +12,6 @@ def test_theme_builder_navigation(sculptor_instance_: SculptorInstance):
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     theme_builder = settings_page.click_on_theme_builder()
 
-    # Verify all controls are visible
     expect(theme_builder.get_accent_color_control()).to_be_visible()
     expect(theme_builder.get_gray_color_control()).to_be_visible()
     expect(theme_builder.get_appearance_control()).to_be_visible()
@@ -31,10 +30,8 @@ def test_theme_builder_change_accent_color(sculptor_instance_: SculptorInstance)
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     theme_builder = settings_page.click_on_theme_builder()
 
-    # Verify default accent color
     theme_builder.expect_accent_color("gray")
 
-    # Change accent color to blue
     theme_builder.select_accent_color("blue")
     theme_builder.expect_accent_color("blue")
 
@@ -50,18 +47,14 @@ def test_theme_builder_reset_to_defaults(sculptor_instance_: SculptorInstance):
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     theme_builder = settings_page.click_on_theme_builder()
 
-    # Change multiple settings away from defaults
     theme_builder.select_accent_color("blue")
     theme_builder.select_danger_color("crimson")
 
-    # Verify they changed
     theme_builder.expect_accent_color("blue")
     theme_builder.expect_danger_color("crimson")
 
-    # Click reset
     theme_builder.click_reset()
 
-    # Verify all values returned to defaults
     theme_builder.expect_accent_color("gray")
     theme_builder.expect_danger_color("tomato")
     theme_builder.expect_gray_color("gray")
@@ -83,13 +76,10 @@ def test_theme_builder_component_gallery_button(sculptor_instance_: SculptorInst
     settings_page = navigate_to_settings_page(page=page)
     theme_builder = settings_page.click_on_theme_builder()
 
-    # Verify the Component Gallery button is visible
     expect(theme_builder.get_component_gallery_button()).to_be_visible()
 
-    # Click the Component Gallery button
     theme_builder.click_component_gallery_button()
 
-    # Verify a Component Gallery tab appears and is active
     gallery_tab = settings_page.get_component_gallery_tab()
     expect(gallery_tab).to_be_visible()
     expect(gallery_tab).to_have_attribute("aria-selected", "true")

--- a/sculptor/tests/integration/frontend/test_turn_footer_interactions.py
+++ b/sculptor/tests/integration/frontend/test_turn_footer_interactions.py
@@ -35,16 +35,13 @@ def test_token_popover_shows_breakdown_on_click(
     alpha_view = get_alpha_chat_view(page)
     expect(alpha_view).to_be_visible()
 
-    # Turn footer should be visible with token count
     turn_footers = alpha_view.get_turn_footers()
     expect(turn_footers.first).to_be_visible()
     expect(turn_footers.first).to_contain_text("tokens")
 
-    # Click on the token count to open the popover
     token_count = alpha_view.get_turn_footer_token_count()
     token_count.click()
 
-    # Token popover should appear with "Input" and "Output" labels
     token_popover = alpha_view.get_token_popover()
     expect(token_popover).to_be_visible()
     expect(token_popover).to_contain_text("Input")
@@ -74,21 +71,17 @@ fake_claude:write_file `{
     alpha_view = get_alpha_chat_view(page)
     expect(alpha_view).to_be_visible()
 
-    # Turn footer should show "1 file"
     turn_footers = alpha_view.get_turn_footers()
     expect(turn_footers.first).to_be_visible()
     expect(turn_footers.first).to_contain_text("1 file")
 
-    # Click on the file count to open the popover
     file_count_trigger = alpha_view.get_turn_footer_file_count()
     file_count_trigger.click()
 
-    # Wait for popover to show the file row, then click it to open the diff
     file_row = alpha_view.get_turn_footer_file_row()
     expect(file_row).to_be_visible()
     file_row.click()
 
-    # The diff panel should open
     diff_panel = get_diff_panel_from_page(page)
     expect(diff_panel).to_be_visible()
 
@@ -118,7 +111,6 @@ fake_claude:write_file `{
     alpha_view = get_alpha_chat_view(page)
     expect(alpha_view).to_be_visible()
 
-    # Open the diff panel via the turn footer's file changes popover
     turn_footers = alpha_view.get_turn_footers()
     expect(turn_footers.first).to_be_visible()
     expect(turn_footers.first).to_contain_text("1 file")
@@ -130,7 +122,6 @@ fake_claude:write_file `{
     expect(file_row).to_be_visible()
     file_row.click()
 
-    # Diff panel should open
     diff_panel = get_diff_panel_from_page(page)
     expect(diff_panel).to_be_visible()
 

--- a/sculptor/tests/integration/frontend/test_turn_summary.py
+++ b/sculptor/tests/integration/frontend/test_turn_summary.py
@@ -37,11 +37,9 @@ fake_claude:write_file `{
     alpha_view = get_alpha_chat_view(page)
     expect(alpha_view).to_be_visible()
 
-    # Turn footer should be visible with file count
     turn_footers = alpha_view.get_turn_footers()
     expect(turn_footers.first).to_be_visible()
 
-    # Footer should contain "1 file" for the single written file
     expect(turn_footers.first).to_contain_text("1 file")
 
 
@@ -71,12 +69,9 @@ fake_claude:multi_step `{
     alpha_view = get_alpha_chat_view(page)
     expect(alpha_view).to_be_visible()
 
-    # Turn footer should show file count
     turn_footers = alpha_view.get_turn_footers()
     expect(turn_footers.first).to_be_visible()
 
-    # Footer should contain "2 files" for the two written files
     expect(turn_footers.first).to_contain_text("2 files")
 
-    # Footer should also contain token info
     expect(turn_footers.first).to_contain_text("tokens")

--- a/sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py
+++ b/sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py
@@ -41,26 +41,20 @@ def test_close_workspace_tab_removes_tab_without_deletion(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create two workspaces.
     start_task_and_wait_for_ready(page, prompt="Task A", workspace_name="Workspace A")
     start_task_and_wait_for_ready(page, prompt="Task B", workspace_name="Workspace B")
 
-    # Step 2: Verify both workspace tabs exist.
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Step 3: Click the first tab to activate it, then click its close button.
     layout.close_workspace_tab(0)
 
-    # Step 4: Verify no delete confirmation dialog appears and tab count drops to 1.
     confirm_dialog = layout.get_delete_confirmation_dialog()
     expect(confirm_dialog).to_be_hidden()
     expect(workspace_tabs).to_have_count(1)
 
-    # Step 5: Navigate to the Home page.
     navigate_to_home_page(page)
 
-    # Step 6: Verify the closed workspace still exists in the workspace list.
     home_page = PlaywrightHomePage(page)
     workspace_rows = home_page.get_workspace_rows()
     expect(workspace_rows).to_have_count(2)
@@ -80,19 +74,15 @@ def test_cmd_w_closes_workspace_tab(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create two workspaces.
     start_task_and_wait_for_ready(page, prompt="Task 1", workspace_name="WS One")
     start_task_and_wait_for_ready(page, prompt="Task 2", workspace_name="WS Two")
 
-    # Step 2: Verify both workspace tabs exist.
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Step 3: Press Cmd+W to close the active tab.
     mod_key = get_playwright_modifier_key()
     page.keyboard.press(f"{mod_key}+w")
 
-    # Step 4: Verify no delete confirmation dialog appears and tab count drops to 1.
     confirm_dialog = layout.get_delete_confirmation_dialog()
     expect(confirm_dialog).to_be_hidden()
     expect(workspace_tabs).to_have_count(1)
@@ -118,27 +108,24 @@ def test_cmd_shift_w_deletes_active_workspace(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create two workspaces. "Delete WS" is active after creation.
+    # "Delete WS" is active after creation.
     start_task_and_wait_for_ready(page, prompt="Task 1", workspace_name="Keep WS")
     start_task_and_wait_for_ready(page, prompt="Task 2", workspace_name="Delete WS")
 
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Step 2: Press Cmd+Shift+W to delete the active workspace.
     mod_key = get_playwright_modifier_key()
     page.keyboard.press(f"{mod_key}+Shift+w")
 
-    # Step 3: Unlike Cmd+W, this opens the delete confirmation dialog.
+    # Unlike Cmd+W, this opens the delete confirmation dialog.
     confirm_dialog = layout.get_delete_confirmation_dialog()
     expect(confirm_dialog).to_be_visible()
 
-    # Step 4: Confirm the deletion; the tab count drops to 1.
     layout.confirm_delete()
     expect(workspace_tabs).to_have_count(1)
 
-    # Step 5: The deleted workspace no longer appears on the Home page. A
-    # closed (not deleted) workspace would still be listed here.
+    # A closed (not deleted) workspace would still be listed here.
     navigate_to_home_page(page)
     home_page = PlaywrightHomePage(page)
     expect(home_page.get_workspace_rows()).to_have_count(1)
@@ -161,30 +148,23 @@ def test_reopen_closed_workspace_from_list(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create two workspaces.
     start_task_and_wait_for_ready(page, prompt="Task A", workspace_name="Closeable WS")
     start_task_and_wait_for_ready(page, prompt="Task B", workspace_name="Remaining WS")
 
-    # Step 2: Verify both workspace tabs exist.
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Step 3: Close the first workspace tab.
     layout.close_workspace_tab(0)
 
-    # Step 4: Verify tab count drops to 1.
     expect(workspace_tabs).to_have_count(1)
 
-    # Step 5: Navigate to the Home page.
     navigate_to_home_page(page)
 
-    # Step 6: Find the closed workspace in the list and click it.
     home_page = PlaywrightHomePage(page)
     closed_workspace_row = home_page.get_workspace_rows().filter(has_text="Closeable WS")
     expect(closed_workspace_row).to_be_visible()
     closed_workspace_row.click()
 
-    # Step 7: Verify tab count goes back to 2.
     expect(workspace_tabs).to_have_count(2)
 
 
@@ -204,30 +184,23 @@ def test_close_all_workspace_tabs_via_context_menu(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create two workspaces.
     start_task_and_wait_for_ready(page, prompt="Task X", workspace_name="WS Alpha")
     start_task_and_wait_for_ready(page, prompt="Task Y", workspace_name="WS Beta")
 
-    # Step 2: Verify both workspace tabs exist.
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Step 3: Right-click one workspace tab to open the context menu.
     workspace_tabs.nth(0).click(button="right")
 
-    # Step 4: Click the 'Close All' item in the context menu.
     close_all_item = layout.get_tab_context_menu_close_all()
     expect(close_all_item).to_be_visible()
     close_all_item.click()
 
-    # Step 5: Verify all workspace tabs are gone.
     expect(workspace_tabs).to_have_count(0)
 
-    # Step 6: Verify the Add Workspace page is shown.
     add_ws_page = PlaywrightAddWorkspacePage(page=page)
     expect(add_ws_page.get_workspace_name_input()).to_be_visible()
 
-    # Step 7: Navigate to the Home page and verify both workspaces still exist.
     navigate_to_home_page(page)
     home_page = PlaywrightHomePage(page)
     expect(home_page.get_workspace_rows()).to_have_count(2)
@@ -248,23 +221,18 @@ def test_close_others_workspace_tabs_via_context_menu(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Step 1: Create two workspaces.
     start_task_and_wait_for_ready(page, prompt="Task P", workspace_name="WS First")
     start_task_and_wait_for_ready(page, prompt="Task Q", workspace_name="WS Second")
 
-    # Step 2: Verify both workspace tabs exist.
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Step 3: Right-click the second workspace tab to open the context menu.
     workspace_tabs.nth(1).click(button="right")
 
-    # Step 4: Click the 'Close Others' item in the context menu.
     close_others_item = layout.get_tab_context_menu_close_others()
     expect(close_others_item).to_be_visible()
     close_others_item.click()
 
-    # Step 5: Verify only 1 workspace tab remains.
     expect(workspace_tabs).to_have_count(1)
 
 
@@ -290,20 +258,16 @@ def test_reopen_closed_workspace_from_home_page(
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Close the first workspace tab
     layout.close_workspace_tab(0)
     expect(workspace_tabs).to_have_count(1)
 
-    # Navigate to Home page
     navigate_to_home_page(page)
 
-    # Click the closed workspace in the list
     home_page = PlaywrightHomePage(page)
     closed_workspace_row = home_page.get_workspace_rows().filter(has_text="Home Reopen WS")
     expect(closed_workspace_row).to_be_visible()
     closed_workspace_row.click()
 
-    # Verify tab count goes back to 2
     expect(workspace_tabs).to_have_count(2)
 
 
@@ -332,11 +296,9 @@ def test_closed_workspace_stays_closed(
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Close the first workspace
     layout.close_workspace_tab(0)
     expect(workspace_tabs).to_have_count(1)
 
-    # Reopen from the closed workspaces dropdown
     pill = layout.get_closed_workspaces_pill()
     expect(pill).to_be_visible()
     pill.click()
@@ -346,14 +308,12 @@ def test_closed_workspace_stays_closed(
     row.click()
     expect(workspace_tabs).to_have_count(2)
 
-    # Close it again
     layout.close_workspace_tab(0)
     expect(workspace_tabs).to_have_count(1)
 
     # Wait a moment for any WebSocket updates to arrive
     page.wait_for_timeout(2000)
 
-    # Verify the workspace stays closed — tab count should still be 1
     expect(workspace_tabs).to_have_count(1)
 
 
@@ -384,7 +344,6 @@ def test_close_after_reopen_from_home_page(
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Close both workspaces via context menu "Close All"
     workspace_tabs.nth(0).click(button="right")
     close_all_item = layout.get_tab_context_menu_close_all()
     expect(close_all_item).to_be_visible()
@@ -398,7 +357,6 @@ def test_close_after_reopen_from_home_page(
     add_ws_page = PlaywrightAddWorkspacePage(page=page)
     expect(add_ws_page.get_workspace_name_input()).to_be_visible()
 
-    # Reopen both from the closed workspaces dropdown
     pill = layout.get_closed_workspaces_pill()
     expect(pill).to_be_visible()
     expect(pill).to_contain_text("2")
@@ -417,14 +375,12 @@ def test_close_after_reopen_from_home_page(
     expect(workspace_tabs).to_have_count(2)
     expect(pill).not_to_be_visible()
 
-    # Close one workspace
     layout.close_workspace_tab(0)
     expect(workspace_tabs).to_have_count(1)
 
     # Wait for any out-of-order WebSocket updates to arrive
     page.wait_for_timeout(3000)
 
-    # Verify the workspace stays closed — dropdown path
     expect(workspace_tabs).to_have_count(1)
 
 
@@ -455,14 +411,12 @@ def test_close_after_reopen_from_home(
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Close both workspaces via context menu "Close All"
     workspace_tabs.nth(0).click(button="right")
     close_all_item = layout.get_tab_context_menu_close_all()
     expect(close_all_item).to_be_visible()
     close_all_item.click()
     expect(workspace_tabs).to_have_count(0)
 
-    # Reopen the first workspace from the Home page
     navigate_to_home_page(page)
     home_page = PlaywrightHomePage(page)
     first_row = home_page.get_workspace_rows().filter(has_text="Home Close A")
@@ -470,21 +424,18 @@ def test_close_after_reopen_from_home(
     first_row.click()
     expect(workspace_tabs).to_have_count(1)
 
-    # Reopen the second workspace from the Home page
     navigate_to_home_page(page)
     second_row = home_page.get_workspace_rows().filter(has_text="Home Close B")
     expect(second_row).to_be_visible()
     second_row.click()
     expect(workspace_tabs).to_have_count(2)
 
-    # Close one workspace
     layout.close_workspace_tab(0)
     expect(workspace_tabs).to_have_count(1)
 
     # Wait for any out-of-order WebSocket updates to arrive
     page.wait_for_timeout(3000)
 
-    # Verify the workspace stays closed — Home page path
     expect(workspace_tabs).to_have_count(1)
 
 
@@ -517,7 +468,6 @@ def test_localstorage_migration_preserves_closed_state(
     workspace_tabs = layout.get_workspace_tabs()
     expect(workspace_tabs).to_have_count(2)
 
-    # Get workspace IDs from tab elements
     open_ws_id = workspace_tabs.nth(0).get_attribute("data-tab-id")
     closed_ws_id = workspace_tabs.nth(1).get_attribute("data-tab-id")
     assert open_ws_id is not None
@@ -547,6 +497,5 @@ def test_localstorage_migration_preserves_closed_state(
     expect(pill).to_be_visible()
     expect(pill).to_contain_text("1")
 
-    # The old localStorage key should have been deleted
     old_key = get_local_storage_item(page, "sculptor-open-workspace-tab-ids")
     assert old_key is None, f"Old localStorage key should have been deleted, but found: {old_key}"

--- a/sculptor/tests/integration/frontend/test_workspace_peek.py
+++ b/sculptor/tests/integration/frontend/test_workspace_peek.py
@@ -33,7 +33,6 @@ def test_workspace_peek_popover_idle_state(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Create a workspace with a simple task that completes immediately
     start_task_and_wait_for_ready(
         page,
         prompt='fake_claude:text `{"text": "All done!"}`',
@@ -43,21 +42,17 @@ def test_workspace_peek_popover_idle_state(
     # Navigate away so we can hover over the workspace tab
     navigate_to_add_workspace_page(page)
 
-    # Hover over the workspace tab to trigger the popover
     workspace_tab = layout.get_workspace_tabs().first
     workspace_tab.hover()
 
-    # Verify the popover appears
     peek = layout.get_workspace_peek_popover()
     expect(peek).to_be_visible()
 
-    # Verify header shows workspace name
     expect(peek.get_header()).to_contain_text("Idle WS")
 
     # No alert banner for idle state
     expect(peek.get_banner()).to_be_hidden()
 
-    # Verify at least one agent row is present
     expect(peek.get_agent_rows().first).to_be_visible()
 
 
@@ -95,25 +90,20 @@ fake_claude:ask_user_question `{
         wait_for_agent_to_finish=False,
     )
 
-    # Verify the Q&A panel is showing (agent is in waiting state)
     auq_panel = get_ask_user_question_panel(page)
     expect(auq_panel).to_be_visible(timeout=30_000)
 
     # Navigate away so we can hover over the workspace tab
     navigate_to_add_workspace_page(page)
 
-    # Hover over the workspace tab to trigger the popover
     workspace_tab = layout.get_workspace_tabs().first
     workspace_tab.hover()
 
-    # Verify the popover appears
     peek = layout.get_workspace_peek_popover()
     expect(peek).to_be_visible()
 
-    # Verify header shows workspace name
     expect(peek.get_header()).to_contain_text("Waiting WS")
 
-    # Verify orange banner shows waiting message
     expect(peek.get_banner()).to_be_visible()
     expect(peek.get_banner()).to_contain_text("needs your input")
 
@@ -128,7 +118,6 @@ def test_workspace_peek_popover_hover_mechanics(
     page = sculptor_instance_.page
     layout = PlaywrightProjectLayoutPage(page=page)
 
-    # Create a workspace with a completed task
     start_task_and_wait_for_ready(
         page,
         prompt='fake_claude:text `{"text": "Done"}`',
@@ -141,18 +130,14 @@ def test_workspace_peek_popover_hover_mechanics(
     workspace_tab = layout.get_workspace_tabs().first
     peek = layout.get_workspace_peek_popover()
 
-    # Initially the popover should not be visible
     expect(peek).to_be_hidden()
 
-    # Hover over the tab — popover should appear
     workspace_tab.hover()
     expect(peek).to_be_visible()
 
-    # Verify all popover sections are present
     expect(peek.get_header()).to_be_visible()
     expect(peek.get_agent_rows().first).to_be_visible()
 
-    # Move mouse away from the tab — popover should dismiss.
     # Move to the top-left corner which is far from the tab.
     page.mouse.move(0, 0)
     expect(peek).to_be_hidden()
@@ -191,7 +176,6 @@ def test_workspace_peek_popover_on_scrolled_tab(
     ws1_tab.scroll_into_view_if_needed()
     ws1_tab.hover()
 
-    # The peek popover should appear
     peek = layout.get_workspace_peek_popover()
     expect(peek).to_be_visible()
 
@@ -254,7 +238,6 @@ def test_workspace_peek_waiting_overrides_running_in_banner(
     # Navigate away so the workspace tab is hoverable
     navigate_to_add_workspace_page(page)
 
-    # Hover over the workspace tab to trigger the popover
     workspace_tab = task_page.get_workspace_tabs().first
     workspace_tab.hover()
 
@@ -280,16 +263,13 @@ def test_peek_popover_shows_diff_stats(sculptor_instance_: SculptorInstance) -> 
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Hover over the workspace tab in the tab bar to trigger the peek popover
     workspace_tab = task_page.get_workspace_tabs().first
     expect(workspace_tab).to_be_visible()
     workspace_tab.hover()
 
-    # The popover should appear with diff stats
     peek = task_page.get_workspace_peek_popover()
     expect(peek).to_be_visible()
 
-    # The footer should show diff additions
     footer = peek.get_footer()
     expect(footer).to_be_visible()
     expect(footer).to_contain_text("+")

--- a/sculptor/tests/integration/frontend/test_workspace_scoped_changes.py
+++ b/sculptor/tests/integration/frontend/test_workspace_scoped_changes.py
@@ -47,7 +47,6 @@ def test_uncommitted_tab_shows_changes_from_all_agents(
     """
     page = sculptor_instance_.page
 
-    # Create first agent that writes a file
     task_page = start_task_and_wait_for_ready(
         page,
         prompt="""\
@@ -58,19 +57,15 @@ fake_claude:write_file `{
         workspace_name="Shared Changes WS",
     )
 
-    # Wait for agent 1 to finish
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Add a second agent to the same workspace
     agent_tab_bar = task_page.get_agent_tab_bar()
     agent_tab_bar.get_add_agent_button().click()
 
-    # Wait for the second agent tab to appear
     agent_tabs = agent_tab_bar.get_agent_tabs()
     expect(agent_tabs).to_have_count(2)
 
-    # Send a task to agent 2 that writes a different file
     task_page_2 = PlaywrightTaskPage(page=page)
     chat_panel_2 = task_page_2.get_chat_panel()
     send_chat_message(
@@ -83,13 +78,11 @@ fake_claude:write_file `{
     )
     wait_for_completed_message_count(chat_panel=chat_panel_2, expected_message_count=2)
 
-    # --- Assert: Agent 2's Changes panel shows BOTH files ---
     task_page_2.activate_changes_panel(scope="uncommitted")
     changes_tree = task_page_2.get_changes_panel().get_changes_tree()
     expect(changes_tree).to_be_visible()
     expect(changes_tree.get_tree_rows()).to_have_count(2)
 
-    # --- Switch to agent 1 and verify its Changes panel also shows BOTH files ---
     agent_tabs.first.click()
 
     task_page.activate_changes_panel(scope="uncommitted")
@@ -114,7 +107,6 @@ def test_review_modal_shows_changes_from_all_agents(
 
     _enable_review_all_via_settings(page)
 
-    # Create first agent that writes a file
     task_page = start_task_and_wait_for_ready(
         page,
         prompt="""\
@@ -128,7 +120,6 @@ fake_claude:write_file `{
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Add a second agent and have it write a different file
     agent_tab_bar = task_page.get_agent_tab_bar()
     agent_tab_bar.get_add_agent_button().click()
 
@@ -147,11 +138,9 @@ fake_claude:write_file `{
     )
     wait_for_completed_message_count(chat_panel=chat_panel_2, expected_message_count=2)
 
-    # Switch to Changes tab and click Review All
     task_page_2.activate_changes_panel()
     task_page_2.click_review_all()
 
-    # The diff panel should show both files
     diff_panel = task_page_2.get_diff_panel()
     expect(diff_panel).to_be_visible()
     expect(diff_panel).to_contain_text("review_file1.py")
@@ -177,7 +166,6 @@ def test_uncommitted_tab_updates_when_other_agent_modifies_files(
     """
     page = sculptor_instance_.page
 
-    # Create first agent that writes a file
     task_page = start_task_and_wait_for_ready(
         page,
         prompt="""\
@@ -191,13 +179,11 @@ fake_claude:write_file `{
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Verify agent 1 initially shows 1 file
     task_page.activate_changes_panel(scope="uncommitted")
     changes_tree = task_page.get_changes_panel().get_changes_tree()
     expect(changes_tree).to_be_visible()
     expect(changes_tree.get_tree_rows()).to_have_count(1)
 
-    # Add second agent and have it write another file
     agent_tab_bar = task_page.get_agent_tab_bar()
     agent_tab_bar.get_add_agent_button().click()
 
@@ -216,10 +202,8 @@ fake_claude:write_file `{
     )
     wait_for_completed_message_count(chat_panel=chat_panel_2, expected_message_count=2)
 
-    # Switch back to agent 1
     agent_tabs.first.click()
 
-    # Agent 1's Changes panel should now show BOTH files
     task_page.activate_changes_panel(scope="uncommitted")
     changes_tree_1 = task_page.get_changes_panel().get_changes_tree()
     expect(changes_tree_1).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_workspace_tab_context_menu_icons.py
+++ b/sculptor/tests/integration/frontend/test_workspace_tab_context_menu_icons.py
@@ -1,10 +1,4 @@
-"""Integration tests for workspace tab context menu rename functionality.
-
-Tests cover:
-- Workspace context menu has a Rename item
-- Inline rename input appears and works on commit (Enter)
-- Inline rename input cancels on Escape
-"""
+"""Integration tests for workspace tab context menu rename functionality."""
 
 from playwright.sync_api import expect
 

--- a/sculptor/tests/integration/frontend/test_workspace_tab_enhancements.py
+++ b/sculptor/tests/integration/frontend/test_workspace_tab_enhancements.py
@@ -1,11 +1,4 @@
-"""Integration tests for workspace tab enhancements.
-
-Tests cover:
-- Cmd+T keyboard shortcut opens the Add Workspace page
-- Cmd+W keyboard shortcut closes the current workspace tab (removes tab, no deletion)
-- X button on the Open Workspace tab navigates to the MRU workspace
-- Context menu Delete action triggers deletion with confirmation
-"""
+"""Integration tests for workspace tab enhancements."""
 
 from playwright.sync_api import expect
 

--- a/sculptor/tests/integration/frontend/test_zen_mode.py
+++ b/sculptor/tests/integration/frontend/test_zen_mode.py
@@ -1,18 +1,4 @@
-"""Integration tests for zen mode and focus mode.
-
-Tests cover:
-- Zen mode keyboard shortcut (Cmd+Shift+\\) hides all UI chrome and panels
-- Exiting zen mode restores all UI chrome and panels
-- Focus mode keyboard shortcut (Cmd+\\) hides panels but keeps chrome
-- Exiting focus mode while in zen mode exits both (full escape)
-- Zen mode preserves pre-existing focus mode on exit
-- Exit button appears and functions correctly in zen mode
-- Panel toggles in zen mode persist on exit
-- Workspace tab navigation (Cmd+[ / Cmd+]) works in zen mode
-- Exit button is hidden by default (opacity 0) but attached to DOM
-- Exit button appears on hover over the top-left hot zone
-- Exit button disappears when mouse leaves the hot zone
-"""
+"""Integration tests for zen mode and focus mode."""
 
 from playwright.sync_api import expect
 

--- a/sculptor/tests/integration/real_claude/helpers.py
+++ b/sculptor/tests/integration/real_claude/helpers.py
@@ -287,11 +287,6 @@ def assert_has_completed_tool_calls(chat_panel: PlaywrightChatPanelElement, min_
         expect(combined).to_have_count(min_count, timeout=RESPONSE_TIMEOUT_MS)
 
 
-# ---------------------------------------------------------------------------
-# Transcript file helpers
-# ---------------------------------------------------------------------------
-
-
 def _extract_workspace_id(url: str) -> str:
     """Extract workspace ID from a Sculptor task page URL."""
     match = re.search(r"/ws/([a-zA-Z0-9_-]+)/", url)

--- a/sculptor/tests/integration/real_claude/test_background_tasks.py
+++ b/sculptor/tests/integration/real_claude/test_background_tasks.py
@@ -44,11 +44,6 @@ _MAX_FIRST_TURN_SECONDS = 15
 _MIN_BG_WAIT_SECONDS = 15
 
 
-# ---------------------------------------------------------------------------
-# Agent tool background task waits for completion
-# ---------------------------------------------------------------------------
-
-
 @real_claude
 @pytest.mark.timeout(300)
 def test_agent_background_task_completes(sculptor_instance_: SculptorInstance) -> None:
@@ -96,11 +91,6 @@ def test_agent_background_task_completes(sculptor_instance_: SculptorInstance) -
         + f"{len(notifications)} notifications received. "
         + f"Started: {started}, Notifications: {notifications}"
     )
-
-
-# ---------------------------------------------------------------------------
-# Bash tool background task waits for completion
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -157,11 +147,6 @@ def test_bash_background_task_completes(sculptor_instance_: SculptorInstance) ->
     assert_no_errors(chat_panel)
 
 
-# ---------------------------------------------------------------------------
-# Bash background task is not killed by process shutdown
-# ---------------------------------------------------------------------------
-
-
 @real_claude
 @pytest.mark.timeout(300)
 def test_bash_background_task_not_killed(sculptor_instance_: SculptorInstance) -> None:
@@ -207,11 +192,6 @@ def test_bash_background_task_not_killed(sculptor_instance_: SculptorInstance) -
     # Also verify the agent received the completion notification
     assert_any_message_contains(chat_panel, "BG-NOTIFICATION-RECEIVED-49201")
     assert_no_errors(chat_panel)
-
-
-# ---------------------------------------------------------------------------
-# ThinkingIndicator stays visible during background Bash task
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -260,11 +240,6 @@ def test_thinking_indicator_visible_during_background_bash(sculptor_instance_: S
     assert_no_errors(chat_panel)
 
 
-# ---------------------------------------------------------------------------
-# Interrupt during background Agent task
-# ---------------------------------------------------------------------------
-
-
 @real_claude
 @pytest.mark.timeout(300)
 def test_interrupt_during_background_agent_task(sculptor_instance_: SculptorInstance) -> None:
@@ -291,11 +266,6 @@ def test_interrupt_during_background_agent_task(sculptor_instance_: SculptorInst
     # Verify recovery
     send_and_wait(chat_panel, "Reply with exactly: BG-AGENT-INTERRUPT-RECOVERED-52018")
     assert_last_message_contains(chat_panel, "BG-AGENT-INTERRUPT-RECOVERED-52018")
-
-
-# ---------------------------------------------------------------------------
-# Interrupt during background Bash task
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -332,11 +302,6 @@ def test_interrupt_during_background_bash_task(sculptor_instance_: SculptorInsta
     # Verify recovery (works whether we interrupted or agent finished naturally)
     send_and_wait(chat_panel, "Reply with exactly: BG-BASH-INTERRUPT-RECOVERED-38201")
     assert_last_message_contains(chat_panel, "BG-BASH-INTERRUPT-RECOVERED-38201")
-
-
-# ---------------------------------------------------------------------------
-# Post-notification assistant message is delivered to the UI
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -386,11 +351,6 @@ def test_post_notification_message_delivered(sculptor_instance_: SculptorInstanc
     assert_no_errors(chat_panel)
 
 
-# ---------------------------------------------------------------------------
-# Follow-up message after background task completes
-# ---------------------------------------------------------------------------
-
-
 @real_claude
 @pytest.mark.timeout(300)
 def test_follow_up_after_background_task(sculptor_instance_: SculptorInstance) -> None:
@@ -424,11 +384,6 @@ def test_follow_up_after_background_task(sculptor_instance_: SculptorInstance) -
         "What code did I ask you to remember? Reply starting with RECALL-DELTA:",
     )
     assert_last_message_contains(chat_panel, "ANCHOR-DELTA-77301")
-
-
-# ---------------------------------------------------------------------------
-# Background subagent pill stops ticking once the subagent finishes
-# ---------------------------------------------------------------------------
 
 
 @real_claude

--- a/sculptor/tests/integration/real_claude/test_edge_cases.py
+++ b/sculptor/tests/integration/real_claude/test_edge_cases.py
@@ -25,11 +25,9 @@ from tests.integration.real_claude.helpers import wait_for_any_assistant_text
 def test_very_long_prompt_via_stdin(sculptor_instance_: SculptorInstance) -> None:
     """Verify the stdin JSON protocol handles large prompts correctly.
 
-    The old approach used a file redirect (< instructions_file); the new one
-    sends the prompt inline as a JSON message on stdin. This tests that large
-    payloads don't get truncated or cause pipe buffer issues.
+    This tests that large payloads don't get truncated or cause pipe buffer
+    issues.
     """
-    # Build a ~10,000 character prompt with 500 items
     items = "\n".join(f"Item {i}: ALPHA-{i:03d}" for i in range(1, 501))
     prompt = f"I am going to give you a long list of items. At the end, I will ask a question.\n{items}\nWhat is Item 250? Reply in the format: ITEM-250-IS: <value>"
     task_page = create_workspace_and_send(sculptor_instance_, prompt)
@@ -104,11 +102,9 @@ def test_interrupt_then_ask_user_question(sculptor_instance_: SculptorInstance) 
         ("Ask me a question using AskUserQuestion: 'Continue with ocean essay?' with options ['Yes', 'No']."),
     )
 
-    # Wait for the question panel
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Answer and verify agent continues
     ask_panel.select_option_by_text("Yes")
     ask_panel.submit()
 
@@ -132,20 +128,16 @@ def test_interrupt_then_plan_mode(sculptor_instance_: SculptorInstance) -> None:
     wait_for_any_assistant_text(chat_panel)
     interrupt_agent(chat_panel)
 
-    # Now enter plan mode
     send_no_wait(
         chat_panel,
         ("Enter plan mode. Present a plan with 3 steps to create a simple Python script. Then ask for approval."),
     )
 
-    # Wait for approval prompt
     ask_panel = get_ask_user_question_panel(page)
     expect(ask_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Approve
     ask_panel.select_option_by_text("Approve")
     ask_panel.submit()
 
-    # Agent should execute
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     assert_no_errors(chat_panel)

--- a/sculptor/tests/integration/real_claude/test_interrupts.py
+++ b/sculptor/tests/integration/real_claude/test_interrupts.py
@@ -31,10 +31,6 @@ from tests.integration.real_claude.helpers import send_no_wait
 from tests.integration.real_claude.helpers import wait_for_any_assistant_text
 from tests.integration.real_claude.helpers import wait_for_streaming_text
 
-# ---------------------------------------------------------------------------
-# THE MOST IMPORTANT TEST: Interrupt during streaming, no amnesia
-# ---------------------------------------------------------------------------
-
 
 @real_claude
 @pytest.mark.timeout(300)
@@ -59,12 +55,10 @@ def test_interrupt_during_streaming_no_amnesia(sculptor_instance_: SculptorInsta
         ),
     )
 
-    # Wait for streaming to begin, then interrupt
     wait_for_streaming_text(chat_panel, "ESSAY-BEGINS-HERE")
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
 
-    # THE CRITICAL CHECK: Does the agent remember the anchor code?
     send_and_wait(
         chat_panel,
         "What is the code I asked you to remember at the start of our conversation? Reply in the format: RECALLED-CODE: <code>",
@@ -84,11 +78,6 @@ def test_interrupt_during_streaming_no_amnesia(sculptor_instance_: SculptorInsta
     # The critical check is that the pre-interrupt context (anchor) is preserved.
     # At least 3 user turns: anchor, essay request, recall question
     assert_transcript_turn_count(transcript, "user", min_count=3)
-
-
-# ---------------------------------------------------------------------------
-# Interrupt during tool execution, no amnesia
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -116,18 +105,12 @@ def test_interrupt_during_tool_execution_no_amnesia(sculptor_instance_: Sculptor
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
 
-    # Verify memory
     send_and_wait(
         chat_panel,
         "What file did you create earlier and what was its content? Reply starting with: TOOL-RECALL:",
     )
     assert_last_message_contains(chat_panel, "anchor-tool.txt")
     assert_last_message_contains(chat_panel, "TOOL-ANCHOR-88312")
-
-
-# ---------------------------------------------------------------------------
-# Multiple interrupts, no amnesia
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -147,7 +130,6 @@ def test_multiple_interrupts_no_amnesia(sculptor_instance_: SculptorInstance) ->
     chat_panel = task_page.get_chat_panel()
     assert_last_message_contains(chat_panel, "MSG-1-ACK")
 
-    # First interrupt (message 2)
     send_no_wait(
         chat_panel,
         "This is message 2. Write a 2000-word essay about dogs. Start with: DOG-ESSAY-START:",
@@ -156,7 +138,6 @@ def test_multiple_interrupts_no_amnesia(sculptor_instance_: SculptorInstance) ->
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
 
-    # Second interrupt (message 3)
     send_no_wait(
         chat_panel,
         "This is message 3. Write a 2000-word essay about cats. Start with: CAT-ESSAY-START:",
@@ -165,7 +146,6 @@ def test_multiple_interrupts_no_amnesia(sculptor_instance_: SculptorInstance) ->
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
 
-    # Message 4: ask Claude to count messages
     send_and_wait(
         chat_panel,
         (
@@ -202,11 +182,6 @@ def test_multiple_interrupts_no_amnesia(sculptor_instance_: SculptorInstance) ->
     assert_transcript_turn_count(transcript, "user", min_count=4)
 
 
-# ---------------------------------------------------------------------------
-# Rapid stop (interrupt very early in streaming)
-# ---------------------------------------------------------------------------
-
-
 @real_claude
 @pytest.mark.timeout(300)
 def test_interrupt_early_streaming(sculptor_instance_: SculptorInstance) -> None:
@@ -218,20 +193,13 @@ def test_interrupt_early_streaming(sculptor_instance_: SculptorInstance) -> None
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Interrupt as soon as any text appears
     wait_for_any_assistant_text(chat_panel)
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
     assert_no_errors(chat_panel)
 
-    # Verify recovery
     send_and_wait(chat_panel, "Reply with exactly: RAPID-STOP-RECOVERED-OK")
     assert_last_message_contains(chat_panel, "RAPID-STOP-RECOVERED-OK")
-
-
-# ---------------------------------------------------------------------------
-# Immediate stop before any output
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -245,24 +213,16 @@ def test_interrupt_before_any_output(sculptor_instance_: SculptorInstance) -> No
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait just for the thinking indicator, then immediately stop
     expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=30_000)
     interrupt_agent(chat_panel)
 
-    # No crash, no InterruptFailure
     messages = chat_panel.get_messages()
     expect(messages.filter(has_text="InterruptFailure")).to_have_count(0)
 
     assert_no_errors(chat_panel)
 
-    # Verify recovery
     send_and_wait(chat_panel, "Reply with exactly: IMMEDIATE-STOP-OK-55023")
     assert_last_message_contains(chat_panel, "IMMEDIATE-STOP-OK-55023")
-
-
-# ---------------------------------------------------------------------------
-# Interrupt and continue with complex multi-step work
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -279,7 +239,6 @@ def test_interrupt_and_continue_with_tools(sculptor_instance_: SculptorInstance)
     wait_for_streaming_text(chat_panel, "VOLCANO-START")
     interrupt_agent(chat_panel)
 
-    # Now do real multi-step work
     send_and_wait(
         chat_panel,
         (
@@ -288,11 +247,6 @@ def test_interrupt_and_continue_with_tools(sculptor_instance_: SculptorInstance)
     )
     assert_last_message_contains(chat_panel, "ALL-POST-INTERRUPT-STEPS-DONE")
     assert_no_errors(chat_panel)
-
-
-# ---------------------------------------------------------------------------
-# Queue message + "Interrupt and send"
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -306,24 +260,16 @@ def test_queue_and_interrupt_and_send(sculptor_instance_: SculptorInstance) -> N
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for streaming to begin
     wait_for_streaming_text(chat_panel, "OCEAN-ESSAY-START")
 
-    # Type a new message and click send (which acts as "interrupt and send")
     interrupt_and_send(
         chat_panel,
         task_page._page,
         "Stop writing. Reply with exactly: INTERRUPT-SEND-SENTINEL-40182",
     )
 
-    # Wait for the new response
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     assert_any_message_contains(chat_panel, "INTERRUPT-SEND-SENTINEL-40182")
-
-
-# ---------------------------------------------------------------------------
-# Queue + interrupt and send, memory preserved
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -337,14 +283,12 @@ def test_interrupt_and_send_memory_preserved(sculptor_instance_: SculptorInstanc
     chat_panel = task_page.get_chat_panel()
     assert_last_message_contains(chat_panel, "FOXTROT-STORED")
 
-    # Start a long essay
     send_no_wait(
         chat_panel,
         "Write a 3000-word essay about space travel. Start with SPACE-ESSAY:",
     )
     wait_for_streaming_text(chat_panel, "SPACE-ESSAY")
 
-    # Interrupt and send a recall question
     interrupt_and_send(
         chat_panel,
         task_page._page,
@@ -353,11 +297,6 @@ def test_interrupt_and_send_memory_preserved(sculptor_instance_: SculptorInstanc
 
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     assert_any_message_contains(chat_panel, "ANCHOR-FOXTROT-62018")
-
-
-# ---------------------------------------------------------------------------
-# Interrupt during background process
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -381,17 +320,11 @@ def test_interrupt_during_background_process(sculptor_instance_: SculptorInstanc
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
 
-    # Verify recovery
     send_and_wait(
         chat_panel,
         "Good, the interrupt worked. Please confirm by saying the phrase BG-INTERRUPT-RECOVERED-61037 so I know you're back.",
     )
     assert_last_message_contains(chat_panel, "BG-INTERRUPT-RECOVERED-61037")
-
-
-# ---------------------------------------------------------------------------
-# Multiple rapid interrupts in sequence
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -415,14 +348,8 @@ def test_multiple_rapid_interrupts(sculptor_instance_: SculptorInstance) -> None
     wait_for_any_assistant_text(chat_panel)
     interrupt_agent(chat_panel)
 
-    # After three rapid interrupts, the agent should still be functional
     send_and_wait(chat_panel, "Reply with exactly: TRIPLE-INTERRUPT-SURVIVED-88341")
     assert_last_message_contains(chat_panel, "TRIPLE-INTERRUPT-SURVIVED-88341")
-
-
-# ---------------------------------------------------------------------------
-# Interrupt during AskUserQuestion
-# ---------------------------------------------------------------------------
 
 
 @real_claude
@@ -443,6 +370,5 @@ def test_stop_button_hidden_during_ask_user_question(sculptor_instance_: Sculpto
     ask_panel = get_ask_user_question_panel(chat_panel._page)
     expect(ask_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # The stop button should NOT be visible when AUQ is showing
     stop_button = chat_panel.get_stop_button()
     expect(stop_button).not_to_be_visible()

--- a/sculptor/tests/integration/real_claude/test_permission_prompt.py
+++ b/sculptor/tests/integration/real_claude/test_permission_prompt.py
@@ -58,7 +58,6 @@ def test_write_to_claude_skill_file(sculptor_instance_: SculptorInstance) -> Non
     --dangerously-skip-permissions is set. Without --permission-prompt-tool stdio
     and auto-approval of can_use_tool control requests, this write fails silently.
     """
-    # Step 1: Ask the agent to write to a .claude/ skill file using the Write tool.
     # We use a unique sentinel so we can verify the exact content was written.
     task_page = create_workspace_and_send(sculptor_instance_, _WRITE_PROMPT)
     chat_panel = task_page.get_chat_panel()

--- a/sculptor/tests/integration/real_claude/test_plan_mode.py
+++ b/sculptor/tests/integration/real_claude/test_plan_mode.py
@@ -36,14 +36,11 @@ def test_plan_mode_enter_and_approve(sculptor_instance_: SculptorInstance) -> No
     chat_panel = task_page.get_chat_panel()
     auq_panel = get_ask_user_question_panel(page)
 
-    # Wait for the approval prompt
     expect(auq_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Approve the plan
     auq_panel.select_option("Approve")
     auq_panel.submit()
 
-    # Agent should execute the plan
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     assert_no_errors(chat_panel)
 
@@ -64,10 +61,8 @@ def test_plan_mode_with_revision(sculptor_instance_: SculptorInstance) -> None:
     chat_panel = task_page.get_chat_panel()
     auq_panel = get_ask_user_question_panel(page)
 
-    # Wait for approval prompt
     expect(auq_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Revise the plan — select "Other" and type the revision
     auq_panel.select_option("Other")
     auq_panel.type_other_text("Change the filename to 'revised.txt' instead of 'original.txt'.")
     auq_panel.submit()
@@ -76,11 +71,9 @@ def test_plan_mode_with_revision(sculptor_instance_: SculptorInstance) -> None:
     expect(auq_panel).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     expect(auq_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Approve the revised plan
     auq_panel.select_option("Approve")
     auq_panel.submit()
 
-    # Agent should execute the revised plan
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     assert_no_errors(chat_panel)
 
@@ -101,10 +94,8 @@ def test_ask_user_question_during_plan_mode(sculptor_instance_: SculptorInstance
     chat_panel = task_page.get_chat_panel()
     auq_panel = get_ask_user_question_panel(page)
 
-    # Wait for the AskUserQuestion panel
     expect(auq_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Answer the question
     auq_panel.select_option("Python")
     auq_panel.submit()
 
@@ -113,11 +104,9 @@ def test_ask_user_question_during_plan_mode(sculptor_instance_: SculptorInstance
     expect(auq_panel).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     expect(auq_panel).to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
 
-    # Approve
     auq_panel.select_option("Approve")
     auq_panel.submit()
 
-    # Agent executes
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=RESPONSE_TIMEOUT_MS)
     assert_no_errors(chat_panel)
 
@@ -135,13 +124,10 @@ def test_interrupt_during_plan_mode(sculptor_instance_: SculptorInstance) -> Non
     )
     chat_panel = task_page.get_chat_panel()
 
-    # Wait for some plan text to appear
     wait_for_streaming_text(chat_panel, "PLAN-MARKER-72045")
 
-    # Interrupt
     interrupt_agent(chat_panel)
     assert_interrupted(chat_panel)
 
-    # Follow-up: verify memory
     send_and_wait(chat_panel, "What were you just planning? Reply starting with PLAN-RECALL:")
     assert_last_message_contains(chat_panel, "PLAN-RECALL")

--- a/sculptor/tests/integration/real_pi/test_background_tasks.py
+++ b/sculptor/tests/integration/real_pi/test_background_tasks.py
@@ -10,15 +10,15 @@ These exercise the two behaviours end-to-end against real pi:
 - the launch turn yields, the main thread stays interactive while the task runs,
   and the completion is reconciled into the conversation when it finishes;
 - a backgrounded task SURVIVES the user stopping a later turn (it is independent
-  of the turn that launched it) — the regression Danver hit, where Stop wrongly
-  killed the task. (No-orphan ON SHUTDOWN is covered by the unit tests:
+  of the turn that launched it) — the regression where Stop wrongly killed the
+  task. (No-orphan ON SHUTDOWN is covered by the unit tests:
   ``agent_wrapper_test.test_shutdown_cancels_background_tasks`` plus the
   extension's ``session_shutdown`` handler.)
 
 Divergence note (REQ-TEST-1): pi surfaces the completion as a reconciled summary
 block rather than a fresh agent turn reacting to a ``task_notification`` (pi
 0.78.0's extension model makes the post-notification agent turn add
-double-emit/race risk for marginal benefit — see the MR).
+double-emit/race risk for marginal benefit).
 """
 
 from __future__ import annotations

--- a/sculptor/tests/integration/regression/test_regression_compaction_message_position.py
+++ b/sculptor/tests/integration/regression/test_regression_compaction_message_position.py
@@ -54,10 +54,8 @@ def test_post_compaction_message_appears_after_context_summary(sculptor_instance
 
     messages = chat_panel.get_messages()
 
-    # Message 0: user message
     expect_message_to_have_role(message=messages.nth(0), role=ElementIDs.USER_MESSAGE)
 
-    # Message 1: pre-compaction assistant message
     expect_message_to_have_role(message=messages.nth(1), role=ElementIDs.ASSISTANT_MESSAGE)
     expect(messages.nth(1)).to_contain_text("Pre-compaction content")
 

--- a/sculptor/tests/integration/regression/test_regression_no_error_block_on_restart_during_auq.py
+++ b/sculptor/tests/integration/regression/test_regression_no_error_block_on_restart_during_auq.py
@@ -82,8 +82,7 @@ def test_no_error_block_after_restart_during_pending_auq(
         # before asserting absence of the error block. The AUQ ToolUseBlock
         # is in the persisted ResponseBlockAgentMessage and re-renders on
         # restart; the block may be collapsed (hidden) by default, so check
-        # existence via to_have_count(1) rather than visibility (matching
-        # the pattern in test_regression_auq_failure_stuck.py). Without this
+        # existence via to_have_count(1) rather than visibility. Without this
         # gate, asserting "error block absent" would pass spuriously before
         # any messages have hydrated.
         task_page_after = PlaywrightTaskPage(page=instance.page)

--- a/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
+++ b/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
@@ -41,11 +41,6 @@ def _get_agent_id_from_url(url: str) -> str:
     return match.group(1)
 
 
-# ---------------------------------------------------------------------------
-# Test 1: ZWSP must not leak into localStorage after sending a message
-# ---------------------------------------------------------------------------
-
-
 @user_story("to see the placeholder and slash suggestions after reloading a workspace")
 def test_placeholder_and_slash_suggestions_survive_reload(sculptor_instance_: SculptorInstance) -> None:
     """Placeholder and / suggestions must work after sending a message and reloading.
@@ -89,11 +84,6 @@ def test_placeholder_and_slash_suggestions_survive_reload(sculptor_instance_: Sc
     type_trigger_char(chat_input, "/")
     mention_list = chat_panel.get_mention_list()
     expect(mention_list).to_be_visible()
-
-
-# ---------------------------------------------------------------------------
-# Test 2: Placeholder must not show on empty paragraphs within content
-# ---------------------------------------------------------------------------
 
 
 @user_story("to not see the placeholder when the editor has content")

--- a/sculptor/tests/integration/regression/test_regression_replay_on_restart.py
+++ b/sculptor/tests/integration/regression/test_regression_replay_on_restart.py
@@ -141,7 +141,7 @@ def test_chat_does_not_replay_after_shutdown_during_auq_wait(
 
     Reproduces hypothesis #4: the v1 loop's AUQ branch deliberately clears
     ``user_input_message_being_processed = None`` while waiting for the
-    answer (commit ``792c82176dc6``). Hypothesis #1's original fix keyed off
+    answer. Hypothesis #1's original fix keyed off
     that local, so it missed this case — the chat that triggered the AUQ
     never got recorded as processed, and on the next run it was re-delivered
     to Claude (which re-emitted the AUQ tool block, duplicating the panel
@@ -171,8 +171,7 @@ def test_chat_does_not_replay_after_shutdown_during_auq_wait(
         _open_workspace_after_restart(instance.page)
         # With the fix: BUILDING → READY (no replay; the historical AUQ
         # block doesn't pin to WAITING because the derived-status walk
-        # breaks on the persisted RequestStopped, per MR !1200's derived.py
-        # change). With the bug: BUILDING → RUNNING → WAITING (Claude
+        # breaks on the persisted RequestStopped). With the bug: BUILDING → RUNNING → WAITING (Claude
         # re-emits AUQ on the replayed chat), and ``READY`` is never
         # reached, so this expect times out.
         expect(_agent_tab(instance.page)).to_have_attribute(

--- a/sculptor/tests/integration/regression/test_regression_task_list_after_restart.py
+++ b/sculptor/tests/integration/regression/test_regression_task_list_after_restart.py
@@ -55,7 +55,6 @@ fake_claude:multi_step `{
         chat_panel = task_page.get_chat_panel()
         wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-        # Open the StatusPill popover and verify task rows are visible.
         tasks_popover = PlaywrightAgentTasksPopoverElement(instance.page)
         tasks_popover.open()
         rows = tasks_popover.get_rows()
@@ -74,7 +73,6 @@ fake_claude:multi_step `{
         expect(workspace_tab).to_be_visible()
         workspace_tab.click()
 
-        # Wait for the agent tab to appear and click it to get to the task page.
         agent_tab_bar = PlaywrightAgentTabBarElement(instance.page)
         agent_tab = agent_tab_bar.get_agent_tabs().first
         expect(agent_tab).to_be_visible(timeout=_BUILD_TIMEOUT_MS)


### PR DESCRIPTION
One of 6 independent PRs from a repo-wide `/crispy-comments` pass (1,727 low-value comments removed across 361 files). Each is rebased directly on `main` and can be reviewed and merged on its own, in any order. **Comment-only changes — no code behavior changes.**

**This PR:** backend integration tests — 89 files.

**Removed:** redundant narration, incidental dev-history, persuasive rationale, correctness arguments, drift-prone restatements (counts/enumerations), commented-out code, and ASCII/divider banners.
**Preserved:** functional directives (`# noqa`, `# type: ignore`, `// eslint-disable`, `@ts-expect-error`, shebangs, license headers, JSDoc) and genuine "why" comments. An independent verification pass reviewed every batch's diff.

**The full set (each independent, base `main`):**
- #97 — backend integration tests (89)  ← this PR
- #98 — backend unit tests (43)
- #99 — backend source (58)
- #100 — frontend tests + stories (75)
- #101 — frontend pages (40)
- #102 — frontend components + shared (56)

(Sent by Claude)