### PR TITLE
[SCU-1551] Codify future-oriented code comment style in the style guide

### DIFF
--- a/docs/development/style/frontend.md
+++ b/docs/development/style/frontend.md
@@ -454,7 +454,7 @@ See [our python style guide](./backend.md) for general naming conventions. Below
 
 ## Comments
 
-Comments can quickly become outdated, leading to confusion rather than clarity. See [Comments](../style_guide.md#comments) for how to write them. In short: comment when the reasoning isn't obvious from the code alone (e.g. config files, workarounds), and write for a future reader rather than narrating the current change. A `TODO` may reference a tracking issue for *planned* work; don't cite a ticket merely to explain why existing code changed.
+Comments can quickly become outdated, leading to confusion rather than clarity. See [Comments](../style_guide.md#comments) for the repo-wide rule (write for a future reader, present-tense rationale, no change-narration). Comment when the reasoning isn't obvious from the code alone — e.g. config files, workarounds.
 
 ## React
 

--- a/docs/development/style/frontend.md
+++ b/docs/development/style/frontend.md
@@ -454,9 +454,7 @@ See [our python style guide](./backend.md) for general naming conventions. Below
 
 ## Comments
 
-Comments can quickly become outdated, leading to confusion rather than clarity. Use comments when:
-* The context or reasoning isn't obvious from the code alone (e.g. config files, workarounds)
-* Referencing related issues, PRs, or planned improvements
+Comments can quickly become outdated, leading to confusion rather than clarity. See [Comments](../style_guide.md#comments) for how to write them. In short: comment when the reasoning isn't obvious from the code alone (e.g. config files, workarounds), and write for a future reader rather than narrating the current change. A `TODO` may reference a tracking issue for *planned* work; don't cite a ticket merely to explain why existing code changed.
 
 ## React
 

--- a/docs/development/style_guide.md
+++ b/docs/development/style_guide.md
@@ -8,18 +8,10 @@ For specific frontend/backend style guides, see the following:
 
 ## Comments
 
-Write comments for the future reader who opens the file cold, with no knowledge
-of the change that introduced them. A comment explains what the present code does
-and why it is shaped this way — including timeless "don't do X, because Y"
-guardrails — in the present tense.
+Write comments for the future reader who opens the file cold, with no knowledge of the change that introduced them. A comment explains what the present code does and why it is shaped this way — including timeless "don't do X, because Y" guardrails — in the present tense.
 
-Do not narrate the change itself: avoid "the old code did X", "this used to be
-Y", "we changed this because…", the bug that prompted the edit, or a ticket ID.
-That history lives in the commit message, the PR description, and `git blame`,
-not in the source, where it only goes stale.
+Do not narrate the change itself: avoid "the old code did X", "this used to be Y", "we changed this because…", the bug that prompted the edit, or a ticket ID cited to explain why existing code changed. That backward-looking history belongs in the commit message, the PR description, and `git blame`, not in the source, where it only goes stale.
 
-Litmus test: if a comment would read as confusing or misleading once its PR is
-ancient history, it is grounded in the task — rewrite it to stand on its own.
-Reframe history as present-tense rationale: "we used to key on `head_ref` and
-main builds ran concurrently" becomes "`head_ref` is empty on push events, so
-key on `github.ref`".
+The exception is forward-looking, not historical: a `TODO`/`FIXME` may reference a tracking issue for planned work that hasn't landed yet, since that orients the future reader toward what's coming rather than rehashing what changed. This is the single carve-out — other guides inherit it and shouldn't add their own ticket-reference exceptions.
+
+Litmus test: if a comment would read as confusing or misleading once its PR is ancient history, it is grounded in the task — rewrite it to stand on its own. Reframe history as present-tense rationale: "we used to key on `head_ref` and main builds ran concurrently" becomes "`head_ref` is empty on push events, so key on `github.ref`".

--- a/docs/development/style_guide.md
+++ b/docs/development/style_guide.md
@@ -5,3 +5,21 @@ Use consistent patterns. Use tools to enforce consistency. See [linting](./linti
 For specific frontend/backend style guides, see the following:
 - [frontend style guide](style/frontend.md)
 - [backend style guide](style/backend.md).
+
+## Comments
+
+Write comments for the future reader who opens the file cold, with no knowledge
+of the change that introduced them. A comment explains what the present code does
+and why it is shaped this way — including timeless "don't do X, because Y"
+guardrails — in the present tense.
+
+Do not narrate the change itself: avoid "the old code did X", "this used to be
+Y", "we changed this because…", the bug that prompted the edit, or a ticket ID.
+That history lives in the commit message, the PR description, and `git blame`,
+not in the source, where it only goes stale.
+
+Litmus test: if a comment would read as confusing or misleading once its PR is
+ancient history, it is grounded in the task — rewrite it to stand on its own.
+Reframe history as present-tense rationale: "we used to key on `head_ref` and
+main builds ran concurrently" becomes "`head_ref` is empty on push events, so
+key on `github.ref`".


### PR DESCRIPTION
## Problem

The repo has no top-level guidance on how to write code comments, and the per-area guidance is thin and slightly contradictory: the frontend style guide lists *"referencing related issues, PRs, or planned improvements"* as a reason to comment, while the backend guide only says to prefer naming over comments. CI/YAML files aren't covered at all.

With no clear standard, comments have drifted toward narrating the *change* — "the old code did X", "this used to be Y", the bug that prompted the edit, ticket IDs — which is written for someone following that PR/ticket and reads as stale or puzzling to a future reader who opens the file cold.

## Change

- Add a top-level **Comments** section to `docs/development/style_guide.md`: write for the future reader, in the present tense; explain what the code does and why (including "don't do X, because Y" guardrails); keep change-narrative and ticket IDs in the commit message / PR / `git blame`. Includes a litmus test and a reframing example.
- Reconcile the frontend guide's comment bullet (`style/frontend.md`) to point at the new section and narrow the issue-referencing allowance to genuinely forward-looking TODOs.
- The backend guide inherits the top-level rule unchanged.

Docs only; no code behavior changes.

Closes SCU-1551.

(Sent by Claude)