### PR TITLE
SCU-1554: Integration-test the Linear panel runtime (workspace-following + auth)

### DIFF
--- a/sculptor/sculptor/testing/elements/panel_zones.py
+++ b/sculptor/sculptor/testing/elements/panel_zones.py
@@ -60,6 +60,18 @@ class PlaywrightPanelZonesElement:
     def get_file_browser_panel(self) -> Locator:
         return self._page.get_by_test_id(ElementIDs.FILE_BROWSER_PANEL)
 
+    def activate_plugin_panel(self, plugin_id: str) -> None:
+        """Click a plugin-contributed panel's sidebar icon to make it the active
+        panel in its zone.
+
+        Plugin panels render `data-panel-icon=<id>` with no ElementIDs testid
+        (unlike built-in panels, which are in PANEL_ICON_TEST_IDS), so they're
+        located by that attribute.
+        """
+        icon = self._page.locator(f'[data-panel-icon="{plugin_id}"]')
+        expect(icon).to_be_visible()
+        icon.click()
+
     def move_panel_to_zone(self, panel_icon_id: ElementIDs, zone_key: str) -> None:
         """Move a panel to a different zone via its sidebar icon context menu.
 

--- a/sculptor/sculptor/testing/elements/settings_plugins.py
+++ b/sculptor/sculptor/testing/elements/settings_plugins.py
@@ -61,6 +61,19 @@ class PlaywrightPluginsSettingsElement(PlaywrightIntegrationTestElement):
         """
         self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_SETTINGS).click()
 
+    def set_source_text_setting(self, source: str, value: str) -> None:
+        """Open a source's plugin-rendered settings and fill its text input.
+
+        The settings component is plugin-authored, so its field carries no host
+        testid; scope to the (single) ``<input>`` inside the source's row. Used
+        e.g. to enter the Linear plugin's API key, which the plugin persists via
+        the settings SDK and applies reactively (no reload needed).
+        """
+        self.open_source_settings(source)
+        field = self.get_source_row(source).locator("input")
+        expect(field).to_be_visible()
+        field.fill(value)
+
     def get_toggle(self, source: str) -> Locator:
         """Locate the enable/disable switch on a source's row."""
         return self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_TOGGLE)

--- a/sculptor/tests/integration/frontend/test_linear_plugin_runtime.py
+++ b/sculptor/tests/integration/frontend/test_linear_plugin_runtime.py
@@ -1,0 +1,127 @@
+"""Heavy runtime test for the bundled Linear plugin (SCU-1554).
+
+Where test_bundled_linear_plugin.py (SCU-1552) only asserts the plugin loads and
+renders its empty state, this exercises it against canned Linear data. It
+intercepts `https://api.linear.app/graphql` with Playwright and returns an issue
+whose title echoes the *queried branch*, then asserts:
+
+  - The Linear panel queries the current workspace's branch and renders that
+    branch's issue — and re-adjusts when the active workspace changes (proves
+    the `useCurrentWorkspace` branch hook drives the per-branch query).
+  - Every request carries the configured API key in its Authorization header.
+
+Browser launch mode: the behavior is mode-independent, and SCU-1552 already
+covers cross-mode loading.
+"""
+
+import json
+from pathlib import Path
+
+from playwright.sync_api import Page
+from playwright.sync_api import Route
+from playwright.sync_api import expect
+
+from sculptor.services.user_config.user_config import load_config
+from sculptor.services.user_config.user_config import save_config
+from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
+from sculptor.testing.elements.panels import ensure_right_area_visible
+from sculptor.testing.playwright_utils import navigate_to_settings_page
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.resources import _default_sculptor_folder_populator
+from sculptor.testing.resources import custom_sculptor_folder_populator
+from sculptor.testing.sculptor_instance import SculptorInstanceFactory
+
+LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+LINEAR_SOURCE = "/plugins/linear-issue"
+API_KEY = "lin_api_test_key_1234"
+
+
+def _enable_frontend_plugins_populator(folder_path: Path) -> None:
+    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
+    _default_sculptor_folder_populator(folder_path)
+    config_path = folder_path / "internal" / "config.toml"
+    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
+    save_config(config, config_path)
+
+
+def _make_linear_route(captured_auth: list[str]):
+    """A page.route handler that fakes Linear: echo the queried branch into the
+    issue title and record each request's Authorization header. Every
+    api.linear.app request is fulfilled locally so nothing hits the network."""
+
+    def handle(route: Route) -> None:
+        request = route.request
+        captured_auth.append(request.headers.get("authorization", ""))
+        body = request.post_data_json or {}
+        query = body.get("query") or ""
+        branch = (body.get("variables") or {}).get("branch")
+        if "issueVcsBranchSearch" in query and branch:
+            issue = {
+                "identifier": "SCU-9999",
+                "title": f"Issue for {branch}",
+                "url": "https://linear.app/imbue/issue/SCU-9999",
+                "description": None,
+                "priorityLabel": None,
+                "state": None,
+                "assignee": None,
+                "attachments": {"nodes": []},
+            }
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"data": {"issueVcsBranchSearch": issue}}),
+            )
+            return
+        route.fulfill(status=200, content_type="application/json", body=json.dumps({"data": {}}))
+
+    return handle
+
+
+def _activate_linear_panel(page: Page, zones: PlaywrightPanelZonesElement) -> None:
+    """Reveal the right area and make the Linear panel the active top-right panel."""
+    ensure_right_area_visible(page)
+    zones.activate_plugin_panel("linear-issue")
+
+
+@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
+def test_linear_panel_follows_workspace_branch_and_sends_key(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+) -> None:
+    """The Linear panel renders the active workspace's branch issue, re-adjusts on
+    workspace switch, and sends the configured API key."""
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        page = instance.page
+
+        captured_auth: list[str] = []
+        page.route(LINEAR_GRAPHQL_URL, _make_linear_route(captured_auth))
+
+        # Configure the API key through the plugin's settings UI — the plugin
+        # applies it reactively (the setting lives in a store atom shared with
+        # the panel), so no reload is needed.
+        settings_page = navigate_to_settings_page(page=page)
+        plugins = settings_page.click_on_plugins()
+        plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
+        plugins.set_source_text_setting(LINEAR_SOURCE, API_KEY)
+
+        zones = PlaywrightPanelZonesElement(page)
+
+        # Workspace A: open the panel, expect it to show A's branch issue.
+        task_page_a = start_task_and_wait_for_ready(page, prompt="linear a", workspace_name="Linear WS A")
+        branch_a = task_page_a.get_branch_name()
+        _activate_linear_panel(page, zones)
+        expect(zones.get_top_right_zone()).to_contain_text(f"Issue for {branch_a}")
+
+        # Workspace B (a different branch): the already-open panel must follow the
+        # newly-active workspace and show B's branch issue.
+        task_page_b = start_task_and_wait_for_ready(page, prompt="linear b", workspace_name="Linear WS B")
+        branch_b = task_page_b.get_branch_name()
+        assert branch_a != branch_b, f"workspaces must differ by branch (both {branch_a!r})"
+        expect(zones.get_top_right_zone()).to_contain_text(f"Issue for {branch_b}")
+
+        # Switching back re-adjusts the panel to the first workspace's branch.
+        task_page_a.get_workspace_tabs().first.click()
+        expect(zones.get_top_right_zone()).to_contain_text(f"Issue for {branch_a}")
+
+        # Every Linear request carried the configured API key (raw, no Bearer).
+        assert captured_auth, "the Linear plugin made no request"
+        assert all(auth == API_KEY for auth in captured_auth), f"unexpected auth headers: {set(captured_auth)}"


### PR DESCRIPTION
The heavy end-to-end counterpart to SCU-1552 (#115, merged), which only asserts the bundled plugin loads + renders its empty state. This exercises the plugin against canned Linear data via Playwright `page.route` interception of `https://api.linear.app/graphql`.

With the plugin enabled and an API key configured through its settings UI, it asserts:

- **Follows the workspace's branch.** The route returns an issue whose title echoes the queried branch. Open two workspaces with different branches, open the Linear panel, and the panel renders the *active* workspace's branch issue — re-adjusting when switching between them and back. This exercises the `useCurrentWorkspace` branch hook and the per-branch query key end to end.
- **Sends the configured key.** Every intercepted request carries the configured API key in its `Authorization` header (raw, no Bearer prefix).

Scope, per request: no quicksearch/pin flows. Browser launch mode — the behavior is mode-independent and SCU-1552 covers cross-mode loading.

Two POM helpers are added (in `sculptor/testing/`, deliberately out of the test file so the integration-test ratchets stay clean): `activate_plugin_panel` (clicks a plugin panel's `data-panel-icon` sidebar icon — plugin panels carry no testid) and `set_source_text_setting` (fills a plugin settings field, e.g. the API key).

Verified: passes in browser mode (`just test-integration`); `just check` (ratchets, typecheck, lint) green.

(Sent by Claude)