### PR TITLE
Prune low-value comments in frontend page components

### DIFF
--- a/sculptor/frontend/src/pages/add-workspace/AddWorkspacePage.tsx
+++ b/sculptor/frontend/src/pages/add-workspace/AddWorkspacePage.tsx
@@ -256,7 +256,6 @@ export const AddWorkspacePage = (): ReactElement => {
       // a duplicate tab.  The flag is cleared by convertNewWorkspaceToTab.
       markDraftCreating(draftId);
 
-      // Create workspace
       const wsResponse = await createWorkspaceV2({
         body: {
           projectId: selectedProjectId,
@@ -329,7 +328,6 @@ export const AddWorkspacePage = (): ReactElement => {
         has_source_branch: sourceBranch != null,
       });
 
-      // Navigate to the new workspace + agent
       navigateToAgent(workspaceId, agentResponse.data.id);
     } catch (error) {
       // Clear the pending-creation flag so auto-open resumes normally.
@@ -439,7 +437,6 @@ export const AddWorkspacePage = (): ReactElement => {
               />
             }
           >
-            {/* Project/repo selector */}
             <RepoSelector
               projects={projects}
               selectedProjectId={selectedProjectId}
@@ -447,7 +444,6 @@ export const AddWorkspacePage = (): ReactElement => {
               className={styles.compactSelector}
             />
 
-            {/* Branch selector */}
             {repoInfo ? (
               mode === WorkspaceInitializationStrategy.IN_PLACE ? (
                 <Tooltip content="In-place workspaces use the current branch in your repository">

--- a/sculptor/frontend/src/pages/debug/ComponentGalleryPage.tsx
+++ b/sculptor/frontend/src/pages/debug/ComponentGalleryPage.tsx
@@ -109,10 +109,6 @@ import { AskUserQuestion } from "~/pages/workspace/components/AskUserQuestion";
 
 import styles from "./ComponentGalleryPage.module.scss";
 
-// ---------------------------------------------------------------------------
-// Mock data
-// ---------------------------------------------------------------------------
-
 const MOCK_BRANCHES = [
   { branch: "main", badges: [] },
   { branch: "feature/auth-flow", badges: [] },
@@ -212,10 +208,6 @@ const MOCK_MULTI_QUESTION_DATA: AskUserQuestionData = {
   toolUseId: "gallery-tool-2",
 };
 
-// ---------------------------------------------------------------------------
-// Navigation sections
-// ---------------------------------------------------------------------------
-
 const SECTIONS = [
   { id: "radix-primitives", label: "Radix Primitives" },
   { id: "status-indicators", label: "Status & Indicators" },
@@ -225,10 +217,6 @@ const SECTIONS = [
   { id: "dialogs-modals", label: "Dialogs & Modals" },
   { id: "cards-banners", label: "Cards & Banners" },
 ] as const;
-
-// ---------------------------------------------------------------------------
-// Section component
-// ---------------------------------------------------------------------------
 
 const Section = ({ id, title, children }: { id: string; title: string; children: ReactNode }): ReactElement => (
   <section id={id} className={styles.section}>
@@ -256,10 +244,6 @@ const ComponentBlock = ({
     </div>
   </div>
 );
-
-// ---------------------------------------------------------------------------
-// Interactive demos
-// ---------------------------------------------------------------------------
 
 const TabBarDemo = (): ReactElement => {
   const [openTabIds, setOpenTabIds] = useState<Array<string>>(["tab-1", "tab-2", "tab-3"]);
@@ -516,10 +500,6 @@ const ActionDialogDemo = (): ReactElement => {
   );
 };
 
-// ---------------------------------------------------------------------------
-// Error boundary for isolating component failures
-// ---------------------------------------------------------------------------
-
 type ErrorBoundaryState = {
   error: Error | null;
 };
@@ -555,11 +535,7 @@ class ComponentErrorBoundary extends Component<{ children: ReactNode; name: stri
   }
 }
 
-// ---------------------------------------------------------------------------
-// Theme settings for the gallery page (differs from app-wide ThemeBuilderSettings
-// by restricting appearance to "light" | "dark" without "system")
-// ---------------------------------------------------------------------------
-
+// Differs from app-wide ThemeBuilderSettings by restricting appearance to "light" | "dark" without "system".
 type ThemeSettings = {
   accentColor: AccentColor;
   appearance: "light" | "dark";
@@ -576,10 +552,6 @@ type ThemeSettings = {
   successColor: AccentColor;
   warningColor: AccentColor;
 };
-
-// ---------------------------------------------------------------------------
-// Theme controls toolbar
-// ---------------------------------------------------------------------------
 
 const ThemeControlSelect = <T extends string>({
   label,
@@ -727,10 +699,6 @@ const ThemeControls = ({
   </div>
 );
 
-// ---------------------------------------------------------------------------
-// Main gallery page
-// ---------------------------------------------------------------------------
-
 const GalleryContent = ({
   settings,
   onSettingsChange,
@@ -810,9 +778,6 @@ const GalleryContent = ({
                 </p>
               </header>
 
-              {/* ============================================================
-                SECTION: Radix Primitives
-                ============================================================ */}
               <Section id="radix-primitives" title="Radix Primitives">
                 <ComponentBlock
                   name="Button"
@@ -1395,9 +1360,6 @@ const GalleryContent = ({
                 </ComponentBlock>
               </Section>
 
-              {/* ============================================================
-                SECTION: Status & Indicators
-                ============================================================ */}
               <Section id="status-indicators" title="Status & Indicators">
                 <ComponentBlock
                   name="PulsingCircle"
@@ -1442,9 +1404,6 @@ const GalleryContent = ({
                 </ComponentBlock>
               </Section>
 
-              {/* ============================================================
-                SECTION: Inputs & Editing
-                ============================================================ */}
               <Section id="inputs-editing" title="Inputs & Editing">
                 <ComponentBlock
                   name="InlineRenameInput"
@@ -1487,9 +1446,6 @@ const GalleryContent = ({
                 </ComponentBlock>
               </Section>
 
-              {/* ============================================================
-                SECTION: Navigation & Selection
-                ============================================================ */}
               <Section id="navigation-selection" title="Navigation & Selection">
                 <ComponentBlock
                   name="TabBar (default)"
@@ -1534,9 +1490,6 @@ const GalleryContent = ({
                 </ComponentBlock>
               </Section>
 
-              {/* ============================================================
-                SECTION: Content Display
-                ============================================================ */}
               <Section id="content-display" title="Content Display">
                 <ComponentBlock
                   name="MarkdownBlock"
@@ -1576,9 +1529,6 @@ const GalleryContent = ({
                 </ComponentBlock>
               </Section>
 
-              {/* ============================================================
-                SECTION: Dialogs & Modals
-                ============================================================ */}
               <Section id="dialogs-modals" title="Dialogs & Modals">
                 <ComponentBlock
                   name="DeleteConfirmationDialog"
@@ -1602,9 +1552,6 @@ const GalleryContent = ({
                 </ComponentBlock>
               </Section>
 
-              {/* ============================================================
-                SECTION: Cards & Banners
-                ============================================================ */}
               <Section id="cards-banners" title="Cards & Banners">
                 <ComponentBlock
                   name="WarningStatusBanner"

--- a/sculptor/frontend/src/pages/settings/SettingsPage.tsx
+++ b/sculptor/frontend/src/pages/settings/SettingsPage.tsx
@@ -82,7 +82,6 @@ export const SettingsPage = (): ReactElement => {
       setActiveSection(sectionParam as SettingsSection);
     }
   }, [searchParams, setActiveSection]);
-  // Read from derived atoms for current values
   const [themeSettings, setThemeSettings] = useAtom(themeBuilderSettingsAtom);
   const configuredDefaultModel = useAtomValue(configuredDefaultModelAtom);
   const userEmail = useAtomValue(userEmailAtom);
@@ -113,7 +112,6 @@ export const SettingsPage = (): ReactElement => {
 
   const { updateField } = useUserConfig();
 
-  // Handler for updating individual settings - now uses snake_case field names.
   const handleSettingChange = async (fieldConstant: UserConfigField, value: unknown): Promise<void> => {
     try {
       await updateField(fieldConstant, value);

--- a/sculptor/frontend/src/pages/settings/components/ActionsSettingsSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/ActionsSettingsSection.tsx
@@ -69,8 +69,6 @@ export const ActionsSettingsSection = ({ setToast }: ActionsSettingsSectionProps
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
-  // --- CRUD handlers (unchanged) ---
-
   const handleAddAction = (): void => {
     setEditingAction(undefined);
     setIsDialogOpen(true);
@@ -290,8 +288,6 @@ export const ActionsSettingsSection = ({ setToast }: ActionsSettingsSectionProps
     input.click();
   };
 
-  // --- DnD handlers (DockingLayout pattern) ---
-
   const resolveActionGroupId = (rowEl: Element): string | null => {
     // Walk up to find the parent group section, if any
     const groupSection = rowEl.closest("[data-group-section]");
@@ -426,8 +422,6 @@ export const ActionsSettingsSection = ({ setToast }: ActionsSettingsSectionProps
     setDropTarget(null);
     dropTargetRef.current = null;
   };
-
-  // --- Render ---
 
   const ungroupedActions = getUngroupedActions();
   const sortedGroups = getSortedGroups();

--- a/sculptor/frontend/src/pages/settings/components/DependenciesSettingsSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/DependenciesSettingsSection.tsx
@@ -38,13 +38,11 @@ export const DependenciesSettingsSection = ({ onSettingChange }: DependenciesSet
     ? `Supported range: ${claude.versionRange.minVersion} \u2013 ${claude.versionRange.maxVersion}`
     : undefined;
 
-  // ── Compact views ──
   const isClaudeHealthy = isManagedUpToDate && !isInstalling && !effectiveInstallError && !installProgress;
   const isGitHealthy = git?.installed === true;
 
   return (
     <SettingsSectionLayout description="Manage external tool dependencies used by Sculptor.">
-      {/* ── Claude ── */}
       <SectionTitle>Claude</SectionTitle>
 
       <SettingRow title="Binary Source" description="Choose how Sculptor locates the Claude CLI binary.">
@@ -185,7 +183,6 @@ export const DependenciesSettingsSection = ({ onSettingChange }: DependenciesSet
 
       <Separator size="4" my="5" />
 
-      {/* ── Git ── */}
       <SectionTitle>Git</SectionTitle>
 
       <SettingRow title="Status" description="Git must be available on your PATH.">

--- a/sculptor/frontend/src/pages/workspace/Types.ts
+++ b/sculptor/frontend/src/pages/workspace/Types.ts
@@ -1,9 +1,5 @@
 import type { ArtifactType, TaskListArtifact } from "../../api";
 
-// ===============================
-// Artifact Types
-// ===============================
-
 export type ArtifactsMap = {
   [ArtifactType.PLAN]?: TaskListArtifact;
 };

--- a/sculptor/frontend/src/pages/workspace/components/PrDetailDropdown.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/PrDetailDropdown.tsx
@@ -115,7 +115,6 @@ export const PrDetailDropdown = ({ prStatus, gitProvider }: PrDetailDropdownProp
 
   return (
     <div className={styles.dropdown} data-testid={ElementIds.PR_DROPDOWN}>
-      {/* Header */}
       <Flex align="center" gap="2" mb="3">
         {prStatus.prWebUrl ? (
           <Link size="2" weight="medium" href={prStatus.prWebUrl} target="_blank" style={{ flex: 1 }} truncate>
@@ -131,7 +130,6 @@ export const PrDetailDropdown = ({ prStatus, gitProvider }: PrDetailDropdownProp
 
       <Separator size="4" mb="3" />
 
-      {/* Pipeline/Checks section */}
       <Flex direction="column" gap="1" mb="3">
         <Text className={styles.sectionTitle}>{ciLabel}</Text>
         {prStatus.pipelineStatus ? (
@@ -164,7 +162,6 @@ export const PrDetailDropdown = ({ prStatus, gitProvider }: PrDetailDropdownProp
         <>
           <Separator size="4" mb="3" />
 
-          {/* CI Babysitter section (experimental) */}
           <Flex direction="column" gap="1" mb="3">
             <Flex align="center" justify="between">
               <Text className={styles.sectionTitle}>CI Babysitter</Text>
@@ -184,7 +181,6 @@ export const PrDetailDropdown = ({ prStatus, gitProvider }: PrDetailDropdownProp
 
       <Separator size="4" mb="3" />
 
-      {/* Approvals section */}
       <Flex direction="column" gap="1" mb="3">
         <Text className={styles.sectionTitle}>
           {reviewLabel} {totalApprovals > 0 && `(${approvedCount}/${totalApprovals})`}
@@ -212,7 +208,6 @@ export const PrDetailDropdown = ({ prStatus, gitProvider }: PrDetailDropdownProp
 
       <Separator size="4" mb="3" />
 
-      {/* Unresolved comments section */}
       <Flex direction="column" gap="1">
         <Text className={styles.sectionTitle}>Unresolved comments {commentCount > 0 && `(${commentCount})`}</Text>
         {commentCount > 0 ? (

--- a/sculptor/frontend/src/pages/workspace/components/WorkspaceBanner.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspaceBanner.tsx
@@ -157,7 +157,6 @@ export const WorkspaceBanner = (): ReactElement | null => {
 
   return (
     <div ref={containerRef} className={styles.banner} data-testid={ElementIds.WORKSPACE_BANNER}>
-      {/* Repo segment */}
       {!hiddenPriorities.has(2) &&
         (repoPath ? (
           <div data-collapse-priority="2">
@@ -173,10 +172,8 @@ export const WorkspaceBanner = (): ReactElement | null => {
           <Skeleton width="120px" height="16px" />
         ))}
 
-      {/* Chevron separator */}
       <span className={styles.chevronSeparator}>&rsaquo;</span>
 
-      {/* Branch name */}
       {branchName ? (
         <Tooltip
           content={isCopied ? "Copied!" : "Workspace branch — click to copy"}
@@ -192,7 +189,6 @@ export const WorkspaceBanner = (): ReactElement | null => {
         <Skeleton width="160px" height="16px" />
       )}
 
-      {/* Arrow + target branch */}
       {shouldShowTargetBranch && (
         <>
           <span className={styles.arrowSeparator}>&rarr;</span>
@@ -219,7 +215,6 @@ export const WorkspaceBanner = (): ReactElement | null => {
         </>
       )}
 
-      {/* "from" + source branch (non-GitLab repos) */}
       {!shouldShowTargetBranch && workspace.sourceBranch && (
         <>
           <Text size="1" className={styles.fromLabel}>
@@ -231,17 +226,14 @@ export const WorkspaceBanner = (): ReactElement | null => {
         </>
       )}
 
-      {/* Spacer */}
       <div className={styles.spacer} data-spacer />
 
-      {/* Diff summary */}
       {!hiddenPriorities.has(1) && (
         <div data-collapse-priority="1">
           <DiffSummary workspaceId={workspaceID} />
         </div>
       )}
 
-      {/* PR button */}
       {!hiddenPriorities.has(4) && shouldShowTargetBranch && (
         <div data-collapse-priority="4">
           <PrButton

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
@@ -421,8 +421,6 @@ export const AlphaChatInterface = ({
 
   // Expose the jump-to-bottom callback to the command palette so Cmd+K →
   // Jump to bottom invokes it directly instead of synthesizing a key event.
-  // Jump-to-top is gone after the upstream removal of `scrollToTop` /
-  // `jump_to_top` keybinding; the palette no longer surfaces that command.
   const handleJumpToBottom = useCallback((): void => {
     exitNavigation();
     scrollToBottom();

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatView.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatView.module.scss
@@ -258,7 +258,6 @@
   @include thin-scrollbar(both);
 }
 
-// Error styling on tool results
 .toolResultError {
   background-color: var(--red-2);
   border-left-color: var(--red-9);
@@ -277,7 +276,6 @@
   padding: var(--space-1) 0;
 }
 
-// Error block
 .errorBlock {
   border-left: 3px solid var(--red-9);
   padding-left: var(--space-2);
@@ -307,7 +305,6 @@
   word-break: break-word;
 }
 
-// Warning block
 .warningBlock {
   border-left: 3px solid var(--orange-9);
   padding-left: var(--space-2);
@@ -324,7 +321,6 @@
   word-break: break-word;
 }
 
-// Resume response indicator
 .resumeIndicator {
   color: var(--gray-9);
   font-size: var(--font-size-2);
@@ -344,7 +340,6 @@
   padding-left: var(--space-3);
 }
 
-// Tool group header
 .toolGroupHeader {
   align-items: baseline;
   cursor: pointer;
@@ -362,7 +357,6 @@
   opacity: 80%;
 }
 
-// Skill pill
 .skillPill {
   color: var(--accent-12);
   font-family: var(--code-font-family);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChipDiffPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChipDiffPopover.tsx
@@ -114,9 +114,7 @@ export const AlphaChipDiffPopover = ({
     // the change against HEAD. Files outside the clone — and plan files at
     // `.claude/plans/`, which are documents, not code changes — have no
     // useful diff context, so route them to a file-view tab that renders the
-    // contents directly. Mirrors the classic-chat fix that landed under
-    // SCU-366; the same bug existed in alpha because the file-chip popover
-    // routed unconditionally through openDiffTab.
+    // contents directly.
     const { display: pathRel, isOutsideWorkspace } = makeRelative(chipData.filePath, workspaceCodePath);
     // `.claude/plans/` always sits at the workspace root, so check the
     // relative path with `startsWith` rather than `includes` on the absolute
@@ -197,7 +195,6 @@ export const AlphaChipDiffPopover = ({
 
   return (
     <div className={styles.popover} data-testid={ElementIds.ALPHA_CHAT_CHIP_POPOVER} onKeyDown={handleKeyDown}>
-      {/* Header */}
       <div className={headerClass.join(" ")}>
         <div className={styles.headerLeft}>
           {chipData.state === "completed" && chipData.isNewFile && (
@@ -256,7 +253,6 @@ export const AlphaChipDiffPopover = ({
         </div>
       </div>
 
-      {/* Body */}
       <div className={styles.body}>
         {chipData.state === "completed" && diffPatches.length > 0 && (
           <div ref={pierreRef}>

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaExitPlanModeBlock.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaExitPlanModeBlock.tsx
@@ -73,9 +73,8 @@ export const AlphaExitPlanModeBlock = ({ toolBlock }: { toolBlock: ToolUseBlock 
   }
 
   if (matchingAnswers) {
-    // Look the answer up by the question's OWN stored text (it varies by harness
-    // and has changed over time) rather than a hardcoded string, so historical
-    // plan turns resolve too.
+    // Look the answer up by the question's OWN stored text (it varies by harness)
+    // rather than a hardcoded string, so historical plan turns resolve too.
     const planQuestion = matchingAnswers.questionData.questions[0]?.question ?? "";
     const answerValue = matchingAnswers.answers[planQuestion] ?? "";
     const isDismissed = answerValue === DISMISSED_ANSWER;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaMarkdownBlock.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaMarkdownBlock.module.scss
@@ -11,12 +11,10 @@
   // column wider than its container (horizontal overflow).
   overflow-wrap: anywhere;
 
-  // First child should not have top margin
   > :first-child {
     margin-top: 0;
   }
 
-  // Last child should not have bottom margin
   > :last-child {
     margin-bottom: 0;
   }
@@ -69,7 +67,6 @@
     margin: 1em 0;
   }
 
-  // Links
   a {
     color: var(--blue-11);
     text-decoration: underline;
@@ -82,7 +79,6 @@
     }
   }
 
-  // Lists
   ul,
   ol {
     margin: 0.5em 0;
@@ -158,7 +154,6 @@
   }
   /* stylelint-enable selector-class-pattern */
 
-  // Inline code
   .inlineCode {
     background-color: var(--gray-4);
     border: 1px solid var(--gray-5);
@@ -196,7 +191,6 @@
     }
   }
 
-  // Horizontal rules
   hr {
     border: none;
     border-top: 1px solid var(--gray-5);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPillRow.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPillRow.tsx
@@ -180,8 +180,6 @@ export const AlphaToolPillRow = ({
     [focusedIndex, pillDataList.length, isPopoverOpen, isExpanded, handleNavigate, setOpenPillId],
   );
 
-  // ─── Popover anchor (virtual) ───────────────────────────────────────────────
-  //
   // Density flips swap the row layout from a single horizontal pill row to a
   // stack of full-width rows. Wiring the popover anchor as a DOM wrapper —
   // PopoverAnchor in default, conditional PopoverAnchor on the active row in

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.module.scss
@@ -17,8 +17,6 @@
   @include thin-scrollbar;
 }
 
-// ─── Entry ────────────────────────────────────────────────────────────────────
-
 // Each entry is a PopoverHeader (with its own padding) plus an optional body.
 // No surrounding padding here — the header and body each style themselves.
 .entry {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.tsx
@@ -16,8 +16,6 @@ import { PopoverHeader } from "./PopoverHeader.tsx";
 import type { PillData } from "./toolPill.types.ts";
 import { makeRelative } from "./toolPillUtils.ts";
 
-// ─── Per-tool structured renderers ──────────────────────────────────────────
-
 export type ToolEntryShellArgs = {
   title: ReactNode;
   meta?: ReactNode;
@@ -297,8 +295,6 @@ export const ToolEntryContent = ({
       return <DefaultEntry {...props} />;
   }
 };
-
-// ─── Main popover component ───────────────────────────────────────────────────
 
 type AlphaToolPopoverProps = {
   pillData: PillData;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/PopoverHeader.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/PopoverHeader.module.scss
@@ -45,8 +45,6 @@
   gap: var(--space-1);
 }
 
-// ─── Title role classes ──────────────────────────────────────────────────────
-//
 // Shared typography roles for content placed inside `<PopoverHeader title={…}>`.
 // PopoverHeader's default title style is a sans-serif "label" (descriptions,
 // tool names). When the title is a code identifier (file path, command,

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/bashBlockStyles.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/bashBlockStyles.module.scss
@@ -133,8 +133,6 @@
   color: var(--accent-11);
 }
 
-/* -- Popover -- */
-
 .popoverContent {
   animation: none !important;
   border-radius: var(--radius-1) !important;

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/atoms.ts
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/atoms.ts
@@ -97,7 +97,6 @@ type SetActiveDiffPayload = SetActiveSingleDiff | SetActiveCombinedDiff | SetAct
 
 /**
  * Build a DiffTab and its identity key from a discriminated union payload.
- * All three tab types share the same "find-or-create, then activate" logic.
  */
 const buildTabFromPayload = (payload: SetActiveDiffPayload, now: number): { tab: DiffTab; tabPath: string } => {
   switch (payload.kind) {
@@ -152,8 +151,6 @@ const buildTabFromPayload = (payload: SetActiveDiffPayload, now: number): { tab:
 
 /**
  * Unified atom that activates (or opens) a diff tab of any kind.
- * Replaces the previous `openDiffTabAtom`, `openCombinedDiffTabAtom`, and
- * `openFileViewTabAtom` — which were ~90% identical.
  */
 export const setActiveDiffTabAtom = atom(null, (get, set, payload: SetActiveDiffPayload) => {
   const stateAtom = diffPanelStateAtomFamily(payload.workspaceId);

--- a/sculptor/frontend/src/pages/workspace/components/tools/askUserQuestionUtils.ts
+++ b/sculptor/frontend/src/pages/workspace/components/tools/askUserQuestionUtils.ts
@@ -8,8 +8,7 @@
  *
  * This is a heuristic — ideally answers would store structured selections
  * rather than a flat string. But this handles option labels that contain
- * ", " (e.g. "Yes, proceed") which the previous split-then-match approach
- * could not.
+ * ", " (e.g. "Yes, proceed").
  */
 export const splitAnswerIntoParts = (
   answerText: string,

--- a/sculptor/frontend/src/pages/workspace/hooks/useSmoothStreaming.ts
+++ b/sculptor/frontend/src/pages/workspace/hooks/useSmoothStreaming.ts
@@ -108,8 +108,6 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
   const lastBatchArrivalTimeRef = useRef<number>(0);
   const [renderedMessage, setRenderedMessage] = useState<ChatMessage | null>(chatMessage ?? null);
 
-  // ── Engine lifecycle ──────────────────────────────────────────────
-
   const ensureEngine = useCallback((): StreamingEngine => {
     if (!engineRef.current) {
       engineRef.current = new StreamingEngine();
@@ -117,8 +115,6 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
     }
     return engineRef.current;
   }, []);
-
-  // ── Animation loop ────────────────────────────────────────────────
 
   const stopAnimationLoop = useCallback((): void => {
     if (rafIdRef.current !== null) {
@@ -197,8 +193,6 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
     };
   }, [ensureEngine, stopAnimationLoop]);
 
-  // ── Snapshot handling ─────────────────────────────────────────────
-
   const handleSnapshot = useCallback(
     (engine: StreamingEngine, snapshot: ChatMessage): void => {
       const isNewMessage = activeMessageIdRef.current !== snapshot.id;
@@ -225,7 +219,6 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
         return;
       }
 
-      // ── Smooth streaming path ───────────────────────────────────
       const prevBufferSize = engine.getBufferSize();
       engine.updateLatestSnapshot(snapshot);
       const newBufferSize = engine.getBufferSize();

--- a/sculptor/frontend/src/pages/workspace/panels/ActionsPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/ActionsPanel.tsx
@@ -276,8 +276,6 @@ export const ActionsPanel = (): ReactElement => {
 
   const isAgentRunning = task?.status === "RUNNING" || task?.status === "BUILDING";
 
-  // --- CRUD handlers ---
-
   const handleAddAction = (): void => {
     setEditingAction(undefined);
     setIsDialogOpen(true);
@@ -523,8 +521,6 @@ export const ActionsPanel = (): ReactElement => {
     setDropTarget(null);
     dropTargetRef.current = null;
   };
-
-  // --- Render ---
 
   const isGroupDrag = activeDragId?.startsWith("group:") ?? false;
   const activeDragAction = !isGroupDrag && activeDragId ? actions.find((a) => a.id === activeDragId) : null;

--- a/sculptor/frontend/src/pages/workspace/panels/TerminalPanel.module.scss
+++ b/sculptor/frontend/src/pages/workspace/panels/TerminalPanel.module.scss
@@ -64,7 +64,6 @@
   padding: var(--space-2) var(--space-3) 0;
 
   /* stylelint-disable selector-class-pattern -- xterm library class names */
-  // Make xterm fill the container
   :global(.xterm) {
     height: 100%;
     width: 100%;

--- a/sculptor/frontend/src/pages/workspace/panels/TerminalPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/TerminalPanel.tsx
@@ -21,9 +21,7 @@ import { getNextTerminalLabel } from "./terminalLabelUtils";
 import styles from "./TerminalPanel.module.scss";
 import { useTerminal } from "./useTerminal";
 
-// ---------------------------------------------------------------------------
 // TerminalInstance — one xterm.js + WebSocket per tab
-// ---------------------------------------------------------------------------
 
 type TerminalTab = {
   id: string;
@@ -52,12 +50,7 @@ const TerminalInstance = ({ workspaceID, terminalIndex, isVisible, onOutput }: T
   );
 };
 
-// ---------------------------------------------------------------------------
 // useWorkspaceTerminalTabs — workspace-scoped access to persisted tab atoms
-//
-// Eliminates the local-state-plus-sync-effects pattern by reading/writing
-// atoms directly, scoped to the current workspaceID.
-// ---------------------------------------------------------------------------
 
 const DEFAULT_TAB: TerminalTab = { id: "terminal-0", index: 0, label: "Terminal 1" };
 const DEFAULT_NEXT_INDEX = 1;
@@ -119,9 +112,7 @@ const useWorkspaceTerminalTabs = (workspaceID: string): WorkspaceTerminalTabsRes
   return { tabs, activeTabId, nextIndex, setTabs, setActiveTabId, setNextIndex };
 };
 
-// ---------------------------------------------------------------------------
 // TerminalPanelWrapper — manages terminal tabs
-// ---------------------------------------------------------------------------
 
 export const TerminalPanelWrapper = (): ReactElement | null => {
   const { workspaceID } = useWorkspacePageParams();

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/atoms.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/atoms.ts
@@ -55,10 +55,6 @@ export const getUncommittedFileStatusMap = (
 /** Per-workspace scope for the Changes tab (independent of the Review All scope). Resets on page refresh. */
 export const changesScopeAtomFamily = atomFamily((_workspaceId: string) => atom<DiffScope>("vs-target-branch"));
 
-// ---------------------------------------------------------------------------
-// Folder expand/collapse atoms — parameterized by state key
-// ---------------------------------------------------------------------------
-
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const createToggleFolderAtom = (key: FolderStateKey) =>
   atom(null, (get, set, { workspaceId, folderPath }: { workspaceId: string; folderPath: string }) => {
@@ -103,10 +99,6 @@ export const collapseAllChangesFoldersAtom = atom(null, (get, set, { workspaceId
   set(stateAtom, { ...state, changesExpandedFolders: [] });
 });
 
-// ---------------------------------------------------------------------------
-// Other state atoms
-// ---------------------------------------------------------------------------
-
 export const toggleViewModeAtom = atom(null, (get, set, { workspaceId }: { workspaceId: string }) => {
   const stateAtom = fileBrowserStateAtomFamily(workspaceId);
   const state = get(stateAtom);
@@ -114,11 +106,9 @@ export const toggleViewModeAtom = atom(null, (get, set, { workspaceId }: { works
   set(stateAtom, { ...state, viewMode });
 });
 
-// ---------------------------------------------------------------------------
 // Folder reveal: expand ancestors, show the file browser panel, and signal
 // FileTree to scroll + briefly highlight the row. Used by @-folder mention
 // chips in chat messages.
-// ---------------------------------------------------------------------------
 
 export type FocusFolderRequest = {
   workspaceId: string;

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/useTreeView.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/useTreeView.ts
@@ -4,10 +4,6 @@ import type { TreeNode } from "./types.ts";
 import type { FlatRowEntry } from "./utils.ts";
 import { collectAllFolderPaths, collectDescendantFolderPaths, getAncestorPaths } from "./utils.ts";
 
-// ---------------------------------------------------------------------------
-// useAgentFileTracking — auto-expand/scroll when agent operates on a file
-// ---------------------------------------------------------------------------
-
 type UseAgentFileTrackingParams = {
   activeFilePath: string | undefined;
   workspaceId: string;
@@ -35,10 +31,6 @@ export const useAgentFileTracking = ({
     prevActivePathRef.current = activePath;
   }, [activeFilePath, expandFolders, workspaceId]);
 };
-
-// ---------------------------------------------------------------------------
-// useSearchAutoExpand — save/restore folder expand state during search
-// ---------------------------------------------------------------------------
 
 type UseSearchAutoExpandParams = {
   isSearchActive: boolean;
@@ -95,10 +87,6 @@ export const useSearchAutoExpand = ({
   }, [isSearchActive, tree, expandFolders, workspaceId, setExpandedFolders]);
 };
 
-// ---------------------------------------------------------------------------
-// useTreeNodeMap — lookup from path → TreeNode for context menus
-// ---------------------------------------------------------------------------
-
 /**
  * Build a lookup map from file path to TreeNode, useful for quickly
  * retrieving descendant folder paths in context menus.
@@ -116,10 +104,6 @@ export const useTreeNodeMap = (tree: Array<TreeNode>): Map<string, TreeNode> => 
     return map;
   }, [tree]);
 };
-
-// ---------------------------------------------------------------------------
-// useCollapseChildren — collapse a folder and all its descendants
-// ---------------------------------------------------------------------------
 
 /**
  * Returns a callback that collapses a folder and all its descendant folders.

--- a/sculptor/frontend/src/pages/workspace/panels/historyPanel/HistoryPanel.module.scss
+++ b/sculptor/frontend/src/pages/workspace/panels/historyPanel/HistoryPanel.module.scss
@@ -8,8 +8,6 @@
   @include thin-scrollbar;
 }
 
-/* Graph column --------------------------------------------------------------- */
-
 .graphColumn {
   align-items: center;
   display: flex;
@@ -60,8 +58,6 @@
   width: 8px;
 }
 
-/* Commit entry --------------------------------------------------------------- */
-
 .commitEntry {
   display: flex;
   flex-direction: column;
@@ -107,8 +103,6 @@
   font-family: var(--font-mono);
 }
 
-/* Commit hover popover ------------------------------------------------------ */
-
 .popoverContent {
   background: var(--color-panel-solid);
   border-radius: var(--radius-4);
@@ -134,8 +128,6 @@
   color: var(--gray-11);
   font-family: var(--font-mono);
 }
-
-/* Commit files --------------------------------------------------------------- */
 
 .commitFiles {
   padding-left: 20px;
@@ -167,8 +159,6 @@
   width: 20px;
 }
 
-/* Merge spur ---------------------------------------------------------------- */
-
 .mergeSpurRow {
   align-items: flex-end;
   display: flex;
@@ -189,15 +179,11 @@
   white-space: nowrap;
 }
 
-/* Side branch (nested under merge commits) ---------------------------------- */
-
 .sideBranch {
   display: flex;
   flex-direction: column;
 }
 
-
-/* Terminus ------------------------------------------------------------------- */
 
 .terminus {
   display: flex;

--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
@@ -17,10 +17,6 @@ import { getColorScale, resolveGrayColor } from "~/common/theme/radixColorHexMap
 import { useResolvedTheme } from "~/common/Utils.ts";
 import { commandActionsAtom } from "~/components/CommandPalette/commandActions.ts";
 
-// ---------------------------------------------------------------------------
-// Pure helper functions (extracted for testability and readability)
-// ---------------------------------------------------------------------------
-
 // ESC character code (0x1B)
 const ESC = "\u001b";
 
@@ -302,10 +298,6 @@ export const shouldClearActiveTerminal = (
   if (!shouldHandleKeybinding(event, binding)) return false;
   return container != null && container.contains(document.activeElement);
 };
-
-// ---------------------------------------------------------------------------
-// useTerminal hook
-// ---------------------------------------------------------------------------
 
 type UseTerminalArgs = {
   /** The backend WebSocket path for this terminal's PTY, e.g.
@@ -680,8 +672,6 @@ export const useTerminal = ({
     };
   }, [isVisible, handleResize]);
 
-  // ── Clear-terminal keybinding (focus-gated) ────────────────────────
-  //
   // Mirrors the `interrupt_agent` pattern in ChatInput.tsx — we read the
   // resolved binding from the keybindings registry and attach a window-level
   // keydown listener that only fires when this terminal instance has


### PR DESCRIPTION
One of 6 independent PRs from a repo-wide `/crispy-comments` pass, each rebased directly on `main` and reviewable/mergeable on its own, in any order. **Comment-only changes — no code behavior changes.**

**This PR:** frontend pages (`src/pages/`) — 28 files.

**Removed:** incidental dev-history, persuasive rationale, correctness arguments, drift-prone restatements, commented-out code, trivial restatements of obvious code, and ASCII/divider banners.
**Kept (this PR only, by request):** standalone comments that explain non-obvious or dense code in plain English for the reader.
**Preserved:** functional directives (`// eslint-disable`, `@ts-expect-error`, `// prettier-ignore`, webpack magic comments, triple-slash references) and JSDoc.

**The full set (each independent, base `main`):**
- #97 — backend integration tests
- #98 — backend unit tests
- #99 — backend source
- #100 — frontend tests + stories
- #101 — frontend pages  ← this PR
- #102 — frontend components + shared

(Sent by Claude)
