### PR TITLE
Reuse the existing CI Babysitter task after a backend restart

### DIFF
--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
@@ -574,10 +574,19 @@ class CIBabysitterCoordinator(Service):
     ) -> TaskID | None:
         with self._lock:
             existing_task_id = state.babysitter_task_id
+        if existing_task_id is None:
+            # In-memory state is rebuilt lazily and starts empty after a restart,
+            # so the babysitter task created in a previous run is forgotten.
+            # Re-adopt the persisted task for this workspace before creating a new
+            # one — otherwise every restart leaves a duplicate "CI Babysitter" tab
+            # (SCU-1530).
+            existing_task_id = self._find_existing_babysitter_task_id(state)
         if existing_task_id is not None:
             with self._data_model_service.open_transaction(RequestID()) as transaction:
                 task = self._task_service.get_task(existing_task_id, transaction)
             if task is not None and not task.is_deleted:
+                with self._lock:
+                    state.babysitter_task_id = existing_task_id
                 return existing_task_id
             with self._lock:
                 state.babysitter_task_id = None
@@ -587,6 +596,26 @@ class CIBabysitterCoordinator(Service):
             with self._lock:
                 state.babysitter_task_id = task_id
         return task_id
+
+    def _find_existing_babysitter_task_id(self, state: CIBabysitterState) -> TaskID | None:
+        """The most recent persisted, non-deleted babysitter task for this
+        workspace, or None.
+
+        Lets a restarted coordinator — whose in-memory ``babysitter_task_id`` is
+        gone — re-adopt the existing babysitter task instead of spawning a
+        duplicate.
+        """
+        with self._data_model_service.open_transaction(RequestID()) as transaction:
+            workspace_tasks = self._workspace_agent_tasks(state.workspace_id, state.project_id, transaction)
+        babysitter_tasks = [
+            task
+            for task in workspace_tasks
+            if isinstance(task.current_state, AgentTaskStateV2) and task.current_state.title == _BABYSITTER_TITLE
+        ]
+        if not babysitter_tasks:
+            return None
+        most_recent = max(babysitter_tasks, key=lambda task: task.created_at)
+        return most_recent.object_id
 
     def _create_babysitter_task(
         self,
@@ -642,6 +671,33 @@ class CIBabysitterCoordinator(Service):
             return task.input_data.default_model
         return _model_from_config_or_fallback(config)
 
+    def _workspace_agent_tasks(
+        self,
+        workspace_id: WorkspaceID,
+        project_id: ProjectID,
+        transaction: DataModelTransaction,
+    ) -> list[Task]:
+        """All of the workspace's non-deleted agent tasks (the babysitter's own
+        included). Returns an empty list if the project's tasks can't be listed."""
+        try:
+            # pyrefly: ignore [missing-attribute]
+            project_tasks = transaction.get_tasks_for_project(
+                project_id=project_id,
+                input_data_classes=(AgentTaskInputsV2,),
+            )
+        except Exception as exc:
+            logger.debug("Could not list workspace tasks: {}", exc)
+            return []
+        return [
+            task
+            for task in project_tasks
+            if isinstance(task.current_state, AgentTaskStateV2)
+            and task.current_state.workspace_id == workspace_id
+            and isinstance(task.input_data, AgentTaskInputsV2)
+            and not task.is_deleted
+            and not task.is_deleting
+        ]
+
     def _workspace_agent_tasks_most_recent_first(
         self,
         workspace_id: WorkspaceID,
@@ -650,26 +706,12 @@ class CIBabysitterCoordinator(Service):
     ) -> list[Task]:
         """The workspace's agent tasks, most-recent-first, excluding
         deleted/deleting tasks and the babysitter's own."""
-        try:
-            # pyrefly: ignore [missing-attribute]
-            project_tasks = transaction.get_tasks_for_project(
-                project_id=project_id,
-                input_data_classes=(AgentTaskInputsV2,),
-            )
-        except Exception as exc:
-            logger.debug("Could not list workspace tasks for inheritance: {}", exc)
-            project_tasks = ()
-        workspace_agent_tasks = [
+        non_babysitter_tasks = [
             task
-            for task in project_tasks
-            if isinstance(task.current_state, AgentTaskStateV2)
-            and task.current_state.workspace_id == workspace_id
-            and isinstance(task.input_data, AgentTaskInputsV2)
-            and not task.is_deleted
-            and not task.is_deleting
-            and task.current_state.title != _BABYSITTER_TITLE
+            for task in self._workspace_agent_tasks(workspace_id, project_id, transaction)
+            if not (isinstance(task.current_state, AgentTaskStateV2) and task.current_state.title == _BABYSITTER_TITLE)
         ]
-        return sorted(workspace_agent_tasks, key=lambda t: t.created_at, reverse=True)
+        return sorted(non_babysitter_tasks, key=lambda t: t.created_at, reverse=True)
 
     def _select_model_for_workspace(
         self,

--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
@@ -658,6 +658,34 @@ def test_scenario_5_mid_turn_queueing_reuses_task(
     assert task_service.delete_task_calls == []
 
 
+def test_restart_reuses_persisted_babysitter_task(
+    env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    """After a restart (fresh in-memory state) a CI failure re-adopts the
+    workspace's persisted babysitter task instead of creating a duplicate.
+
+    Regression for SCU-1530: the babysitter task id lived only in the
+    coordinator's in-memory state, so a restart forgot it and spawned a second
+    "CI Babysitter" task. Here the task already exists in the database but the
+    coordinator's _state is empty, exactly as it is right after a restart.
+    """
+    existing_babysitter = _make_agent_task(
+        env, ClaudeCodeSDKAgentConfig(), "2026-01-01T00:00:00", title="CI Babysitter"
+    )
+    env.tasks.append(existing_babysitter)
+    env.tasks_by_id[existing_babysitter.object_id] = existing_babysitter
+
+    coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
+    _seed_baseline(coordinator, env.workspace_id)
+
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
+
+    # No new task is created; the prompt is delivered to the persisted babysitter.
+    assert task_service.create_task_calls == []
+    assert len(task_service.create_message_calls) == 1
+    assert task_service.create_message_calls[0][1] == existing_babysitter.object_id
+
+
 def test_scenario_6_human_push_non_interference(
     env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
 ) -> None:

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -26,10 +26,12 @@ from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.pr_popover import PlaywrightPrPopoverElement
 from sculptor.testing.elements.terminal import get_agent_terminal_panel
 from sculptor.testing.elements.terminal import wait_for_xterm_substring
+from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 from sculptor.testing.playwright_utils import full_spa_reload
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 from sculptor.testing.user_stories import user_story
 
 # A registered terminal program that opts into automated prompts: it signals
@@ -384,3 +386,68 @@ def test_settings_selector_lists_only_driveable_harnesses(sculptor_instance_: Sc
     finally:
         opt_in.unlink(missing_ok=True)
         no_opt_in.unlink(missing_ok=True)
+
+
+@user_story("to keep a single CI Babysitter tab across restarts instead of a duplicate")
+def test_restart_reuses_existing_babysitter_tab(
+    sculptor_instance_factory_: SculptorInstanceFactory, tmp_path: Path
+) -> None:
+    """A CI failure after a backend restart reuses the existing 'CI Babysitter'
+    tab instead of spawning a duplicate.
+
+    Regression for SCU-1530. The coordinator tracked the babysitter task id
+    only in memory, so after a restart it no longer knew a babysitter task
+    already existed for the workspace and created a second one — leaving two
+    'CI Babysitter' tabs. The fix re-adopts the persisted babysitter task, so a
+    post-restart failure delivers its prompt to the existing tab.
+    """
+    state_file = tmp_path / "glab_state"
+    pipeline_id_file = tmp_path / "pipeline_id"
+    state_file.write_text("failed")
+    pipeline_id_file.write_text("100")
+
+    # First launch: a failed pipeline spawns the one-and-only babysitter tab and
+    # delivers the configured prompt to it.
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        _enable_babysitter(instance)
+        _install_state_driven_glab(instance, state_file, pipeline_id_file)
+        _set_remote(instance, _FAKE_GITLAB_REMOTE)
+
+        start_task_and_wait_for_ready(instance.page, "say hello")
+        _bump_pipeline_id_after_baseline(instance.page, pipeline_id_file, "101")
+
+        agent_tabs = PlaywrightAgentTabBarElement(instance.page)
+        babysitter_tab = agent_tabs.get_agent_tab_by_name("CI Babysitter")
+        expect(babysitter_tab).to_have_count(1, timeout=60_000)
+        babysitter_tab.first.click()
+        alpha_chat = get_alpha_chat_view(instance.page)
+        pipeline_prompts = alpha_chat.get_messages().filter(has_text=_PIPELINE_PROMPT_FRAGMENT)
+        expect(pipeline_prompts).to_have_count(1)
+
+    # Restart against the same database, then drive another CI failure. The
+    # coordinator's in-memory babysitter_task_id is gone after the restart, so
+    # it must re-discover the persisted babysitter task rather than create a new
+    # one.
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        layout = PlaywrightProjectLayoutPage(page=instance.page)
+        workspace_tab = layout.get_workspace_tabs().first
+        expect(workspace_tab).to_be_visible()
+        workspace_tab.click()
+
+        agent_tabs = PlaywrightAgentTabBarElement(instance.page)
+        babysitter_tab = agent_tabs.get_agent_tab_by_name("CI Babysitter")
+        expect(babysitter_tab).to_have_count(1)
+        babysitter_tab.first.click()
+        alpha_chat = get_alpha_chat_view(instance.page)
+        pipeline_prompts = alpha_chat.get_messages().filter(has_text=_PIPELINE_PROMPT_FRAGMENT)
+        expect(pipeline_prompts).to_have_count(1)
+
+        # Re-establish the post-restart baseline poll (still at id=101), then
+        # bump so a fresh PIPELINE_FAILED transition fires. With the fix this is
+        # delivered to the existing babysitter tab (its prompt count goes to 2)
+        # and there is still exactly one tab. With the bug a duplicate
+        # 'CI Babysitter' tab is created instead.
+        _bump_pipeline_id_after_baseline(instance.page, pipeline_id_file, "102")
+
+        expect(pipeline_prompts).to_have_count(2, timeout=60_000)
+        expect(agent_tabs.get_agent_tab_by_name("CI Babysitter")).to_have_count(1)


### PR DESCRIPTION
## Original bug

[SCU-1530](https://linear.app/imbue/issue/SCU-1530): **CI Babysitter creates a duplicate agent tab after restart.**

> After a restart, the CI Babysitter often spins up a second "CI Babysitter" agent tab instead of reusing the existing one, leaving duplicates. On restart, always detect an already-existing babysitter agent for the workspace and reuse it rather than creating a new one.

## Hypotheses considered

1. **In-memory `babysitter_task_id` is lost on restart, so the coordinator creates a fresh "CI Babysitter" task on the next CI failure.** — **REPRODUCED** (this PR).
2. **The frontend renders one babysitter task as two tabs (a UI de-dup bug).** — **DISCARDED**: the duplicate is a real second `Task` row, not a render artifact. The e2e shows the post-restart prompt landing on a *different* task than the original (the original tab's prompt count never reaches 2 on buggy code), which only happens if a second task was created server-side.

## For each reproduced bug

### CI Babysitter spawns a duplicate tab after a backend restart

**Repro steps** (driven by the e2e test `test_restart_reuses_existing_babysitter_tab`, which mirrors a real session):
1. Enable the CI Babysitter and point the workspace at a remote whose `glab` reports an **open MR with a failed pipeline** (fake `glab`, pipeline id `100`).
2. Start an agent in the workspace (`say hello`).
3. Let the baseline poll land, then bump the pipeline id `100 → 101` to trigger a `PIPELINE_FAILED` transition. A **"CI Babysitter"** tab appears and receives the configured prompt (one tab, one prompt).
4. **Restart the Sculptor backend** against the same database (exit the instance, spawn a fresh one).
5. Reopen the workspace, let the post-restart baseline poll land, then bump the pipeline id `101 → 102` to trigger another `PIPELINE_FAILED`.

**Expected vs actual**
- Expected: the post-restart failure reuses the existing "CI Babysitter" tab (still exactly one tab; the existing tab receives the second prompt).
- Actual: a **second "CI Babysitter" tab** is created, leaving two duplicate tabs.

**Before**
![Before — two CI Babysitter tabs after restart](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1530-proof/scu-1530-before-buggy-final.jpeg)

_Two "CI Babysitter" tabs (plus "Claude 1") after the restart-then-fail flow. The failing test output: `expect(pipeline_prompts).to_have_count(2)` → actual `1` (the original tab never received the second prompt — it went to the new duplicate). `1 failed in 154.95s`._

**Root cause**
`CIBabysitterCoordinator` stores the per-workspace babysitter `Task` id only in its in-memory `_state` dict, which is rebuilt lazily and starts empty after a backend restart. On a CI failure, `_ensure_babysitter_task` read `state.babysitter_task_id`, found `None`, and went straight to `_create_babysitter_task` — without ever checking the database for the babysitter `Task` that a previous run already persisted. The babysitter `Task` row itself is fully persistent (it survives the restart and shows as a tab), so creating another one produces two "CI Babysitter" tabs for the same workspace.

**Fix**
When the in-memory `babysitter_task_id` is absent, `_ensure_babysitter_task` now first calls `_find_existing_babysitter_task_id`, which queries the workspace's persisted agent tasks and returns the most-recent non-deleted task titled "CI Babysitter". If one exists it is re-adopted into `_state` (and re-validated via `get_task`) instead of creating a new task; only when none exists is a fresh task created. The `get_tasks_for_project` query already used for most-recently-used agent resolution was factored into a shared `_workspace_agent_tasks` helper, so the new lookup and the existing `_workspace_agent_tasks_most_recent_first` share one query (and the single existing pyrefly suppression — the `no-pyrefly-ignore` ratchet count is unchanged).

**Test**
- Path: `sculptor/tests/integration/frontend/test_ci_babysitter.py::test_restart_reuses_existing_babysitter_tab`
- Kind: e2e (Playwright). Uses `sculptor_instance_factory_` to restart the backend against the same database, FakeClaude (the bug is in Sculptor's own task-DB logic, not Claude's responses).
- Also added a fast backend unit test: `sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py::test_restart_reuses_persisted_babysitter_task` (a babysitter task in the DB + empty in-memory state ⇒ reuse, no new task). It fails on the pre-fix code and passes after.
- Failing-test commit: `e3f6eb0870`
- Fix commit: `2e17b0d261`
- Unit-test (self-review) commit: `1eb38dc067`

**After**
![After — one CI Babysitter tab after restart](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1530-proof/scu-1530-after-fixed-final.jpeg)

_Exactly one "CI Babysitter" tab after the same restart-then-fail flow; the post-restart prompt is delivered to the existing tab. `1 passed in 95.42s` on the committed code._

## Deferred follow-ups

- If a workspace already has multiple "CI Babysitter" tasks from a pre-fix run, this change adopts the most-recent and stops creating new duplicates, but does not delete the older duplicate tasks. Cleaning up pre-existing duplicates is out of scope for this fix (low impact — only affects workspaces that already hit the bug and were never cleaned up).

## Review notes

_(no outstanding review notes — the self-review's MEDIUM finding "discovery path covered only by the slow e2e" was acted on by adding the unit test above; the LOW pre-existing-duplicates note is captured under Deferred follow-ups.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
