### PR TITLE
SCU-1553: Unit-test the linear-issue plugin's logic and type-check it in CI

### DIFF
--- a/sculptor/frontend/plugins/linear-issue/src/components/IssueDetails.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/IssueDetails.tsx
@@ -3,14 +3,7 @@ import { Markdown, openExternal } from "@sculptor/plugin-sdk";
 import { ExternalLink, GitPullRequest } from "lucide-react";
 import type { ReactElement } from "react";
 
-import { isPullRequestAttachment, type LinearIssue } from "../linear/client.ts";
-
-// "https://github.com/owner/repo/pull/74" -> "#74"; GitLab merge requests -> "!74".
-const prLabel = (url: string): string => {
-  const match = url.match(/\/(?:pull|merge_requests)\/(\d+)/);
-  if (!match) return "PR";
-  return `${url.includes("/merge_requests/") ? "!" : "#"}${match[1]}`;
-};
+import { isPullRequestAttachment, type LinearIssue, prLabel } from "../linear/client.ts";
 
 /** The expanded body of a ticket: metadata, markdown description, and links out. */
 export const IssueDetails = ({ issue }: { issue: LinearIssue }): ReactElement => {

--- a/sculptor/frontend/plugins/linear-issue/src/linear/client.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/client.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isPullRequestAttachment, type LinearAttachment, prLabel } from "./client.ts";
+
+const attachment = (url: string): LinearAttachment => ({ url, sourceType: "github", title: null });
+
+describe("isPullRequestAttachment", () => {
+  it("matches GitHub pull and GitLab merge-request URLs", () => {
+    expect(isPullRequestAttachment(attachment("https://github.com/o/r/pull/74"))).toBe(true);
+    expect(isPullRequestAttachment(attachment("https://gitlab.com/o/r/-/merge_requests/12"))).toBe(true);
+  });
+
+  it("rejects non-PR URLs", () => {
+    expect(isPullRequestAttachment(attachment("https://github.com/o/r/commit/abc123"))).toBe(false);
+    expect(isPullRequestAttachment(attachment("https://example.com/pulls"))).toBe(false);
+  });
+});
+
+describe("prLabel", () => {
+  it("labels GitHub pulls with #<n>", () => {
+    expect(prLabel("https://github.com/o/r/pull/74")).toBe("#74");
+  });
+
+  it("labels GitLab merge requests with !<n>", () => {
+    expect(prLabel("https://gitlab.com/o/r/-/merge_requests/12")).toBe("!12");
+  });
+
+  it("falls back to 'PR' when there is no number", () => {
+    expect(prLabel("https://github.com/o/r")).toBe("PR");
+  });
+
+  it("keys the sigil off the matched route, not a substring of the whole URL", () => {
+    // A GitHub pull whose query string mentions "/merge_requests/" must still
+    // read as "#", not "!".
+    expect(prLabel("https://github.com/o/r/pull/74?ref=/merge_requests/9")).toBe("#74");
+  });
+});

--- a/sculptor/frontend/plugins/linear-issue/src/linear/client.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/client.ts
@@ -159,3 +159,13 @@ export const searchIssues = async (inputs: {
 /** Whether an attachment points at a code-host pull/merge request. */
 export const isPullRequestAttachment = (attachment: LinearAttachment): boolean =>
   /\/(pull|merge_requests)\//.test(attachment.url);
+
+/** Short label for a PR/MR URL: "#74" for a GitHub pull, "!74" for a GitLab MR. */
+export const prLabel = (url: string): string => {
+  const match = url.match(/\/(pull|merge_requests)\/(\d+)/);
+  if (!match) return "PR";
+  // Key the sigil off the matched route segment, not a substring scan of the
+  // whole URL — a query string or fragment could otherwise contain
+  // "/merge_requests/" and mislabel a GitHub pull as a GitLab MR.
+  return `${match[1] === "merge_requests" ? "!" : "#"}${match[2]}`;
+};

--- a/sculptor/frontend/plugins/linear-issue/src/linear/sources.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/sources.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { LinearIssue } from "./client.ts";
+import { mergeTickets } from "./sources.ts";
+
+const issue = (identifier: string): LinearIssue => ({
+  identifier,
+  title: identifier,
+  url: `https://linear.app/x/${identifier}`,
+  description: null,
+  priorityLabel: null,
+  state: null,
+  assignee: null,
+  attachments: [],
+});
+
+describe("mergeTickets", () => {
+  it("orders branch (primary) first, then PR-linked, then pinned", () => {
+    const result = mergeTickets({ primary: issue("A"), prLinked: [issue("B")], pinned: [issue("C")] });
+    expect(result.map((ticket) => ticket.issue.identifier)).toEqual(["A", "B", "C"]);
+    expect(result[0]).toMatchObject({ isPrimary: true, sources: ["branch"] });
+    expect(result[1]).toMatchObject({ isPrimary: false, sources: ["pr"] });
+    expect(result[2]).toMatchObject({ isPrimary: false, sources: ["pinned"] });
+  });
+
+  it("de-duplicates an issue seen via several sources, unioning its sources and keeping primary", () => {
+    const a = issue("A");
+    const result = mergeTickets({ primary: a, prLinked: [a], pinned: [a] });
+    expect(result).toHaveLength(1);
+    expect(result[0].isPrimary).toBe(true);
+    expect(result[0].sources).toEqual(["branch", "pr", "pinned"]);
+  });
+
+  it("works with no primary (e.g. branch has no linked issue)", () => {
+    const result = mergeTickets({ primary: null, prLinked: [], pinned: [issue("C")] });
+    expect(result.map((ticket) => ticket.issue.identifier)).toEqual(["C"]);
+    expect(result[0]).toMatchObject({ isPrimary: false, sources: ["pinned"] });
+  });
+
+  it("keeps a pinned issue that is also the primary first and primary", () => {
+    const a = issue("A");
+    const result = mergeTickets({ primary: a, prLinked: [], pinned: [issue("B"), a] });
+    expect(result.map((ticket) => ticket.issue.identifier)).toEqual(["A", "B"]);
+    expect(result[0]).toMatchObject({ isPrimary: true, sources: ["branch", "pinned"] });
+  });
+});

--- a/sculptor/frontend/plugins/linear-issue/src/linear/ticket.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/ticket.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTicket } from "./ticket.ts";
+
+describe("parseTicket", () => {
+  it("pulls the ticket out of a Sculptor branch name", () => {
+    expect(parseTicket("user/scu-1495-example")).toEqual({ key: "SCU", number: 1495, identifier: "SCU-1495" });
+  });
+
+  it("accepts a raw identifier and upper-cases the team key", () => {
+    expect(parseTicket("SCU-1552")).toEqual({ key: "SCU", number: 1552, identifier: "SCU-1552" });
+    expect(parseTicket("abc-7")).toEqual({ key: "ABC", number: 7, identifier: "ABC-7" });
+  });
+
+  it("takes the first ticket when several appear", () => {
+    expect(parseTicket("user/scu-1-and-abc-2")?.identifier).toBe("SCU-1");
+  });
+
+  it("requires a team key of at least two letters", () => {
+    expect(parseTicket("x-9")).toBeNull();
+  });
+
+  it("returns null when there is no ticket (or no input)", () => {
+    expect(parseTicket("main")).toBeNull();
+    expect(parseTicket("")).toBeNull();
+    expect(parseTicket(null)).toBeNull();
+  });
+});

--- a/sculptor/frontend/src/plugins/sdk/actions.test.ts
+++ b/sculptor/frontend/src/plugins/sdk/actions.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openExternal } from "./actions.ts";
+
+describe("openExternal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens http(s) URLs in a new tab with noopener,noreferrer", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    openExternal("https://linear.app/issue/SCU-1");
+    expect(open).toHaveBeenCalledWith("https://linear.app/issue/SCU-1", "_blank", "noopener,noreferrer");
+    openExternal("http://example.com/x");
+    expect(open).toHaveBeenCalledWith("http://example.com/x", "_blank", "noopener,noreferrer");
+  });
+
+  it("refuses non-http(s) schemes", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    for (const url of ["javascript:alert(1)", "data:text/html,<x>", "file:///etc/passwd", "mailto:a@b.com"]) {
+      openExternal(url);
+    }
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/sculptor/frontend/tsconfig.json
+++ b/sculptor/frontend/tsconfig.json
@@ -5,7 +5,13 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "paths": { "~/*": ["./src/*"] },
+    "paths": {
+      "~/*": ["./src/*"],
+      // Bundled plugins import the SDK by its bare specifier; resolve it to host
+      // source so `tsc` type-checks them (they're included below). Mirrors each
+      // plugin's own tsconfig path and the vite/import-map resolution.
+      "@sculptor/plugin-sdk": ["./src/plugins/sdk/index.ts"]
+    },
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -27,6 +33,7 @@
   },
   "include": [
     "src",
+    "plugins",
     "src/globals.d.ts",
     "src/generated-types.d.ts",
     "eslint.config.ts",

--- a/sculptor/frontend/vitest.config.ts
+++ b/sculptor/frontend/vitest.config.ts
@@ -12,13 +12,18 @@ export default defineConfig({
   resolve: {
     alias: {
       "~": path.resolve(__dirname, "src"),
+      // Resolve the bare SDK specifier to host source, mirroring the bundled
+      // plugins' tsconfig path, so plugin tests can import `@sculptor/plugin-sdk`.
+      "@sculptor/plugin-sdk": path.resolve(__dirname, "src/plugins/sdk/index.ts"),
     },
   },
   test: {
     environment: "jsdom",
     globals: false,
     setupFiles: ["./vitest.setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    // `plugins/**` covers the bundled plugins' own unit tests (e.g. linear-issue);
+    // they import only plugin-local modules plus the aliased SDK above.
+    include: ["src/**/*.test.{ts,tsx}", "plugins/**/*.test.{ts,tsx}"],
     css: { modules: { classNameStrategy: "non-scoped" } },
   },
 });


### PR DESCRIPTION
Sibling of SCU-1552 (#115). #115 integration-tests the bundled plugin's **load + render** across launch modes; this adds the fast, isolated layer beneath it: **unit tests of the plugin's pure logic** and a **type-check gate**. Stacked on #115 — targets that branch; rebases to `main` after it merges.

## Unit tests (run under the host vitest)
Extends `vitest.config.ts` to include `plugins/**` and alias `@sculptor/plugin-sdk` to host source, then covers the plugin's pure logic:
- `parseTicket` — branch → ticket id, plus edges (raw id, lowercase, first-of-many, sub-two-letter key, no-match/null).
- `mergeTickets` — dedup, source-union, branch-primary ordering, no-primary, pinned-also-primary.
- `isPullRequestAttachment` / `prLabel` — GitHub pull vs GitLab MR parsing. `prLabel` moves from `IssueDetails.tsx` into the `linear/` core so it's testable without rendering a component.
- SDK `openExternal` — http/https opened with `noopener,noreferrer`; `javascript:`/`data:`/`file:`/`mailto:` refused.

16 tests, all passing.

## Type-check gate
The plugin's TypeScript was **never type-checked in CI** — the nested esbuild build strips types — so a type error could ship silently. This includes `plugins/` in the host `tsconfig.json` (and maps the SDK specifier), so the existing `npm run tsc` / `just check` now type-checks the plugin too. It passes clean today.

(Sent by Claude)