### PR TITLE
Prune low-value comments in backend source

### DIFF
--- a/.claude/skills/measure-react-renders/scripts/ws_frequency.py
+++ b/.claude/skills/measure-react-renders/scripts/ws_frequency.py
@@ -27,8 +27,6 @@ import urllib.request
 from collections import defaultdict
 from pathlib import Path
 
-# websocket-client is used for direct WS capture (see analyze_ws_traffic)
-
 
 def free_port():
     with socket.socket() as s:

--- a/.claude/skills/update-help-docs/scripts/process-screenshots.py
+++ b/.claude/skills/update-help-docs/scripts/process-screenshots.py
@@ -13,10 +13,6 @@ TARGET_WIDTH = 1200  # Standard width for documentation
 TARGET_HEIGHT = 800  # Standard height for documentation
 BACKGROUND_COLOR = (166, 170, 145)  # Sage green background (#A6AA91)
 MIN_BORDER_WIDTH = 40  # Minimum border thickness (pixels) on all sides
-# Alternative colors:
-# (255, 255, 255) - White
-# (243, 244, 246) - Tailwind gray-100
-# (17, 24, 39) - Dark mode background
 
 def remove_border(img, border_color, tolerance=10):
     """

--- a/sculptor/builder/darwin.py
+++ b/sculptor/builder/darwin.py
@@ -86,7 +86,7 @@ def validate_binary(
     This is meant to be called by the build script, it uses typer to print coloured responses. It returns a bool of whether the check was successful.
     """
 
-    # Allow overriding via env like the Bash version
+    # Allow overriding via env
     lipo = lipo or os.environ.get("LIPO") or "lipo"
     file_bin = file_bin or os.environ.get("FILE_BIN") or "file"
     otool = otool or os.environ.get("OTOOL") or "otool"
@@ -151,7 +151,6 @@ def validate_binary(
     else:
         typer.secho("   otool not found on PATH", fg=typer.colors.YELLOW)
 
-    # codesign -dv --verbose=2
     if which(codesign_bin):
         rc, out, err = _run([codesign_bin, "-dv", "--verbose=2", str(binary_path)])
         if rc == 0:

--- a/sculptor/conftest.py
+++ b/sculptor/conftest.py
@@ -27,13 +27,11 @@ from sculptor.web.middleware import shutdown_event
 EXPLICITLY_IMPORTED_FIXTURES = (empty_temp_git_repo, initial_commit_repo, browser_panel_fixture_server_)
 
 
-# ---------------------------------------------------------------------------
 # Session budget: fail remaining tests when time runs out so pytest exits
 # cleanly and writes JUnit XML. Controlled by SESSION_TIMEOUT_SECONDS env var.
 #
 # Must be in the root conftest (not a subdirectory conftest imported via
 # `import *`) so hooks are registered before pytest_sessionstart fires.
-# ---------------------------------------------------------------------------
 _SESSION_START_ENV_KEY = "_PYTEST_SESSION_START_TIME"
 
 

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -1245,8 +1245,6 @@ class ClaudeOutputProcessor:
             self._transcript_collector.record_stdin(stdin_line)
         self.process.write_stdin(stdin_line)
 
-    # ========== Control Request Handling ==========
-
     def _maybe_handle_control_request(self, line: str) -> bool:
         """Handle control_request messages from the CLI.
 
@@ -1351,8 +1349,6 @@ class ClaudeOutputProcessor:
         except (OSError, AssertionError) as e:
             logger.info("Failed to send control response for request_id={}: {}", request_id, e)
 
-    # ========== Context Usage Request Handling ==========
-
     def _send_context_usage_request(self) -> None:
         """Send a get_context_usage control request on stdin.
 
@@ -1437,8 +1433,6 @@ class ClaudeOutputProcessor:
             }
         )
         self.output_message_queue.put(TurnMetricsAgentMessage(turn_metrics=enriched))
-
-    # ========== Streaming Methods ==========
 
     def _handle_stream_event(self, event: ParsedStreamEvent) -> None:
         """Handle streaming event:

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -856,9 +856,8 @@ def handle_enter_plan_mode_and_ask(args: dict, emit_streaming: bool) -> list[dic
     """Enter plan mode and immediately ask a question — in a single CLI turn.
 
     Under the SDK MCP path the AUQ resolves via ``mcp__sculptor__ask_user_question``
-    rather than the killed-and-resumed built-in. The original "ParsedAssistantResponse
-    before content_block_stop" reproduction is no longer relevant: the MCP flow
-    never blocks the CLI mid-stream.
+    rather than the killed-and-resumed built-in, and the MCP flow never blocks the
+    CLI mid-stream.
     """
     questions = args["questions"]
 

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -79,8 +79,6 @@ class ElementIDs(StrEnum):
     REPO_PATH_DROPDOWN_SHORTCUT_HINT = "REPO_PATH_DROPDOWN_SHORTCUT_HINT"
     REPO_PATH_DROPDOWN_ALERT_OK = "REPO_PATH_DROPDOWN_ALERT_OK"
 
-    # Task Modal
-
     # Command Palette (replaces the legacy Search Modal; Cmd+K)
     COMMAND_PALETTE_OPEN_BUTTON = "COMMAND_PALETTE_OPEN_BUTTON"
     COMMAND_PALETTE = "COMMAND_PALETTE"
@@ -182,8 +180,6 @@ class ElementIDs(StrEnum):
     LIGHTBOX_NAV_PREVIOUS = "LIGHTBOX_NAV_PREVIOUS"
     LIGHTBOX_NAV_NEXT = "LIGHTBOX_NAV_NEXT"
     LIGHTBOX_COUNTER = "LIGHTBOX_COUNTER"
-
-    # Artifact Panel
 
     # File Browser Panel
     FILE_BROWSER_PANEL = "FILE_BROWSER_PANEL"
@@ -341,8 +337,6 @@ class ElementIDs(StrEnum):
     # Report Problem ("Give Feedback") popover
     REPORT_PROBLEM_POPOVER = "REPORT_PROBLEM_POPOVER"
 
-    # These show up in multiple places
-
     # Onboarding page
     ONBOARDING_WELCOME_STEP = "ONBOARDING_WELCOME_STEP"
     ONBOARDING_EMAIL_INPUT = "ONBOARDING_EMAIL_INPUT"
@@ -453,8 +447,6 @@ class ElementIDs(StrEnum):
     PI_INSTALL_BUTTON = "pi-install-button"
     PI_INSTALL_PROGRESS = "pi-install-progress"
     PI_UP_TO_DATE = "pi-up-to-date"
-
-    # Onboarding install flow
 
     # Custom backend settings (in Experimental tab)
     SETTINGS_CUSTOM_BACKEND_COMMAND = "SETTINGS_CUSTOM_BACKEND_COMMAND"

--- a/sculptor/sculptor/database/alembic/examples/json_schema_migration.py
+++ b/sculptor/sculptor/database/alembic/examples/json_schema_migration.py
@@ -26,10 +26,7 @@ def downgrade() -> None:
 
 
 OBJECT_TYPE = "UpdateGoalAgentMessage"
-TABLES_AND_PRIMARY_KEYS = (
-    ("saved_agent_message", "snapshot_id"),
-    # ("saved_agent_message_latest", "object_id"),
-)
+TABLES_AND_PRIMARY_KEYS = (("saved_agent_message", "snapshot_id"),)
 
 
 def _select_rows(table_name: str, primary_key: str) -> sa.TextClause:

--- a/sculptor/sculptor/foundation/frozen_utils.py
+++ b/sculptor/sculptor/foundation/frozen_utils.py
@@ -29,7 +29,6 @@ class FrozenDict(dict[T, TV], FrozenMapping[T, TV]):
 
     @cached_property
     def _hash(self) -> int:
-        # hashing the frozenset of items is fine
         return hash(self._key())
 
     def __hash__(self) -> int:  # type: ignore

--- a/sculptor/sculptor/interfaces/environments/agent_execution_environment.py
+++ b/sculptor/sculptor/interfaces/environments/agent_execution_environment.py
@@ -61,8 +61,6 @@ class AgentExecutionEnvironment(Protocol):
     - get_artifacts_path(): Per-task artifacts directory: {root}/artifacts/tasks/{task_id}/
     """
 
-    # ===== Properties =====
-
     @property
     def supports_terminal(self) -> bool:
         """Whether the environment supports a terminal/TTY."""
@@ -72,8 +70,6 @@ class AgentExecutionEnvironment(Protocol):
     def concurrency_group(self) -> ConcurrencyGroup:
         """The concurrency group for process and thread management."""
         ...
-
-    # ===== Path Management =====
 
     def get_state_path(self) -> Path:
         """Get the per-task state directory path.
@@ -122,8 +118,6 @@ class AgentExecutionEnvironment(Protocol):
         """Convert a host filesystem path to an environment path."""
         ...
 
-    # ===== File Operations =====
-
     def exists(self, path: str) -> bool:
         """Check if a path exists in the environment."""
         ...
@@ -156,8 +150,6 @@ class AgentExecutionEnvironment(Protocol):
             EnvironmentFailure: if the file cannot be deleted.
         """
         ...
-
-    # ===== Process Management =====
 
     def run_process_in_background(
         self,
@@ -226,8 +218,6 @@ class AgentExecutionEnvironment(Protocol):
         """
         ...
 
-    # ===== Tool Binary Resolution =====
-
     def get_tool_binary_path(self, tool: Dependency) -> str | None:
         """Resolve the path to a tool binary.
 
@@ -238,8 +228,6 @@ class AgentExecutionEnvironment(Protocol):
             The resolved path to the binary, or None if not found.
         """
         ...
-
-    # ===== System Configuration =====
 
     def get_system_prompt(self) -> str | None:
         """Get the environment-specific system prompt content.
@@ -257,8 +245,6 @@ class AgentExecutionEnvironment(Protocol):
         agent. Values are intentionally not exposed.
         """
         ...
-
-    # ===== Terminal Management =====
 
     def start_terminal_manager(
         self,

--- a/sculptor/sculptor/interfaces/environments/base.py
+++ b/sculptor/sculptor/interfaces/environments/base.py
@@ -41,9 +41,7 @@ class Environment(BaseModel, abc.ABC):
     concurrency_group: ConcurrencyGroup
     _terminal_manager: TerminalManager | None = PrivateAttr(default=None)
 
-    # ===== Capability Properties =====
-    # These properties advertise which features each environment supports.
-    # Code should check these properties instead of using isinstance() checks.
+    # Code should check these capability properties instead of using isinstance() checks.
 
     @property
     @abc.abstractmethod

--- a/sculptor/sculptor/services/project_service/default_implementation.py
+++ b/sculptor/sculptor/services/project_service/default_implementation.py
@@ -137,13 +137,13 @@ class DefaultProjectService(ProjectService):
                 # Wait for the monitoring interval or until stop event is set
                 # wait() returns True if the event is set, False if timeout occurred
                 if stop_event.wait(timeout=interval_in_seconds):
-                    break  # Stop event was set, exit the loop
+                    break
 
             except Exception as e:
                 log_exception(e, "Error in project path monitoring")
                 # Continue monitoring even if there's an error, but check for stop event
                 if stop_event.wait(timeout=interval_in_seconds):
-                    break  # Stop event was set, exit the loop
+                    break
 
         logger.info("Project path monitoring thread stopped")
 

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_agent_execution_environment.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_agent_execution_environment.py
@@ -86,8 +86,6 @@ class LocalAgentExecutionEnvironment(AgentExecutionEnvironment):
         host_state_path.mkdir(parents=True, exist_ok=True)
         host_artifacts_path.mkdir(parents=True, exist_ok=True)
 
-    # ===== Properties =====
-
     # TODO(SCU-135): Remove this property when git/diff operations move to workspace level.
     # This property exists to support EnvironmentAcquiredRunnerMessage.environment field,
     # which will be removed when workspace-level API endpoints replace task-level access.
@@ -109,8 +107,6 @@ class LocalAgentExecutionEnvironment(AgentExecutionEnvironment):
     def concurrency_group(self) -> ConcurrencyGroup:
         """The concurrency group for process and thread management."""
         return self._environment.concurrency_group
-
-    # ===== Path Management =====
 
     def get_state_path(self) -> Path:
         """Get the per-task state directory path.
@@ -150,8 +146,6 @@ class LocalAgentExecutionEnvironment(AgentExecutionEnvironment):
         """Convert a host filesystem path to an environment path."""
         return self._environment.to_environment_path(path)
 
-    # ===== File Operations =====
-
     def exists(self, path: str) -> bool:
         """Check if a path exists in the environment."""
         return self._environment.exists(path)
@@ -172,8 +166,6 @@ class LocalAgentExecutionEnvironment(AgentExecutionEnvironment):
     def delete_file_or_directory(self, path: str) -> None:
         """Delete a file or directory from the environment."""
         return self._environment.delete_file_or_directory(path)
-
-    # ===== Process Management =====
 
     def run_process_in_background(
         self,
@@ -233,13 +225,9 @@ class LocalAgentExecutionEnvironment(AgentExecutionEnvironment):
             on_output=on_output,
         )
 
-    # ===== Tool Binary Resolution =====
-
     def get_tool_binary_path(self, tool: Dependency) -> str | None:
         """Resolve the path to a tool binary."""
         return self._dependency_management_service.resolve_binary_path(tool)
-
-    # ===== System Configuration =====
 
     def get_system_prompt(self) -> str | None:
         """Get the environment-specific system prompt content."""
@@ -248,8 +236,6 @@ class LocalAgentExecutionEnvironment(AgentExecutionEnvironment):
     def get_project_env_var_names(self) -> list[str]:
         """Get the names of project-configured environment variables."""
         return self._environment.get_project_env_var_names()
-
-    # ===== Terminal Management =====
 
     def start_terminal_manager(
         self,

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_environment.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_environment.py
@@ -103,8 +103,6 @@ class LocalEnvironment(Environment):
         """
         self._sculpt_terminal_env_vars = env_vars
 
-    # ===== Capability Properties =====
-
     @property
     def supports_terminal(self) -> bool:
         """Local environments support terminal via direct pty management."""

--- a/sculptor/sculptor/state/chat_state.py
+++ b/sculptor/sculptor/state/chat_state.py
@@ -12,10 +12,6 @@ from sculptor.foundation.pydantic_serialization import build_discriminator
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import ToolUseID
 
-# ========================
-# Chat Type Definitions
-# ========================
-
 
 class ContentBlock(SerializableModel):
     object_type: str = Field(..., description="Type discriminator for content blocks")
@@ -228,11 +224,6 @@ class ChatMessage(SerializableModel):
         default=None,
         description="Interface that sent this message, e.g. 'sculpt'",
     )
-
-
-# ========================
-# AskUserQuestion Types
-# ========================
 
 
 class QuestionOption(SerializableModel):

--- a/sculptor/sculptor/state/claude_state.py
+++ b/sculptor/sculptor/state/claude_state.py
@@ -109,11 +109,6 @@ def split_text_and_media(text: str) -> list[TextBlock | FileBlock]:
     return result
 
 
-# ===========================================
-# Parsed Agent Message Type Definitions
-# ===========================================
-
-
 class ParsedStreamEvent(SerializableModel, ABC):
     pass
 
@@ -328,11 +323,6 @@ ParsedAgentResponsePassthrough = (
 
 # the tool results are not parsed in this kind of message
 ParsedAgentResponseTypeSimple = ParsedAgentResponsePassthrough | ParsedUserResponseTypeSimple
-
-
-# ===========================================
-# Parsing claude code json files
-# ===========================================
 
 
 def get_tool_invocation_string(tool_name: str, tool_input: ToolInput, _tool_result: str | None = None) -> str:

--- a/sculptor/sculptor/state/messages.py
+++ b/sculptor/sculptor/state/messages.py
@@ -47,11 +47,6 @@ class ModelOption(SerializableModel):
     display_name: str
 
 
-# ==================================
-# Backend Message Type Definitions
-# ==================================
-
-
 class AgentMessageSource(StrEnum):
     """
     Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)

--- a/sculptor/sculptor/tasks/handlers/run_agent/setup.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/setup.py
@@ -88,7 +88,6 @@ def wait_for_initial_message_and_process_queue(
     leaf_persistent_user_message_types = extract_leaf_types(PersistentUserMessageUnion)
     assert all(isinstance(message, leaf_persistent_user_message_types) for message in re_queued_messages)
     assert isinstance(re_queued_messages, tuple)
-    # after the above checks, this cast is now safe
     re_queued_messages = cast(tuple[PersistentUserMessageUnion, ...], re_queued_messages)
 
     return re_queued_messages, initial_message
@@ -235,7 +234,6 @@ def load_initial_task_state(services: ServiceCollectionForTask, task: Task) -> t
         task_row = transaction.get_task(task.object_id)
         assert task_row is not None, "Task must exist in the database"
         if task_row.current_state is None:
-            # After Phase 1 workspace integration, all tasks must have current_state with workspace_id.
             # Tasks are created with current_state in start_task(), so this should never happen.
             raise RuntimeError(f"Task {task.object_id} has no current_state. All tasks must have initial state.")
         logger.debug("loading existing task state...")

--- a/sculptor/sculptor/testing/auto_update_mock.py
+++ b/sculptor/sculptor/testing/auto_update_mock.py
@@ -200,10 +200,6 @@ class MockSculptorElectronAPI:
         self._page.evaluate("localStorage.removeItem('__sculptor_mock_enabled'); delete window.sculptor")
         full_spa_reload(self._page)
 
-    # ------------------------------------------------------------------
-    # Pushing status events (simulates main → renderer)
-    # ------------------------------------------------------------------
-
     def push_status(self, status: Mapping[str, object]) -> None:
         """Invoke the callback registered by ``useAutoUpdateListener``."""
         self._page.evaluate(
@@ -224,20 +220,12 @@ class MockSculptorElectronAPI:
             status,
         )
 
-    # ------------------------------------------------------------------
-    # IPC call recording (renderer → main)
-    # ------------------------------------------------------------------
-
     def get_ipc_calls(self, *, method: str | None = None) -> list[dict[str, object]]:
         """Return recorded IPC calls, optionally filtered by method name."""
         calls: list[dict[str, object]] = self._page.evaluate("window.sculptor._ipcCalls")
         if method is not None:
             calls = [c for c in calls if c["method"] == method]
         return calls
-
-    # ------------------------------------------------------------------
-    # Configuring IPC failures
-    # ------------------------------------------------------------------
 
     def configure_ipc_failure(self, method: str, error_message: str) -> None:
         """Make a specific IPC method reject with an error.

--- a/sculptor/sculptor/testing/auto_update_server.py
+++ b/sculptor/sculptor/testing/auto_update_server.py
@@ -186,10 +186,6 @@ class AutoUpdateTestServer:
         if self._thread is not None:
             self._thread.join(timeout=_THREAD_JOIN_TIMEOUT_SECONDS)
 
-    # ------------------------------------------------------------------
-    # Test helpers
-    # ------------------------------------------------------------------
-
     def set_update(
         self,
         version: str,
@@ -279,11 +275,6 @@ class AutoUpdateTestServer:
         with self._state.lock:
             self._state.request_paths.clear()
             self._state.request_user_agents.clear()
-
-
-# ---------------------------------------------------------------------------
-# Pytest fixture
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="session")

--- a/sculptor/sculptor/testing/elements/settings_pi.py
+++ b/sculptor/sculptor/testing/elements/settings_pi.py
@@ -9,9 +9,8 @@ from sculptor.testing.elements.base import PlaywrightIntegrationTestElement
 class PlaywrightPiSettingsElement(PlaywrightIntegrationTestElement):
     """Page Object Model for the Pi (experimental) section in Settings.
 
-    Mirrors ``PlaywrightClaudeCliSettingsElement``; pi gained a managed-install
-    mode this cycle, so the controls (mode selector, install/retry, progress)
-    parallel Claude's.
+    Mirrors ``PlaywrightClaudeCliSettingsElement``: the controls (mode selector,
+    install/retry, progress) parallel Claude's.
     """
 
     def get_mode_selector(self) -> Locator:

--- a/sculptor/sculptor/testing/playwright_conftest.py
+++ b/sculptor/sculptor/testing/playwright_conftest.py
@@ -78,13 +78,11 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     items[:] = factory_tests + electron_tests + browser_tests
 
 
-# ---------------------------------------------------------------------------
 # Session budget guard lives in the root conftest.py (pytest_runtest_setup
 # hook). It uses pytest.fail() rather than pytest.exit() because with xdist,
 # pytest.exit() crashes the worker and the controller then blocks in
 # execnet.safe_terminate() waiting for other workers that may be stuck in
 # per-test timeouts.
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="session")

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -58,10 +58,7 @@ from sculptor.testing.test_repo_factory import TestRepoFactory
 # Timeout for the initial SPA render after server startup (shared + factory instances).
 # Longer than the default 30s to allow headroom for cold Electron starts on CI.
 # Cold Electron startup on the contended shared CI runners (the
-# ``integration_tests_electron`` job) regularly takes 50-60s — well past the
-# previous 45s ceiling.
-# Bumping to 90s eats one extra wall-second per failure but lets the slow path
-# pass instead of erroring in fixture setup.
+# ``integration_tests_electron`` job) regularly takes 50-60s.
 _INITIAL_RENDER_TIMEOUT_MS = 90_000
 
 
@@ -165,11 +162,11 @@ def _get_or_create_shared_instance(
     port_manager = PortManager()
     backend_port = port_manager.get_free_port()
 
-    # Temp directories
     sculptor_folder = Path(tempfile.mkdtemp(prefix="sculptor_test_"))
     tmp_path = Path(tempfile.mkdtemp(prefix="sculptor_tmp_"))
     default_timeout_ms = _DEFAULT_TIMEOUT_MS
 
+    # Temp directories
     # Create a fake bin directory and prepend it to PATH before spawning the
     # backend subprocess, so tests can drop fake CLIs (e.g. gh) into the
     # directory at any time and have the running backend find them via PATH

--- a/sculptor/sculptor/testing/sculptor_instance.py
+++ b/sculptor/sculptor/testing/sculptor_instance.py
@@ -177,10 +177,6 @@ class SculptorInstance:
         """
         return self.server.url
 
-    # ------------------------------------------------------------------
-    # Between-test cleanup
-    # ------------------------------------------------------------------
-
     def _create_fresh_repo(self) -> None:
         """Reset the project repo to a known state for the next test.
 

--- a/sculptor/sculptor/testing/timing_report.py
+++ b/sculptor/sculptor/testing/timing_report.py
@@ -35,11 +35,9 @@ def record_phase_duration(report: pytest.TestReport) -> None:
     report.user_properties.append((f"duration_{report.when}", duration_s))
 
 
-# ---------------------------------------------------------------------------
 # JSONL timeline — one line per test phase with absolute timestamps, worker
 # ID and PID so that CPU profiling data (pidstat) can be cross-referenced
 # with individual test execution windows.
-# ---------------------------------------------------------------------------
 
 _TIMELINE_PATH = os.environ.get("TEST_TIMELINE_PATH")
 _timeline_file = None  # lazily opened on first write

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -395,12 +395,8 @@ WORKER_THREAD_COUNT = 40
 
 def on_startup():
     # Based on https://github.com/Kludex/starlette/issues/1724#issuecomment-1717476987
-    # Which I found from https://github.com/fastapi/fastapi/discussions/4593
-    # Also looked at https://github.com/fastapi/fastapi/issues/4221 but that appears to be out of date; Does not work.
-
-    # This is where+how we can set the number of worker threads in the app's underlying pool.
-    # I found this to verify the number of workers we actually have (defaults to 40)
-    # and ensure that we're not going to run out under load from long-running requests.
+    # Sets the number of worker threads in the app's underlying pool so we don't
+    # run out under load from long-running requests.
     limiter = anyio.to_thread.current_default_thread_limiter()
     limiter.total_tokens = WORKER_THREAD_COUNT
 
@@ -658,11 +654,6 @@ def _cleanup_task_file_attachments(
         except Exception as e:
             log_exception(e, "Failed to delete {file_path}", file_path=file_path)
     logger.info("Cleaned up {} file(s) for task {}", len(file_paths), task_id)
-
-
-# =====================
-# Workspace Endpoints
-# =====================
 
 
 @router.post("/api/v1/workspaces")
@@ -1583,11 +1574,6 @@ def get_skills(
             except Exception as e:
                 log_exception(e, "Failed to get skills")
                 raise HTTPException(status_code=500, detail="Failed to get skills") from e
-
-
-# =====================
-# Workspace-Scoped Agent Endpoints
-# =====================
 
 
 def _get_workspace_or_404(
@@ -2545,11 +2531,6 @@ def get_logged_in_or_anonymous_telemetry_info() -> telemetry.TelemetryInfo:
     if not logged_in_info:
         return get_onboarding_telemetry_info()
     return logged_in_info
-
-
-# ====================
-# Onboarding routes and Helpers
-# ====================
 
 
 @router.get("/api/v1/config/status")

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -126,7 +126,7 @@ class StartTaskRequest(RequestModel):
     initialization_strategy: WorkspaceInitializationStrategy = WorkspaceInitializationStrategy.IN_PLACE
     name: str | None = None
     source_branch: str | None = None
-    # New field for workspace selection - mutually exclusive with initialization_strategy
+    # Mutually exclusive with initialization_strategy.
     # When provided, the task will be created in an existing workspace
     workspace_id: WorkspaceID | None = None
     enter_plan_mode: bool = False

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -511,13 +511,6 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
         request_finished_messages = {
             x.request_id for x in self._messages if isinstance(x, PersistentRequestCompleteAgentMessage)
         }
-        # NOTE: this used to exclude ``RequestStoppedAgentMessage`` as a workaround
-        # for an older bug — interrupted/SIGTERM'd chats were re-delivered to
-        # Claude on the next agent run, and the exclusion kept status pinned at
-        # RUNNING during that re-processing window. With those bugs fixed at the
-        # runner layer the
-        # re-processing no longer happens, so a RequestStopped really does mean
-        # "this chat is settled — agent is idle, user can send a new message."
         # If the agent has emitted an AskUserQuestion / ExitPlanMode whose
         # answer hasn't arrived yet, the task is WAITING regardless of
         # whether the in-flight request has formally completed. Under the

--- a/sculptor/sculptor/web/middleware.py
+++ b/sculptor/sculptor/web/middleware.py
@@ -261,9 +261,7 @@ class App(FastAPI):
 @asynccontextmanager
 async def lifespan(app: App):
     """
-    Formerly `@app.on_event("startup")`, this is used to initialize the application.
-    (It has to be async.)
-
+    Initializes the application. (It has to be async.)
     """
     ensure_sculptor_folder_ready()
     cleanup_obsolete_mru_files()

--- a/tools/sculpt/sculpt/commands/data_types.py
+++ b/tools/sculpt/sculpt/commands/data_types.py
@@ -9,9 +9,6 @@ from pydantic import BaseModel
 from pydantic import Field
 
 
-# -- Workspace outputs --------------------------------------------------------
-
-
 class WorkspaceCreateOutput(BaseModel):
     """Output of ``sculpt workspace create --json``."""
 
@@ -77,9 +74,6 @@ class WorkspaceDeleteOutput(BaseModel):
     id: str = Field(description="Deleted workspace ID")
 
 
-# -- Repo outputs -------------------------------------------------------------
-
-
 class RepoItem(BaseModel):
     """Single item in ``sculpt repo list --json`` / ``sculpt repo show --json``."""
 
@@ -88,9 +82,6 @@ class RepoItem(BaseModel):
     path: str = Field(description="Local filesystem path")
     accessible: bool = Field(description="Whether the path is accessible")
     created_at: str | None = Field(description="ISO 8601 datetime of creation")
-
-
-# -- Agent outputs ------------------------------------------------------------
 
 
 class AgentCreateOutput(BaseModel):
@@ -182,9 +173,6 @@ class AgentInterruptOutput(BaseModel):
     id: str = Field(description="Interrupted agent ID")
 
 
-# -- Run output ---------------------------------------------------------------
-
-
 class RunOutput(BaseModel):
     """Output of ``sculpt run --json``."""
 
@@ -193,9 +181,6 @@ class RunOutput(BaseModel):
     strategy: str = Field(description="Workspace initialization strategy")
     model: str = Field(description="LLM model identifier")
     prompt: str = Field(description="The task prompt")
-
-
-# -- Error output -------------------------------------------------------------
 
 
 class ErrorOutput(BaseModel):


### PR DESCRIPTION
One of 6 independent PRs from a repo-wide `/crispy-comments` pass, each rebased directly on `main` and reviewable/mergeable on its own, in any order. **Comment-only changes — no code behavior changes.**

**This PR:** backend source — 30 files.

**Removed:** incidental dev-history, persuasive rationale, correctness arguments, drift-prone restatements (counts/enumerations), commented-out code, and ASCII/divider banners.
**Kept (this PR only, by request):** standalone narration comments that describe the code immediately below them — the `# do X` directly above the code that does X — to help readers less fluent in the code. (~111 such comments were restored after the initial pass.)
**Preserved:** functional directives (`# noqa`, `# type: ignore`, `// eslint-disable`, `@ts-expect-error`, shebangs, license headers, JSDoc).

**The full set (each independent, base `main`):**
- #97 — backend integration tests (89)
- #98 — backend unit tests (43)
- #99 — backend source (30)  ← this PR
- #100 — frontend tests + stories (75)
- #101 — frontend pages (40)
- #102 — frontend components + shared (56)

(Sent by Claude)
