### PR TITLE
Scope attachments-dir system prompt to media only (SCU-286)

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/harness.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/harness.py
@@ -105,7 +105,7 @@ For videos (MP4, WebM, MOV):
 The media will be rendered inline in the chat UI. Users can click to view full-size or play videos.
 Only absolute local paths (starting with /) are supported. HTTP URLs will not be rendered.
 
-Place downloads in the workspace attachments directory which is referenced below.
+The workspace attachments directory (referenced below) is ONLY for media you intend to display inline in the chat — images and videos such as screenshots or screen recordings. Do NOT put markdown files, documents, reports, notes, code, logs, or any other non-media files there. Write those into the repository or working directory instead.
 </MediaDisplay instructions>
 
 """

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -70,7 +70,7 @@ For videos (MP4, WebM, MOV):
 The media will be rendered inline in the chat UI. Users can click to view full-size or play videos.
 Only absolute local paths (starting with /) are supported. HTTP URLs will not be rendered.
 
-Place downloads in the workspace attachments directory which is referenced below.
+The workspace attachments directory (referenced below) is ONLY for media you intend to display inline in the chat — images and videos such as screenshots or screen recordings. Do NOT put markdown files, documents, reports, notes, code, logs, or any other non-media files there. Write those into the repository or working directory instead.
 </MediaDisplay instructions>
 """
 


### PR DESCRIPTION
## Original bug

> **SCU-286 — Update our system prompt to stop putting markdown files in attachments** (label: Bug)
> https://linear.app/imbue/issue/SCU-286/update-our-system-prompt-to-stop-putting-markdown-files-in-attachments
>
> (Ticket description was empty; no comments.)

The agent saves markdown files (reports, notes, plans) into the workspace
*attachments* directory. That directory is only meant for media the agent
wants to display inline in the chat (screenshots, screen recordings) — see the
`<MediaDisplay instructions>` block of the hidden system prompt.

## Root cause

The `<MediaDisplay instructions>` block of `_HIDDEN_SYSTEM_PROMPT` ended with
"Place downloads in the workspace attachments directory which is referenced
below." The word "downloads" is broad and carries no restriction scoping the
directory to media intended for display. Because the attachments directory is
the only writable scratch location explicitly named in the prompt, the agent
generalizes "downloads" to mean any file it produces — including markdown
reports, notes, and plans — and writes them there. The directory's real
purpose is media rendered inline in the chat via `<img>`/`<video>` tags (and
the location where uploaded user files are stored).

The identical block, with the identical buggy line, exists in **both** agent
harnesses, so both are updated:
- `sculptor/sculptor/agents/default/claude_code_sdk/harness.py` (Claude)
- `sculptor/sculptor/agents/pi_agent/harness.py` (Pi)

## Change

This is a prompt-wording update only. The closing sentence of the
`<MediaDisplay instructions>` block in each harness is rewritten to scope the
attachments directory to displayable media and explicitly exclude non-media
files:

```diff
-Place downloads in the workspace attachments directory which is referenced below.
+The workspace attachments directory (referenced below) is ONLY for media you intend to display inline in the chat — images and videos such as screenshots or screen recordings. Do NOT put markdown files, documents, reports, notes, code, logs, or any other non-media files there. Write those into the repository or working directory instead.
```

The per-environment line from `LocalEnvironment.get_system_prompt()` ("Save any
media you want to display (e.g. screenshots, video recordings) to this
directory") is left as-is — it is already media-scoped and now reinforces the
harness wording.

## Commits

- `2606800799` — Scope attachments-dir system prompt to media only (Claude harness)
- `aa5c776536` — Scope Pi agent attachments-dir system prompt to media only (Pi harness)

## Testing

No automated test accompanies this change, by maintainer direction: it is a
one-line prompt-wording update in each harness, and the user-visible symptom
(the agent writing markdown into the attachments directory) is real-Claude-driven
and nondeterministic — it can't be deterministically asserted in Playwright or
`fake_claude`, and the literal prompt text is self-evident in the diff above.

Backend checks pass on the change: `ruff format --check` (2 files already
formatted), `ruff check` (all checks passed), `pyrefly check` (0 errors),
`just ratchets` OK, `just test-unit-backend` OK. The existing harness tests
(including `test_pi_hidden_system_prompt_declares_media_display_and_attachments`)
still pass. Frontend lint/type/test steps were not run — this worktree has no
frontend deps installed — but the change is backend-only Python.

(Sent by Claude)
