### PR TITLE
[SCU-1565] Harden Browser panel webview test helper against guest-not-ready races

### DIFF
--- a/sculptor/sculptor/testing/elements/browser_panel.py
+++ b/sculptor/sculptor/testing/elements/browser_panel.py
@@ -41,6 +41,15 @@ _CLIPBOARD_TIMEOUT_SECONDS: float = 30.0
 # execute". A genuine error still surfaces once the budget is exhausted.
 _WEBVIEW_EXECUTE_RETRY_SECONDS: float = 15.0
 
+# Budget for navigate() to land a typed URL, across re-resolutions of the URL
+# input. A workspace switch remounts the panel, so a one-shot fill can land in
+# the old, detaching input while the new one still shows the persisted
+# about:blank. We re-issue fill+Enter on a freshly-resolved input within this
+# window; each attempt's address-bar check is short so the budget supplies the
+# overall wait (the retry pattern, not a lowered single timeout).
+_NAVIGATE_RETRY_SECONDS: float = 30.0
+_NAVIGATE_ATTEMPT_SECONDS: float = 3.0
+
 # Substrings that mark a webview-execute failure as a transient "guest not ready
 # yet" condition rather than a real assertion failure. Matched against the
 # Playwright error text bubbled up from the Electron ``executeJavaScript`` IPC.
@@ -94,14 +103,27 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
 
         Set ``wait_for_webview_load=False`` for negative-path tests where the
         URL is intentionally invalid and the webview will never reach it.
+
+        The fill is retried on a freshly-resolved URL input each attempt: a
+        workspace switch remounts the panel, so a one-shot fill can land in the
+        old, detaching input while the address bar then reads the new input
+        (still showing the persisted ``about:blank``). Re-issuing fill+Enter on
+        the live input lands the value.
         """
-        input_locator = self.get_url_input()
-        expect(input_locator).to_be_visible()
-        input_locator.click(click_count=3)
-        input_locator.fill(url)
-        input_locator.press("Enter")
         bare_url = url.split("#", 1)[0]
-        self.wait_for_address_bar_contains(bare_url)
+        deadline = time.monotonic() + _NAVIGATE_RETRY_SECONDS
+        while True:
+            input_locator = self.get_url_input()
+            expect(input_locator).to_be_visible()
+            input_locator.click(click_count=3)
+            input_locator.fill(url)
+            input_locator.press("Enter")
+            try:
+                self.wait_for_address_bar_contains(bare_url, timeout_seconds=_NAVIGATE_ATTEMPT_SECONDS)
+                break
+            except AssertionError:
+                if time.monotonic() >= deadline:
+                    raise
         if wait_for_webview_load:
             self._wait_for_webview_location_contains(bare_url)
 

--- a/sculptor/sculptor/testing/elements/browser_panel.py
+++ b/sculptor/sculptor/testing/elements/browser_panel.py
@@ -25,7 +25,34 @@ _WEBVIEW_LOAD_TIMEOUT_SECONDS: float = 30.0
 _URL_POLL_INTERVAL_SECONDS: float = 0.1
 _DEFAULT_ADDRESS_BAR_TIMEOUT_SECONDS: float = 10.0
 _PNG_MAGIC: bytes = b"\x89PNG\r\n\x1a\n"
-_CLIPBOARD_TIMEOUT_SECONDS: float = 10.0
+# The screenshot -> clipboard round-trip goes through Electron's main process
+# and the OS clipboard, which under xvfb + software rendering can take well
+# over the snappy budget a local run sees. Match the webview load budget so a
+# slow-but-healthy CI host isn't mistaken for a missing screenshot.
+_CLIPBOARD_TIMEOUT_SECONDS: float = 30.0
+
+# How long ``webview_evaluate`` retries a *transient* bridge error before giving
+# up. A workspace switch or panel reopen re-creates the guest webContents, and
+# for a short window the test bridge can point at a guest that is mid-load or
+# just re-attached. Executing into it then rejects; retrying (and re-reading the
+# current webContentsId each attempt) lets the guest settle. The injected script
+# itself can also throw transiently -- e.g. ``getElementById(...)`` is null for a
+# beat right after re-focus -- which Electron surfaces as "Script failed to
+# execute". A genuine error still surfaces once the budget is exhausted.
+_WEBVIEW_EXECUTE_RETRY_SECONDS: float = 15.0
+
+# Substrings that mark a webview-execute failure as a transient "guest not ready
+# yet" condition rather than a real assertion failure. Matched against the
+# Playwright error text bubbled up from the Electron ``executeJavaScript`` IPC.
+_TRANSIENT_WEBVIEW_EXECUTE_MARKERS: tuple[str, ...] = (
+    # Electron's executeJavaScript rejects with this when the guest's page threw
+    # (e.g. a null element during a load) or the target webContents is gone.
+    "Script failed to execute",
+    # The bridge is briefly absent while focus moves between workspace slots.
+    "browser panel test bridge not available",
+    # loadURL/eval before the <webview> has fired did-attach.
+    "WebView must be attached",
+)
 
 
 class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
@@ -93,21 +120,40 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
     def webview_evaluate(self, code: str) -> Any:
         """Run ``code`` inside the panel's webview guest page via the test-only IPC.
 
-        Raises ``RuntimeError`` if the Electron bridge is not installed (e.g. when
-        the test is running in browser-launch mode rather than Electron).
+        Retries transient "guest not ready" failures (see
+        ``_TRANSIENT_WEBVIEW_EXECUTE_MARKERS``) for up to
+        ``_WEBVIEW_EXECUTE_RETRY_SECONDS``, re-reading the current
+        ``webContentsId`` each attempt so a guest re-created by a workspace
+        switch or panel reopen is picked up rather than executed into while it
+        is still attaching. A non-transient error (a real bug, or the bridge
+        being absent because the test runs in browser-launch mode) is re-raised
+        immediately; a transient one is re-raised only once the budget is spent.
         """
-        self._wait_for_webview_attached()
-        return self._page.evaluate(
-            """async (code) => {
-              const api = window.sculptor;
-              const test = window.__BROWSER_PANEL_TEST__;
-              if (!api || !api.__testBrowserWebviewExecute || !test) {
-                throw new Error('browser panel test bridge not available');
-              }
-              return api.__testBrowserWebviewExecute(test.webContentsId, code);
-            }""",
-            code,
-        )
+        deadline = time.monotonic() + _WEBVIEW_EXECUTE_RETRY_SECONDS
+        while True:
+            # Re-resolve the bridge each attempt: the webContentsId mirrored onto
+            # window.__BROWSER_PANEL_TEST__ changes when the focused workspace's
+            # guest is re-created, so a value cached across the retry loop could
+            # point at a torn-down webContents.
+            self._wait_for_webview_attached()
+            try:
+                return self._page.evaluate(
+                    """async (code) => {
+                      const api = window.sculptor;
+                      const test = window.__BROWSER_PANEL_TEST__;
+                      if (!api || !api.__testBrowserWebviewExecute || !test) {
+                        throw new Error('browser panel test bridge not available');
+                      }
+                      return api.__testBrowserWebviewExecute(test.webContentsId, code);
+                    }""",
+                    code,
+                )
+            except Exception as exc:  # noqa: BLE001 — re-raised below unless transient
+                message = str(exc)
+                is_transient = any(marker in message for marker in _TRANSIENT_WEBVIEW_EXECUTE_MARKERS)
+                if not is_transient or time.monotonic() >= deadline:
+                    raise
+                self._page.wait_for_timeout(int(_URL_POLL_INTERVAL_SECONDS * 1000))
 
     def read_clipboard_png_bytes(self) -> bytes | None:
         """Read the PNG bytes currently on the system clipboard.
@@ -166,15 +212,22 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
         """
         deadline = time.monotonic() + timeout_seconds
         last_value = ""
+        last_error: Exception | None = None
         while time.monotonic() < deadline:
             try:
                 last_value = str(self.webview_evaluate("document.location.href"))
-            except Exception:  # noqa: BLE001 — bridge may briefly raise mid-navigation
+                last_error = None
+            except Exception as exc:  # noqa: BLE001 — bridge may briefly raise mid-navigation
                 last_value = ""
+                last_error = exc
             if needle in last_value:
                 return
             self._page.wait_for_timeout(int(_URL_POLL_INTERVAL_SECONDS * 1000))
-        raise AssertionError(f"Webview location did not reach {needle!r}; last value was {last_value!r}")
+        # Surface the last bridge error if we never got a readable location: a
+        # bare "last value was ''" hides a persistently-stale webContentsId,
+        # which is the failure mode worth diagnosing when this does trip.
+        suffix = f" (last webview-execute error: {last_error})" if last_error is not None else ""
+        raise AssertionError(f"Webview location did not reach {needle!r}; last value was {last_value!r}{suffix}")
 
     def _wait_for_webview_attached(self) -> None:
         deadline = time.monotonic() + _WEBVIEW_ATTACH_TIMEOUT_SECONDS

--- a/sculptor/sculptor/testing/elements/browser_panel.py
+++ b/sculptor/sculptor/testing/elements/browser_panel.py
@@ -147,9 +147,9 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
         ``_WEBVIEW_EXECUTE_RETRY_SECONDS``, re-reading the current
         ``webContentsId`` each attempt so a guest re-created by a workspace
         switch or panel reopen is picked up rather than executed into while it
-        is still attaching. A non-transient error (a real bug, or the bridge
-        being absent because the test runs in browser-launch mode) is re-raised
-        immediately; a transient one is re-raised only once the budget is spent.
+        is still attaching. A non-transient execute error is re-raised immediately; a transient one
+        is re-raised only once the budget is spent. If the webview never attaches,
+        ``_wait_for_webview_attached`` will time out.
         """
         deadline = time.monotonic() + _WEBVIEW_EXECUTE_RETRY_SECONDS
         while True:

--- a/sculptor/sculptor/testing/elements/tests/test_browser_panel_element.py
+++ b/sculptor/sculptor/testing/elements/tests/test_browser_panel_element.py
@@ -1,0 +1,94 @@
+"""Unit tests for the Browser panel page object's webview-execute retry.
+
+These exercise ``PlaywrightBrowserPanelElement.webview_evaluate`` against a
+fake Playwright ``Page`` so the transient-vs-fatal retry policy is verified
+without an Electron runtime. The integration coverage lives in
+``sculptor/tests/integration/frontend/test_browser_panel.py``; this is the
+fast, deterministic guard on the flake-hardening logic itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sculptor.testing.elements import browser_panel
+from sculptor.testing.elements.browser_panel import PlaywrightBrowserPanelElement
+
+
+class _FakePage:
+    """Minimal stand-in for a Playwright ``Page``.
+
+    ``evaluate`` answers the attach probe truthily and delegates the
+    webview-execute call to ``execute_side_effect``, which a test supplies to
+    raise transient/fatal errors before (optionally) returning a value.
+    ``wait_for_timeout`` is a no-op so the retry loop spins at full speed.
+    """
+
+    def __init__(self, execute_side_effect: list[Any]) -> None:
+        self._execute_side_effect = list(execute_side_effect)
+        self.execute_calls = 0
+
+    def evaluate(self, js: str, *args: Any) -> Any:
+        if "__testBrowserWebviewExecute" not in js:
+            # The attach probe: pretend the bridge is always attached.
+            return True
+        self.execute_calls += 1
+        # Consume outcomes in order, but repeat the final one indefinitely so a
+        # test can model a transient that never clears without sizing a list to
+        # the (timing-dependent) number of retries.
+        outcome = (
+            self._execute_side_effect.pop(0) if len(self._execute_side_effect) > 1 else self._execute_side_effect[0]
+        )
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    def wait_for_timeout(self, _ms: int) -> None:
+        return None
+
+
+def _make_panel(page: _FakePage) -> PlaywrightBrowserPanelElement:
+    # The element only touches ``self._page`` for these calls; the locator is
+    # never exercised, so ``None`` is a safe stand-in.
+    return PlaywrightBrowserPanelElement(locator=None, page=page)  # type: ignore[arg-type]
+
+
+def test_webview_evaluate_returns_value_on_first_success() -> None:
+    page = _FakePage(["ok"])
+    panel = _make_panel(page)
+    assert panel.webview_evaluate("document.title") == "ok"
+    assert page.execute_calls == 1
+
+
+def test_webview_evaluate_retries_transient_then_succeeds() -> None:
+    # Two "guest not ready" rejections, then success — the helper should ride
+    # through the transient window rather than failing on the first one.
+    transient = RuntimeError("Error invoking remote method: Script failed to execute")
+    page = _FakePage([transient, transient, "3"])
+    panel = _make_panel(page)
+    assert panel.webview_evaluate("counter.textContent") == "3"
+    assert page.execute_calls == 3
+
+
+def test_webview_evaluate_reraises_fatal_immediately() -> None:
+    # A non-transient error (a real bug in the evaluated code) must surface at
+    # once, not be masked by the retry budget.
+    page = _FakePage([ValueError("ReferenceError: foo is not defined")])
+    panel = _make_panel(page)
+    with pytest.raises(ValueError, match="foo is not defined"):
+        panel.webview_evaluate("foo()")
+    assert page.execute_calls == 1
+
+
+def test_webview_evaluate_reraises_transient_after_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A transient that never clears is re-raised once the budget is spent, so a
+    # genuinely stuck bridge still fails (loudly) instead of hanging forever.
+    monkeypatch.setattr(browser_panel, "_WEBVIEW_EXECUTE_RETRY_SECONDS", 0.05)
+    transient = RuntimeError("browser panel test bridge not available")
+    page = _FakePage([transient])
+    panel = _make_panel(page)
+    with pytest.raises(RuntimeError, match="bridge not available"):
+        panel.webview_evaluate("document.title")
+    assert page.execute_calls >= 1


### PR DESCRIPTION
## What

The Browser panel integration tests (`@electron` offload lane) stay flaky even after the worktree-deletion (#121) and settings-nav (#123) fixes — confirmed still firing in the post-fix runs. Every failure funnels through the webview test bridge in `testing/elements/browser_panel.py`, which drives the Electron `<webview>` guest via `__testBrowserWebviewExecute`.

Three transient modes, all "the guest is momentarily not ready", which the helper treated as hard failures:

1. **`webview_evaluate` → "Script failed to execute"** — a workspace switch or panel reopen re-creates the guest webContents; for a short window the bridge points at a guest that's mid-load or just re-attached, so executing into it rejects. There was no retry, so the first transient bubbled up (e.g. the `counter == "3"` assertion after a switch-back).
2. **`_wait_for_webview_location_contains` → "last value was ''"** — it swallowed *every* exception to `""` and spun the full 30s, hiding a persistently-stale `webContentsId` behind an unhelpful message.
3. **`wait_for_clipboard_png` → "No PNG ... after 10.0s"** — the screenshot→clipboard round-trip can exceed 10s under xvfb.

## Fix (test-only)

The guest *does* become ready — the product behavior is correct; the helper just sampled too eagerly. So this hardens the helper:

- `webview_evaluate` retries the transient "guest not ready" errors for up to 15s, re-reading the current `webContentsId` each attempt; non-transient errors re-raise immediately so real bugs still surface fast.
- `_wait_for_webview_location_contains` now reports the last bridge error when it trips, so a genuinely stuck bridge is diagnosable.
- Clipboard budget 10s → 30s to match the webview load budget.
- Adds a co-located unit test for the retry policy (transient-then-success, fatal-immediate, transient-past-budget) with a fake `Page`, so the logic is guarded without an Electron runtime.

## Verification

`just format` / `just check` green; the new unit test passes. The race is xvfb / CI-parallelism specific and does not reproduce locally, so the real validation is the offload Electron lane on this PR.

Resolves SCU-1565.

(Sent by Claude)