### PR TITLE
Bump ratchets lint pin 0.3.1 → 0.4.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,7 +92,7 @@ jobs:
             ${{ runner.temp }}/ratchets-cargo/.crates2.json
           # Bump the version suffix in lockstep with `ratchets_version` in the
           # justfile, and bump the -v3 suffix whenever the cached `path:` set changes.
-          key: ratchets-bin-${{ runner.os }}-0.3.1-v3
+          key: ratchets-bin-${{ runner.os }}-0.4.0-v3
 
       - name: Install ratchets
         env:

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ fi
 
 # Pinned version of the `ratchets` lint binary (https://crates.io/crates/ratchets).
 # Bump this and re-run `just install-ratchets` (and update CI) when adopting a new release.
-ratchets_version := "0.3.1"
+ratchets_version := "0.4.0"
 
 # Reusable snippet to abort early when the `ratchets` CLI is not installed.
 _require_ratchets := '''


### PR DESCRIPTION
## What

Bump the pinned `ratchets` lint binary from **0.3.1 → 0.4.0** (published on crates.io).

- `justfile`: `ratchets_version := "0.4.0"` (drives `just install-ratchets`).
- `.github/workflows/checks.yml`: bump the ratchets binary cache key in lockstep (`…-0.4.0-v3`) so CI rebuilds the cache under the new version instead of restoring the 0.3.1 binary.

## Why

0.4.0 switches its regex engine to [resharp](https://crates.io/crates/resharp) (RE#). On this repo's `ratchets check` workload (1727 files, 53 rules), measured on an idle machine over 10 serial runs per version (single min + max trimmed):

| version | median wall | p95 wall | user-CPU (median) |
|---|---|---|---|
| 0.3.1 | 3.45 s | 3.48 s | 28.50 s |
| 0.4.0 | 2.95 s | 2.98 s | 24.46 s |

→ **~14–15% faster wall time** and ~14% less total CPU. The difference is significant at the 95% level (Welch t-test p ≈ 1.3e-11; bootstrap 95% CI of the median difference ≈ [0.45, 0.54] s). Same result otherwise: the full rule budget still passes (`ratchets check` exits 0).

## Verification

- Installed the published 0.4.0 from crates.io (`cargo install ratchets --version 0.4.0 --locked`) and confirmed `ratchets check` runs this repo green.
- A single confirmation run reproduced the speedup (2.97 s vs 3.51 s wall).

## CI note

The first CI run rebuilds the ratchets binary cache under the new `…-0.4.0-v3` key (a one-time ~30 s `cargo install`), then no-ops on subsequent runs.

(Sent by Claude)
