### PR TITLE
Prune low-value comments in frontend components and shared modules

### DIFF
--- a/sculptor/frontend/forge.config.ts
+++ b/sculptor/frontend/forge.config.ts
@@ -1,13 +1,9 @@
 import fs from "node:fs";
-// Import Node.js path utility for resolving file paths across platforms
 import path from "node:path";
 
-// Import Electron Fuses types and options for security configuration
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import type { MakerDMGConfig } from "@electron-forge/maker-dmg";
-// Import the Fuses plugin to apply security settings at build time
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
-// Import Vite plugin for modern bundling and development experience
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import type { ForgeConfig, ForgeMakeResult } from "@electron-forge/shared-types";
 
@@ -77,7 +73,6 @@ let config = {
         // Name of the Windows setup executable file
         setupExe: "sculptor-setup.exe",
       },
-      // Only run this maker on Windows platforms
       platforms: ["win32"],
     },
     {
@@ -133,7 +128,6 @@ let config = {
         },
         name: "Sculptor",
       }),
-      // Only run on macOS (darwin)
       platforms: ["darwin"],
     },
     {
@@ -147,7 +141,6 @@ let config = {
           bin: "Sculptor",
         },
       },
-      //Only run on Linux platforms
       platforms: ["linux"],
     },
   ],
@@ -175,7 +168,6 @@ let config = {
     // Fuses plugin for security hardening - disables potentially dangerous features
     // These settings are applied at build time and cannot be changed at runtime
     new FusesPlugin({
-      // Use version 1 of the fuses system
       version: FuseVersion.V1,
       // Disable running as Node.js (prevents access to Node APIs in renderer)
       [FuseV1Options.RunAsNode]: false,

--- a/sculptor/frontend/public/plugins/sculpty/main.js
+++ b/sculptor/frontend/public/plugins/sculpty/main.js
@@ -24,10 +24,6 @@
  * data matches src/assets/logos/{peace,joy,excitement}.svg.
  */
 
-// ---------------------------------------------------------------------------
-// Squiggle artwork + per-mood tuning
-// ---------------------------------------------------------------------------
-
 const SHAPES = {
   sleeping: {
     fill: "#B4D3BA",
@@ -79,17 +75,9 @@ const SIZE = 96;
 const VIEWBOX = 336;
 const SVG_NS = "http://www.w3.org/2000/svg";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const lerp = (a, b, t) => a + (b - a) * t;
 const easeInOut = (x) => (x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2);
 const reducedMotion = () => typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-// ---------------------------------------------------------------------------
-// Plugin entry
-// ---------------------------------------------------------------------------
 
 export default function activate() {
   const el = document.createElement("div");

--- a/sculptor/frontend/src/common/Types.ts
+++ b/sculptor/frontend/src/common/Types.ts
@@ -1,9 +1,5 @@
 export type PropsWithClassName<T = unknown> = T & { className?: string };
 
-// ===============================
-// Core ID Types
-// ===============================
-
 export type RequestID = string;
 export type TaskID = string;
 export type ProjectID = string;

--- a/sculptor/frontend/src/common/autoUpdateUtils.ts
+++ b/sculptor/frontend/src/common/autoUpdateUtils.ts
@@ -11,7 +11,6 @@ export function getUpdateChannelDisplayName(channel: UpdateChannel): string {
 
 /**
  * Returns a human-readable status string for the current auto-update state.
- * Used by both the VersionPopover and the Settings page.
  */
 export function getUpdateStatusText(
   status: AutoUpdateStatus | null,

--- a/sculptor/frontend/src/common/state/atoms/taskDetails.ts
+++ b/sculptor/frontend/src/common/state/atoms/taskDetails.ts
@@ -11,24 +11,19 @@ import type { ArtifactsMap } from "../../../pages/workspace/Types";
  * This is accumulated from incremental TaskUpdate messages.
  */
 export type TaskDetailState = {
-  // Chat messages
   completedChatMessages: Array<ChatMessage>;
   inProgressChatMessage: ChatMessage | null;
   queuedChatMessages: Array<ChatMessage>;
   workingUserMessageId: string | null;
-  // Artifacts
   artifacts: ArtifactsMap;
-  // AskUserQuestion state
   pendingUserQuestion: AskUserQuestionData | null;
   submittedQuestionAnswers: Record<string, SubmittedQuestionAnswers>;
-  // Plan mode state
   isInPlanMode: boolean;
   // Background tasks whose ``task_started`` has arrived but whose
   // ``task_notification`` has not. Drives the alpha status pill's
   // "waiting for background task" label so it doesn't claim the agent is
   // thinking while the harness is actually idle (SCU-387).
   pendingBackgroundTaskIds: Array<string>;
-  // Error state
   error?: string;
 };
 

--- a/sculptor/frontend/src/common/state/hooks/useProjectSkills.ts
+++ b/sculptor/frontend/src/common/state/hooks/useProjectSkills.ts
@@ -29,10 +29,8 @@ const fetchProjectSkills = async (projectId: string, signal: AbortSignal): Promi
 // queries refresh via explicit invalidation; the project hook overrides
 // `staleTime` to a short window so the next `/` press or remount after the
 // window picks up on-disk edits (the user adds a skill file and types `/`
-// again). The bespoke fetcher this replaced cleared its cache on every `/`
-// keystroke — a 10s window preserves that "feels-fresh-on-each-/" UX while
-// still deduping rapid `/` re-presses, the eager prefetch, and concurrent
-// editor mounts within the window.
+// again), while still deduping rapid `/` re-presses, the eager prefetch, and
+// concurrent editor mounts within the window.
 const PROJECT_SKILLS_STALE_TIME_MS = 10_000;
 
 /**

--- a/sculptor/frontend/src/common/state/hooks/useSkills.ts
+++ b/sculptor/frontend/src/common/state/hooks/useSkills.ts
@@ -17,8 +17,8 @@ type UseSkillsResult = {
 /**
  * SkillsPanel-facing thin wrapper around `useWorkspaceSkills`. Adds the static
  * `BUILTIN_SKILLS` to the API results and sorts the merged list. While the
- * API fetch is in flight the merged list is empty (not just "API-only") to
- * match the prior behavior where the panel showed nothing during loads.
+ * API fetch is in flight the merged list is empty (not just "API-only"), so
+ * the panel shows nothing during loads.
  */
 export const useSkills = (): UseSkillsResult => {
   const { workspaceID } = useWorkspacePageParams();

--- a/sculptor/frontend/src/common/state/hooks/useUnifiedStream.ts
+++ b/sculptor/frontend/src/common/state/hooks/useUnifiedStream.ts
@@ -63,18 +63,14 @@ export const useUnifiedStream = (): void => {
 
   const onMessage = useCallback(
     (data: StreamingUpdate): void => {
-      // ========================================================================
       // Handle task views (for task list/sidebar)
-      // ========================================================================
       if (data.taskViewsByTaskId) {
         updateTasks(data.taskViewsByTaskId);
       }
 
-      // ========================================================================
       // Handle task details (for chat pages)
       //    Process ALL tasks, even if not currently viewing them
       // NOTE: This is O(activeTasks) because we only get a task update if something happens
-      // ========================================================================
       if (data.taskUpdateByTaskId && Object.keys(data.taskUpdateByTaskId).length > 0) {
         Object.entries(data.taskUpdateByTaskId).forEach(([taskId, taskUpdate]) => {
           updateTaskDetail({
@@ -114,9 +110,7 @@ export const useUnifiedStream = (): void => {
         });
       }
 
-      // ========================================================================
       // Handle user update
-      // ========================================================================
       if (data.userUpdate) {
         const userUpdate = data.userUpdate;
 
@@ -138,18 +132,14 @@ export const useUnifiedStream = (): void => {
         }
       }
 
-      // ========================================================================
       // Handle workspace branch updates
-      // ========================================================================
       if (data.workspaceBranchByWorkspaceId && Object.keys(data.workspaceBranchByWorkspaceId).length > 0) {
         Object.entries(data.workspaceBranchByWorkspaceId).forEach(([workspaceId, branchInfo]) => {
           updateWorkspaceBranch({ workspaceId, branchInfo: branchInfo ?? null });
         });
       }
 
-      // ========================================================================
       // Handle workspace remote-branches updates
-      // ========================================================================
       if (
         data.workspaceRemoteBranchesByWorkspaceId &&
         Object.keys(data.workspaceRemoteBranchesByWorkspaceId).length > 0
@@ -159,18 +149,14 @@ export const useUnifiedStream = (): void => {
         });
       }
 
-      // ========================================================================
       // Handle workspace setup status updates
-      // ========================================================================
       if (data.workspaceSetupStatusByWorkspaceId && Object.keys(data.workspaceSetupStatusByWorkspaceId).length > 0) {
         Object.entries(data.workspaceSetupStatusByWorkspaceId).forEach(([workspaceId, setupStatus]) => {
           updateWorkspaceSetupStatus({ workspaceId, status: setupStatus ?? null });
         });
       }
 
-      // ========================================================================
       // Handle workspace setup live output chunks
-      // ========================================================================
       if (data.workspaceSetupOutputByWorkspaceId && Object.keys(data.workspaceSetupOutputByWorkspaceId).length > 0) {
         Object.entries(data.workspaceSetupOutputByWorkspaceId).forEach(([workspaceId, chunks]) => {
           chunks.forEach((chunk) => {
@@ -179,32 +165,24 @@ export const useUnifiedStream = (): void => {
         });
       }
 
-      // ========================================================================
       // Handle dependencies status updates
-      // ========================================================================
       if (data.dependenciesStatus) {
         setDependenciesStatus(data.dependenciesStatus);
       }
 
-      // ========================================================================
       // Handle PR status updates
-      // ========================================================================
       if (data.prStatusByWorkspaceId && Object.keys(data.prStatusByWorkspaceId).length > 0) {
         Object.entries(data.prStatusByWorkspaceId).forEach(([workspaceId, prStatus]) => {
           updatePrStatus({ workspaceId, prStatus: prStatus ?? null });
         });
       }
 
-      // ========================================================================
       // Handle finished request IDs
-      // ========================================================================
       if (data.finishedRequestIds && data.finishedRequestIds.length > 0) {
         acknowledgeRequests(data.finishedRequestIds);
       }
 
-      // ========================================================================
       // Handle /btw side-chat streaming updates
-      // ========================================================================
       if (data.btwUpdate) {
         handleBtwUpdate({
           requestId: data.btwUpdate.requestId,
@@ -214,9 +192,7 @@ export const useUnifiedStream = (): void => {
         });
       }
 
-      // ========================================================================
       // Handle ui open-file events (sculpt ui open-file)
-      // ========================================================================
       if (data.uiOpenFileByWorkspaceId && Object.keys(data.uiOpenFileByWorkspaceId).length > 0) {
         Object.entries(data.uiOpenFileByWorkspaceId).forEach(([workspaceId, action]) => {
           openFileFromUiEvent({
@@ -227,9 +203,7 @@ export const useUnifiedStream = (): void => {
         });
       }
 
-      // ========================================================================
       // Handle agent webview commands (sculpt ui webview-navigate / webview-refresh)
-      // ========================================================================
       if (data.uiWebviewCommandByWorkspaceId && Object.keys(data.uiWebviewCommandByWorkspaceId).length > 0) {
         Object.entries(data.uiWebviewCommandByWorkspaceId).forEach(([workspaceId, action]) => {
           store.set(agentWebviewStateAtomFamily(workspaceId), (prev) => ({ ...prev, command: action }));

--- a/sculptor/frontend/src/common/state/hooks/useWebsocket.ts
+++ b/sculptor/frontend/src/common/state/hooks/useWebsocket.ts
@@ -139,7 +139,6 @@ export function useWebsocket<T>({
       }
     };
 
-    // Initial connection
     connect();
 
     // Cleanup function

--- a/sculptor/frontend/src/components/AgentLightboxContext.tsx
+++ b/sculptor/frontend/src/components/AgentLightboxContext.tsx
@@ -36,10 +36,9 @@ export const AgentLightboxProvider = ({ taskId, children }: AgentLightboxProvide
   const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
   const [lightboxPath, setLightboxPath] = useState<string | null>(null);
 
-  // Reset media registry and close lightbox when switching agents.
-  // This replaces the previous key={taskID} approach which remounted
-  // the entire subtree, causing scroll container DOM element swaps
-  // and visible scroll flickering.
+  // Reset media registry and close lightbox when switching agents. Resetting in
+  // an effect rather than remounting the subtree (via key={taskId}) avoids scroll
+  // container DOM element swaps and visible scroll flickering.
   useEffect(() => {
     listsRef.current.clear();
     setLightboxPath(null);

--- a/sculptor/frontend/src/components/CommandPalette/atoms.ts
+++ b/sculptor/frontend/src/components/CommandPalette/atoms.ts
@@ -5,8 +5,8 @@ import type { CommandId, PageId } from "./types.ts";
 export const commandPaletteOpenAtom = atom<boolean>(false);
 
 /**
- * Search query. Intentionally not persisted: the old SearchModal persisted
- * its query and reopened with stale text, which caused confusing behavior.
+ * Search query. Intentionally not persisted: persisting it would reopen the
+ * palette with stale text.
  */
 export const commandPaletteSearchAtom = atom<string>("");
 

--- a/sculptor/frontend/src/components/CommandPalette/builtinCommands/panels.ts
+++ b/sculptor/frontend/src/components/CommandPalette/builtinCommands/panels.ts
@@ -17,8 +17,7 @@ import type { Command } from "../types.ts";
 // Actions, Terminal, …) live on `view.panels`. The `view.panels` page
 // title intentionally matches what users search for ("Toggle panel
 // visibility...") so typing it surfaces the page that actually lists
-// panels — earlier the equivalent string used the word "plugin", which
-// turned out to be opaque to coworkers.
+// panels.
 export const buildPanelCommands = (runtime: CommandRuntime): Array<Command> => [
   {
     id: "view.toggle_layout",

--- a/sculptor/frontend/src/components/CommandPalette/commandActions.ts
+++ b/sculptor/frontend/src/components/CommandPalette/commandActions.ts
@@ -10,12 +10,7 @@ import { useEffect, useRef } from "react";
  * the palette converge on a single function instead of going through a
  * synthesized KeyboardEvent.
  *
- * Why this exists: previously the palette synthesized real keydown events
- * to fire the chat/tab/agent handlers. That dance had to defer the
- * dispatch via setTimeout(0) (so the palette's Radix dialog had time to
- * unmount), depended on the binding still being mapped, and was untestable.
- *
- * The map keys are the eight actions the palette exposes — they don't
+ * The map keys are the actions the palette exposes — they don't
  * mirror keybinding ids 1:1 because some palette commands could one day
  * point at actions with no shortcut.
  */

--- a/sculptor/frontend/src/components/CommandPalette/dynamic/agentCommands.ts
+++ b/sculptor/frontend/src/components/CommandPalette/dynamic/agentCommands.ts
@@ -12,9 +12,7 @@ const taskDisplayTitle = (task: { title?: string | null; initialPrompt: string }
 /**
  * Surfaces agents in the palette, scoped to the workspace the user is
  * currently viewing. Cross-workspace switching is intentionally not
- * supported: the user said "we only need to be able to switch between
- * agents in the current workspace" — every other entry-point either
- * cluttered the root list or made the flow slower.
+ * supported.
  *
  * Flow:
  *   "Switch agent…" (root, primary)  →  agents.switch sub-page  →  one

--- a/sculptor/frontend/src/components/CommandPalette/dynamic/panels.ts
+++ b/sculptor/frontend/src/components/CommandPalette/dynamic/panels.ts
@@ -21,12 +21,11 @@ import type { Command, DynamicProvider } from "../types.ts";
  *   - Scoped to the `view.panels` sub-page so the root list isn't
  *     dominated by N "Toggle X" rows. The user opens the page via
  *     "Toggle panel visibility..." (see builtinCommands/panels.ts).
- *   - The palette closes after each toggle. Earlier we used
- *     `keepOpen: true` so users could flip several panels in a row, but
- *     mounting a heavy panel (e.g. the file browser) while the palette
- *     is still on screen made the toggle feel noticeably laggier than
- *     toggling via the topbar button. Closing first lets the panel mount
- *     alone, matching the mouse-toggle latency.
+ *   - The palette closes after each toggle rather than using
+ *     `keepOpen: true`. Mounting a heavy panel (e.g. the file browser)
+ *     while the palette is still on screen makes the toggle feel
+ *     noticeably laggier than toggling via the topbar button. Closing
+ *     first lets the panel mount alone, matching the mouse-toggle latency.
  *
  * Ranking:
  *   - `boost` lifts these rows above same-tier Settings sub-page entries

--- a/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceActions.ts
+++ b/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceActions.ts
@@ -12,9 +12,7 @@ const workspaceName = (description: string | undefined): string => (description 
 
 /**
  * Surfaces the right-click menu actions for the CURRENT workspace in
- * Cmd+K. Cross-workspace action picking is intentionally not supported:
- * the user said "we only want to take workspace actions on the workspace
- * we are on right now."
+ * Cmd+K. Cross-workspace action picking is intentionally not supported.
  *
  * Flow:
  *   "Workspace actions…" (root, primary, only when ctx.activeWorkspaceId)
@@ -98,8 +96,6 @@ export const buildWorkspaceActionsProvider = (
       });
     }
 
-    // ── "Open in..." sub-page ───────────────────────────────────────────
-    //
     // Stays in sync with the workspace metadata bar's repo-path dropdown
     // — both consume `getOpenWithItems()` from openInApp/items.ts.
     const openWithItems = getOpenWithItems();

--- a/sculptor/frontend/src/components/CommandPalette/groups.ts
+++ b/sculptor/frontend/src/components/CommandPalette/groups.ts
@@ -35,7 +35,7 @@ export const groupOrder = (id: CommandGroupId | string): number =>
 
 /**
  * Look up the display heading for a group id. Falls back to the raw id for
- * unknown strings, matching the previous behavior.
+ * unknown strings.
  */
 export const groupHeading = (id: CommandGroupId | string): string =>
   (COMMAND_GROUPS_BY_ID as Record<string, CommandGroup | undefined>)[id]?.heading ?? id;

--- a/sculptor/frontend/src/components/CommandPalette/hooks.ts
+++ b/sculptor/frontend/src/components/CommandPalette/hooks.ts
@@ -334,8 +334,7 @@ export const useRunCommand = (): ((cmd: Command, opts?: { keepOpen?: boolean }) 
       // which watches `commandPalettePendingAtom` and pulls focus back to
       // its own input ref after the perform settles. Keeping the focus
       // logic next to the input ref (rather than querying the DOM here)
-      // also lets us drop the `document.querySelector` lookup that this
-      // hook previously did.
+      // avoids a `document.querySelector` lookup in this hook.
     },
     [ctx, close, pushPage, setPending],
   );

--- a/sculptor/frontend/src/components/CommandPalette/useCommandRuntime.ts
+++ b/sculptor/frontend/src/components/CommandPalette/useCommandRuntime.ts
@@ -84,13 +84,8 @@ export const useCommandRuntime = (): CommandRuntime => {
 
   const { updateField } = useUserConfig();
 
-  // ── Stable runtime methods ─────────────────────────────────────────
-  //
   // Each method below is a useEvent-style stable callback: identity
   // never changes, the body always runs against the latest closure.
-  // This is what previously the latest-values-ref pattern did inline
-  // in CommandRegistrations.tsx, lifted into a proper helper so the
-  // intent is obvious and the wiring file is readable.
   const invokeAction = useEvent((id: CommandActionId): void => {
     const actions = store.get(commandActionsAtom);
     actions[id]?.();

--- a/sculptor/frontend/src/components/CommandPalette/useContextActionRuntimes.ts
+++ b/sculptor/frontend/src/components/CommandPalette/useContextActionRuntimes.ts
@@ -17,15 +17,11 @@ import { useGitAndOpenInRuntime } from "./contextActions/useGitAndOpenInRuntime.
 
 /**
  * Build the `WorkspaceActionRuntime` and `AgentActionRuntime` objects
- * the dynamic providers need. Extracted from `CommandRegistrations.tsx`
- * so the wiring file is the orchestrator, not the implementation.
+ * the dynamic providers need.
  *
  * The close handlers come from `useWorkspaceTabActions`, the same hook
  * `WorkspaceTabs.tsx` consumes — so the right-click context menu and
- * the Cmd+K palette share one implementation of close + navigate. (MR
- * !1021 flagged the previous duplication: the palette closed the
- * tab but skipped the navigation step, leaving the workspace contents
- * displayed and the user's last "Close All" looking like a no-op.)
+ * the Cmd+K palette share one implementation of close + navigate.
  */
 export const useContextActionRuntimes = (): {
   workspaceActionRuntime: WorkspaceActionRuntime;

--- a/sculptor/frontend/src/components/FileUploadUtils.ts
+++ b/sculptor/frontend/src/components/FileUploadUtils.ts
@@ -5,10 +5,9 @@ import { getBackendCapabilities } from "~/common/state/atoms/backendCapabilities
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
 // NOTE: we can support PDF uploads but Claude Code can not read PDFs
 const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif"] as const; // ".pdf"
-const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"] as const; // "application/pdf"
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"] as const;
 
 export const validateFile = (file: File): { valid: boolean; error?: string } => {
-  // Check file size
   if (file.size > MAX_FILE_SIZE) {
     return {
       valid: false,
@@ -16,7 +15,6 @@ export const validateFile = (file: File): { valid: boolean; error?: string } => 
     };
   }
 
-  // Check file extension
   const fileNameLower = file.name.toLowerCase();
   const hasValidExtension = ALLOWED_EXTENSIONS.some((ext) => fileNameLower.endsWith(ext));
   if (!hasValidExtension) {
@@ -26,7 +24,6 @@ export const validateFile = (file: File): { valid: boolean; error?: string } => 
     };
   }
 
-  // Check MIME type
   if (!ALLOWED_MIME_TYPES.includes(file.type as (typeof ALLOWED_MIME_TYPES)[number])) {
     return {
       valid: false,

--- a/sculptor/frontend/src/components/HoverCard.tsx
+++ b/sculptor/frontend/src/components/HoverCard.tsx
@@ -10,8 +10,7 @@ import styles from "./HoverCard.module.scss";
 // REOPEN_GRACE_PERIOD_MS) opens with zero delay — so sliding the mouse from
 // one chip to the next feels seamless. The group also tracks the most recent
 // opener id; when it changes, sibling cards that are still open force-close
-// themselves so only one popover in the group is ever visible. Ported from
-// AlphaPromptNavigator.
+// themselves so only one popover in the group is ever visible.
 const REOPEN_GRACE_PERIOD_MS = 300;
 
 type GroupState = {

--- a/sculptor/frontend/src/components/MentionChip.tsx
+++ b/sculptor/frontend/src/components/MentionChip.tsx
@@ -314,8 +314,7 @@ const EntityMentionChip = ({
           {...wrapperProps}
           className={classnames(
             // Reuse the `@`-chip palette so every chip family (file, folder,
-            // skill, entity) shares one accent scheme. Per-type colours
-            // (amber/teal/violet) were retired — entity type now reads off
+            // skill, entity) shares one accent scheme. Entity type reads off
             // the leading icon and the `data-entity-type` attribute.
             isClickable ? styles.clickableMention : styles.mention,
             entityStyles.entityChip,

--- a/sculptor/frontend/src/components/PulsingCircle.tsx
+++ b/sculptor/frontend/src/components/PulsingCircle.tsx
@@ -40,11 +40,9 @@ export const PulsingCircle = forwardRef<HTMLDivElement, PulsingCircleProps>((pro
 
   return (
     <FlexSvg {...props} ref={ref}>
-      {/* Pulsing outer circle */}
       <circle cx="50%" cy="50%" r="25%" fill={outerColorVal}>
         <animate attributeName="r" values="40%;48%;40%" dur="2.0s" repeatCount="indefinite" />
       </circle>
-      {/* Inner circle */}
       <circle cx="50%" cy="50%" r="25%" fill={innerColorVal} />
     </FlexSvg>
   );

--- a/sculptor/frontend/src/components/Toast.module.scss
+++ b/sculptor/frontend/src/components/Toast.module.scss
@@ -5,7 +5,6 @@
   gap: 10px;
   list-style: none;
   margin: 0;
-  // width: 390px;
   max-width: 100vw;
   outline: none;
   padding: 25px;

--- a/sculptor/frontend/src/components/fuzzyFileScorer.ts
+++ b/sculptor/frontend/src/components/fuzzyFileScorer.ts
@@ -3,8 +3,8 @@
  *
  * Key design choices:
  * - Character pre-filter: quickly rejects paths that cannot possibly match
- *   (all query chars must appear as a subsequence in the path). This
- *   eliminates ~95% of candidates in O(n+m) before any scoring begins.
+ *   (all query chars must appear as a subsequence in the path), in O(n+m)
+ *   before any scoring begins.
  * - Filename bias: tries to match the query against just the final path
  *   segment first and multiplies the score by FILENAME_BONUS_MULTIPLIER.
  *   Matches in the filename are almost always what the user wants.

--- a/sculptor/frontend/src/components/onboarding-wizard/InstallationStep.tsx
+++ b/sculptor/frontend/src/components/onboarding-wizard/InstallationStep.tsx
@@ -332,7 +332,6 @@ export const InstallationStep = ({ onComplete, isLoading, error }: InstallationS
 
       {/* Dependencies Section */}
       <Flex direction="column" gap="3">
-        {/* Claude CLI */}
         <DependencyCard
           name="Claude Code CLI"
           cliName="claude"
@@ -350,7 +349,6 @@ export const InstallationStep = ({ onComplete, isLoading, error }: InstallationS
           installProgress={dependencies?.claude?.installProgress ?? null}
         />
 
-        {/* Git */}
         <DependencyCard
           name="Git"
           cliName="git"

--- a/sculptor/frontend/src/components/panels/atoms.ts
+++ b/sculptor/frontend/src/components/panels/atoms.ts
@@ -8,13 +8,11 @@ import { atomWithDebouncedStorage } from "~/common/state/atoms/atomWithDebounced
 import type { LayoutSide, PanelDefinition, PanelId, ZoneId } from "~/components/panels/types.ts";
 import { LAYOUT_SIDES, SIDE_ZONE_MAP, ZONE_IDS } from "~/components/panels/types.ts";
 
-// ── Panel registry atom ─────────────────────────────────────────────
 // Writable atom holding the current set of registered panels.
 // Starts empty; set via PanelRegistryProvider (React) or
 // createPanelStore (tests / programmatic).
 export const panelRegistryAtom = atom<ReadonlyArray<PanelDefinition>>([]);
 
-// ── Primary atoms with localStorage persistence ──────────────────────
 // Debounced: a single drag-and-drop move updates all four move-related
 // atoms in the same frame. Synchronous localStorage writes would stack up on
 // the drop frame and produce visible lag — debouncing keeps in-memory state
@@ -50,8 +48,6 @@ export const panelEnabledAtom = atomWithStorage<Record<PanelId, boolean>>("sculp
   getOnInit: true,
 });
 
-// ── Focus mode atoms (persisted) ─────────────────────────────────────
-
 export const focusModeActiveAtom = atomWithStorage<boolean>("sculptor-focus-mode-active", false, undefined, {
   getOnInit: true,
 });
@@ -63,8 +59,6 @@ export const focusModeSavedVisibilityAtom = atomWithStorage<Partial<Record<ZoneI
   { getOnInit: true },
 );
 
-// ── Zen mode atoms (persisted) ───────────────────────────────────────
-
 export const zenModeActiveAtom = atomWithStorage<boolean>("sculptor-zen-mode-active", false, undefined, {
   getOnInit: true,
 });
@@ -74,8 +68,6 @@ export const zenModeActiveAtom = atomWithStorage<boolean>("sculptor-zen-mode-act
 export const didZenImplyFocusModeAtom = atomWithStorage<boolean>("sculptor-zen-mode-implied-focus", false, undefined, {
   getOnInit: true,
 });
-
-// ── Non-persisted atoms ──────────────────────────────────────────────
 
 // Tracks the currently active workspace ID for per-workspace panel layout.
 // Set by WorkspacePageContent on mount/navigation; null when not viewing a workspace.
@@ -95,13 +87,10 @@ export const chatPanelMountedAtom = atom<boolean>(false);
 // a terminal to act on at all.
 export const terminalPanelMountedAtom = atom<boolean>(false);
 
-// ── Panel-to-keybinding mapping ─────────────────────────────────────
 // Synthetic keybinding ID for a panel; used as the key into
 // `userConfig.keybindings` for per-panel shortcuts.
 export const panelKeybindingId = (panelId: PanelId): KeybindingId => `panel_${panelId}`;
 
-// ── Enabled-state helpers ───────────────────────────────────────────
-// ── Shortcuts (derived from the keybinding registry) ────────────────
 // Read-only map of panel id → bound shortcut string, sourced from
 // `keybindingsMapAtom` via `panel_<id>` keys. Disabled panels and
 // panels with empty/null bindings are omitted entirely.
@@ -120,7 +109,6 @@ export const panelShortcutsAtom = atom<Record<PanelId, string>>((get) => {
   return result;
 });
 
-// ── Memoized derived atom factories ──────────────────────────────────
 // Each zone ID maps to a stable atom instance to avoid creating new atoms
 // on every render (which causes infinite re-render loops in Jotai).
 
@@ -191,7 +179,6 @@ export const isBottomVisibleAtom = atom<boolean>((get) => {
   return get(isZoneVisibleAtomMap.get("bottom")!);
 });
 
-// ── Side-level visibility (for bottom bar toggle buttons) ───────────
 // Stores the per-zone visibility snapshot taken when a side is hidden,
 // so it can be fully restored when toggled back on.
 export const savedSideVisibilityAtom = atom<Partial<Record<LayoutSide, Partial<Record<ZoneId, boolean>>>>>({});
@@ -243,12 +230,10 @@ export const activePanelInZoneAtom = (zoneId: ZoneId): Atom<PanelDefinition | un
   return activePanelInZoneAtomMap.get(zoneId)!;
 };
 
-// ── Expand mode ──────────────────────────────────────────────────────
 // When non-null, the layout enters "expand mode": only the zone containing
 // this panel and the center diff area are visible; everything else is hidden.
 export const expandedPanelIdAtom = atom<PanelId | null>(null);
 
-// ── Derived zone atom for "files" panel ────────────────────────────
 // Narrows the subscription so consumers that only need the zone for the
 // "files" panel don't re-render when other panels' zone assignments change.
 export const filesZoneAtom = atom<ZoneId | undefined>((get) => {
@@ -256,14 +241,12 @@ export const filesZoneAtom = atom<ZoneId | undefined>((get) => {
   return assignments["files"] as ZoneId | undefined;
 });
 
-// ── File Browser tab state (per workspace) ───────────────────────────
 export type FileBrowserTab = "all" | "changes" | "history";
 
 export const activeFileBrowserTabAtomFamily = atomFamily((workspaceId: string) =>
   atomWithStorage<FileBrowserTab>(`sculptor-fb-tab-${workspaceId}`, "all"),
 );
 
-// ── Store factory ────────────────────────────────────────────────────
 // Unified way to create an initialised panel store.  Usable in tests,
 // Storybook decorators, or the main app bootstrap.
 

--- a/sculptor/frontend/src/components/panels/hooks.ts
+++ b/sculptor/frontend/src/components/panels/hooks.ts
@@ -23,16 +23,12 @@ import type { LayoutSide, PanelDefinition, PanelId, ZoneId } from "~/components/
 import { SIDE_ZONE_MAP, ZONE_IDS } from "~/components/panels/types.ts";
 import { computeToggleAction } from "~/components/panels/utils.ts";
 
-// ── usePanelById ────────────────────────────────────────────────────
-
 /** Look up a single panel definition from the registry by ID. */
 export const usePanelById = (id: PanelId | null): PanelDefinition | undefined => {
   const registry = useAtomValue(panelRegistryAtom);
   if (!id) return undefined;
   return registry.find((p) => p.id === id);
 };
-
-// ── usePanelsByZone ─────────────────────────────────────────────────
 
 /** Per-zone enabled-panel lists. Use this for any guard or layout logic that
  *  must respect `panelEnabledAtom` — disabled panels are filtered out. */
@@ -48,8 +44,6 @@ export const usePanelsByZone = (): Partial<Record<ZoneId, ReadonlyArray<PanelId>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, zonePanelArrays);
 };
-
-// ── usePanelEnabled ─────────────────────────────────────────────────
 
 type UsePanelEnabledResult = {
   enabled: Record<PanelId, boolean>;
@@ -96,8 +90,6 @@ export const usePanelEnabled = (): UsePanelEnabledResult => {
 
   return { enabled, setEnabled };
 };
-
-// ── usePanelActions ─────────────────────────────────────────────────
 
 type UsePanelActionsResult = {
   movePanel: (panelId: PanelId, targetZone: ZoneId, insertIndex?: number) => void;
@@ -275,8 +267,6 @@ export const usePanelActions = (): UsePanelActionsResult => {
   return { movePanel, togglePanel };
 };
 
-// ── useSideToggle ───────────────────────────────────────────────────
-
 type UseSideToggleResult = {
   isVisible: boolean;
   toggle: () => void;
@@ -407,8 +397,6 @@ export const useSideToggle = (side: LayoutSide): UseSideToggleResult => {
   return { isVisible, toggle };
 };
 
-// ── useFocusMode ────────────────────────────────────────────────────
-
 type UseFocusModeResult = {
   isFocusModeActive: boolean;
   toggleFocusMode: () => void;
@@ -500,8 +488,6 @@ export const useFocusMode = (): UseFocusModeResult => {
   return { isFocusModeActive, toggleFocusMode };
 };
 
-// ── useZenMode ──────────────────────────────────────────────────────
-
 type UseZenModeResult = {
   isZenModeActive: boolean;
   toggleZenMode: () => void;
@@ -547,8 +533,6 @@ export const useZenMode = (): UseZenModeResult => {
 
   return { isZenModeActive, toggleZenMode };
 };
-
-// ── usePanelKeyboardShortcuts ───────────────────────────────────────
 
 /**
  * PyCharm/VS Code-style focus-then-toggle dispatch. Disabled panels are

--- a/sculptor/frontend/src/components/panels/types.ts
+++ b/sculptor/frontend/src/components/panels/types.ts
@@ -1,20 +1,17 @@
 import type { LucideIcon } from "lucide-react";
 import type { ComponentType } from "react";
 
-// Zone IDs
 export const ZONE_IDS = ["top-left", "bottom-left", "bottom", "top-right", "bottom-right"] as const;
 export type ZoneId = (typeof ZONE_IDS)[number];
 
 // Panel IDs — dynamic string type since panels are registered at runtime
 export type PanelId = string;
 
-// Context menu item type
 export type ContextMenuItem = {
   label: string;
   action: () => void;
 };
 
-// Panel definition type
 export type PanelDefinition = {
   id: PanelId;
   displayName: string;

--- a/sculptor/frontend/src/components/panels/utils.ts
+++ b/sculptor/frontend/src/components/panels/utils.ts
@@ -2,8 +2,6 @@ import { SIBLING_TOP_ZONE } from "~/components/panels/constants.ts";
 import type { DropTarget } from "~/components/panels/SidebarDropZone";
 import type { PanelId, ZoneId } from "~/components/panels/types.ts";
 
-// ── Toggle logic ─────────────────────────────────────────────────────
-
 export type ToggleAction =
   | { type: "close-zone"; zone: ZoneId }
   | { type: "switch-panel"; zone: ZoneId; panelId: PanelId }
@@ -31,8 +29,6 @@ export const computeToggleAction = (inputs: {
   return { type: "open-zone", zone };
 };
 
-// ── Zone constraint logic ────────────────────────────────────────────
-
 /** Returns true if moving a panel to a bottom zone would leave its sibling top zone empty.
  *  `panelsByZone` must reflect *enabled* panels only — disabled panels don't render
  *  and so don't satisfy the "non-empty top" invariant. */
@@ -46,8 +42,6 @@ export const isZoneMoveDisabled = (inputs: {
   const panels = inputs.panelsByZone[siblingTop] ?? [];
   return !panels.some((pid) => pid !== inputs.panelId);
 };
-
-// ── Sidebar content logic ────────────────────────────────────────────
 
 /** Returns true when a sidebar zone has visible content (icons or an incoming drop target).
  *  During a drag, we still count the dragged icon so the divider stays until the drop completes. */

--- a/sculptor/frontend/src/components/useWorkspaceTabActions.ts
+++ b/sculptor/frontend/src/components/useWorkspaceTabActions.ts
@@ -20,9 +20,7 @@ import { COMPONENT_GALLERY_TAB_ID, HOME_TAB_ID, SETTINGS_TAB_ID } from "./worksp
 /**
  * The three "close-tab" handlers used by the workspace tab bar AND the
  * Cmd+K command palette. Both surfaces must close + navigate identically;
- * keeping the logic in one hook avoids the kind of drift that previously
- * left the palette's Close action removing the tab without closing the
- * workspace contents (per review of MR !1021).
+ * keeping the logic in one hook avoids drift between them.
  *
  * Returns three handlers and the `navigateToNextTab` helper so callers
  * that want to close-then-navigate (e.g. delete flows) can reuse the

--- a/sculptor/frontend/src/electron/devIcon.ts
+++ b/sculptor/frontend/src/electron/devIcon.ts
@@ -21,10 +21,6 @@ import * as PImage from "pureimage";
 
 import { logger } from "./logger";
 
-// ---------------------------------------------------------------------------
-// Font discovery
-// ---------------------------------------------------------------------------
-
 /**
  * Well-known monospace font paths per platform.  Checked first before falling
  * back to `fc-list` on Linux.
@@ -60,10 +56,6 @@ function findFont(): string | null {
 
   return null;
 }
-
-// ---------------------------------------------------------------------------
-// Hue-shift helpers
-// ---------------------------------------------------------------------------
 
 function hashString(s: string): number {
   let h = 0;
@@ -125,10 +117,6 @@ function invertAndHueShift(bitmap: Buffer, hueShift: number): void {
     bitmap[i + 2] = Math.round(nb * 255);
   }
 }
-
-// ---------------------------------------------------------------------------
-// Text overlay
-// ---------------------------------------------------------------------------
 
 /**
  * Render text overlays onto the icon bitmap:
@@ -193,10 +181,6 @@ function renderTextOverlays(
 
   return Buffer.from(img.data);
 }
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 type DevIconOptions = {
   /** Large label rendered at the top of the icon (e.g. "src", "pytest"). */

--- a/sculptor/frontend/src/electron/main.ts
+++ b/sculptor/frontend/src/electron/main.ts
@@ -1021,7 +1021,6 @@ app.whenReady().then(async () => {
   }
 
   traceMark("electron.app_ready");
-  // Create application menu
   createApplicationMenu();
 
   ipcMain.handle(BACKEND_PORT_CHANNEL_NAME, () => PORT);
@@ -1092,7 +1091,6 @@ app.whenReady().then(async () => {
     registerTestIpcHandlers(ipcMain);
   }
 
-  // New file storage handlers
   ipcMain.handle(SAVE_FILE_CHANNEL_NAME, async (_event, fileData: ArrayBuffer, originalFilename: string) => {
     try {
       const userDataPath = app.getPath("userData");
@@ -1134,7 +1132,6 @@ app.whenReady().then(async () => {
         ".mp4": "video/mp4",
         ".webm": "video/webm",
         ".mov": "video/quicktime",
-        // ".pdf": "application/pdf",
       };
       if (!mimeTypes[ext]) {
         throw new Error(`Unsupported file extension: ${ext}`);

--- a/sculptor/frontend/vite.main.config.ts
+++ b/sculptor/frontend/vite.main.config.ts
@@ -4,14 +4,14 @@ import { defineConfig } from "vite";
 export default defineConfig({
   build: {
     // By default, forge will bundle everything in `.vite/build`.
-    outDir: ".vite/build", // explicitly set output directory
+    outDir: ".vite/build",
     lib: {
       entry: "src/electron/main.ts",
       formats: ["cjs"], // Use CommonJS format for Electron main process
       fileName: () => "main.cjs",
     },
     rollupOptions: {
-      external: ["electron"], // don't bundle Electron
+      external: ["electron"],
     },
   },
 });

--- a/sculptor/frontend/vite.preload.config.ts
+++ b/sculptor/frontend/vite.preload.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   build: {
     // By default, forge will bundle everything in `.vite/build`.
-    outDir: ".vite/build", // explicitly set output directory
+    outDir: ".vite/build",
     lib: {
       entry: "src/preload.ts",
       formats: ["cjs"], // Use CommonJS format for Electron preload script


### PR DESCRIPTION
One of 6 independent PRs from a repo-wide `/crispy-comments` pass, each rebased directly on `main` and reviewable/mergeable on its own, in any order. **Comment-only changes — no code behavior changes.**

**This PR:** frontend components, common, electron, and build configs — 36 files.

**Removed:** incidental dev-history, persuasive rationale, correctness arguments, drift-prone restatements, commented-out code, trivial restatements of obvious code, and ASCII/divider banners.
**Kept (this PR only, by request):** standalone comments that explain non-obvious or dense code in plain English for the reader.
**Preserved:** functional directives (`// eslint-disable`, `@ts-expect-error`, `// prettier-ignore`, webpack magic comments, triple-slash references) and JSDoc.

**The full set (each independent, base `main`):**
- #97 — backend integration tests
- #98 — backend unit tests
- #99 — backend source
- #100 — frontend tests + stories
- #101 — frontend pages
- #102 — frontend components + shared  ← this PR

(Sent by Claude)
