### PR TITLE
[SCU-1556] test: stop settings-nav cleanup losing a race to the add-workspace redirect

### DIFF
--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -476,8 +476,24 @@ def navigate_to_settings_page(page: Page, **_kwargs: object) -> PlaywrightSettin
     altogether — important under the ``sculptor://app`` origin, where the
     built renderer references assets via absolute paths and a fresh document
     navigation is unnecessary just to change routes.
+
+    A single hash assignment can lose a race with an in-flight imperative
+    redirect: deleting the last workspace makes WorkspacePage queue a
+    ``navigate("/ws/new/<uuid>")`` that can commit *after* this assignment and
+    bounce the page back off ``/settings``. React Router defers the
+    hashchange-driven navigation in a transition, so the imperative navigate
+    can win. Re-assert the hash until the settings route actually sticks — once
+    it does, WorkspacePage has unmounted and nothing redirects away again.
     """
-    page.evaluate("window.location.hash = '/settings'")
+    page.wait_for_function(
+        """() => {
+            if (!window.location.hash.startsWith('#/settings')) {
+                window.location.hash = '/settings';
+                return false;
+            }
+            return true;
+        }"""
+    )
     return PlaywrightSettingsPage(page=page)
 
 

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -467,33 +467,39 @@ def request_with_retry(
 
 
 def navigate_to_settings_page(page: Page, **_kwargs: object) -> PlaywrightSettingsPage:
-    """Navigate to the settings page by setting the SPA hash route.
+    """Open Settings the way a user does — click the gear in the top bar.
 
-    Mirrors how a user reaches settings: a hash-only navigation within the
-    already-loaded SPA, with no document reload. Assigning
-    ``window.location.hash`` fires a ``hashchange`` event the hash router
-    handles, so this avoids re-fetching ``index.html`` (and its assets)
-    altogether — important under the ``sculptor://app`` origin, where the
-    built renderer references assets via absolute paths and a fresh document
-    navigation is unnecessary just to change routes.
+    The settings button lives in the persistent ``TopBar``, which ``PageLayout``
+    renders on every in-app route (Home, Add Workspace, Workspace, Settings), so
+    it is reachable from any state this helper is called from — including the
+    add-workspace page that pre-test cleanup lands on after deleting all
+    workspaces. Clicking routes via React Router with no document reload, so it
+    keeps the WebSocket connection alive and avoids re-fetching ``index.html``
+    (and its assets) under the ``sculptor://app`` origin, where the built
+    renderer references assets via absolute paths.
 
-    A single hash assignment can lose a race with an in-flight imperative
-    redirect: deleting the last workspace makes WorkspacePage queue a
-    ``navigate("/ws/new/<uuid>")`` that can commit *after* this assignment and
-    bounce the page back off ``/settings``. React Router defers the
-    hashchange-driven navigation in a transition, so the imperative navigate
-    can win. Re-assert the hash until the settings route actually sticks — once
-    it does, WorkspacePage has unmounted and nothing redirects away again.
+    The click is retried until the settings page actually renders. A single
+    click can lose a race with an in-flight imperative redirect: deleting the
+    last workspace makes WorkspacePage queue a ``navigate("/ws/new/<uuid>")``
+    that may commit *after* our navigation and bounce us off ``/settings``.
+    Re-clicking from the now-settled state lands cleanly — the redirect only
+    fires while WorkspacePage is mounted, so once we reach Settings nothing
+    redirects away again.
     """
-    page.wait_for_function(
-        """() => {
-            if (!window.location.hash.startsWith('#/settings')) {
-                window.location.hash = '/settings';
-                return false;
-            }
-            return true;
-        }"""
-    )
+    settings_button = page.get_by_test_id(ElementIDs.SETTINGS_BUTTON)
+    settings_page_marker = page.get_by_test_id(ElementIDs.SETTINGS_PAGE)
+
+    def _click_into_settings() -> None:
+        expect(settings_button).to_be_visible(timeout=5_000)
+        settings_button.click()
+        expect(settings_page_marker).to_be_visible(timeout=5_000)
+
+    retry(
+        stop=stop_after_delay(30),
+        wait=wait_fixed(0.1),
+        retry=retry_if_exception_type(AssertionError),
+        reraise=True,
+    )(_click_into_settings)()
     return PlaywrightSettingsPage(page=page)
 
 


### PR DESCRIPTION
## What

Fixes the `offload` integration-test suite, which started failing on `main` at the React 18→19 / react-router 6→7 dependency-modernization merge.

## Root cause

The shared `_pre_test` cleanup deletes all workspaces, then navigates to **Settings → Repositories** to remove leftover projects. `navigate_to_settings_page` set `window.location.hash = '/settings'` once and immediately clicked the Repositories nav.

Deleting the last workspace makes `WorkspacePage` queue an imperative `navigate("/ws/new/<uuid>")`. Under react-router 7 the hashchange-driven navigation to `/settings` is deferred inside a transition, so that imperative redirect can commit **afterward** and bounce the page back to the add-workspace screen. The Repositories nav is then never present, and the click times out after 30s. Playwright traces confirm the page was showing add-workspace (not settings) at the timeout.

Before the bump (React 18 / react-router 6) the redirect settled first, so this race never lost. It surfaced as a consistently-failing `test_file_browser.py::test_click_file_opens_diff_panel` plus several "flaky" setup timeouts — all sharing the identical `set hash=/settings → click SETTINGS_NAV_REPOSITORIES` sequence in cleanup.

## Fix

Re-assert the hash until the `/settings` route actually commits (via `page.wait_for_function`), instead of firing once and hoping it sticks. Once the page lands on `/settings`, `WorkspacePage` has unmounted and nothing redirects away again. Pure test-infra change — no product code is touched.

## Verification

Lint/format/typecheck pass locally. Real confirmation is a green `offload` run on this PR.

(Sent by Claude)