### PR TITLE
Prune low-value comments in backend unit tests

### DIFF
--- a/sculptor/builder/test_cli.py
+++ b/sculptor/builder/test_cli.py
@@ -21,7 +21,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
         ("0.1.2rc1", "sculptor-v0.1.2rc1", True),
         ("0.1.2", "sculptor-v0.1.2", True),
         ("0.1.2rc1", "sculptor-v0.1.2.rc1", True),  # PEP 440-normalized equality
-        ("0.34.0.dev0", "sculptor-v0.0.99rc1", False),  # the bug we hit: dev on a tag
+        ("0.34.0.dev0", "sculptor-v0.0.99rc1", False),  # dev on a tag
         ("0.34.0.dev0", "sculptor-v0.34.0.dev0", False),  # dev version, even if it matches
         ("0.1.3", "sculptor-v0.1.2", False),  # mismatch
         ("0.1.2", "sculptor-vNOTAVERSION", False),  # unparseable tag

--- a/sculptor/sculptor/agents/default/artifact_creation_test.py
+++ b/sculptor/sculptor/agents/default/artifact_creation_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for artifact_creation helpers (Phase 3 task list reader)."""
+"""Unit tests for artifact_creation helpers."""
 
 import json
 from pathlib import Path

--- a/sculptor/sculptor/agents/default/claude_code_sdk/diff_tracker_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/diff_tracker_test.py
@@ -251,7 +251,6 @@ def normalize_diff(diff: str | None) -> str | None:
     # and replaces with "index 0000000..0000000 100644"
     diff = re.sub(r"index [0-9a-f]+\.\.[0-9a-f]+", "index 0000000..0000000", diff)
 
-    # For new files: "index 0000000000..b47864eced" -> "index 0000000..0000000"
     diff = re.sub(r"index [0-9a-f]+\.\.[0-9a-f]+", "index 0000000..0000000", diff)
 
     return diff
@@ -304,7 +303,6 @@ index 0000000..0000000
 
 def test_no_newline_at_end_of_file(test_root_concurrency_group: ConcurrencyGroup) -> None:
     """Test handling files without newline at end."""
-    # Adding newline to file without one
     result = create_unified_diff(
         "no_newline.txt", "Line without newline", "Line without newline\n", test_root_concurrency_group
     )

--- a/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_utils_test.py
@@ -381,9 +381,6 @@ def test_get_user_instructions_plan_revision_no_reenter_when_not_in_plan_mode() 
     assert "requested revisions" in result
 
 
-# ---- get_claude_command tests ----
-
-
 def _get_command_string(
     system_prompt: str = "",
     session_id: str | None = None,
@@ -444,9 +441,6 @@ def test_get_claude_command_fast_mode_and_effort_combined() -> None:
     assert "--effort high" in cmd
 
 
-# --- Tests for get_claude_command resolve_binary_path ---
-
-
 def test_get_claude_command_with_binary_path() -> None:
     cmd = get_claude_command(
         system_prompt="test",
@@ -505,18 +499,6 @@ def test_get_claude_command_disables_builtin_auq_and_exit_plan_mode() -> None:
     bash_cmd = _get_command_string()
     assert "--disallowed-tools" in bash_cmd
     assert "AskUserQuestion,ExitPlanMode" in bash_cmd
-
-
-# ---------------------------------------------------------------------------
-# Prototype: deterministically emulate Claude stdout for a failed Edit.
-#
-# Models the pattern surfaced in session d4fffd07-0662-4b40-8f73-5d8ed2c32e9e
-# where Claude emitted an Edit tool_use without first Reading the file and got
-# back `is_error=True` with "File has not been read yet." The file on disk is
-# unchanged by the failed Edit, so DiffTracker must produce no diff, and
-# `_create_tool_content` must fall through to GenericToolContent so the real
-# error text reaches the chip popover instead of a bogus diff body.
-# ---------------------------------------------------------------------------
 
 
 def _make_repo_with_file_ending_in_newline(

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -44,8 +44,6 @@ from sculptor.state.claude_state import ParsedTaskStartedResponse
 from sculptor.state.claude_state import ParsedToolResultResponseSimple
 from sculptor.state.claude_state import parse_claude_code_json_lines_simple
 
-# ========== JSONL Round-Trip Tests ==========
-
 
 def test_init_message_roundtrip() -> None:
     session_id = f"test-{uuid4().hex}"
@@ -166,9 +164,6 @@ def test_end_message_roundtrip() -> None:
     assert parsed.is_error is False
 
 
-# ========== Command Parsing Tests ==========
-
-
 def test_parse_default_command() -> None:
     command, args = _parse_prompt("Hello, help me with code")
     assert command is None
@@ -191,9 +186,6 @@ def test_parse_unknown_command() -> None:
     command, args = _parse_prompt("fake_claude:nonexistent")
     assert command == "nonexistent"
     assert args == {}
-
-
-# ========== Command Handler Tests ==========
 
 
 def test_handle_default() -> None:
@@ -632,9 +624,6 @@ def test_handle_parallel_tools(tmp_path: Path) -> None:
     assert "second" in messages[2]["message"]["content"][0]["content"]
 
 
-# ========== Generate ID Tests ==========
-
-
 def test_generate_id_uniqueness() -> None:
     ids = {generate_id("msg") for _ in range(100)}
     assert len(ids) == 100
@@ -646,9 +635,6 @@ def test_generate_id_prefix() -> None:
 
     tool_id = generate_id("toolu")
     assert tool_id.startswith("toolu_fakeclaude_")
-
-
-# ========== End-to-End Subprocess Test ==========
 
 
 def test_end_to_end_subprocess() -> None:
@@ -692,9 +678,6 @@ def test_end_to_end_unknown_command_exits_with_error() -> None:
     assert result.returncode == 1
 
 
-# ========== Determinism Test ==========
-
-
 def test_determinism_same_output_for_same_input() -> None:
     """Same command + args should produce structurally identical output (modulo IDs)."""
     args = {"text": "deterministic test"}
@@ -706,9 +689,6 @@ def test_determinism_same_output_for_same_input() -> None:
     assert len(messages_1) == len(messages_2)
     assert messages_1[0]["type"] == messages_2[0]["type"]
     assert messages_1[0]["message"]["content"][0]["text"] == messages_2[0]["message"]["content"][0]["text"]
-
-
-# ========== Streaming Tests ==========
 
 
 def test_handle_text_with_streaming() -> None:
@@ -733,9 +713,6 @@ def test_handle_write_file_with_streaming(tmp_path: Path) -> None:
     )
     stream_events = [m for m in messages if m.get("type") == "stream_event"]
     assert len(stream_events) > 0
-
-
-# ========== Handler Roundtrip Tests ==========
 
 
 @pytest.mark.parametrize("emit_streaming", [True, False])

--- a/sculptor/sculptor/database/alembic/version_tests/test_20fea77a3f5a.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_20fea77a3f5a.py
@@ -62,12 +62,10 @@ class TestAddDiffStatusAndDiffUpdatedAt(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check diff_status and diff_updated_at columns exist on workspace
         workspace_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(workspace)"))}
         assert "diff_status" in workspace_columns, "diff_status column not found in workspace"
         assert "diff_updated_at" in workspace_columns, "diff_updated_at column not found in workspace"
 
-        # Check diff_status and diff_updated_at columns exist on workspace_latest
         workspace_latest_columns = {
             row[1] for row in connection.execute(sa.text("PRAGMA table_info(workspace_latest)"))
         }

--- a/sculptor/sculptor/database/alembic/version_tests/test_2755d9e9f872.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_2755d9e9f872.py
@@ -20,7 +20,6 @@ class TestAddLastReadAtToTask(MigrationTestFixture):
         return "8522ec5edc2a"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (
@@ -35,7 +34,6 @@ class TestAddLastReadAtToTask(MigrationTestFixture):
             {"project_id": PROJECT_ID},
         )
 
-        # Insert a task
         input_data = json.dumps(
             {
                 "object_type": "AgentTaskInputsV2",
@@ -86,11 +84,9 @@ class TestAddLastReadAtToTask(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check last_read_at column exists on task
         task_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(task)"))}
         assert "last_read_at" in task_columns, "last_read_at column not found in task"
 
-        # Check last_read_at column exists on task_latest
         task_latest_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(task_latest)"))}
         assert "last_read_at" in task_latest_columns, "last_read_at column not found in task_latest"
 

--- a/sculptor/sculptor/database/alembic/version_tests/test_593675cc4b70.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_593675cc4b70.py
@@ -26,7 +26,6 @@ class TestAddPlanModeFieldsToChatInputUserMessage(MigrationTestFixture):
         return "b1a2c3d4e5f6"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (
@@ -41,7 +40,6 @@ class TestAddPlanModeFieldsToChatInputUserMessage(MigrationTestFixture):
             {"project_id": PROJECT_ID},
         )
 
-        # Insert a task
         input_data = json.dumps(
             {
                 "object_type": "AgentTaskInputsV2",
@@ -96,7 +94,6 @@ class TestAddPlanModeFieldsToChatInputUserMessage(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Verify the ChatInputUserMessage is preserved
         result = connection.execute(
             sa.text("SELECT message FROM saved_agent_message WHERE object_id = :object_id"),
             {"object_id": MESSAGE_ID},

--- a/sculptor/sculptor/database/alembic/version_tests/test_5dd608c57dc6.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_5dd608c57dc6.py
@@ -20,7 +20,6 @@ class TestRemoveCommandInputUserMessage(MigrationTestFixture):
         return "811610e55bae"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (
@@ -35,7 +34,6 @@ class TestRemoveCommandInputUserMessage(MigrationTestFixture):
             {"project_id": PROJECT_ID},
         )
 
-        # Insert a task
         input_data = json.dumps(
             {
                 "object_type": "AgentTaskInputsV2",
@@ -97,7 +95,6 @@ class TestRemoveCommandInputUserMessage(MigrationTestFixture):
             )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check only the ChatInputUserMessage row remains
         result = connection.execute(sa.text("SELECT json_extract(message, '$.object_type') FROM saved_agent_message"))
         remaining_types = [row[0] for row in result]
         assert remaining_types == ["ChatInputUserMessage"], (

--- a/sculptor/sculptor/database/alembic/version_tests/test_6ab148aeec31.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_6ab148aeec31.py
@@ -164,7 +164,6 @@ class TestDropProductLoggingColumns(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # The dropped columns must be gone from every affected table.
         for table in ("project", "project_latest"):
             columns = {row[1] for row in connection.execute(sa.text(f"PRAGMA table_info({table})"))}
             assert "is_loggable" not in columns, f"is_loggable column still exists in {table}"
@@ -185,7 +184,6 @@ class TestDropProductLoggingColumns(MigrationTestFixture):
         assert "user_settings_before_insert" not in triggers, "user_settings_before_insert trigger was not dropped"
         assert "project_before_insert" not in triggers, "project_before_insert trigger was not dropped"
 
-        # The seeded rows (and their surviving columns) must be preserved.
         project_row = connection.execute(
             sa.text("SELECT name FROM project WHERE object_id = :object_id"),
             {"object_id": PROJECT_ID},

--- a/sculptor/sculptor/database/alembic/version_tests/test_811610e55bae.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_811610e55bae.py
@@ -20,7 +20,6 @@ class TestTasksRequireWorkspace(MigrationTestFixture):
         return "9bb41574855c"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project (
@@ -111,17 +110,14 @@ class TestTasksRequireWorkspace(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check workspace tables exist
         tables = {row[0] for row in connection.execute(sa.text("SELECT name FROM sqlite_master WHERE type='table'"))}
         assert "workspace" in tables, "workspace table not found"
         assert "workspace_latest" in tables, "workspace_latest table not found"
 
-        # Check a workspace was created
         workspace_rows = connection.execute(sa.text("SELECT COUNT(*) FROM workspace")).fetchone()
         assert workspace_rows is not None
         assert workspace_rows[0] >= 1, "No workspace rows were created"
 
-        # Check task_latest current_state now contains workspace_id
         result = connection.execute(
             sa.text("""
                 SELECT json_extract(current_state, '$.workspace_id')

--- a/sculptor/sculptor/database/alembic/version_tests/test_8522ec5edc2a.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_8522ec5edc2a.py
@@ -67,17 +67,14 @@ class TestDropWorkspaceStatusColumn(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check status column no longer exists on workspace
         workspace_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(workspace)"))}
         assert "status" not in workspace_columns, "status column still in workspace table"
 
-        # Check status column no longer exists on workspace_latest
         workspace_latest_columns = {
             row[1] for row in connection.execute(sa.text("PRAGMA table_info(workspace_latest)"))
         }
         assert "status" not in workspace_latest_columns, "status column still in workspace_latest table"
 
-        # Check other workspace data is preserved
         result = connection.execute(
             sa.text("""
                 SELECT object_id, description, diff_status, initialization_strategy

--- a/sculptor/sculptor/database/alembic/version_tests/test_865d3a5b4f84.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_865d3a5b4f84.py
@@ -20,7 +20,6 @@ class TestDropArchiveColumnsFromTask(MigrationTestFixture):
         return "2755d9e9f872"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (
@@ -90,17 +89,14 @@ class TestDropArchiveColumnsFromTask(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check is_archived and is_archiving columns are removed from task
         task_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(task)"))}
         assert "is_archived" not in task_columns, "is_archived column still exists in task"
         assert "is_archiving" not in task_columns, "is_archiving column still exists in task"
 
-        # Check is_archived and is_archiving columns are removed from task_latest
         task_latest_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(task_latest)"))}
         assert "is_archived" not in task_latest_columns, "is_archived column still exists in task_latest"
         assert "is_archiving" not in task_latest_columns, "is_archiving column still exists in task_latest"
 
-        # Check the existing task's other data is preserved
         result = connection.execute(
             sa.text("SELECT object_id, outcome FROM task WHERE object_id = :task_id"),
             {"task_id": TASK_ID},

--- a/sculptor/sculptor/database/alembic/version_tests/test_a53ed60690f5.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_a53ed60690f5.py
@@ -20,7 +20,6 @@ class TestDropParentTaskId(MigrationTestFixture):
         return "5dd608c57dc6"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (
@@ -99,15 +98,12 @@ class TestDropParentTaskId(MigrationTestFixture):
         )
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        # Check parent_task_id column no longer exists in task
         task_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(task)"))}
         assert "parent_task_id" not in task_columns, "parent_task_id still in task table"
 
-        # Check parent_task_id column no longer exists in task_latest
         task_latest_columns = {row[1] for row in connection.execute(sa.text("PRAGMA table_info(task_latest)"))}
         assert "parent_task_id" not in task_latest_columns, "parent_task_id still in task_latest table"
 
-        # Check task data is preserved
         result = connection.execute(
             sa.text("SELECT object_id, outcome FROM task_latest WHERE object_id = :task_id"),
             {"task_id": TASK_ID},

--- a/sculptor/sculptor/database/alembic/version_tests/test_ad24ef11df19.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_ad24ef11df19.py
@@ -20,7 +20,6 @@ class TestRemoveMessageFeedbackUserMessage(MigrationTestFixture):
         return "a53ed60690f5"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (
@@ -65,7 +64,6 @@ class TestRemoveMessageFeedbackUserMessage(MigrationTestFixture):
             },
         )
 
-        # Insert saved_agent_messages
         messages = [
             ("snap-msg-1", "msg-1", "MessageFeedbackUserMessage"),
             ("snap-msg-2", "msg-2", "ChatInputUserMessage"),

--- a/sculptor/sculptor/database/alembic/version_tests/test_b1a2c3d4e5f6.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_b1a2c3d4e5f6.py
@@ -21,7 +21,6 @@ class TestConvertArchivedOutcomeToDeleted(MigrationTestFixture):
         return "0fb6dc48c8ef"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (

--- a/sculptor/sculptor/database/alembic/version_tests/test_bcc42be33ebc.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_bcc42be33ebc.py
@@ -20,7 +20,6 @@ class TestBackfillTargetBranchDefault(MigrationTestFixture):
         return "eedceaef0697"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project_latest (

--- a/sculptor/sculptor/database/alembic/version_tests/test_d58cd1a270b9.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_d58cd1a270b9.py
@@ -22,7 +22,6 @@ class TestHardDeleteTasksMissingWorkspaceId(MigrationTestFixture):
         return "593675cc4b70"
 
     def seed(self, connection: sa.engine.Connection) -> None:
-        # Insert a project
         connection.execute(
             sa.text("""
                 INSERT INTO project (

--- a/sculptor/sculptor/foundation/async_monkey_patches_test.py
+++ b/sculptor/sculptor/foundation/async_monkey_patches_test.py
@@ -109,7 +109,7 @@ def test_log_exception() -> None:
             x = 1 / 0
         except Exception as e:
             log_exception(e, "Test log_exception")
-            assert True  # If we reach here, the test passes
+            assert True
         else:
             assert False, "log_exception did not raise an exception"
 
@@ -121,7 +121,7 @@ def test_log_exception_with_priority() -> None:
             x = 1 / 0
         except Exception as e:
             log_exception(e, "Test log_exception", priority=ExceptionPriority.LOW_PRIORITY)
-            assert True  # If we reach here, the test passes
+            assert True
         else:
             assert False, "log_exception did not raise an exception"
 

--- a/sculptor/sculptor/foundation/processes/local_process_background_test.py
+++ b/sculptor/sculptor/foundation/processes/local_process_background_test.py
@@ -53,12 +53,10 @@ def test_run_background_with_queue() -> None:
 
     proc.wait(timeout=5.0)
 
-    # Read from queue
     line, is_stdout = output_queue.get(timeout=1.0)
     assert line == "test output\n"
     assert is_stdout
 
-    # Queue should be empty now
     with pytest.raises(Empty):
         output_queue.get(block=False)
 
@@ -95,14 +93,11 @@ def test_run_background_real_time_queue() -> None:
     output_queue = Queue()
     start_time = time.time()
 
-    # Command that outputs with delays
     proc = run_background(["sh", "-c", "echo 'immediate'; sleep 0.5; echo 'delayed'"], output_queue=output_queue)
 
-    # Get first line immediately
     line1, is_stdout1 = output_queue.get(timeout=0.2)
     time1 = time.time() - start_time
 
-    # Get second line after delay
     line2, is_stdout2 = output_queue.get(timeout=1.0)
     time2 = time.time() - start_time
 
@@ -110,27 +105,23 @@ def test_run_background_real_time_queue() -> None:
 
     assert line1 == "immediate\n"
     assert is_stdout1
-    assert time1 < 0.3  # First line should come quickly
+    assert time1 < 0.3
 
     assert line2 == "delayed\n"
     assert is_stdout2
-    assert time2 > 0.4  # Second line should come after delay
+    assert time2 > 0.4
 
     assert proc.returncode == 0
 
 
 def test_run_background_poll_and_is_finished() -> None:
     """Test polling and checking if process is finished."""
-    # Fast command
     proc = run_background(["echo", "quick"])
 
-    # Initially might still be running
     time.sleep(0.01)
 
-    # Wait for completion
     proc.wait(timeout=5.0)
 
-    # After wait, should be finished
     assert proc.is_finished()
     assert proc.poll() == 0
     assert proc.returncode == 0
@@ -140,15 +131,12 @@ def test_run_background_long_running_poll() -> None:
     """Test polling a long-running process."""
     proc = run_background(["sleep", "2"])
 
-    # Should not be finished immediately
     assert not proc.is_finished()
     assert proc.poll() is None
     assert proc.returncode is None
 
-    # Wait for completion
     proc.wait(timeout=5.0)
 
-    # Should be finished now
     assert proc.is_finished()
     assert proc.poll() == 0
     assert proc.returncode == 0
@@ -158,16 +146,12 @@ def test_run_background_terminate() -> None:
     """Test terminating a background process."""
     proc = run_background(["sleep", "10"])
 
-    # Process should be running
     time.sleep(0.1)
     assert not proc.is_finished()
 
-    # Terminate it
     proc.terminate(force_kill_seconds=2.0)
 
-    # Should be terminated now
     assert proc.is_finished()
-    # Return code will be non-zero due to termination
     assert proc.returncode != 0
 
 
@@ -180,12 +164,10 @@ def test_run_background_wait_timeout() -> None:
         proc.wait(timeout=0.5)
 
     elapsed = time.time() - start_time
-    assert elapsed < 1.0  # Should timeout quickly
+    assert elapsed < 1.0
 
-    # Process should still be running
     assert not proc.is_finished()
 
-    # Clean up
     proc.terminate()
 
 
@@ -194,7 +176,6 @@ def test_run_background_with_cwd() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
 
-        # Create test files
         (tmpdir_path / "test1.txt").touch()
         (tmpdir_path / "test2.txt").touch()
 
@@ -339,17 +320,13 @@ def test_run_background_shutdown_event() -> None:
 
     proc = run_background(["sleep", "10"], shutdown_event=shutdown_event, shutdown_timeout_sec=1.0)
 
-    # Let it run briefly
     time.sleep(0.2)
     assert not proc.is_finished()
 
-    # Trigger shutdown
     shutdown_event.set()
 
-    # Wait for shutdown to complete
     time.sleep(1.5)
 
-    # Process should be terminated
     assert proc.is_finished()
     assert proc.returncode != 0
 
@@ -369,17 +346,13 @@ def test_run_background_compound_shutdown_event() -> None:
         shutdown_timeout_sec=1.0,
     )
 
-    # Let it run briefly
     time.sleep(0.2)
     assert not proc.is_finished()
 
-    # Trigger one of the compound events
     event2.set()
 
-    # Wait for shutdown
     time.sleep(1.5)
 
-    # Process should be terminated
     assert proc.is_finished()
     assert proc.returncode != 0
 
@@ -406,12 +379,10 @@ def test_run_background_get_queue() -> None:
     custom_queue = Queue()
     proc = run_background(["echo", "test"], output_queue=custom_queue)
 
-    # get_queue should return our custom queue
     assert proc.get_queue() is custom_queue
 
     proc.wait(timeout=5.0)
 
-    # Output should be in our custom queue
     line, is_stdout = custom_queue.get(timeout=1.0)
     assert line == "test\n"
     assert is_stdout
@@ -421,19 +392,16 @@ def test_run_background_concurrent_processes() -> None:
     """Test running multiple background processes concurrently."""
     procs = []
 
-    # Start multiple processes
     for i in range(3):
         proc = run_background(["sh", "-c", f"sleep 0.{i}; echo 'Process {i}'"])
         procs.append(proc)
 
-    # Wait for all to complete
     results = []
     for i, proc in enumerate(procs):
         stdout, stderr = proc.wait_and_read(timeout=5.0)
         results.append((i, stdout.strip()))
         assert proc.returncode == 0
 
-    # Verify all processes completed successfully
     for i, output in results:
         assert output == f"Process {i}"
 
@@ -462,14 +430,12 @@ def test_run_background_queue_ordering() -> None:
 
     proc.wait(timeout=5.0)
 
-    # Read all lines from queue
     lines = []
     while not output_queue.empty():
         line, is_stdout = output_queue.get()
         if is_stdout:
             lines.append(line.strip())
 
-    # Verify order
     assert len(lines) == 5
     for i in range(5):
         assert lines[i] == f"Line {i + 1}"
@@ -488,15 +454,12 @@ def test_run_background_empty_output() -> None:
 
 def test_run_background_timeout_parameter() -> None:
     """Test that the timeout parameter is passed to the underlying process."""
-    # This should timeout because sleep takes longer than timeout
     proc = run_background(["sleep", "10"], timeout=0.5)
 
-    # The process should fail due to timeout
     start_time = time.time()
     return_code = proc.wait(timeout=2.0)
     elapsed = time.time() - start_time
 
-    # Should have timed out quickly
     assert elapsed < 1.5
     assert return_code != 0
 
@@ -517,14 +480,12 @@ def test_run_background_interleaved_stdout_stderr() -> None:
     """Test that stdout and stderr maintain their order in the queue."""
     output_queue = Queue()
 
-    # Command that interleaves stdout and stderr
     proc = run_background(
         ["sh", "-c", "echo 'out1'; echo 'err1' >&2; echo 'out2'; echo 'err2' >&2"], output_queue=output_queue
     )
 
     proc.wait(timeout=5.0)
 
-    # Collect all output
     output = []
     while not output_queue.empty():
         line, is_stdout = output_queue.get()
@@ -543,7 +504,6 @@ def test_run_background_partial_line_handling() -> None:
     """Test handling of output without trailing newlines."""
     output_queue = Queue()
 
-    # Command that outputs without newline at the end
     proc = run_background(["sh", "-c", "printf 'no newline'"], output_queue=output_queue)
 
     stdout, stderr = proc.wait_and_read(timeout=5.0)
@@ -555,7 +515,6 @@ def test_run_background_partial_line_handling() -> None:
     while not output_queue.empty():
         queue_items.append(output_queue.get())
 
-    # If there are items, verify they're correct
     assert len(queue_items) == 1
     line, is_stdout = queue_items[0]
     assert "no newline" in line
@@ -593,7 +552,6 @@ def test_run_background_thread_safety() -> None:
         except Exception as e:
             errors.append(e)
 
-    # Start threads
     threads = [
         threading.Thread(target=poll_thread),
         threading.Thread(target=check_thread),
@@ -603,13 +561,11 @@ def test_run_background_thread_safety() -> None:
     for t in threads:
         t.start()
 
-    # Wait for process and threads
     proc.wait(timeout=5.0)
 
     for t in threads:
         t.join()
 
-    # Check no errors occurred
     assert len(errors) == 0
     assert proc.returncode == 0
 

--- a/sculptor/sculptor/foundation/processes/local_process_blocking_test.py
+++ b/sculptor/sculptor/foundation/processes/local_process_blocking_test.py
@@ -29,7 +29,6 @@ def test_run_blocking_simple_command() -> None:
 
 def test_run_blocking_with_stderr() -> None:
     """Test command that writes to stderr."""
-    # Use a command that writes to stderr
     result = run_blocking(["sh", "-c", "echo 'error message' >&2"], timeout=5.0, is_checked=False)
 
     assert result.returncode == 0
@@ -59,11 +58,9 @@ def test_run_blocking_with_cwd() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
 
-        # Create a test file in the temp directory
         test_file = tmpdir_path / "test.txt"
         test_file.write_text("test content")
 
-        # Run ls in the temp directory
         result = run_blocking(["ls"], timeout=5.0, cwd=tmpdir_path)
 
         assert result.returncode == 0
@@ -72,10 +69,8 @@ def test_run_blocking_with_cwd() -> None:
 
 def test_run_blocking_timeout() -> None:
     """Test that command actually times out when exceeding timeout."""
-    # Use a real command that will take longer than the timeout
     start_time = time.time()
     with pytest.raises(ProcessTimeoutError):
-        # This sleep command will take 10 seconds but we only give it 0.5 seconds
         run_blocking(["sleep", "10"], timeout=0.5)
 
     elapsed_time = time.time() - start_time
@@ -92,13 +87,11 @@ def test_run_blocking_with_shutdown_event() -> None:
         time.sleep(0.5)
         shutdown_event.set()
 
-    # Start a thread that will set the shutdown event
     shutdown_thread = threading.Thread(target=set_shutdown_event)
     shutdown_thread.start()
 
     start_time = time.time()
     try:
-        # Run a command that would normally take 10 seconds
         run_blocking(
             ["sleep", "10"],
             timeout=15.0,  # Long timeout to ensure shutdown event is what stops it
@@ -125,13 +118,11 @@ def test_run_blocking_with_compound_event() -> None:
         time.sleep(0.5)
         event2.set()
 
-    # Start a thread that will set one of the compound events
     event_thread = threading.Thread(target=set_event2)
     event_thread.start()
 
     start_time = time.time()
     try:
-        # Run a command that would normally take 10 seconds
         run_blocking(
             ["sleep", "10"],
             timeout=15.0,
@@ -144,7 +135,6 @@ def test_run_blocking_with_compound_event() -> None:
         )
         elapsed_time = time.time() - start_time
 
-        # The command should have been interrupted
         assert elapsed_time < 3.0
     finally:
         event_thread.join()
@@ -160,12 +150,10 @@ def trace_on_line_callback(line: str, _: bool):
 
 def test_run_blocking_output_callback() -> None:
     """Test that output is properly logged via the callback."""
-    # Capture log output at TRACE level
     log_capture = io.StringIO()
     handler_id = logger.add(log_capture, level="TRACE", format="{message}")
 
     try:
-        # Run a command that produces multiple lines of output
         result = run_blocking(
             ["sh", "-c", "echo 'line1'; echo 'line2' >&2; echo 'line3'"],
             timeout=5.0,
@@ -173,15 +161,12 @@ def test_run_blocking_output_callback() -> None:
             trace_on_line_callback=trace_on_line_callback,
         )
 
-        # Get the captured log output
         log_output = log_capture.getvalue()
 
-        # Verify that output lines were logged with "> " prefix
         assert "> line1" in log_output
         assert "> line2" in log_output
         assert "> line3" in log_output
 
-        # Also verify the command completed successfully
         assert result.returncode == 0
         assert "line1" in result.stdout
         assert "line3" in result.stdout
@@ -192,7 +177,6 @@ def test_run_blocking_output_callback() -> None:
 
 def test_run_blocking_trace_log_context() -> None:
     """Test that trace log context affects logging output."""
-    # Capture log output with structured logging
     log_capture = io.StringIO()
     handler_id = logger.add(
         log_capture,
@@ -204,7 +188,6 @@ def test_run_blocking_trace_log_context() -> None:
     trace_context = {"request_id": "test-123", "user": "test_user"}
 
     try:
-        # Run command with trace context
         result = run_blocking(
             ["echo", "test with context"],
             timeout=5.0,
@@ -213,15 +196,11 @@ def test_run_blocking_trace_log_context() -> None:
             trace_on_line_callback=trace_on_line_callback,
         )
 
-        # The command should have succeeded
         assert result.returncode == 0
         assert result.stdout.strip() == "test with context"
 
-        # Get the captured log output
         log_output = log_capture.getvalue()
 
-        # Verify that the trace context was included in the logs
-        # The format should show the extra context and message
         assert "test-123" in log_output
         assert "test_user" in log_output
     finally:
@@ -230,7 +209,6 @@ def test_run_blocking_trace_log_context() -> None:
 
 def test_run_blocking_output_traced_flag() -> None:
     """Test that is_output_traced parameter controls whether output is logged."""
-    # Test with tracing disabled
     log_capture_disabled = io.StringIO()
     handler_id_disabled = logger.add(log_capture_disabled, level="TRACE", format="{message}")
 
@@ -250,7 +228,6 @@ def test_run_blocking_output_traced_flag() -> None:
     finally:
         logger.remove(handler_id_disabled)
 
-    # Test with tracing enabled (default)
     log_capture_enabled = io.StringIO()
     handler_id_enabled = logger.add(log_capture_enabled, level="TRACE", format="{message}")
 
@@ -265,7 +242,6 @@ def test_run_blocking_output_traced_flag() -> None:
         assert result.returncode == 0
         assert result.stdout.strip() == "traced output enabled"
 
-        # When is_output_traced=True, output should be logged
         log_output_enabled = log_capture_enabled.getvalue()
         assert "traced output enabled" in log_output_enabled
     finally:
@@ -306,7 +282,6 @@ def test_run_blocking_command_not_found() -> None:
     with pytest.raises(ProcessSetupError) as exc_info:
         run_blocking(["nonexistent_command_12345"], timeout=5.0)
 
-    # The error should mention the command couldn't be found
     error_msg = str(exc_info.value)
     assert "nonexistent_command_12345" in error_msg
 
@@ -347,7 +322,6 @@ def test_run_blocking_mixed_stdout_stderr() -> None:
 
 def test_run_blocking_env_variables() -> None:
     """Test that environment variables are accessible."""
-    # Set a custom env variable and verify the command can read it
     old_value = os.environ.get("TEST_RUN_BLOCKING_VAR")
     try:
         os.environ["TEST_RUN_BLOCKING_VAR"] = "test_value_123"

--- a/sculptor/sculptor/foundation/processes/local_process_streaming_test.py
+++ b/sculptor/sculptor/foundation/processes/local_process_streaming_test.py
@@ -15,7 +15,6 @@ OutputCaputurerOutT = TypeVar("OutputCaputurerOutT", bound=tuple[str, bool] | in
 OutputCapturer = Callable[[], tuple[Callable[[str, bool], None], list[OutputCaputurerOutT]]]
 
 
-# Pytest fixtures for callback creation
 @pytest.fixture
 def output_capturer() -> OutputCapturer:
     """Fixture that returns a function to create output capture callbacks."""
@@ -70,7 +69,6 @@ def failing_callback() -> OutputCapturer:
     return _create_callback
 
 
-# Test functions for run_streaming
 def test_run_streaming_simple_output(output_capturer: OutputCapturer) -> None:
     """Test streaming a simple echo command."""
     on_output, captured_output = output_capturer()
@@ -107,7 +105,6 @@ def test_run_streaming_mixed_stdout_stderr(output_capturer: OutputCapturer) -> N
     assert result.returncode == 0
     assert len(captured_output) == 2
 
-    # Find stdout and stderr lines
     stdout_lines = [line for line, is_stdout in captured_output if is_stdout]
     stderr_lines = [line for line, is_stdout in captured_output if not is_stdout]
 
@@ -128,9 +125,7 @@ def test_run_streaming_no_trailing_newline(output_capturer: OutputCapturer) -> N
     result = run_streaming(["echo", "-n", "no newline"], on_output)
 
     assert result.returncode == 0
-    # No callback should be triggered since there's no complete line
     assert len(captured_output) == 1
-    # But the output should still be in the result
     assert result.stdout == "no newline"
 
 
@@ -152,13 +147,11 @@ def test_run_streaming_real_time_output(timestamp_capturer: TimestampCapturer) -
     start_time = time.time()
     on_output, captured_output = timestamp_capturer(start_time)
 
-    # Command that outputs lines with delays
     result = run_streaming(["sh", "-c", "echo 'immediate'; sleep 0.5; echo 'delayed'"], on_output)
 
     assert result.returncode == 0
     assert len(captured_output) == 2
 
-    # First line should come immediately
     assert captured_output[0][1] < 0.1
     # Second line should come after ~0.5 seconds
     assert captured_output[1][1] > 0.4
@@ -168,7 +161,6 @@ def test_run_streaming_callback_order(output_capturer: OutputCapturer) -> None:
     """Test that callbacks are called in the correct order."""
     on_output, captured_output = output_capturer()
 
-    # Generate numbered lines to verify order
     result = run_streaming(["sh", "-c", 'for i in 1 2 3 4 5; do echo "Line $i"; done'], on_output)
 
     assert result.returncode == 0
@@ -193,8 +185,8 @@ def test_run_streaming_large_lines(output_capturer: OutputCapturer) -> None:
     assert len(captured_output) == 1
     # The output should be exactly line_size ' ' characters + 1 newline
     assert len(captured_output[0][0]) == line_size + 1  # +1 for the newline that echo adds
-    assert captured_output[0][0].startswith(" " * 100)  # Check it starts with whitespaces
-    assert captured_output[0][0].endswith("\n")  # Check it ends with newline
+    assert captured_output[0][0].startswith(" " * 100)
+    assert captured_output[0][0].endswith("\n")
     assert captured_output[0][1] is True
 
 
@@ -210,14 +202,11 @@ def test_run_streaming_with_timeout(output_capturer: OutputCapturer) -> None:
     """Test streaming with timeout."""
     on_output, captured_output = output_capturer()
 
-    # Command that will timeout
     with pytest.raises(ProcessError):
         run_streaming(["sh", "-c", "echo 'before sleep'; sleep 10; echo 'after sleep'"], on_output, timeout=0.5)
 
-    # Should have captured output before timeout
     assert len(captured_output) >= 1
     assert captured_output[0][0] == "before sleep\n"
-    # Should not have captured output after timeout
     assert not any("after sleep" in line for line, _ in captured_output)
 
 
@@ -230,12 +219,10 @@ def test_run_streaming_with_shutdown_event(output_capturer: OutputCapturer) -> N
         time.sleep(0.5)
         shutdown_event.set()
 
-    # Start thread to trigger shutdown
     shutdown_thread = threading.Thread(target=_set_shutdown)
     shutdown_thread.start()
 
     try:
-        # Command that outputs lines slowly
         result = run_streaming(
             ["sh", "-c", 'for i in 1 2 3 4 5; do echo "Line $i"; sleep 0.3; done'],
             on_output,
@@ -244,7 +231,6 @@ def test_run_streaming_with_shutdown_event(output_capturer: OutputCapturer) -> N
             is_checked=False,
         )
 
-        # Should have captured some but not all lines
         assert len(captured_output) >= 2
         assert captured_output[0][0] == "Line 1\n"
         assert captured_output[1][0] == "Line 2\n"
@@ -258,7 +244,6 @@ def test_run_streaming_non_zero_exit(output_capturer: OutputCapturer) -> None:
     """Test streaming with non-zero exit code."""
     on_output, captured_output = output_capturer()
 
-    # Command that outputs then fails
     with pytest.raises(ProcessError) as exc_info:
         run_streaming(["sh", "-c", "echo 'before failure'; exit 42"], on_output, is_checked=True)
 
@@ -285,7 +270,6 @@ def test_run_streaming_with_cwd(output_capturer: OutputCapturer) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
 
-        # Create test files
         (tmpdir_path / "test1.txt").touch()
         (tmpdir_path / "test2.txt").touch()
 
@@ -302,7 +286,6 @@ def test_run_streaming_partial_lines(output_capturer: OutputCapturer) -> None:
     """Test handling of output that doesn't end with newline in the middle."""
     on_output, captured_output = output_capturer()
 
-    # This command outputs a partial line followed by a complete line
     result = run_streaming(["sh", "-c", "printf 'partial'; sleep 0.1; echo ' complete'"], on_output)
 
     assert result.returncode == 0
@@ -311,5 +294,4 @@ def test_run_streaming_partial_lines(output_capturer: OutputCapturer) -> None:
     line, is_stdout = captured_output[0]
     assert line == "partial complete\n"
     assert is_stdout
-    # The full output is captured in the result
     assert result.stdout == "partial complete\n"

--- a/sculptor/sculptor/services/data_model_service/sql_implementation_test.py
+++ b/sculptor/sculptor/services/data_model_service/sql_implementation_test.py
@@ -305,13 +305,6 @@ def test_frozen_json_schema_baseline_covers_every_persisted_model() -> None:
     assert set(frozen_schemas.keys()) == set(latest_schemas.keys()), missing_models_message
 
 
-# ============================================================================
-# MIGRATION CORRECTNESS TESTS
-# These tests verify that the Alembic migration chain produces a correct
-# schema and that triggers work properly after migration.
-# ============================================================================
-
-
 def _get_schema_info(engine) -> dict[str, Any]:  # noqa: ANN001
     """Extract a normalized schema description from a database engine for comparison."""
     inspector = inspect(engine)
@@ -619,13 +612,6 @@ def _get_migration_fixtures() -> list[MigrationTestFixture]:
     return discover_test_fixtures()
 
 
-# ============================================================================
-# MIGRATION FIXTURE TESTS
-# These tests ensure every migration has a test fixture and that
-# each fixture's seed/verify logic runs successfully.
-# ============================================================================
-
-
 def test_every_migration_has_a_test_fixture() -> None:
     """Enforce that every migration file has a companion test fixture file."""
     from sculptor.database.alembic.migration_test_utils import get_all_migration_revision_ids
@@ -652,14 +638,6 @@ def test_migration_fixture(fixture: MigrationTestFixture) -> None:
     from sculptor.database.alembic.migration_test_utils import run_migration_fixture_test
 
     run_migration_fixture_test(fixture)
-
-
-# ============================================================================
-# OBSERVER BEHAVIOR TESTS
-# These tests verify the current behavior by mocking observer notifications
-# via queue.put() calls. This ensures refactoring doesn't break existing
-# functionality.
-# ============================================================================
 
 
 def test_observer_notification_project_upsert(test_db_service: SQLDataModelService) -> None:
@@ -966,12 +944,6 @@ def test_lock_debug_logging_on_begin_immediate_failure(
                     pass
         except OperationalError:
             pass
-
-
-# ============================================================================
-# WORKSPACE STREAMING TESTS
-# These tests verify workspace changes are tracked and streamed correctly.
-# ============================================================================
 
 
 def test_observer_notification_workspace_upsert(

--- a/sculptor/sculptor/services/task_service/threaded_implementation_test.py
+++ b/sculptor/sculptor/services/task_service/threaded_implementation_test.py
@@ -134,16 +134,12 @@ def test_subscribe_to_user_messages(
 ) -> None:
     user_session = authenticate_anonymous(test_service_collection, RequestID())
     service = test_service_collection.task_service
-    # add the task
     task = get_simple_task(user_session, specimen_project)
     with user_session.open_transaction(test_service_collection) as transaction:
         service.create_task(task, transaction)
-    # add the first message
     first_user_message = get_user_input_message(task.object_id, "Hello, world!")
     with user_session.open_transaction(test_service_collection) as transaction:
-        # cast is safe because every instantiated Message is in MessageTypes
         service.create_message(cast(MessageTypes, first_user_message), task.object_id, transaction)
-    # subscribe to the messages
     with service.subscribe_to_user_and_sculptor_system_messages(task_id=task.object_id) as message_queue:
         # Ignore any sculptor system messages and wait for the first user message.
         for _ in range(99):
@@ -152,10 +148,8 @@ def test_subscribe_to_user_messages(
                 break
         else:
             assert False, "Did not receive the first user message."
-        # add a second message
         second_user_message = get_user_input_message(task.object_id, "Goodbye, world!")
         with user_session.open_transaction(test_service_collection) as transaction:
-            # cast is safe because every instantiated Message is in MessageTypes
             service.create_message(cast(MessageTypes, second_user_message), task.object_id, transaction)
         for _ in range(99):
             message = message_queue.get(timeout=1)
@@ -171,25 +165,17 @@ def test_subscribe_to_complete_tasks_for_user(
 ) -> None:
     user_session = authenticate_anonymous(test_service_collection, RequestID())
     service = test_service_collection.task_service
-    # add the task
     task = get_simple_task(user_session, specimen_project)
     with user_session.open_transaction(test_service_collection) as transaction:
         service.create_task(task, transaction)
-    # add the first message
     first_user_message = get_user_input_message(task.object_id, "Hello, world!")
     with user_session.open_transaction(test_service_collection) as transaction:
-        # cast is safe because every instantiated Message is in MessageTypes
         service.create_message(cast(MessageTypes, first_user_message), task.object_id, transaction)
-    # subscribe to the messages
     with service.subscribe_to_all_tasks_for_user(user_reference=task.user_reference) as message_queue:
-        # make sure that the queue already has the first message
         assert_message_is_in_update(message_queue, first_user_message, task.object_id)
-        # add a second message
         second_user_message = get_user_input_message(task.object_id, "Goodbye, world!")
         with user_session.open_transaction(test_service_collection) as transaction:
-            # cast is safe because every instantiated Message is in MessageTypes
             service.create_message(cast(MessageTypes, second_user_message), task.object_id, transaction)
-        # check that the queue receives the second message
         assert_message_is_in_update(message_queue, second_user_message, task.object_id)
 
 

--- a/sculptor/sculptor/services/workspace_service/environment_manager/default_implementation_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/default_implementation_test.py
@@ -62,7 +62,6 @@ def test_simple_local_environment_run(
     """Test creating a local environment and running a process in it."""
     project_path = initial_commit_repo[0]
 
-    # Create environment directly with project path (no image concept)
     environment = environment_manager.create_environment(
         project_path=project_path,
         project_id=test_project.object_id,
@@ -92,19 +91,16 @@ def test_simple_local_environment_run_with_content(
     """Test that files in the project path are accessible in the environment."""
     project_path = initial_commit_repo[0]
 
-    # Create a test file in the project directory
     test_file_name = "test_file.txt"
     test_file_content = "hello"
     (project_path / test_file_name).write_text(test_file_content)
 
-    # Create environment directly with project path
     environment = environment_manager.create_environment(
         project_path=project_path,
         project_id=test_project.object_id,
         concurrency_group=test_root_concurrency_group,
     )
     try:
-        # The environment should be able to access files in the project directory
         process = environment.run_process_in_background(["cat", test_file_name], secrets={})
         queue = process.get_queue()
         while not process.is_finished() or not queue.empty():
@@ -127,7 +123,6 @@ def test_create_environment_directly(
     """Test creating an environment directly from a project path."""
     project_path = initial_commit_repo[0]
 
-    # Create environment directly
     environment = environment_manager.create_environment(
         project_path=project_path,
         project_id=test_project.object_id,
@@ -135,9 +130,7 @@ def test_create_environment_directly(
     )
 
     try:
-        # Verify the environment is working
         assert environment.is_alive()
-        # Verify the workspace points to the project path
         assert isinstance(environment, LocalEnvironment)
     finally:
         environment.close()
@@ -152,7 +145,6 @@ def test_resume_environment(
     """Test resuming an environment from an environment ID."""
     project_path = initial_commit_repo[0]
 
-    # Create initial environment
     environment = environment_manager.create_environment(
         project_path=project_path,
         project_id=test_project.object_id,
@@ -161,7 +153,6 @@ def test_resume_environment(
     environment_id = environment.environment_id
     environment.close()
 
-    # Resume the environment using the explicit resume_environment method
     resumed_environment = environment_manager.resume_environment(
         environment_id=environment_id,
         project_path=project_path,
@@ -170,7 +161,6 @@ def test_resume_environment(
     )
 
     try:
-        # Verify the environment is working
         assert resumed_environment.is_alive()
         assert resumed_environment.environment_id == environment_id
     finally:

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_agent_execution_environment_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_agent_execution_environment_test.py
@@ -1,10 +1,4 @@
-"""Tests for LocalAgentExecutionEnvironment wrapper.
-
-Tests verify:
-1. Per-task namespaced state and artifacts paths
-2. Delegation to underlying Environment for other operations
-3. Directory creation on initialization
-"""
+"""Tests for LocalAgentExecutionEnvironment wrapper."""
 
 from pathlib import Path
 from unittest.mock import MagicMock

--- a/sculptor/sculptor/services/workspace_service/workspace_service_test.py
+++ b/sculptor/sculptor/services/workspace_service/workspace_service_test.py
@@ -157,7 +157,6 @@ def test_delete_workspace(
     test_project: Project,
 ) -> None:
     """Test deleting a workspace."""
-    # Create workspace
     with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
         workspace = test_service_collection.workspace_service.create_workspace(
             project=test_project,
@@ -174,7 +173,6 @@ def test_delete_workspace(
         existing_workspace = transaction.get_workspace(workspace_id)
         assert existing_workspace is not None
 
-    # Delete workspace
     with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
         test_service_collection.workspace_service.delete_workspace(workspace_id, transaction)
 
@@ -204,7 +202,6 @@ def test_workspace_lookup_via_transaction(
     This verifies the design that workspace lookups should use the transaction
     directly, not WorkspaceService methods.
     """
-    # Create workspace
     with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
         workspace = test_service_collection.workspace_service.create_workspace(
             project=test_project,
@@ -234,7 +231,6 @@ def test_workspace_list_via_transaction(
     This verifies the design that workspace lookups should use the transaction
     directly, not WorkspaceService methods.
     """
-    # Create two workspaces
     with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
         workspace1 = test_service_collection.workspace_service.create_workspace(
             project=test_project,
@@ -341,7 +337,6 @@ def test_refresh_workspace_diff_creates_diff_artifact(
         )
         workspace_id = workspace.object_id
 
-    # Refresh diff (no longer takes transaction, returns None)
     test_service_collection.workspace_service.refresh_workspace_diff(workspace_id)
 
     # Verify workspace has diff_status=READY and diff_updated_at set
@@ -402,7 +397,6 @@ def test_maybe_refresh_workspace_diff_always_refreshes(
         )
         workspace_id = workspace.object_id
 
-    # Maybe refresh (no longer takes transaction, returns None)
     test_service_collection.workspace_service.maybe_refresh_workspace_diff(workspace_id)
 
     # Verify workspace has diff_status=READY and diff_updated_at set
@@ -549,7 +543,6 @@ def test_delete_workspace_removes_environment_directory(
     rmtree.  This test verifies the full lifecycle: create workspace -> create
     environment -> delete workspace -> directory eventually gone.
     """
-    # Create workspace
     with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
         workspace = test_service_collection.workspace_service.create_workspace(
             project=test_project,

--- a/sculptor/sculptor/state/claude_state_test.py
+++ b/sculptor/sculptor/state/claude_state_test.py
@@ -8,10 +8,6 @@ from sculptor.state.claude_state import get_tool_invocation_string
 from sculptor.state.claude_state import parse_claude_code_json_lines_simple
 from sculptor.state.claude_state import split_text_and_media
 
-# =============================================
-# Tests for extract_media_tags_from_text
-# =============================================
-
 
 def test_extract_img_tags_no_img_tags_returns_text_unchanged() -> None:
     text = "Hello, this is plain text with no images."
@@ -83,11 +79,6 @@ def test_extract_img_tags_single_quotes() -> None:
     assert paths == ["/path/to/image.png"]
 
 
-# =============================================
-# Tests for video tag extraction
-# =============================================
-
-
 def test_extract_video_tag_single_local_path() -> None:
     text = '<video src="/workspace/attachments/screenshots/recording.webm" controls></video>'
     cleaned, paths = extract_media_tags_from_text(text)
@@ -135,11 +126,6 @@ def test_extract_img_tag_multiline_closing_tag() -> None:
     cleaned, paths = extract_media_tags_from_text(text)
     assert cleaned == ""
     assert paths == ["/path/image.png"]
-
-
-# =============================================
-# Tests for non-media file extension filtering
-# =============================================
 
 
 def test_extract_img_tag_html_file_left_untouched() -> None:
@@ -201,11 +187,6 @@ def test_extract_img_tag_case_insensitive_extension() -> None:
     cleaned, paths = extract_media_tags_from_text(text)
     assert cleaned == ""
     assert paths == ["/path/to/image.PNG"]
-
-
-# =============================================
-# Tests for split_text_and_media
-# =============================================
 
 
 def test_split_text_and_media_no_media() -> None:
@@ -275,11 +256,6 @@ def test_split_text_and_media_mixed_img_and_video() -> None:
         TextBlock(text="Recording:"),
         FileBlock(source="/tmp/rec.webm"),
     ]
-
-
-# =============================================
-# Integration test: parse_claude_code_json_lines_simple with media tags
-# =============================================
 
 
 def test_parse_assistant_message_extracts_img_tags_into_file_blocks() -> None:
@@ -398,11 +374,6 @@ def test_parse_assistant_message_extracts_video_tag_into_file_block() -> None:
     file_block = blocks[1]
     assert isinstance(file_block, FileBlock)
     assert file_block.source == "/workspace/attachments/screenshots/recording.webm"
-
-
-# =============================================
-# Tests for get_tool_invocation_string
-# =============================================
 
 
 def test_get_tool_invocation_string_skill_returns_skill_name() -> None:

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -62,7 +62,6 @@ def test_drop_already_processed_messages_with_processed_id() -> None:
     """Test dropping messages up to last_processed_input_message_id."""
     user_queue: Queue[Message] = Queue()
 
-    # Create test messages
     msg1 = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="First message",
@@ -84,19 +83,16 @@ def test_drop_already_processed_messages_with_processed_id() -> None:
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
 
-    # Add messages to queue
     user_queue.put(msg1)
     user_queue.put(msg2)
     user_queue.put(target_msg)
     user_queue.put(msg3)
 
-    # Drop messages up to target
     dropped, _ = _drop_already_processed_messages(
         last_processed_input_message_id=target_msg.message_id,
         user_message_queue=user_queue,
     )
 
-    # Verify results
     assert len(dropped) == 3
     assert dropped == (msg1, msg2, target_msg)
     assert user_queue.qsize() == 1
@@ -107,7 +103,6 @@ def test_drop_already_processed_messages_none_values() -> None:
     """Test edge case with None value for last_processed_input_message_id."""
     user_queue: Queue[Message] = Queue()
 
-    # Create test messages
     msg1 = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="First message",
@@ -122,7 +117,6 @@ def test_drop_already_processed_messages_none_values() -> None:
     user_queue.put(msg1)
     user_queue.put(msg2)
 
-    # Test with None - should not drop anything
     dropped, _ = _drop_already_processed_messages(
         last_processed_input_message_id=None,
         user_message_queue=user_queue,

--- a/sculptor/sculptor/testing/test_repo_factory.py
+++ b/sculptor/sculptor/testing/test_repo_factory.py
@@ -45,10 +45,8 @@ class TestRepoFactory:
         """
         repo_dir = self.base_path / name
 
-        # Get the standard test project state
         initial_state = get_test_project_state()
 
-        # Build the repository
         repo = MockRepoState.build_locally(
             state=initial_state, local_dir=repo_dir, concurrency_group=self.concurrency_group
         )

--- a/sculptor/sculptor/utils/logs_test.py
+++ b/sculptor/sculptor/utils/logs_test.py
@@ -14,7 +14,6 @@ def test_log_rotation(tmp_path: Path):
         setup_loggers(log_file, level="TRACE", rotation="1 KB", retention=2)
         # write a small line
         logger.info("hello")
-        # check that the log file exists
         time.sleep(1.0)
         assert log_file.exists(), "log file should exist"
         # write a big line

--- a/sculptor/sculptor/utils/tracing_test.py
+++ b/sculptor/sculptor/utils/tracing_test.py
@@ -180,8 +180,7 @@ def test_combined_output_is_valid_chrome_json(tmp_path: Path) -> None:
 
 def test_atomic_write_preserves_prior_file_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A mid-write serialization failure must not clobber a pre-existing file
-    at ``trace_to_path``, and must not leak a ``.tmp`` sibling. Pins the
-    atomic-write contract in the plan's "Atomic write" sub-bullet."""
+    at ``trace_to_path``, and must not leak a ``.tmp`` sibling."""
     out = tmp_path / "trace.json"
     prior_content = b"PRIOR_CONTENT"
     out.write_bytes(prior_content)

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -112,9 +112,6 @@ def test_get_session_token_returns_204_and_sets_cookie_even_when_header_not_set(
     assert "test_token" in response.headers["set-cookie"]
 
 
-# The remaining tests go below.
-
-
 def _create_workspace(
     transaction: DataModelTransaction,
     services: CompleteServiceCollection,
@@ -672,11 +669,6 @@ def test_get_artifact_data_returns_422_if_agent_id_is_not_valid(
     assert response.status_code == 404
 
 
-# =====================
-# Workspace auto-deletion and orphaned task protection tests
-# =====================
-
-
 def test_delete_agent_does_not_delete_workspace_when_other_agents_exist(
     client: TestClient, test_services: CompleteServiceCollection, test_project: Project
 ) -> None:
@@ -687,17 +679,14 @@ def test_delete_agent_does_not_delete_workspace_when_other_agents_exist(
         task_1 = _create_task_in_workspace(transaction, user_session, test_project, test_services, workspace)
         task_2 = _create_task_in_workspace(transaction, user_session, test_project, test_services, workspace)
 
-    # Delete task_1
     response = client.delete(f"/api/v1/workspaces/{workspace.object_id}/agents/{task_1.object_id}")
     assert response.status_code in (200, 204)
 
-    # Verify workspace still exists
     with user_session.open_transaction(test_services) as transaction:
         remaining_workspace = transaction.get_workspace(workspace.object_id)
         assert remaining_workspace is not None, "Workspace should still exist when another task uses it"
         assert not remaining_workspace.is_deleted
 
-    # Verify task_2 still exists
     with user_session.open_transaction(test_services) as transaction:
         remaining_task = test_services.task_service.get_task(task_2.object_id, transaction)
         assert remaining_task is not None
@@ -713,11 +702,10 @@ def test_delete_last_agent_preserves_workspace(
         workspace = _create_workspace(transaction, test_services, test_project, description="solo workspace")
         task = _create_task_in_workspace(transaction, user_session, test_project, test_services, workspace)
 
-    # Delete the only agent
     response = client.delete(f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}")
     assert response.status_code in (200, 204)
 
-    # Verify workspace still exists (agents are managed independently from workspaces)
+    # Workspace survives because agents are managed independently from workspaces.
     with user_session.open_transaction(test_services) as transaction:
         remaining_workspace = transaction.get_workspace(workspace.object_id)
         assert remaining_workspace is not None, "Workspace should survive when its last agent is deleted"
@@ -733,7 +721,6 @@ def test_restore_agent_fails_when_workspace_deleted(
         workspace = _create_workspace(transaction, test_services, test_project, description="restore test workspace")
         task = _create_task_in_workspace(transaction, user_session, test_project, test_services, workspace)
 
-    # Set task to FAILED state
     with user_session.open_transaction(test_services) as transaction:
         fetched_task = test_services.task_service.get_task(task.object_id, transaction)
         assert fetched_task is not None
@@ -741,20 +728,14 @@ def test_restore_agent_fails_when_workspace_deleted(
         # pyrefly: ignore [missing-attribute]
         transaction.upsert_task(updated_task)
 
-    # Delete the workspace directly
     with user_session.open_transaction(test_services) as transaction:
         test_services.workspace_service.delete_workspace(workspace.object_id, transaction)
 
-    # Attempt to restore — should fail with 404 because workspace is gone
+    # Restore should fail with 404 because the workspace is gone.
     response = client.post(
         f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/restore",
     )
     assert response.status_code == 404
-
-
-# =====================
-# Mark read / unread tests
-# =====================
 
 
 def test_mark_read_sets_last_read_at(
@@ -796,13 +777,11 @@ def test_mark_unread_clears_last_read_at(
         workspace = _create_workspace(transaction, test_services, test_project)
         task = _create_task_in_workspace(transaction, user_session, test_project, test_services, workspace)
 
-    # First mark as read
     response = client.patch(
         f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/mark-read",
     )
     assert response.status_code == 200
 
-    # Then mark as unread
     response = client.patch(
         f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/mark-unread",
     )
@@ -826,9 +805,6 @@ def test_mark_unread_returns_404_if_agent_does_not_exist(
     assert response.status_code == 404
 
 
-# --- Auto-send intro help message tests ---
-
-
 def test_create_agent_sends_intro_message_for_first_agent(
     client: TestClient, test_services: CompleteServiceCollection, test_project: Project
 ) -> None:
@@ -845,7 +821,6 @@ def test_create_agent_sends_intro_message_for_first_agent(
     assert response.status_code == 200
     agent_id = response.json()["id"]
 
-    # Verify the intro message was persisted in the DB
     with user_session.open_transaction(test_services) as transaction:
         saved_messages = test_services.task_service.get_saved_messages_for_task(TaskID(agent_id), transaction)
     assert len(saved_messages) == 1
@@ -860,12 +835,10 @@ def test_create_agent_does_not_send_intro_message_when_agents_exist(
     """Users with existing agents should not get an auto-sent intro message."""
     user_session = authenticate_anonymous(test_services, RequestID())
 
-    # Create a workspace with an existing agent
     with user_session.open_transaction(test_services) as transaction:
         workspace = _create_workspace(transaction, test_services, test_project)
         _create_task_in_workspace(transaction, user_session, test_project, test_services, workspace)
 
-    # Create a second agent in the same workspace
     response = client.post(
         f"/api/v1/workspaces/{workspace.object_id}/agents",
         json=model_dump(CreateAgentRequest(model=LLMModel.CLAUDE_4_SONNET), is_camel_case=True),
@@ -873,7 +846,6 @@ def test_create_agent_does_not_send_intro_message_when_agents_exist(
     assert response.status_code == 200
     agent_id = response.json()["id"]
 
-    # No intro message should be in the DB for the new agent
     with user_session.open_transaction(test_services) as transaction:
         saved_messages = test_services.task_service.get_saved_messages_for_task(TaskID(agent_id), transaction)
     assert len(saved_messages) == 0

--- a/sculptor/sculptor/web/app_files_and_folders_test.py
+++ b/sculptor/sculptor/web/app_files_and_folders_test.py
@@ -57,7 +57,6 @@ def _populate_repo(repo_path: Path) -> None:
             ext = extensions[f % len(extensions)]
             (dir_path / f"file_{f:02d}{ext}").write_text(f"// file {d}-{f}\n")
 
-    # Also create a top-level file
     (repo_path / "README.md").write_text("# Test repo\n")
 
 

--- a/sculptor/sculptor/web/app_streams_test.py
+++ b/sculptor/sculptor/web/app_streams_test.py
@@ -72,19 +72,15 @@ def server_app(
 
 @pytest.fixture
 def server_url(server_app: FastAPI) -> Generator[str, None, None]:
-    # Start server in a separate thread
     config = uvicorn.Config(app=server_app, host="127.0.0.1", port=0, log_level="debug")
     server = ServerWithReadyFlag(config)
     server_thread = ObservableThread(target=server.run)
     server_thread.start()
 
-    # Wait for server to be actually ready
     server._ready_event.wait()
 
-    # figure out what port was bound
     server_port = only(only(server.servers).sockets).getsockname()[-1]
 
-    # Now make requests using the actual port
     yield f"http://127.0.0.1:{server_port}"
 
     # pyrefly: ignore [missing-attribute]
@@ -121,7 +117,6 @@ def stream_response(url: str) -> Generator[Queue[str], None, None]:
 
 def _stream_lines_into_queue_from_websocket(ws: Connection, is_done: threading.Event, queue: Queue[str]) -> None:
     try:
-        # Iterate over the response line by line
         while True:
             if is_done.is_set():
                 break
@@ -205,7 +200,6 @@ def test_unified_stream_emits_task_updates(
         assert task_update is not None, "Did not receive task update after creating message"
         in_progress = task_update.get("inProgressChatMessage")
         assert in_progress is not None
-        # Check that the message text is in the content blocks
         content_blocks = in_progress.get("content", [])
         assert any(
             block.get("text") == "streaming smoke test message"
@@ -244,5 +238,4 @@ def test_unified_stream_emits_notifications_and_finished_requests(
 
         assert any(entry.get("message") == notification.message for entry in notifications)
 
-        # Just verify that we got some finished request IDs in the stream
         assert len(finished_request_ids) > 0, "Should receive finished request IDs in the stream"

--- a/sculptor/sculptor/web/derived_task_status_test.py
+++ b/sculptor/sculptor/web/derived_task_status_test.py
@@ -1,17 +1,4 @@
-"""Regression tests for CodingAgentTaskView.status after restart mid-agent-turn.
-
-Historical context: this file originally enforced "status RUNNING after restart
-when the only completion is a RequestStopped, because the agent is re-processing."
-That behavior was a workaround for a prompt-replay bug: when Sculptor was SIGTERM'd
-mid-turn the runner used to silently re-deliver the prompt to Claude on the next
-agent run, so RequestStopped really did precede a re-processing window.
-
-With those bugs fixed at the runner layer, the re-processing no longer happens.
-RequestStopped now genuinely means "this chat is settled; the user can send a new
-message." Status should be READY, not RUNNING. The exclusion of RequestStopped
-from ``request_finished_messages`` in ``derived.py`` has been removed accordingly,
-and the test below has been updated to assert the new behavior.
-"""
+"""Regression tests for CodingAgentTaskView.status after restart mid-agent-turn."""
 
 from sculptor.config.settings import SculptorSettings
 from sculptor.database.models import AgentTaskInputsV2
@@ -94,11 +81,6 @@ def test_status_is_ready_after_request_stopped_and_environment_reacquired() -> N
     prompt is recorded as processed and NOT re-delivered to Claude on the next
     agent run. The post-restart agent is therefore idle — the user can send a
     new message — so status should be READY.
-
-    This test previously asserted RUNNING as a workaround for the replay bug
-    (RequestStopped was excluded from "finished" so status stayed RUNNING during
-    the unwanted re-processing). That exclusion is gone now that the runner
-    doesn't re-process.
     """
     task = _make_task()
     view = _make_task_view(task)

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -507,7 +507,6 @@ def test_convert_agent_messages_to_task_update_processes_tool_results_during_str
     assert isinstance(tool_content, GenericToolContent)
     assert tool_content.text == "file contents here"
 
-    # Now streaming completes
     streaming_complete = StreamingMessageCompleteAgentMessage(message_id=AgentMessageID())
 
     state = convert_agent_messages_to_task_update(
@@ -519,7 +518,6 @@ def test_convert_agent_messages_to_task_update_processes_tool_results_during_str
     )
 
     assert state.is_streaming_active is False
-    # Tool result should still be there
     in_progress_msg = state.in_progress_chat_message
     assert in_progress_msg is not None
     assert isinstance(in_progress_msg.content[1], ToolResultBlock)

--- a/sculptor/sculptor/web/mr_status_test.py
+++ b/sculptor/sculptor/web/mr_status_test.py
@@ -54,11 +54,6 @@ def _empty_pipeline_and_details(cmd, _working_dir):  # noqa: ANN001
     return _make_finished("[]")
 
 
-# ---------------------------------------------------------------------------
-# Open MR with matching target → normal open status
-# ---------------------------------------------------------------------------
-
-
 def test_open_mr_matching_target() -> None:
     mr = _open_mr(100, target_branch="main")
 
@@ -75,11 +70,6 @@ def test_open_mr_matching_target() -> None:
     assert result.pr_state == "open"
     assert result.pr_iid == 100
     assert result.mismatched_pr_iid is None
-
-
-# ---------------------------------------------------------------------------
-# Open MR with mismatched target → pr_state=none + mismatch fields
-# ---------------------------------------------------------------------------
 
 
 def test_open_mr_mismatched_target() -> None:
@@ -99,11 +89,6 @@ def test_open_mr_mismatched_target() -> None:
     assert result.mismatched_pr_web_url == "https://gitlab.com/project/-/merge_requests/200"
 
 
-# ---------------------------------------------------------------------------
-# No MRs at all → pr_state=none, no mismatch
-# ---------------------------------------------------------------------------
-
-
 def test_no_mrs_at_all() -> None:
     def cli_handler(cmd, _working_dir):  # noqa: ANN001
         return _make_finished("[]")
@@ -113,11 +98,6 @@ def test_no_mrs_at_all() -> None:
 
     assert result.pr_state == "none"
     assert result.mismatched_pr_iid is None
-
-
-# ---------------------------------------------------------------------------
-# Merged MR with matching target → pr_state=merged
-# ---------------------------------------------------------------------------
 
 
 def test_merged_mr_matching_target() -> None:
@@ -136,11 +116,6 @@ def test_merged_mr_matching_target() -> None:
     assert result.pr_state == "merged"
     assert result.pr_iid == 300
     assert result.mismatched_pr_iid is None
-
-
-# ---------------------------------------------------------------------------
-# Multiple open MRs, one matches target → normal open status
-# ---------------------------------------------------------------------------
 
 
 def test_multiple_open_mrs_one_matches() -> None:
@@ -164,11 +139,6 @@ def test_multiple_open_mrs_one_matches() -> None:
     assert result.mismatched_pr_iid is None
 
 
-# ---------------------------------------------------------------------------
-# Multiple open MRs, none match target → mismatch with first
-# ---------------------------------------------------------------------------
-
-
 def test_multiple_open_mrs_none_match() -> None:
     mrs = [
         _open_mr(500, target_branch="develop"),
@@ -188,11 +158,6 @@ def test_multiple_open_mrs_none_match() -> None:
     assert result.mismatched_pr_target_branch == "develop"
 
 
-# ---------------------------------------------------------------------------
-# origin/ prefix is stripped from target branch
-# ---------------------------------------------------------------------------
-
-
 def test_origin_prefix_stripped() -> None:
     mr = _open_mr(600, target_branch="main")
 
@@ -208,11 +173,6 @@ def test_origin_prefix_stripped() -> None:
 
     assert result.pr_state == "open"
     assert result.pr_iid == 600
-
-
-# ---------------------------------------------------------------------------
-# Open MR with has_conflicts → flag flows through to PrStatusInfo
-# ---------------------------------------------------------------------------
 
 
 def test_open_mr_has_conflicts_flag_flows_through() -> None:
@@ -231,11 +191,6 @@ def test_open_mr_has_conflicts_flag_flows_through() -> None:
 
     assert result.pr_state == "open"
     assert result.has_conflicts is True
-
-
-# ---------------------------------------------------------------------------
-# Closed-not-merged MR with matching target → pr_state=closed
-# ---------------------------------------------------------------------------
 
 
 def test_closed_mr_matching_target() -> None:

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -96,11 +96,6 @@ def _captured_query(cmd: list[str]) -> str:
     raise AssertionError(f"no query= argument found in command: {cmd}")
 
 
-# ---------------------------------------------------------------------------
-# Open PR with matching target → normal open status
-# ---------------------------------------------------------------------------
-
-
 def test_open_pr_matching_target() -> None:
     with _patch_cli(_graphql_handler([_open_node(100, base_ref="main")])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
@@ -108,11 +103,6 @@ def test_open_pr_matching_target() -> None:
     assert result.pr_state == "open"
     assert result.pr_iid == 100
     assert result.mismatched_pr_iid is None
-
-
-# ---------------------------------------------------------------------------
-# Open PR with mismatched target → pr_state=none + mismatch fields
-# ---------------------------------------------------------------------------
 
 
 def test_open_pr_mismatched_target() -> None:
@@ -125,22 +115,12 @@ def test_open_pr_mismatched_target() -> None:
     assert result.mismatched_pr_web_url == "https://github.com/org/repo/pull/200"
 
 
-# ---------------------------------------------------------------------------
-# No PRs at all → pr_state=none, no mismatch
-# ---------------------------------------------------------------------------
-
-
 def test_no_prs_at_all() -> None:
     with _patch_cli(_graphql_handler([])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.pr_state == "none"
     assert result.mismatched_pr_iid is None
-
-
-# ---------------------------------------------------------------------------
-# Merged PR with matching target → pr_state=merged
-# ---------------------------------------------------------------------------
 
 
 def test_merged_pr_matching_target() -> None:
@@ -150,11 +130,6 @@ def test_merged_pr_matching_target() -> None:
     assert result.pr_state == "merged"
     assert result.pr_iid == 300
     assert result.mismatched_pr_iid is None
-
-
-# ---------------------------------------------------------------------------
-# Multiple open PRs, one matches target → normal open status
-# ---------------------------------------------------------------------------
 
 
 def test_multiple_open_prs_one_matches() -> None:
@@ -171,11 +146,6 @@ def test_multiple_open_prs_one_matches() -> None:
     assert result.mismatched_pr_iid is None
 
 
-# ---------------------------------------------------------------------------
-# Multiple open PRs, none match target → mismatch with first
-# ---------------------------------------------------------------------------
-
-
 def test_multiple_open_prs_none_match() -> None:
     nodes = [
         _open_node(500, base_ref="develop"),
@@ -190,11 +160,6 @@ def test_multiple_open_prs_none_match() -> None:
     assert result.mismatched_pr_target_branch == "develop"
 
 
-# ---------------------------------------------------------------------------
-# Closed-not-merged PR with matching target → pr_state=closed
-# ---------------------------------------------------------------------------
-
-
 def test_closed_pr_matching_target() -> None:
     with _patch_cli(_graphql_handler([_closed_node(800, base_ref="main")])):
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
@@ -203,11 +168,6 @@ def test_closed_pr_matching_target() -> None:
     assert result.pr_iid == 800
     assert result.pr_title == "PR #800"
     assert result.pr_web_url == "https://github.com/org/repo/pull/800"
-
-
-# ---------------------------------------------------------------------------
-# Both a merged and a closed PR target this branch → merged wins
-# ---------------------------------------------------------------------------
 
 
 def test_merged_takes_precedence_over_closed() -> None:
@@ -223,11 +183,6 @@ def test_merged_takes_precedence_over_closed() -> None:
 
     assert result.pr_state == "merged"
     assert result.pr_iid == 820
-
-
-# ---------------------------------------------------------------------------
-# Open PR detail (checks, reviews, comments) comes from the single graphql call
-# ---------------------------------------------------------------------------
 
 
 def test_open_pr_details_fetched_in_single_graphql_call() -> None:
@@ -364,11 +319,6 @@ def test_unknown_field_usage_error_not_classified_as_not_authenticated() -> None
 
     assert result.error_category != "not_authenticated"
     assert result.error_category == "transient"
-
-
-# ---------------------------------------------------------------------------
-# Rate-limit errors surface as a rate_limited category
-# ---------------------------------------------------------------------------
 
 
 def test_rate_limit_surfaces_error() -> None:

--- a/sculptor/sculptor/web/skills_test.py
+++ b/sculptor/sculptor/web/skills_test.py
@@ -277,12 +277,10 @@ def test_discover_skills_combines_skills_and_commands(tmp_path: Path, monkeypatc
     fake_home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
-    # Create a skill
     skill_dir = tmp_path / ".claude" / "skills" / "alpha"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: alpha\ndescription: A skill\n---\n")
 
-    # Create a command
     commands_dir = tmp_path / ".claude" / "commands"
     commands_dir.mkdir(parents=True)
     (commands_dir / "beta.md").write_text("---\ndescription: A command\n---\n")
@@ -300,12 +298,10 @@ def test_discover_skills_deduplicates_by_name(tmp_path: Path, monkeypatch: pytes
     fake_home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
-    # Create a skill named "deploy"
     skill_dir = tmp_path / ".claude" / "skills" / "deploy"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: deploy\ndescription: Skill version\n---\n")
 
-    # Create a command also named "deploy"
     commands_dir = tmp_path / ".claude" / "commands"
     commands_dir.mkdir(parents=True)
     (commands_dir / "deploy.md").write_text("---\ndescription: Command version\n---\n")
@@ -349,18 +345,15 @@ def test_discover_skills_includes_home_directory_skills(tmp_path: Path, monkeypa
     fake_home = tmp_path / "home"
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
-    # Repo skill
     repo_dir = tmp_path / "repo"
     skill_dir = repo_dir / ".claude" / "skills" / "repo-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: repo-skill\ndescription: From repo\n---\n")
 
-    # Home skill
     home_skill_dir = fake_home / ".claude" / "skills" / "home-skill"
     home_skill_dir.mkdir(parents=True)
     (home_skill_dir / "SKILL.md").write_text("---\nname: home-skill\ndescription: From home\n---\n")
 
-    # Home command
     home_commands_dir = fake_home / ".claude" / "commands"
     home_commands_dir.mkdir(parents=True)
     (home_commands_dir / "home-command.md").write_text("---\ndescription: Home command\n---\n")
@@ -381,12 +374,10 @@ def test_discover_skills_repo_skills_take_precedence_over_home(
 
     repo_dir = tmp_path / "repo"
 
-    # Repo skill named "shared"
     skill_dir = repo_dir / ".claude" / "skills" / "shared"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: shared\ndescription: Repo version\n---\n")
 
-    # Home skill also named "shared"
     home_skill_dir = fake_home / ".claude" / "skills" / "shared"
     home_skill_dir.mkdir(parents=True)
     (home_skill_dir / "SKILL.md").write_text("---\nname: shared\ndescription: Home version\n---\n")
@@ -405,12 +396,10 @@ def test_discover_skills_repo_command_takes_precedence_over_home_skill(
 
     repo_dir = tmp_path / "repo"
 
-    # Repo *command* named "shared"
     repo_commands = repo_dir / ".claude" / "commands"
     repo_commands.mkdir(parents=True)
     (repo_commands / "shared.md").write_text("---\ndescription: Repo command\n---\n")
 
-    # Home *skill* also named "shared"
     home_skill_dir = fake_home / ".claude" / "skills" / "shared"
     home_skill_dir.mkdir(parents=True)
     (home_skill_dir / "SKILL.md").write_text("---\nname: shared\ndescription: Home skill\n---\n")

--- a/sculptor/sculptor/web/terminal_close_test.py
+++ b/sculptor/sculptor/web/terminal_close_test.py
@@ -10,7 +10,7 @@ LocalTerminalManager managing a real pty + shell. Asserts:
 The shell-pid capture is intentionally agnostic about the underlying
 pty implementation -- it reads ``_helper.shell_pid``
 (posix_spawn-backed SpawnedPtyProcess) or ``_handle.shell_pid``
-(forkserver-backed SpawnedPtyProcess from !1138), whichever exists --
+(forkserver-backed SpawnedPtyProcess), whichever exists --
 so this test survives the pty implementation swap regardless of which
 approach lands.
 """
@@ -51,7 +51,7 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only")
 def _shell_pid(manager: LocalTerminalManager) -> int:
     """Read the shell pid in a way that works across all current pty backends:
     ``_helper.shell_pid`` (posix_spawn helper), ``_handle.shell_pid``
-    (forkserver helper from !1138), or ``_pid`` (legacy direct fork)."""
+    (forkserver helper), or ``_pid`` (legacy direct fork)."""
     pty_process = manager._pty_process
     assert pty_process is not None
     for attr in ("_helper", "_handle"):

--- a/tools/sculpt/tests/unit/test_ui.py
+++ b/tools/sculpt/tests/unit/test_ui.py
@@ -55,7 +55,6 @@ class TestUiOpenFile:
         assert "file" in result.output
 
     def test_missing_workspace_returns_2(self, runner: CliRunner) -> None:
-        # Make sure env var is not set.
         os.environ.pop("SCULPT_WORKSPACE_ID", None)
         result = runner.invoke(app, ["ui", "open-file", "/tmp/something.txt"])
         assert result.exit_code == 2

--- a/tools/sculpt/tests/unit/test_ws_client.py
+++ b/tools/sculpt/tests/unit/test_ws_client.py
@@ -234,7 +234,6 @@ def test_fetch_agent_state_skips_null_message() -> None:
         task_views={task_id: _make_task_view(task_id=task_id)},
         task_updates={task_id: {"chatMessages": [{"role": "user", "content": "hi"}]}},
     )
-    # Server sends "null" first, then the real dump
     shutdown_event = threading.Event()
     ready_event = threading.Event()
     server_info: dict[str, Any] = {}


### PR DESCRIPTION
One of 6 independent PRs from a repo-wide `/crispy-comments` pass (1,727 low-value comments removed across 361 files). Each is rebased directly on `main` and can be reviewed and merged on its own, in any order. **Comment-only changes — no code behavior changes.**

**This PR:** backend unit tests — 43 files.

**Removed:** redundant narration, incidental dev-history, persuasive rationale, correctness arguments, drift-prone restatements (counts/enumerations), commented-out code, and ASCII/divider banners.
**Preserved:** functional directives (`# noqa`, `# type: ignore`, `// eslint-disable`, `@ts-expect-error`, shebangs, license headers, JSDoc) and genuine "why" comments. An independent verification pass reviewed every batch's diff.

**The full set (each independent, base `main`):**
- #97 — backend integration tests (89)
- #98 — backend unit tests (43)  ← this PR
- #99 — backend source (58)
- #100 — frontend tests + stories (75)
- #101 — frontend pages (40)
- #102 — frontend components + shared (56)

(Sent by Claude)