### PR TITLE
[SCU-1549] Serialize main builds: key CI concurrency on github.ref

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -27,9 +27,17 @@ on:
     tags:
       - 'sculptor-v*'
 
-# Builds are expensive; let runs finish rather than cancel mid-flight.
+# Builds are expensive, so never cancel an in-flight build (cancel-in-progress:
+# false). Key on github.ref so every main push shares one group and the builds
+# serialize, while each sculptor-v* tag gets its own group and builds
+# independently. Do NOT key on head_ref: it is empty outside pull_request events,
+# so on push/tag builds the group collapses to a unique run_id and every run gets
+# its own group of one -- no serialization. With a shared group and no
+# cancellation, a new main push waits behind the running build and a still-newer
+# push supersedes the pending, never-started one, so the next build to start is
+# always the newest main.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,11 +9,14 @@ on:
   push:
     branches: [main]
 
-# GitLab's `auto_cancel.on_new_commit: interruptible` equivalent. PR runs
-# cancel on new pushes; main runs are queued (no cancel) so we don't lose
-# signal on merged commits.
+# GitLab's `auto_cancel.on_new_commit: interruptible` equivalent. Key on
+# github.ref: PR runs (refs/pull/N/merge) collapse per-PR and cancel on new
+# pushes; main runs (refs/heads/main) share one group and queue (cancel-in-progress
+# is false off PRs) so we don't lose signal on merged commits. Do NOT key on
+# head_ref -- it is empty on push, so main collapses to a unique run_id and never
+# queues.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Pin the GITHUB_TOKEN scopes this workflow needs. The

--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -6,9 +6,12 @@ on:
   push:
     branches: [main]
 
-# Offload runs cost real Modal time, so let runs finish.
+# Offload runs cost real Modal time, so never cancel a run. Key on github.ref so
+# every main push shares one group and serializes; each PR (refs/pull/N/merge)
+# keeps its own group. Do NOT key on head_ref -- it is empty on push, so main
+# would collapse to a unique run_id and never queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Problem

`build-desktop`, `checks`, and `offload` keyed their concurrency group on `${{ github.workflow }}-${{ github.head_ref || github.run_id }}`. `github.head_ref` is populated only on `pull_request` events, but these workflows build/test `main` via `push` (and tags), so the key fell back to `github.run_id` — unique per run. Every `main` run landed in its own group of one, so nothing serialized and auto-builds of `main` ran **concurrently**.

## Change

Key on `${{ github.workflow }}-${{ github.ref }}` instead (comments + key only; no job logic touched):

- **`refs/heads/main`** is shared across main pushes → they serialize into one queue.
- **Each `sculptor-v*` tag** has its own ref → release builds stay independent.
- **`refs/pull/N/merge`** is per-PR → PR runs in `checks`/`offload` still collapse as before (and `checks` still cancels superseded PR runs via its existing `cancel-in-progress` expression).

## Behavior

With `cancel-in-progress: false`, the running build is never cancelled. A new `main` push waits behind it; a still-newer push supersedes the *pending* (never-started) run. So when the current build finishes, the next to start is the **latest `main` at that point** — newest-wins without killing in-flight work. This is GitHub's built-in queue behavior for a stable group key, so no custom logic is needed.

## Notes

- Also fixes `checks.yml`'s stale comment claiming `main` runs were queued (they weren't), and stops `offload.yml` from spending concurrent Modal time on superseded `main` commits.
- No UI/visual surface, so no screenshot — the before/after is the queueing behavior described above.

Closes SCU-1549.

(Sent by Claude)