### PR TITLE
SCU-1552: Test the bundled Linear plugin across launch modes (+ dev-build fix)

### DIFF
--- a/sculptor/frontend/vite-plugins/bundled-plugins.ts
+++ b/sculptor/frontend/vite-plugins/bundled-plugins.ts
@@ -29,39 +29,53 @@ const COMPILED_PLUGIN_IDS: ReadonlyArray<string> = ["linear-issue"];
 const buildCompiledPlugin = async (frontendRoot: string, id: string): Promise<void> => {
   const sourceDir = path.join(frontendRoot, "plugins", id);
   const outDir = path.join(frontendRoot, "public", "plugins", id);
-  await build({
-    configFile: false, // don't reload the host config — that would recurse
-    root: sourceDir,
-    publicDir: false,
-    logLevel: "warn",
-    // A compiled plugin is a production artifact: it shares the host's React
-    // singleton via the import map, which provides only the prod
-    // `react/jsx-runtime` (not `react/jsx-dev-runtime`). Pin production —
-    // otherwise this nested build inherits the dev server's mode and the JSX
-    // transform emits the dev runtime, which, not being externalized, gets
-    // bundled in and drags `process.env.NODE_ENV` into a browser bundle
-    // ("process is not defined"). The `define` is belt-and-suspenders: it
-    // replaces any residual `process.env.NODE_ENV` so no `process` global can
-    // reach the browser.
-    mode: "production",
-    define: { "process.env.NODE_ENV": JSON.stringify("production") },
-    plugins: [react()],
-    build: {
-      outDir,
-      emptyOutDir: true,
-      sourcemap: true,
-      lib: {
-        entry: path.join(sourceDir, "src", "index.tsx"),
-        formats: ["es"],
-        fileName: (): string => "main.js",
+  // A compiled plugin is a production artifact: it shares the host's React
+  // singleton via the import map, which provides only the prod
+  // `react/jsx-runtime` (not `react/jsx-dev-runtime`). It MUST build as
+  // production, or the JSX transform emits the dev runtime and plugin renders
+  // crash with "jsxDEV is not a function" (and a bundled dev runtime would also
+  // drag `process` in).
+  //
+  // Vite derives `isProduction` from `process.env.NODE_ENV || mode`, so NODE_ENV
+  // *wins* over our `mode: "production"`. In the dev-server path (`just start`,
+  // electron dev) the outer server sets NODE_ENV=development, which would force
+  // this nested build to dev despite `mode`. Pin NODE_ENV for the build so it's
+  // production in every path; restore it afterward so the outer dev server is
+  // unaffected. `mode` + the `define` are kept as defense-in-depth.
+  const priorNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  try {
+    await build({
+      configFile: false, // don't reload the host config — that would recurse
+      root: sourceDir,
+      publicDir: false,
+      logLevel: "warn",
+      mode: "production",
+      define: { "process.env.NODE_ENV": JSON.stringify("production") },
+      plugins: [react()],
+      build: {
+        outDir,
+        emptyOutDir: true,
+        sourcemap: true,
+        lib: {
+          entry: path.join(sourceDir, "src", "index.tsx"),
+          formats: ["es"],
+          fileName: (): string => "main.js",
+        },
+        rollupOptions: {
+          external: [...RUNTIME_MODULE_SPECIFIERS],
+          // Don't hash — the manifest references the entry as "main.js" by name.
+          output: { entryFileNames: "main.js", assetFileNames: "[name][extname]" },
+        },
       },
-      rollupOptions: {
-        external: [...RUNTIME_MODULE_SPECIFIERS],
-        // Don't hash — the manifest references the entry as "main.js" by name.
-        output: { entryFileNames: "main.js", assetFileNames: "[name][extname]" },
-      },
-    },
-  });
+    });
+  } finally {
+    if (priorNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = priorNodeEnv;
+    }
+  }
   // The manifest is served alongside the bundle; the host fetches it first.
   fs.copyFileSync(path.join(sourceDir, "manifest.json"), path.join(outDir, "manifest.json"));
 };

--- a/sculptor/sculptor/testing/elements/settings_plugins.py
+++ b/sculptor/sculptor/testing/elements/settings_plugins.py
@@ -51,6 +51,16 @@ class PlaywrightPluginsSettingsElement(PlaywrightIntegrationTestElement):
         """Click the remove (trash) button on a source's row."""
         self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_REMOVE).click()
 
+    def open_source_settings(self, source: str) -> None:
+        """Reveal a source's plugin-rendered settings component (clicks the gear).
+
+        The settings component is the plugin's own React, mounted under the
+        plugin error boundary, so revealing it exercises the bundle's render
+        path — not just whether it loaded. Its content then appears inside the
+        source's row (see ``get_source_row``).
+        """
+        self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_SETTINGS).click()
+
     def get_toggle(self, source: str) -> Locator:
         """Locate the enable/disable switch on a source's row."""
         return self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_TOGGLE)

--- a/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
+++ b/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
@@ -1,0 +1,81 @@
+"""Integration test for the bundled Linear example plugin (SCU-1552).
+
+Unlike test_plugin_loader.py — which exercises the loader against synthetic
+fixture-server plugins — this targets the *real* bundled `linear-issue` plugin,
+the one the host Vite build compiles into `public/plugins/`. It asserts the
+built-in source both:
+
+  1. loads — the bundle was fetched, validated, imported, and activated, and
+  2. renders its own React — the plugin's settings component mounts and shows
+     its content.
+
+A broken build fails here: a bundle that throws at import (e.g. a dev-JSX build
+that dragged `process.env.NODE_ENV` in) never reaches "loaded"; one that throws
+at render (e.g. calling `jsxDEV` against a host that only ships the prod JSX
+runtime) trips the plugin error boundary, so the settings text never appears.
+
+Runs in both browser and electron launch modes, since the plugin ships bundled
+into the served build for every mode.
+"""
+
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.services.user_config.user_config import load_config
+from sculptor.services.user_config.user_config import save_config
+from sculptor.testing.elements.settings_plugins import PlaywrightPluginsSettingsElement
+from sculptor.testing.playwright_utils import navigate_to_settings_page
+from sculptor.testing.resources import _default_sculptor_folder_populator
+from sculptor.testing.resources import custom_sculptor_folder_populator
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.sculptor_instance import SculptorInstanceFactory
+
+# The built-in source the host registers for the bundled Linear plugin.
+LINEAR_SOURCE = "/plugins/linear-issue"
+# Stable text from the plugin's own settings component (LinearSettings). The
+# plugin error boundary would replace it on a render failure, so asserting it
+# confirms the plugin's React actually ran.
+LINEAR_SETTINGS_TEXT = "Personal API key from Linear"
+
+
+def _enable_frontend_plugins_populator(folder_path: Path) -> None:
+    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
+    _default_sculptor_folder_populator(folder_path)
+    config_path = folder_path / "internal" / "config.toml"
+    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
+    save_config(config, config_path)
+
+
+def _assert_linear_plugin_loads_and_renders(plugins: PlaywrightPluginsSettingsElement) -> None:
+    """The built-in Linear plugin loads, then renders its own settings React."""
+    plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
+    plugins.open_source_settings(LINEAR_SOURCE)
+    expect(plugins.get_source_row(LINEAR_SOURCE)).to_contain_text(LINEAR_SETTINGS_TEXT)
+
+
+@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
+def test_bundled_linear_plugin_loads_and_renders(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+) -> None:
+    """In a browser, the bundled Linear plugin loads and renders its UI."""
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        settings_page = navigate_to_settings_page(page=instance.page)
+        plugins = settings_page.click_on_plugins()
+        _assert_linear_plugin_loads_and_renders(plugins)
+
+
+@pytest.mark.electron
+def test_bundled_linear_plugin_loads_and_renders_in_electron(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """In Electron, the bundled Linear plugin loads and renders its UI."""
+    settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
+    settings_page.click_on_experimental().set_frontend_plugins(enabled=True)
+    try:
+        plugins = settings_page.click_on_plugins()
+        _assert_linear_plugin_loads_and_renders(plugins)
+    finally:
+        # Leave the shared instance's flag as we found it for the next test.
+        settings_page.click_on_experimental().set_frontend_plugins(enabled=False)


### PR DESCRIPTION
**SCU-1552.** Targets `main`. Carries two things: a dev-build **fix** for the bundled plugin and the **integration test** that caught it.

## Why the fix is here
#74 (the Linear plugin) was squash-merged to `main` **without** its final dev-JSX fix, so `main` still has the bug: the dev-server plugin build emits the dev JSX runtime and renders the panel as `s.jsxDEV is not a function` under `just start` / electron dev. #74 is merged and frozen, so the fix rides in with its regression test here.

### The fix
`bundled-plugins.ts`: the nested plugin build pinned `mode: "production"`, but Vite derives `isProduction` from `process.env.NODE_ENV || mode` — so the dev server's `NODE_ENV=development` overrode it. Pin `process.env.NODE_ENV=production` around the nested build (restored after, so the outer dev server is untouched). Production builds (`vite build`) were already fine; this repairs the dev path.

## The test
Targets the **real bundled** `linear-issue` plugin (the host build's output, shipped in every launch mode), not a synthetic fixture. Asserts the built-in source both:

1. **loads** (`expect_loaded`, name "Linear", v0.1.0) — fetched, validated, imported, activated; and
2. **renders its own React** — the plugin's settings component mounts and shows its content.

These map to the two real failure modes: an import-time crash (dev-JSX dragging `process` in) never reaches "loaded"; a render-time crash (`jsxDEV`) trips the plugin error boundary so the settings text never appears.

Runs in **browser and electron** modes (the `@pytest.mark.electron` variant). The electron variant is what catches this class — browser integration tests serve a prebuilt production `dist`, while electron runs the dev server (the buggy path). On the first run before the fix, the electron variant failed exactly as described; with the fix, both pass. Adds an `open_source_settings` helper to the Plugins settings POM.

(Sent by Claude)