### PR TITLE
Fix flaky worktree branch-deletion tests by polling for branch deletion

### DIFF
--- a/sculptor/tests/integration/frontend/test_worktree_deletion_policies.py
+++ b/sculptor/tests/integration/frontend/test_worktree_deletion_policies.py
@@ -125,6 +125,26 @@ def _wait_for_worktree_removed(
     raise AssertionError(f"worktree {worktree_path} was not removed within {timeout_ms}ms")
 
 
+def _wait_for_branch_deleted(
+    page: Page, repo_path: Path, branch: str, failure_message: str, timeout_ms: int = 30_000
+) -> None:
+    """Poll until `branch` is gone, raising `failure_message` on timeout.
+
+    Branch deletion runs as a separate `git branch -d`/`-D` subprocess *after*
+    `git worktree remove` completes, so the branch can still exist for a moment
+    after the worktree disappears. `_wait_for_worktree_removed` returns as soon
+    as the worktree is gone, which under load can be before branch deletion has
+    run — asserting branch absence right then races. Polling here gives the
+    deletion subprocess a deadline to finish before we conclude it failed.
+    """
+    deadline_steps = timeout_ms // 100
+    for _ in range(deadline_steps):
+        if not _branch_exists(repo_path, branch):
+            return
+        page.wait_for_timeout(100)
+    raise AssertionError(failure_message)
+
+
 @user_story("to preserve my worktree branch after deleting the workspace when policy is 'never'")
 def test_never_policy_preserves_branch(sculptor_instance_: SculptorInstance) -> None:
     page = sculptor_instance_.page
@@ -157,8 +177,11 @@ def test_delete_if_safe_with_merged_branch(sculptor_instance_: SculptorInstance)
     _delete_workspace_via_api(page, workspace_id)
 
     _wait_for_worktree_removed(page, sculptor_instance_.project_path, worktree_path)
-    assert not _branch_exists(sculptor_instance_.project_path, branch_name), (
-        f"branch {branch_name} should be deleted under 'delete_if_safe' when merged"
+    _wait_for_branch_deleted(
+        page,
+        sculptor_instance_.project_path,
+        branch_name,
+        f"branch {branch_name} should be deleted under 'delete_if_safe' when merged",
     )
 
 
@@ -195,6 +218,9 @@ def test_always_policy_force_deletes_branch(sculptor_instance_: SculptorInstance
     _delete_workspace_via_api(page, workspace_id)
 
     _wait_for_worktree_removed(page, sculptor_instance_.project_path, worktree_path)
-    assert not _branch_exists(sculptor_instance_.project_path, branch_name), (
-        f"branch {branch_name} should be force-deleted under 'always'"
+    _wait_for_branch_deleted(
+        page,
+        sculptor_instance_.project_path,
+        branch_name,
+        f"branch {branch_name} should be force-deleted under 'always'",
     )


### PR DESCRIPTION
## Problem

Under heavy offload CI load, `test_delete_if_safe_with_merged_branch` (and the analogous `test_always_policy_force_deletes_branch`) in `test_worktree_deletion_policies.py` intermittently fail with:

```
AssertionError: branch imbue/policy-safe-merged should be deleted under 'delete_if_safe' when merged
```

This is a **test-timing race, not a product bug** — the deletion behavior and ordering are correct.

## Root cause

`remove_worktree()` runs two separate git subprocesses in sequence:
1. `git worktree remove <dest>`
2. `git branch -d` (for `delete_if_safe`) / `-D` (for `always`)

The shared `_wait_for_worktree_removed()` helper polls `git worktree list` and returns the instant the worktree disappears — i.e. after step 1 but potentially **before** step 2 has run. The two "branch deleted" tests then asserted branch absence **once, immediately**, so under load they checked too early and saw the not-yet-deleted branch.

The "branch preserved" variants (`test_never_policy_preserves_branch`, `test_delete_if_safe_with_unmerged_branch`) don't flake because asserting "still exists" early is in the safe direction. Only the two "branch deleted" variants race.

## Fix

Add a `_wait_for_branch_deleted()` helper that polls `_branch_exists` until the branch is gone (mirroring the existing `_wait_for_worktree_removed`, same 100ms-step loop and `page.wait_for_timeout` style — no `time.sleep`), raising the existing assertion message on timeout. Use it in the two racy tests. This gives the `git branch -d`/`-D` subprocess a deadline to complete before we conclude deletion failed, closing the race window. The "preserved" tests keep their direct asserts since they aren't racy.

No product code changed.

## Verification

- Integration tests (`test_worktree_deletion_policies.py`): **4 passed**, including both changed tests.
- `just format`, `just check` (lint, typecheck, ratchets, file-hygiene), `just test-unit`: all green.

(Sent by Claude)