### PR TITLE
[SCU-1477] Ignore the .pyre/ type-checker cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ fly/_warmup/
 **/.dmypy.json
 **/dmypy.json
 
+# pyre
+**/.pyre/
+
 # pycharm
 **/.idea/
 


### PR DESCRIPTION
## What

Add `**/.pyre/` to `.gitignore` so the local cache directory written by the Pyre type checker is never tracked.

## Why

`.pyre/` is a generated cache, not source. Ignoring it keeps stale cache directories out of version control — including ones left over on developer machines from before the repo's migration to Pyrefly (SCU-1477). The rule is placed next to the existing `**/.mypy_cache/` entry, grouping it with the other type-checker artifacts.

## Notes

- The repo now type-checks with Pyrefly (`just typecheck` runs `pyrefly check`), which runs daemon-less with no persistent project-root cache, so no separate `.pyrefly/` entry is needed.
- `just format` and `just check` (ratchets, typecheck, lint, file-hygiene) pass. The full unit suite was not run because a `.gitignore`-only change cannot affect test outcomes.

(Sent by Claude)