### PR TITLE
Expand the review Comments category to cover comment-rot patterns

### DIFF
--- a/.claude/skills/code-review-checklist/SKILL.md
+++ b/.claude/skills/code-review-checklist/SKILL.md
@@ -163,6 +163,15 @@ This category applies when the stated goal is an MR/PR body produced by an auton
 
 ### Comments
 - Comments describe the code and explain *why*; they are not narration.
+- No incidental history or persuasive rationale — strip comments that explain
+  today's bug fix, argue for the code's correctness, or narrate how the code
+  used to work. The comment should help a future maintainer, not relitigate
+  the change that introduced it.
+- No restating volatile facts from the surrounding code (a count of subclasses,
+  a list of variants/enum cases, the call sites of a function). These pin the
+  comment to a moment in time and rot quickly — follow DRY.
+- No ASCII-art banners or box-drawing section dividers. They add visual noise
+  without conveying anything a plain one-line comment does not.
 - No editorializing — strip frustration, jokes, hedging-as-mood, and
   exaggeration, keeping any underlying fact.
 - No pointers to throwaway docs, tickets, or plan phases — `agent_docs/...`

--- a/.claude/skills/code-review-checklist/SKILL.md
+++ b/.claude/skills/code-review-checklist/SKILL.md
@@ -163,7 +163,7 @@ This category applies when the stated goal is an MR/PR body produced by an auton
 
 ### Comments
 - Comments describe the code and explain *why*; they are not narration.
-- No incidental history or persuasive rationale — strip comments that explain
+- No incidental history or defensive justification — strip comments that explain
   today's bug fix, argue for the code's correctness, or narrate how the code
   used to work. The comment should help a future maintainer, not relitigate
   the change that introduced it.


### PR DESCRIPTION
## Summary

Expands the **Comments** category in the `code-review-checklist` skill so it catches several comment problems it previously missed — ones that rot or add noise over time. These mirror the comment-pruning guidance already used elsewhere.

## What changed

Adds three checks to the Comments category in `.claude/skills/code-review-checklist/SKILL.md`:

- **Incidental history / persuasive rationale** — flags comments that explain today's bug fix, argue for the code's correctness, or narrate how the code used to work, rather than helping a future maintainer.
- **Restating volatile facts** — flags comments that duplicate facts from nearby code (subclass counts, variant/enum lists, a function's call sites). These pin the comment to a moment in time and drift out of date (DRY).
- **ASCII-art banners / box-drawing dividers** — flags decorative section dividers that add visual noise without conveying anything a plain one-line comment does not.

The pre-existing checks (narration, editorializing, throwaway-doc pointers, PII) are unchanged. Consistent with the checklist's report-only design, these are flagged in the findings output rather than auto-edited.

## Scope

Documentation-only change to a single skill file. No code paths affected.

(Sent by Claude)
