### PR TITLE
Move workspace setup status into the workspace banner

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/AgentTerminalPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/AgentTerminalPanel.tsx
@@ -18,6 +18,9 @@ type AgentTerminalPanelProps = {
  * the backend-owned PTY (the WebSocket reconnects with the replay buffer),
  * not from keeping xterm mounted. useTerminal's 4404 retry covers the
  * agent-still-BUILDING window before the backend handler registers the PTY.
+ *
+ * Workspace setup status is surfaced in the WorkspaceBanner (a workspace-level
+ * concern shared by all agents), not here.
  */
 export const AgentTerminalPanel = ({ taskId }: AgentTerminalPanelProps): ReactElement => {
   useTerminalChatActions(taskId);

--- a/sculptor/frontend/src/pages/workspace/components/WorkspaceBanner.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspaceBanner.tsx
@@ -23,6 +23,7 @@ import { PrButton } from "./PrButton";
 import { RepoSegment } from "./RepoSegment";
 import { TargetBranchSelector } from "./TargetBranchSelector";
 import styles from "./WorkspaceBanner.module.scss";
+import { WorkspaceSetupStatus } from "./WorkspaceSetupStatus";
 
 export const WorkspaceBanner = (): ReactElement | null => {
   const isZenModeActive = useAtomValue(zenModeActiveAtom);
@@ -220,6 +221,14 @@ export const WorkspaceBanner = (): ReactElement | null => {
 
       <div className={styles.spacer} data-spacer />
 
+      {/* Workspace setup status (renders only once a run exists) */}
+      {!hiddenPriorities.has(3) && (
+        <div data-collapse-priority="3">
+          <WorkspaceSetupStatus workspaceId={workspaceID} />
+        </div>
+      )}
+
+      {/* Diff summary */}
       {!hiddenPriorities.has(1) && (
         <div data-collapse-priority="1">
           <DiffSummary workspaceId={workspaceID} />

--- a/sculptor/frontend/src/pages/workspace/components/WorkspaceSetupStatus.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspaceSetupStatus.module.scss
@@ -1,0 +1,66 @@
+// Compact setup-status segment for the WorkspaceBanner. Adopts the banner's
+// branch-segment idiom (small inline-flex chip, gray-a3 hover) so it reads as
+// one more banner item alongside the branch and diff summary.
+
+.pill {
+  align-items: center;
+  border-radius: var(--radius-1);
+  color: var(--gray-11);
+  cursor: pointer;
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: var(--space-1);
+  padding: 2px 6px;
+  transition: background var(--duration-fast) ease;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--gray-a3);
+    outline: none;
+  }
+}
+
+.pillOpen,
+.pillOpen:hover {
+  background: var(--accent-a3);
+}
+
+.pillInert {
+  cursor: default;
+
+  &:hover,
+  &:focus-visible {
+    background: transparent;
+  }
+}
+
+.pillError {
+  color: var(--red-11);
+}
+
+.icon {
+  color: var(--gray-11);
+  flex-shrink: 0;
+}
+
+.pillError .icon {
+  color: var(--red-11);
+}
+
+.label {
+  color: inherit;
+  font-size: var(--font-size-1);
+  white-space: nowrap;
+}
+
+.truncationBanner {
+  background: var(--amber-a3);
+  color: var(--amber-11);
+  font-size: var(--font-size-1);
+  padding: var(--space-1) var(--space-3);
+}
+
+.popoverEmpty {
+  color: var(--gray-9);
+  font-style: italic;
+}

--- a/sculptor/frontend/src/pages/workspace/components/WorkspaceSetupStatus.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspaceSetupStatus.tsx
@@ -1,0 +1,294 @@
+import { Anchor as PopoverAnchor } from "@radix-ui/react-popover";
+import { IconButton, Popover, Tooltip } from "@radix-ui/themes";
+import { useAtomValue } from "jotai";
+import { Pencil, RotateCcw, Square, TerminalIcon } from "lucide-react";
+import type { CSSProperties, KeyboardEvent, ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ElementIds } from "~/api";
+import { workspaceSetupOutputAtomFamily } from "~/common/state/atoms/workspaceSetupOutput";
+import { workspaceSetupStatusAtomFamily } from "~/common/state/atoms/workspaceSetupStatus";
+
+import bashStyles from "./chat-alpha/bashBlockStyles.module.scss";
+import type { BashBlockState } from "./chat-alpha/BashStatusBadge";
+import { BashStatusBadge } from "./chat-alpha/BashStatusBadge";
+import { formatDuration } from "./chat-alpha/durationUtils";
+import { useSetupCommandActions } from "./useSetupCommandActions";
+import styles from "./WorkspaceSetupStatus.module.scss";
+
+type WorkspaceSetupStatusProps = {
+  workspaceId: string;
+};
+
+const SETUP_LABEL = "Setup";
+const POPOVER_STYLE: CSSProperties = {
+  maxHeight: 380,
+  overflow: "hidden",
+  padding: 0,
+};
+
+function useElapsedSinceStart(startedAt: number | null, isRunning: boolean): string {
+  const [now, setNow] = useState<number>(() => Date.now() / 1000);
+  useEffect(() => {
+    if (!isRunning) return;
+    const id = setInterval(() => {
+      setNow(Date.now() / 1000);
+    }, 100);
+    return (): void => clearInterval(id);
+  }, [isRunning]);
+  if (startedAt === null) return "0.0s";
+  return formatDuration(Math.max(0, now - startedAt));
+}
+
+function durationBetween(startedAt: number | null, finishedAt: number | null): string {
+  if (startedAt === null || finishedAt === null) return "";
+  return formatDuration(Math.max(0, finishedAt - startedAt));
+}
+
+/**
+ * The workspace setup command's run status, as a compact segment in the
+ * WorkspaceBanner. Setup is a workspace concern shared by every agent in the
+ * workspace (one run per workspace, gated on workspace state — not agent
+ * type), so it lives in workspace-level chrome rather than the per-agent chat
+ * intro or terminal panel.
+ *
+ * Renders only once a run exists (pending/running/succeeded/failed/legacy);
+ * the `null`/`not_configured` onboarding CTA lives in the chat intro
+ * (`SetupStatusCard`). The pill carries the badge and the inline
+ * cancel/rerun/edit actions; clicking it opens a popover with the command and
+ * captured log.
+ */
+export const WorkspaceSetupStatus = ({ workspaceId }: WorkspaceSetupStatusProps): ReactElement | null => {
+  const status = useAtomValue(workspaceSetupStatusAtomFamily(workspaceId));
+  const output = useAtomValue(workspaceSetupOutputAtomFamily(workspaceId));
+  const { workspace, currentCommand, handleCancel, handleRerun, handleEdit } = useSetupCommandActions(workspaceId);
+
+  const popoverOutputRef = useRef<HTMLDivElement | null>(null);
+  const pillRef = useRef<HTMLSpanElement | null>(null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+  const togglePopover = useCallback(() => setIsPopoverOpen((prev) => !prev), []);
+  const handlePillKeyDown = useCallback((e: KeyboardEvent<HTMLSpanElement>): void => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setIsPopoverOpen((prev) => !prev);
+    }
+  }, []);
+
+  const isRunning = status?.status === "running";
+  const startedAt = typeof status?.startedAt === "number" ? status.startedAt : null;
+  const finishedAt = typeof status?.finishedAt === "number" ? status.finishedAt : null;
+  const isLogTruncated = status?.logTruncated === true;
+  const liveElapsed = useElapsedSinceStart(startedAt, isRunning);
+
+  // While the popover is open during a run, autoscroll new chunks into view.
+  useEffect(() => {
+    if (popoverOutputRef.current && isPopoverOpen && isRunning) {
+      popoverOutputRef.current.scrollTop = popoverOutputRef.current.scrollHeight;
+    }
+  }, [output?.text, isPopoverOpen, isRunning]);
+
+  // The onboarding/config affordance for the pre-run states lives in the chat
+  // intro, so the banner stays quiet until a run actually exists.
+  if (status === null || status.status === "not_configured") {
+    return null;
+  }
+
+  const editButton = (
+    <Tooltip content="Edit command">
+      <IconButton
+        variant="ghost"
+        size="1"
+        data-testid={ElementIds.SETUP_EDIT_BUTTON}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleEdit();
+        }}
+        aria-label="Edit setup command"
+      >
+        <Pencil size={12} />
+      </IconButton>
+    </Tooltip>
+  );
+
+  if (status.status === "pending") {
+    // Queued: inert (no popover) until the run starts. `aria-disabled` keeps
+    // the framework's actionability contract honest during the transient gap
+    // before the pill turns interactive (mirrors SetupStatusCard / SCU-1215).
+    return (
+      <span className={`${styles.pill} ${styles.pillInert}`} data-testid="setup-status-card" aria-disabled>
+        <TerminalIcon size={13} className={styles.icon} aria-hidden="true" />
+        <span className={styles.label}>{SETUP_LABEL}</span>
+        <span className={`${bashStyles.badge} ${bashStyles.badgeRunning}`} data-testid="setup-status-badge">
+          queued
+        </span>
+        {editButton}
+      </span>
+    );
+  }
+
+  // "Migrated" rows are terminal-state runs backfilled from the legacy
+  // PTY-based setup path: no recorded run_id and no captured command. Showing
+  // the project's current command would misleadingly imply we know what ran.
+  const isMigrated =
+    (status.status === "succeeded" || status.status === "failed" || status.status === "legacy") &&
+    (status.runId === null || status.runId === undefined);
+
+  // Prefer the command that actually ran for this workspace over the project's
+  // current setting (they can differ); fall back to a placeholder.
+  const persistedCommand =
+    typeof workspace?.setupCommand === "string" && workspace.setupCommand.length > 0 ? workspace.setupCommand : null;
+  const commandRan = persistedCommand ?? (isMigrated ? null : currentCommand);
+  const commandForPopover = commandRan ?? (isMigrated ? "(command not recorded)" : "workspace setup");
+
+  let badgeState: BashBlockState;
+  let badgeDuration: string;
+  if (status.status === "running") {
+    badgeState = "executing";
+    badgeDuration = liveElapsed;
+  } else if (status.status === "succeeded") {
+    badgeState = "completed";
+    badgeDuration = durationBetween(startedAt, finishedAt);
+  } else if (status.status === "failed") {
+    badgeState = "error";
+    badgeDuration = durationBetween(startedAt, finishedAt);
+  } else {
+    badgeState = "completed";
+    badgeDuration = "previous";
+  }
+
+  const shouldShowLog = status.status !== "legacy";
+  const rawLogText = output?.text ?? "";
+  // Prefix the body with "Exit code N" on failure, matching how Sculptor's
+  // bash tool calls render their popover. Stderr is already merged into the
+  // captured stream by the runner, so it appears inline like in a terminal.
+  const exitCodePrefix =
+    status.status === "failed" && typeof status.exitCode === "number" ? `Exit code ${status.exitCode}\n` : "";
+  const logText = `${exitCodePrefix}${rawLogText}`;
+  const hasLogText = logText.length > 0;
+  const canOpenPopover = shouldShowLog;
+  const hasCommandChanged = persistedCommand !== null && currentCommand !== null && persistedCommand !== currentCommand;
+  // Rerun is gated on the project having a command — the backend reads it from
+  // `project.workspace_setup_command` and 422s when blank, so an unguarded
+  // button would silently no-op when the user has cleared the setting.
+  const isRerunVisible =
+    (status.status === "succeeded" || status.status === "failed" || status.status === "legacy") &&
+    currentCommand !== null;
+  const isError = status.status === "failed";
+
+  const actions = (
+    <>
+      <BashStatusBadge state={badgeState} isBackground={false} duration={badgeDuration} testId="setup-status-badge" />
+      {isRunning && (
+        <Tooltip content="Cancel setup">
+          <IconButton
+            variant="ghost"
+            size="1"
+            data-testid="setup-cancel-button"
+            onClick={(e) => {
+              e.stopPropagation();
+              void handleCancel();
+            }}
+            aria-label="Cancel setup"
+          >
+            <Square size={12} />
+          </IconButton>
+        </Tooltip>
+      )}
+      {isRerunVisible && (
+        <Tooltip content={hasCommandChanged ? "Rerun setup (command has changed)" : "Rerun setup"}>
+          <IconButton
+            variant={hasCommandChanged ? "soft" : "ghost"}
+            color={hasCommandChanged ? "amber" : undefined}
+            size="1"
+            data-testid="setup-rerun-button"
+            data-command-changed={hasCommandChanged ? "true" : "false"}
+            onClick={(e) => {
+              e.stopPropagation();
+              void handleRerun();
+            }}
+            aria-label={hasCommandChanged ? "Rerun setup (command has changed)" : "Rerun setup"}
+          >
+            <RotateCcw size={12} />
+          </IconButton>
+        </Tooltip>
+      )}
+      {editButton}
+    </>
+  );
+
+  const pillClassName = [styles.pill, isError ? styles.pillError : null, isPopoverOpen ? styles.pillOpen : null]
+    .filter(Boolean)
+    .join(" ");
+
+  // Legacy rows have no captured log, so the pill is non-interactive (no
+  // popover) — just the badge and any rerun/edit affordances.
+  if (!canOpenPopover) {
+    return (
+      <span className={`${pillClassName} ${styles.pillInert}`} data-testid="setup-status-card">
+        <TerminalIcon size={13} className={styles.icon} aria-hidden="true" />
+        <span className={styles.label}>{SETUP_LABEL}</span>
+        {actions}
+      </span>
+    );
+  }
+
+  // Anchor + own onClick rather than Popover.Trigger: Trigger composes its
+  // toggle via Radix Slot, which is unreliable with the action IconButtons
+  // nested in the pill. The anchor pattern (as in AlphaToolPillRow /
+  // SetupStatusCard) lets the pill own its click cleanly.
+  return (
+    <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+      <PopoverAnchor asChild>
+        <span
+          ref={pillRef}
+          className={pillClassName}
+          data-testid="setup-status-card"
+          role="button"
+          aria-haspopup="dialog"
+          aria-expanded={isPopoverOpen}
+          tabIndex={0}
+          onClick={togglePopover}
+          onKeyDown={handlePillKeyDown}
+        >
+          <TerminalIcon size={13} className={styles.icon} aria-hidden="true" />
+          <span className={styles.label}>{SETUP_LABEL}</span>
+          {actions}
+        </span>
+      </PopoverAnchor>
+      <Popover.Content
+        side="bottom"
+        sideOffset={4}
+        align="end"
+        collisionPadding={16}
+        className={bashStyles.popoverContent}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => {
+          // Clicks inside the pill shouldn't auto-close — let the pill's own
+          // onClick toggle it (or the action IconButtons handle themselves).
+          if (pillRef.current?.contains(e.target as Node)) e.preventDefault();
+        }}
+        style={POPOVER_STYLE}
+      >
+        <div className={bashStyles.popover}>
+          <div className={bashStyles.popoverSection}>
+            <span className={bashStyles.popoverCommand}>
+              <span className={bashStyles.prompt}>$</span> {commandForPopover}
+              <div className={bashStyles.popoverSummary}>workspace setup command</div>
+            </span>
+          </div>
+          {isLogTruncated && (
+            <div className={styles.truncationBanner} data-testid="setup-status-truncation">
+              Output was truncated. Showing first and last portions.
+            </div>
+          )}
+          <div className={bashStyles.popoverSection}>
+            <div ref={popoverOutputRef} className={bashStyles.popoverBody} data-testid="setup-status-output">
+              {hasLogText ? logText : <span className={styles.popoverEmpty}>(no output)</span>}
+              {isRunning && <span className={bashStyles.streamCursor} />}
+            </div>
+          </div>
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  );
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/SetupStatusCard.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/SetupStatusCard.module.scss
@@ -44,17 +44,6 @@
   outline: none;
 }
 
-.rowOpen,
-.rowOpen:hover,
-.rowOpen:focus-visible {
-  background: var(--accent-a3);
-  color: var(--accent-11);
-}
-
-.rowError {
-  color: var(--red-11);
-}
-
 .rowNoToggle {
   cursor: default;
 }
@@ -77,14 +66,6 @@
   align-self: center;
   color: var(--gray-8);
   flex-shrink: 0;
-}
-
-.rowOpen .rowIcon {
-  color: var(--accent-11);
-}
-
-.rowError .rowIcon {
-  color: var(--red-11);
 }
 
 .rowLabel {
@@ -114,24 +95,11 @@
   white-space: nowrap;
 }
 
-.rowOpen .rowTitle {
-  color: var(--accent-11);
-}
-
-.rowError .rowTitle {
-  color: var(--red-11);
-}
-
 // `$` shell prompt leading the command. Lighter than the command itself
 // so it reads as a typographic cue rather than a glyph.
 .rowPrompt {
   color: var(--gray-8);
   user-select: none;
-}
-
-.rowPlaceholder {
-  color: var(--gray-9);
-  font-style: italic;
 }
 
 // Aside column: status badge / duration / action icon buttons. The
@@ -145,16 +113,4 @@
   display: inline-flex;
   flex-shrink: 0;
   gap: var(--space-2);
-}
-
-.popoverEmpty {
-  color: var(--gray-9);
-  font-style: italic;
-}
-
-.truncationBanner {
-  background: var(--amber-a3);
-  color: var(--amber-11);
-  font-size: var(--font-size-1);
-  padding: var(--space-1) var(--space-3);
 }

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/SetupStatusCard.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/SetupStatusCard.tsx
@@ -1,24 +1,14 @@
-import { Anchor as PopoverAnchor } from "@radix-ui/react-popover";
-import { IconButton, Popover, Tooltip } from "@radix-ui/themes";
+import { IconButton, Tooltip } from "@radix-ui/themes";
 import { useAtomValue } from "jotai";
-import { Pencil, Play, RotateCcw, Square, TerminalIcon } from "lucide-react";
-import type { CSSProperties, HTMLAttributes, KeyboardEvent, ReactElement, ReactNode } from "react";
-import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { Pencil, Play, TerminalIcon } from "lucide-react";
+import type { HTMLAttributes, ReactElement, ReactNode } from "react";
+import { forwardRef } from "react";
 
 import { ElementIds } from "~/api";
-import { resolveWorkspaceSetupCommand } from "~/common/setupDefaults";
-import { workspaceSetupOutputAtomFamily } from "~/common/state/atoms/workspaceSetupOutput";
 import { workspaceSetupStatusAtomFamily } from "~/common/state/atoms/workspaceSetupStatus";
-import { useOpenSettings } from "~/common/state/hooks/useOpenSettings";
-import { useProject } from "~/common/state/hooks/useProjects";
-import { useWorkspace } from "~/common/state/hooks/useWorkspace";
 
 import { SetupConfigPrompt } from "../SetupConfigPrompt";
-import bashStyles from "./bashBlockStyles.module.scss";
-import type { BashBlockState } from "./BashStatusBadge";
-import { BashStatusBadge } from "./BashStatusBadge";
-import { formatDuration } from "./durationUtils";
-import { useCloseOnChatScroll } from "./hooks/useChatScroll";
+import { useSetupCommandActions } from "../useSetupCommandActions";
 import styles from "./SetupStatusCard.module.scss";
 
 type SetupStatusCardProps = {
@@ -26,28 +16,6 @@ type SetupStatusCardProps = {
 };
 
 const SETUP_LABEL = "Setup";
-// Cadence for ticking the live elapsed-time readout while setup is running.
-const LIVE_TIMER_TICK_MS = 100;
-const POPOVER_STYLE: CSSProperties = {
-  maxHeight: 380,
-  overflow: "hidden",
-  padding: 0,
-};
-
-const postNoBody = async (path: string): Promise<Response> => fetch(path, { method: "POST" });
-
-function useElapsedSinceStart(startedAt: number | null, isRunning: boolean): string {
-  const [now, setNow] = useState<number>(() => Date.now() / 1000);
-  useEffect(() => {
-    if (!isRunning) return;
-    const id = setInterval(() => {
-      setNow(Date.now() / 1000);
-    }, LIVE_TIMER_TICK_MS);
-    return (): void => clearInterval(id);
-  }, [isRunning]);
-  if (startedAt === null) return "0.0s";
-  return formatDuration(Math.max(0, now - startedAt));
-}
 
 // Render a multiline command on a single line by joining nonblank lines with
 // `&&`. Matches the bash-tool-call convention of showing one command-shaped
@@ -65,9 +33,6 @@ function joinCommandForHeader(command: string): string {
 type SetupRowProps = {
   title: ReactNode;
   aside: ReactNode;
-  isOpen?: boolean;
-  isError?: boolean;
-  interactive?: boolean;
   testId?: string;
 } & Omit<HTMLAttributes<HTMLDivElement>, "title">;
 
@@ -75,42 +40,24 @@ type SetupRowProps = {
 // `[icon] Label · [title] [aside]` layout but pulls icon size and
 // typography from the chat-intro detail rows so this reads as the 5th
 // header row in the AlphaChatIntro stack.
-//
-// forwardRef + props passthrough lets the surrounding code attach a ref
-// (used as the popover anchor) and event handlers (click / keydown to
-// toggle the popover) without SetupRow having to know about either.
-const SetupRow = forwardRef<HTMLDivElement, SetupRowProps>(
-  ({ title, aside, isOpen = false, isError = false, interactive = false, testId, className, ...rest }, ref) => {
-    const classNames = [styles.row];
-    if (isOpen) classNames.push(styles.rowOpen);
-    if (isError) classNames.push(styles.rowError);
-    if (!interactive) classNames.push(styles.rowNoToggle);
-    if (className) classNames.push(className);
+const SetupRow = forwardRef<HTMLDivElement, SetupRowProps>(({ title, aside, testId, className, ...rest }, ref) => {
+  const classNames = [styles.row, styles.rowNoToggle];
+  if (className) classNames.push(className);
 
-    return (
-      <div
-        ref={ref}
-        className={classNames.join(" ")}
-        role={interactive ? "button" : undefined}
-        aria-haspopup={interactive ? "dialog" : undefined}
-        aria-expanded={interactive ? isOpen : undefined}
-        tabIndex={interactive ? 0 : undefined}
-        data-testid={testId}
-        {...rest}
-      >
-        <span className={styles.rowLeading}>
-          <TerminalIcon size={14} className={styles.rowIcon} aria-hidden="true" />
-          <span className={styles.rowLabel}>{SETUP_LABEL}</span>
-          <span className={styles.rowSeparator} aria-hidden="true">
-            ·
-          </span>
+  return (
+    <div ref={ref} className={classNames.join(" ")} data-testid={testId} {...rest}>
+      <span className={styles.rowLeading}>
+        <TerminalIcon size={14} className={styles.rowIcon} aria-hidden="true" />
+        <span className={styles.rowLabel}>{SETUP_LABEL}</span>
+        <span className={styles.rowSeparator} aria-hidden="true">
+          ·
         </span>
-        <span className={styles.rowTitle}>{title}</span>
-        <span className={styles.rowAside}>{aside}</span>
-      </div>
-    );
-  },
-);
+      </span>
+      <span className={styles.rowTitle}>{title}</span>
+      <span className={styles.rowAside}>{aside}</span>
+    </div>
+  );
+});
 SetupRow.displayName = "SetupRow";
 
 const CommandTitle = ({ command }: { command: string }): ReactElement => (
@@ -122,61 +69,19 @@ const CommandTitle = ({ command }: { command: string }): ReactElement => (
   </>
 );
 
+/**
+ * The pre-run setup affordance shown in the chat intro: a "configure a setup
+ * command" CTA when none is set, or a one-click "Run setup" row when a command
+ * exists but this workspace was created before it was configured.
+ *
+ * Once a run actually exists (pending/running/succeeded/failed/legacy) its
+ * status is surfaced in the workspace banner (`WorkspaceSetupStatus`), not
+ * here — setup is a workspace concern, not a per-agent one — so this returns
+ * null for those states.
+ */
 export const SetupStatusCard = ({ workspaceId }: SetupStatusCardProps): ReactElement | null => {
   const status = useAtomValue(workspaceSetupStatusAtomFamily(workspaceId));
-  const output = useAtomValue(workspaceSetupOutputAtomFamily(workspaceId));
-  const workspace = useWorkspace(workspaceId);
-  const project = useProject(workspace?.projectId ?? "");
-  const openSettings = useOpenSettings();
-  const popoverOutputRef = useRef<HTMLDivElement | null>(null);
-  const rowRef = useRef<HTMLDivElement | null>(null);
-  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
-  // Dismiss on chat scroll for consistency with the other chat popovers.
-  const closeOnScroll = useCallback((): void => setIsPopoverOpen(false), []);
-  useCloseOnChatScroll(closeOnScroll, isPopoverOpen);
-  const togglePopover = useCallback(() => setIsPopoverOpen((prev) => !prev), []);
-  const handleRowKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>): void => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      setIsPopoverOpen((prev) => !prev);
-    }
-  }, []);
-  const isRunning = status?.status === "running";
-  const startedAt = typeof status?.startedAt === "number" ? status.startedAt : null;
-  const finishedAt = typeof status?.finishedAt === "number" ? status.finishedAt : null;
-  const isLogTruncated = status?.logTruncated === true;
-  const liveElapsed = useElapsedSinceStart(startedAt, isRunning);
-
-  // While the popover is open during a run, autoscroll new chunks into view.
-  useEffect(() => {
-    if (popoverOutputRef.current && isPopoverOpen && isRunning) {
-      popoverOutputRef.current.scrollTop = popoverOutputRef.current.scrollHeight;
-    }
-  }, [output?.text, isPopoverOpen, isRunning]);
-
-  const handleCancel = useCallback(async () => {
-    try {
-      await postNoBody(`/api/v1/workspaces/${workspaceId}/setup/cancel`);
-    } catch (err) {
-      console.error("Failed to cancel setup:", err);
-    }
-  }, [workspaceId]);
-
-  const handleRerun = useCallback(async () => {
-    try {
-      await postNoBody(`/api/v1/workspaces/${workspaceId}/setup/rerun`);
-    } catch (err) {
-      console.error("Failed to rerun setup:", err);
-    }
-  }, [workspaceId]);
-
-  const handleEdit = useCallback((): void => {
-    if (project?.objectId) {
-      openSettings("repositories", project.objectId);
-    } else {
-      openSettings("repositories");
-    }
-  }, [project?.objectId, openSettings]);
+  const { currentCommand, handleRerun, handleEdit } = useSetupCommandActions(workspaceId);
 
   const editButton = (
     <Tooltip content="Edit command">
@@ -195,268 +100,52 @@ export const SetupStatusCard = ({ workspaceId }: SetupStatusCardProps): ReactEle
     </Tooltip>
   );
 
-  // Mirror the backend's tri-state resolution: a null stored value runs the
-  // current default ("git fetch origin ..."), an empty string means the user
-  // cleared it (run nothing), any other string is custom.
-  const currentCommand = resolveWorkspaceSetupCommand(project?.workspaceSetupCommand);
-
   if (status === null) {
     return <SetupConfigPrompt />;
+  }
+
+  // A run exists (pending/running/succeeded/failed/legacy): the banner owns it.
+  if (status.status !== "not_configured") {
+    return null;
   }
 
   // The workspace was created before a setup command was configured. If the
   // project now has one, offer a one-click Run; otherwise fall back to the
   // configure-CTA.
-  if (status.status === "not_configured") {
-    if (currentCommand === null) {
-      return <SetupConfigPrompt />;
-    }
-    const runHeader = joinCommandForHeader(currentCommand);
-    return (
-      <SetupRow
-        testId="setup-status-card"
-        title={
-          <Tooltip content={currentCommand} side="bottom">
-            <span>
-              <CommandTitle command={runHeader} />
-            </span>
-          </Tooltip>
-        }
-        aside={
-          <>
-            <Tooltip content="Run setup">
-              <IconButton
-                variant="soft"
-                size="1"
-                data-testid="setup-run-button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void handleRerun();
-                }}
-                aria-label="Run setup"
-              >
-                <Play size={12} />
-              </IconButton>
-            </Tooltip>
-            {editButton}
-          </>
-        }
-      />
-    );
+  if (currentCommand === null) {
+    return <SetupConfigPrompt />;
   }
 
-  // "Migrated" workspaces are terminal-state rows backfilled from the legacy
-  // PTY-based setup path. They have no recorded run_id and no captured
-  // command — falling through to the project's current command would
-  // misleadingly imply we know what actually ran. Show a placeholder
-  // instead, matching the synthetic-output placeholder in the popover.
-  const isMigrated =
-    (status.status === "succeeded" || status.status === "failed" || status.status === "legacy") &&
-    (status.runId === null || status.runId === undefined);
-
-  // Command resolution priority:
-  // 1) the persisted command that ran for this workspace (workspace.setupCommand) —
-  //    shows "what was run", which may differ from the project's current setting
-  // 2) project.workspaceSetupCommand (current value) — only used pre-run, while
-  //    we have not yet persisted what we ran (e.g. status="pending")
-  // 3) literal "workspace setup" placeholder (or "(command not recorded)" for
-  //    migrated rows where we genuinely don't know what ran)
-  const persistedCommand =
-    typeof workspace?.setupCommand === "string" && workspace.setupCommand.length > 0 ? workspace.setupCommand : null;
-  const commandRan = persistedCommand ?? (isMigrated ? null : currentCommand);
-  const commandHeader = commandRan
-    ? joinCommandForHeader(commandRan)
-    : isMigrated
-      ? "(command not recorded)"
-      : "workspace setup";
-  const titleNode = commandRan ? (
-    <Tooltip content={commandRan} side="bottom">
-      <span>
-        <CommandTitle command={commandHeader} />
-      </span>
-    </Tooltip>
-  ) : (
-    <span className={styles.rowPlaceholder}>{commandHeader}</span>
-  );
-
-  if (status.status === "pending") {
-    // The queued card carries the same `setup-status-card` testid as the
-    // interactive (popover-opening) card it becomes once the run starts, but
-    // while pending it renders inert — no row click handler. `aria-disabled`
-    // makes that transient gap honest: the framework's actionability contract
-    // holds a click until the card turns interactive, instead of dispatching it
-    // onto the inert row where it is silently dropped (SCU-1215). The early
-    // `not_configured`/`legacy` rows are deliberately left alone — they render
-    // as plain, non-interactive divs (no role, default cursor) and do not
-    // misrepresent themselves, and gating them would also disable the Run/Edit
-    // buttons nested inside the same row.
-    return (
-      <SetupRow
-        testId="setup-status-card"
-        aria-disabled
-        title={titleNode}
-        aside={
-          <>
-            <span className={`${bashStyles.badge} ${bashStyles.badgeRunning}`} data-testid="setup-status-badge">
-              queued
-            </span>
-            {editButton}
-          </>
-        }
-      />
-    );
-  }
-
-  let badgeState: BashBlockState;
-  let badgeDuration: string;
-  if (status.status === "running") {
-    badgeState = "executing";
-    badgeDuration = liveElapsed;
-  } else if (status.status === "succeeded") {
-    badgeState = "completed";
-    badgeDuration = durationBetween(startedAt, finishedAt);
-  } else if (status.status === "failed") {
-    badgeState = "error";
-    badgeDuration = durationBetween(startedAt, finishedAt);
-  } else {
-    badgeState = "completed";
-    badgeDuration = "previous";
-  }
-
-  const shouldShowLog = status.status !== "legacy";
-  const rawLogText = output?.text ?? "";
-  // Prefix the body with "Exit code N\n" on failure, matching how Sculptor's
-  // bash tool calls render their popover (success → no prefix; failure →
-  // exit code at the top, then output). Stderr is already merged into the
-  // captured stream by the runner, so it appears inline like in a terminal.
-  const exitCodePrefix =
-    status.status === "failed" && typeof status.exitCode === "number" ? `Exit code ${status.exitCode}\n` : "";
-  const logText = `${exitCodePrefix}${rawLogText}`;
-  // The card is clickable to open the popover for any non-legacy run.
-  // Commands that produce no stdout (e.g. the default
-  // `git fetch origin 2>/dev/null || true`) still benefit from a
-  // popover so the user can confirm the run finished and see the
-  // empty-output placeholder, rather than the row silently going inert.
-  const canOpenPopover = shouldShowLog;
-  const hasLogText = logText.length > 0;
-  const hasCommandChanged = persistedCommand !== null && currentCommand !== null && persistedCommand !== currentCommand;
-  // Rerun is gated on the project having a command — the backend reads it from
-  // `project.workspace_setup_command` and 422s when blank, so an unguarded
-  // button would silently no-op when the user has cleared the setting.
-  const isRerunVisible =
-    (status.status === "succeeded" || status.status === "failed" || status.status === "legacy") &&
-    currentCommand !== null;
-
-  const aside = (
-    <>
-      <BashStatusBadge state={badgeState} isBackground={false} duration={badgeDuration} testId="setup-status-badge" />
-      {isRunning ? (
-        <Tooltip content="Cancel setup">
-          <IconButton
-            variant="ghost"
-            size="1"
-            data-testid="setup-cancel-button"
-            onClick={(e) => {
-              e.stopPropagation();
-              void handleCancel();
-            }}
-            aria-label="Cancel setup"
-          >
-            <Square size={12} />
-          </IconButton>
-        </Tooltip>
-      ) : null}
-      {isRerunVisible && (
-        <Tooltip content={hasCommandChanged ? "Rerun setup (command has changed)" : "Rerun setup"}>
-          <IconButton
-            variant={hasCommandChanged ? "soft" : "ghost"}
-            color={hasCommandChanged ? "amber" : undefined}
-            size="1"
-            data-testid="setup-rerun-button"
-            data-command-changed={hasCommandChanged ? "true" : "false"}
-            onClick={(e) => {
-              e.stopPropagation();
-              void handleRerun();
-            }}
-            aria-label={hasCommandChanged ? "Rerun setup (command has changed)" : "Rerun setup"}
-          >
-            <RotateCcw size={12} />
-          </IconButton>
-        </Tooltip>
-      )}
-      {editButton}
-    </>
-  );
-
-  const isError = status.status === "failed";
-
-  if (!canOpenPopover) {
-    return <SetupRow testId="setup-status-card" isError={isError} title={titleNode} aside={aside} />;
-  }
-
-  // Use PopoverAnchor + the row's own onClick instead of Popover.Trigger.
-  // Trigger composes its toggle handler via Radix Slot, which has been
-  // unreliable here (likely due to the action IconButtons inside the row
-  // interfering with the trigger's event composition / focus management
-  // on subsequent opens). The anchor pattern is what AlphaToolPillRow
-  // uses and works cleanly: the row owns its click, and
-  // onPointerDownOutside keeps clicks inside the row from auto-closing
-  // before our click handler runs.
+  const runHeader = joinCommandForHeader(currentCommand);
   return (
-    <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-      <PopoverAnchor asChild>
-        <SetupRow
-          ref={rowRef}
-          testId="setup-status-card"
-          isOpen={isPopoverOpen}
-          isError={isError}
-          interactive
-          title={titleNode}
-          aside={aside}
-          onClick={togglePopover}
-          onKeyDown={handleRowKeyDown}
-        />
-      </PopoverAnchor>
-      <Popover.Content
-        side="bottom"
-        sideOffset={4}
-        align="start"
-        collisionPadding={16}
-        className={bashStyles.popoverContent}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onPointerDownOutside={(e) => {
-          // Clicks inside the row should not auto-close the popover — let
-          // the row's own onClick toggle it (or the action IconButtons
-          // handle their own behavior).
-          if (rowRef.current?.contains(e.target as Node)) e.preventDefault();
-        }}
-        style={POPOVER_STYLE}
-      >
-        <div className={bashStyles.popover}>
-          <div className={bashStyles.popoverSection}>
-            <span className={bashStyles.popoverCommand}>
-              <span className={bashStyles.prompt}>$</span> {commandRan ?? commandHeader}
-              <div className={bashStyles.popoverSummary}>workspace setup command</div>
-            </span>
-          </div>
-          {isLogTruncated && (
-            <div className={styles.truncationBanner} data-testid="setup-status-truncation">
-              Output was truncated. Showing first and last portions.
-            </div>
-          )}
-          <div className={bashStyles.popoverSection}>
-            <div ref={popoverOutputRef} className={bashStyles.popoverBody} data-testid="setup-status-output">
-              {hasLogText ? logText : <span className={styles.popoverEmpty}>(no output)</span>}
-              {isRunning && <span className={bashStyles.streamCursor} />}
-            </div>
-          </div>
-        </div>
-      </Popover.Content>
-    </Popover.Root>
+    <SetupRow
+      testId="setup-status-card"
+      title={
+        <Tooltip content={currentCommand} side="bottom">
+          <span>
+            <CommandTitle command={runHeader} />
+          </span>
+        </Tooltip>
+      }
+      aside={
+        <>
+          <Tooltip content="Run setup">
+            <IconButton
+              variant="soft"
+              size="1"
+              data-testid="setup-run-button"
+              onClick={(e) => {
+                e.stopPropagation();
+                void handleRerun();
+              }}
+              aria-label="Run setup"
+            >
+              <Play size={12} />
+            </IconButton>
+          </Tooltip>
+          {editButton}
+        </>
+      }
+    />
   );
 };
-
-function durationBetween(startedAt: number | null, finishedAt: number | null): string {
-  if (startedAt === null || finishedAt === null) return "";
-  return formatDuration(Math.max(0, finishedAt - startedAt));
-}

--- a/sculptor/frontend/src/pages/workspace/components/useSetupCommandActions.ts
+++ b/sculptor/frontend/src/pages/workspace/components/useSetupCommandActions.ts
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+
+import type { Project, Workspace } from "~/api";
+import { resolveWorkspaceSetupCommand } from "~/common/setupDefaults";
+import { useOpenSettings } from "~/common/state/hooks/useOpenSettings";
+import { useProject } from "~/common/state/hooks/useProjects";
+import { useWorkspace } from "~/common/state/hooks/useWorkspace";
+
+type SetupCommandActions = {
+  workspace: Workspace | null;
+  project: Project | null;
+  /** The project's current command, tri-state-resolved (null = run nothing). */
+  currentCommand: string | null;
+  handleCancel: () => Promise<void>;
+  handleRerun: () => Promise<void>;
+  handleEdit: () => void;
+};
+
+const postNoBody = async (path: string): Promise<Response> => fetch(path, { method: "POST" });
+
+/**
+ * Shared cancel / rerun / edit handlers and current-command resolution for the
+ * workspace setup command. Used by both the chat-intro config affordance
+ * (`SetupStatusCard`) and the run-status segment in the workspace banner
+ * (`WorkspaceSetupStatus`) so the two don't drift.
+ */
+export function useSetupCommandActions(workspaceId: string): SetupCommandActions {
+  const workspace = useWorkspace(workspaceId);
+  const project = useProject(workspace?.projectId ?? "");
+  const openSettings = useOpenSettings();
+
+  const handleCancel = useCallback(async () => {
+    try {
+      await postNoBody(`/api/v1/workspaces/${workspaceId}/setup/cancel`);
+    } catch (err) {
+      console.error("Failed to cancel setup:", err);
+    }
+  }, [workspaceId]);
+
+  const handleRerun = useCallback(async () => {
+    try {
+      await postNoBody(`/api/v1/workspaces/${workspaceId}/setup/rerun`);
+    } catch (err) {
+      console.error("Failed to rerun setup:", err);
+    }
+  }, [workspaceId]);
+
+  const handleEdit = useCallback((): void => {
+    if (project?.objectId) {
+      openSettings("repositories", project.objectId);
+    } else {
+      openSettings("repositories");
+    }
+  }, [project?.objectId, openSettings]);
+
+  // Mirror the backend's tri-state resolution: a null stored value runs the
+  // current default ("git fetch origin ..."), an empty string means the user
+  // cleared it (run nothing), any other string is custom.
+  const currentCommand = resolveWorkspaceSetupCommand(project?.workspaceSetupCommand);
+
+  return { workspace, project, currentCommand, handleCancel, handleRerun, handleEdit };
+}

--- a/sculptor/tests/integration/frontend/test_terminal_agent_basic.py
+++ b/sculptor/tests/integration/frontend/test_terminal_agent_basic.py
@@ -11,8 +11,10 @@ import re
 from playwright.sync_api import Page
 from playwright.sync_api import expect
 
+from sculptor.constants import ElementIDs
 from sculptor.testing.elements.agent_tab import PlaywrightAgentTabBarElement
 from sculptor.testing.elements.file_tree import get_changes_tree
+from sculptor.testing.elements.setup_status import PlaywrightSetupStatusElement
 from sculptor.testing.elements.terminal import expect_chat_replaces_terminal_panel
 from sculptor.testing.elements.terminal import expect_terminal_panel_replaces_chat
 from sculptor.testing.elements.terminal import get_agent_terminal_panel
@@ -20,6 +22,7 @@ from sculptor.testing.elements.terminal import get_agent_terminal_textarea
 from sculptor.testing.elements.terminal import get_xterm_buffer_text
 from sculptor.testing.elements.terminal import run_command_in_agent_terminal
 from sculptor.testing.elements.terminal import wait_for_xterm_substring
+from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -159,3 +162,51 @@ def test_terminal_agent_tabs_do_not_leak_content(sculptor_instance_: SculptorIns
     assert "LEAK-CHECK-BRAVO" not in get_xterm_buffer_text(page), (
         "Terminal 1 shows Terminal 2's output -- tab contents leaked across agents"
     )
+
+
+@user_story("to see whether the workspace setup command ran when using a terminal agent")
+def test_terminal_agent_surfaces_setup_status(sculptor_instance_: SculptorInstance) -> None:
+    """A terminal agent runs the workspace setup command and surfaces its status.
+
+    Setup is gated on workspace state, not agent type, so a terminal agent runs
+    it just like a chat agent. The status is surfaced in the workspace banner
+    (workspace-level chrome shared by all agents), so it shows even though a
+    terminal agent has no chat intro — without it a setup run (including a
+    failure) would be invisible.
+    """
+    page = sculptor_instance_.page
+
+    # Configure a project setup command with a recognizable marker.
+    settings_page = navigate_to_settings_page(page=page)
+    settings_page.click_on_repositories().expand_repo_config()
+    setup_input = page.get_by_test_id(ElementIDs.SETTINGS_WORKSPACE_SETUP_COMMAND_INPUT).first
+    expect(setup_input).to_be_visible()
+    setup_input.fill('echo "SCULPTOR_TERMINAL_SETUP_MARKER_24680"')
+    setup_input.blur()
+    page.wait_for_timeout(500)
+
+    # Create a workspace whose FIRST agent is a terminal agent: the terminal
+    # handler itself acquires the environment and triggers setup.
+    start_task_and_wait_for_ready(
+        page,
+        workspace_name="Terminal Setup WS",
+        agent_type="terminal",
+        model_name=None,
+    )
+
+    # This is a terminal agent (terminal panel, no chat), yet the setup status
+    # is surfaced — in the workspace banner. Scope the card lookup to the banner
+    # to prove it's workspace-level chrome, not the agent panel.
+    expect(get_agent_terminal_panel(page)).to_be_visible()
+    banner = page.get_by_test_id(ElementIDs.WORKSPACE_BANNER)
+    card = banner.get_by_test_id(ElementIDs.SETUP_STATUS_CARD)
+    expect(card).to_be_visible(timeout=60_000)
+
+    # Wait for a terminal state (the rerun button mounts only once the run has
+    # finished), then open the popover and confirm the marker — proving the
+    # setup command actually ran for the terminal agent. Mirrors the gating in
+    # test_workspace_setup_status.py to avoid racing pending->running->succeeded.
+    setup = PlaywrightSetupStatusElement(page)
+    expect(setup.get_rerun_button()).to_be_visible(timeout=60_000)
+    card.click()
+    expect(setup.get_output()).to_contain_text("SCULPTOR_TERMINAL_SETUP_MARKER_24680")


### PR DESCRIPTION
## Summary

The workspace setup command's run status (running / succeeded / failed, logs, cancel / rerun) was rendered in the per-agent chat intro. That had two problems:

- **Terminal agents have no chat intro**, so a setup run — including a *failure* — was completely invisible to them.
- In chat, the card **permanently occupied space** at the top of the agent pane instead of scrolling away like other intro content.

Setup is a **workspace** concern, not a per-agent one: there is a single run per workspace, gated on workspace state rather than agent type, and every agent in the workspace shares it. This moves the run status into the `WorkspaceBanner` — workspace-level chrome shown above both the chat and terminal panels.

## Changes

- **New `WorkspaceSetupStatus`** — a compact banner pill (status badge + inline cancel/rerun/edit) with a logs popover. Renders only once a run exists (`pending`/`running`/`succeeded`/`failed`/`legacy`); participates in the banner's progressive-collapse at priority 3.
- **`SetupStatusCard` slimmed** to the chat-intro onboarding affordance only (the configure-a-command CTA, and the one-click Run-setup row for workspaces configured after creation). Run states are now owned by the banner.
- **Extracted `useSetupCommandActions`** for the shared cancel/rerun/edit handlers and command resolution, so the two surfaces can't drift.

All `setup-*` test ids are preserved, and the chat-intro card and the banner pill are **mutually exclusive by state**, so the existing page-wide test helpers keep working.

## Testing

- `just check` and `just test-unit` green.
- 38 setup / banner / chat-intro integration tests pass: the full setup-status suite, banner, banner-overflow, chat-intro, system-reminder, worktree, the setup-command regressions, and the terminal agent.
- Adds `test_terminal_agent_surfaces_setup_status` (a terminal-first workspace runs setup and surfaces it in the banner).

## Known limitation

A terminal-first workspace in the `not_configured` state (a command added in Settings *after* the workspace was created, before any run) won't show the one-click "Run setup" CTA — that affordance lives in the chat intro, which terminal agents don't have. Setup still runs automatically on fresh workspaces; this only affects the manual run-it-now case, which remains reachable via Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)