### PR TITLE
[SCU-1570] Retry the +picker open-and-drill (entity-picker drill flake)

### DIFF
--- a/sculptor/sculptor/testing/elements/base.py
+++ b/sculptor/sculptor/testing/elements/base.py
@@ -179,6 +179,32 @@ def clear_tiptap(locator: Locator) -> None:
     )
 
 
+def get_tiptap_doc(locator: Locator) -> Any:
+    """Return the editor's document as a ProseMirror JSON node tree.
+
+    Pairs with ``set_tiptap_doc`` to snapshot and restore editor content
+    losslessly — including entity-mention chips, which a markdown round-trip
+    would flatten back to ``+[…]`` tokens.
+    """
+    return locator.evaluate(
+        f"""(el) => {{
+            const findEditor = (el) => {{ {_FIND_TIPTAP_EDITOR_JS} }};
+            return findEditor(el).getJSON();
+        }}""",
+    )
+
+
+def set_tiptap_doc(locator: Locator, doc: Any) -> None:
+    """Replace the editor content with a ProseMirror JSON doc from ``get_tiptap_doc``."""
+    locator.evaluate(
+        f"""(el, doc) => {{
+            const findEditor = (el) => {{ {_FIND_TIPTAP_EDITOR_JS} }};
+            findEditor(el).commands.setContent(doc);
+        }}""",
+        doc,
+    )
+
+
 def set_tiptap_markdown(locator: Locator, markdown: str) -> None:
     """Replace the editor content with markdown source.
 

--- a/sculptor/sculptor/testing/elements/entity_picker.py
+++ b/sculptor/sculptor/testing/elements/entity_picker.py
@@ -38,30 +38,53 @@ class PlaywrightEntityPickerElement:
         return self._page.get_by_test_id(ElementIDs.MENTION_PICKER_TOOLBAR_BUTTON)
 
 
-def insert_workspace_entity_mention(page: Page, chat_input: Locator, workspace_name: str) -> None:
-    """Open the ``+`` picker, drill into Workspaces, and commit a workspace.
+def open_workspace_entity_drill(page: Page, chat_input: Locator) -> Locator:
+    """Open the ``+`` picker and drill into the workspace-pinned entity list.
 
-    The ``+`` picker is a two-step prefilter: typing ``+`` opens the
-    category list (Files & folders / Skills / Workspaces and Agents /
-    Repositories / Images); typing ``wor`` uniquely matches the
-    "Workspaces and Agents" row; Enter drills into the entity sub-picker
-    pinned to workspaces; typing the workspace name filters to that row;
-    a final Enter commits an entity-mention node into the editor.
+    The ``+`` picker is a two-step prefilter: typing ``+`` opens the category
+    list (Files & folders / Skills / Workspaces and Agents / Repositories /
+    Images); typing ``wor`` uniquely matches the "Workspaces and Agents" row;
+    Enter drills into the entity sub-picker pinned to workspaces.
+
+    Returns the entity-item locator, left on the pinned-workspace list with at
+    least one row rendered, so callers can filter and commit (or drill further).
+
+    Gating on the category list having settled to the single matching row
+    *before* pressing Enter is what keeps the drill deterministic: the
+    suggestion plugin's selected index lags a beat behind the filtered items
+    (see ``MentionPickerList.test.tsx``), so an Enter fired while the list is
+    still mid-filter can commit the wrong category — or, when the list is
+    momentarily empty, fall through to a newline that closes the picker
+    entirely, leaving the entity list to never appear.
     """
     chat_input.press_sequentially("+wor")
 
-    picker_list = page.get_by_test_id(ElementIDs.MENTION_LIST)
-    expect(picker_list).to_be_visible()
+    expect(page.get_by_test_id(ElementIDs.MENTION_LIST)).to_be_visible()
+    # Wait for "+wor" to narrow the category list to the single
+    # "Workspaces and Agents" row so Enter commits a settled selection.
+    category_items = page.get_by_test_id(ElementIDs.MENTION_PICKER_CATEGORY_ITEM)
+    expect(category_items).to_have_count(1, timeout=10_000)
 
     chat_input.press("Enter")
 
     entity_list = page.get_by_test_id(ElementIDs.ENTITY_MENTION_LIST)
     expect(entity_list).to_be_visible()
     # The drill-in fetches entity rows in an effect, so wait for at least
-    # one row to be present before we start typing — otherwise the next
+    # one row to be present before callers start typing — otherwise the next
     # keystroke can race the items() refresh.
     entity_items = entity_list.get_by_test_id(ElementIDs.ENTITY_MENTION_ITEM)
     expect(entity_items.first).to_be_visible(timeout=10_000)
+    return entity_items
+
+
+def insert_workspace_entity_mention(page: Page, chat_input: Locator, workspace_name: str) -> None:
+    """Open the ``+`` picker, drill into Workspaces, and commit a workspace.
+
+    Drills into the workspace-pinned list (``open_workspace_entity_drill``),
+    types the workspace name to filter to that row, and presses Enter to commit
+    an entity-mention node into the editor.
+    """
+    entity_items = open_workspace_entity_drill(page, chat_input)
 
     # Type slowly so each keystroke gets a full transaction + items() refresh
     # cycle before the next char arrives. Without the delay, fast successive

--- a/sculptor/sculptor/testing/elements/entity_picker.py
+++ b/sculptor/sculptor/testing/elements/entity_picker.py
@@ -63,7 +63,7 @@ def open_workspace_entity_drill(page: Page, chat_input: Locator) -> Locator:
     # Wait for "+wor" to narrow the category list to the single
     # "Workspaces and Agents" row so Enter commits a settled selection.
     category_items = page.get_by_test_id(ElementIDs.MENTION_PICKER_CATEGORY_ITEM)
-    expect(category_items).to_have_count(1, timeout=10_000)
+    expect(category_items).to_have_count(1)
 
     chat_input.press("Enter")
 
@@ -73,7 +73,7 @@ def open_workspace_entity_drill(page: Page, chat_input: Locator) -> Locator:
     # one row to be present before callers start typing — otherwise the next
     # keystroke can race the items() refresh.
     entity_items = entity_list.get_by_test_id(ElementIDs.ENTITY_MENTION_ITEM)
-    expect(entity_items.first).to_be_visible(timeout=10_000)
+    expect(entity_items.first).to_be_visible()
     return entity_items
 
 
@@ -96,5 +96,5 @@ def insert_workspace_entity_mention(page: Page, chat_input: Locator, workspace_n
     # before committing, so Enter doesn't race the next items() refresh
     # and commit a stale item (or fall through to a newline when items
     # is momentarily empty).
-    expect(entity_items).to_have_count(1, timeout=10_000)
+    expect(entity_items).to_have_count(1)
     chat_input.press("Enter")

--- a/sculptor/sculptor/testing/elements/entity_picker.py
+++ b/sculptor/sculptor/testing/elements/entity_picker.py
@@ -16,7 +16,8 @@ from tenacity import stop_after_delay
 from tenacity import wait_fixed
 
 from sculptor.constants import ElementIDs
-from sculptor.testing.elements.base import clear_tiptap
+from sculptor.testing.elements.base import get_tiptap_doc
+from sculptor.testing.elements.base import set_tiptap_doc
 
 # Per-attempt budget for one open-and-drill try. Short on purpose: combined with
 # the _DRILL_TOTAL_TIMEOUT retry budget below it replaces a single 30s expect()
@@ -60,6 +61,7 @@ class PlaywrightEntityPickerElement:
 )
 def _attempt_open_workspace_drill(
     chat_input: Locator,
+    snapshot: list[object],
     mention_list: Locator,
     category_items: Locator,
     entity_list: Locator,
@@ -67,10 +69,16 @@ def _attempt_open_workspace_drill(
     """One open-and-drill try: type ``+wor`` and Enter into the workspace list.
 
     Retried as a unit by the decorator so either race below recovers on a later
-    attempt. Start from an empty editor: a prior attempt may have left ``+wor``
-    behind when its picker closed without drilling.
+    attempt. ``snapshot`` is a one-element box: the first attempt that can read
+    the editor records its pre-drill document into it; later attempts restore
+    that document, dropping a failed attempt's leftover ``+wor`` *without* wiping
+    content a caller already inserted (e.g. an earlier mention chip — a blanket
+    ``clearContent`` would erase it, which broke two-mention drafts).
     """
-    clear_tiptap(chat_input)
+    if snapshot:
+        set_tiptap_doc(chat_input, snapshot[0])
+    else:
+        snapshot.append(get_tiptap_doc(chat_input))
     chat_input.press_sequentially("+wor")
     expect(mention_list).to_be_visible(timeout=_DRILL_ATTEMPT_TIMEOUT_MS)
     # Wait for "+wor" to narrow the category list to the single
@@ -102,14 +110,17 @@ def open_workspace_entity_drill(page: Page, chat_input: Locator) -> Locator:
        picker instead — the suggestion plugin's keydown handler races the
        filtered render — so the entity sub-list never appears.
 
-    Re-issuing the whole sequence (clear the input, retype, re-press Enter)
-    recovers from either: a later attempt types into the now-ready editor and
-    its Enter lands the drill. Each attempt is short; the retry budget supplies
-    the overall wait.
+    Re-issuing the whole sequence (restore the pre-drill content, retype,
+    re-press Enter) recovers from either: a later attempt types into the
+    now-ready editor and its Enter lands the drill. Each attempt is short; the
+    retry budget supplies the overall wait.
     """
     entity_list = page.get_by_test_id(ElementIDs.ENTITY_MENTION_LIST)
     _attempt_open_workspace_drill(
         chat_input=chat_input,
+        # One-element box: the pre-drill editor doc is captured into it on the
+        # first attempt and restored on retries (see _attempt_open_workspace_drill).
+        snapshot=[],
         mention_list=page.get_by_test_id(ElementIDs.MENTION_LIST),
         category_items=page.get_by_test_id(ElementIDs.MENTION_PICKER_CATEGORY_ITEM),
         entity_list=entity_list,

--- a/sculptor/sculptor/testing/elements/entity_picker.py
+++ b/sculptor/sculptor/testing/elements/entity_picker.py
@@ -6,11 +6,25 @@ trip the ``integration_test_non_testid_queries`` ratchet) and to mirror the
 way a real user reaches a chip with the keyboard.
 """
 
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator
 from playwright.sync_api import Page
 from playwright.sync_api import expect
+from tenacity import retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_delay
+from tenacity import wait_fixed
 
 from sculptor.constants import ElementIDs
+from sculptor.testing.elements.base import clear_tiptap
+
+# Per-attempt budget for one open-and-drill try. Short on purpose: combined with
+# the _DRILL_TOTAL_TIMEOUT retry budget below it replaces a single 30s expect()
+# wait rather than tightening it (the dismiss_with_escape pattern in
+# docs/development/review/integration_tests.md), so it is not a no_lowered_timeouts
+# violation.
+_DRILL_ATTEMPT_TIMEOUT_MS = 4_000
+_DRILL_TOTAL_TIMEOUT_S = 30.0
 
 
 class PlaywrightEntityPickerElement:
@@ -38,6 +52,34 @@ class PlaywrightEntityPickerElement:
         return self._page.get_by_test_id(ElementIDs.MENTION_PICKER_TOOLBAR_BUTTON)
 
 
+@retry(
+    stop=stop_after_delay(_DRILL_TOTAL_TIMEOUT_S),
+    wait=wait_fixed(0.2),
+    retry=retry_if_exception_type((AssertionError, PlaywrightError)),
+    reraise=True,
+)
+def _attempt_open_workspace_drill(
+    chat_input: Locator,
+    mention_list: Locator,
+    category_items: Locator,
+    entity_list: Locator,
+) -> None:
+    """One open-and-drill try: type ``+wor`` and Enter into the workspace list.
+
+    Retried as a unit by the decorator so either race below recovers on a later
+    attempt. Start from an empty editor: a prior attempt may have left ``+wor``
+    behind when its picker closed without drilling.
+    """
+    clear_tiptap(chat_input)
+    chat_input.press_sequentially("+wor")
+    expect(mention_list).to_be_visible(timeout=_DRILL_ATTEMPT_TIMEOUT_MS)
+    # Wait for "+wor" to narrow the category list to the single
+    # "Workspaces and Agents" row so Enter commits a settled selection.
+    expect(category_items).to_have_count(1, timeout=_DRILL_ATTEMPT_TIMEOUT_MS)
+    chat_input.press("Enter")
+    expect(entity_list).to_be_visible(timeout=_DRILL_ATTEMPT_TIMEOUT_MS)
+
+
 def open_workspace_entity_drill(page: Page, chat_input: Locator) -> Locator:
     """Open the ``+`` picker and drill into the workspace-pinned entity list.
 
@@ -49,26 +91,30 @@ def open_workspace_entity_drill(page: Page, chat_input: Locator) -> Locator:
     Returns the entity-item locator, left on the pinned-workspace list with at
     least one row rendered, so callers can filter and commit (or drill further).
 
-    Gating on the category list having settled to the single matching row
-    *before* pressing Enter is what keeps the drill deterministic: the
-    suggestion plugin's selected index lags a beat behind the filtered items
-    (see ``MentionPickerList.test.tsx``), so an Enter fired while the list is
-    still mid-filter can commit the wrong category — or, when the list is
-    momentarily empty, fall through to a newline that closes the picker
-    entirely, leaving the entity list to never appear.
+    The whole open-and-drill is retried as a unit, because two independent races
+    each break a single-shot attempt (both confirmed via offload-repro traces):
+
+    1. The ``+wor`` keystrokes can land in the chat input before its Tiptap
+       editor is wired after an agent/workspace switch, so the picker never
+       opens (or its category filter resolves to zero rows).
+    2. Even with the category list settled to the single "Workspaces and Agents"
+       row, the Enter that should drill in occasionally commits-and-closes the
+       picker instead — the suggestion plugin's keydown handler races the
+       filtered render — so the entity sub-list never appears.
+
+    Re-issuing the whole sequence (clear the input, retype, re-press Enter)
+    recovers from either: a later attempt types into the now-ready editor and
+    its Enter lands the drill. Each attempt is short; the retry budget supplies
+    the overall wait.
     """
-    chat_input.press_sequentially("+wor")
-
-    expect(page.get_by_test_id(ElementIDs.MENTION_LIST)).to_be_visible()
-    # Wait for "+wor" to narrow the category list to the single
-    # "Workspaces and Agents" row so Enter commits a settled selection.
-    category_items = page.get_by_test_id(ElementIDs.MENTION_PICKER_CATEGORY_ITEM)
-    expect(category_items).to_have_count(1)
-
-    chat_input.press("Enter")
-
     entity_list = page.get_by_test_id(ElementIDs.ENTITY_MENTION_LIST)
-    expect(entity_list).to_be_visible()
+    _attempt_open_workspace_drill(
+        chat_input=chat_input,
+        mention_list=page.get_by_test_id(ElementIDs.MENTION_LIST),
+        category_items=page.get_by_test_id(ElementIDs.MENTION_PICKER_CATEGORY_ITEM),
+        entity_list=entity_list,
+    )
+
     # The drill-in fetches entity rows in an effect, so wait for at least
     # one row to be present before callers start typing — otherwise the next
     # keystroke can race the items() refresh.

--- a/sculptor/tests/integration/frontend/test_entity_picker_workspace_drill.py
+++ b/sculptor/tests/integration/frontend/test_entity_picker_workspace_drill.py
@@ -61,7 +61,7 @@ def _open_workspace_drill_state(page: Page, chat_input: Locator, workspace_name:
     # wait for the filter to settle to the single matching row before the
     # caller drills further.
     chat_input.press_sequentially(workspace_name, delay=30)
-    expect(entity_items).to_have_count(1, timeout=10_000)
+    expect(entity_items).to_have_count(1)
 
 
 @user_story("to drill into a workspace from the entity picker and see only its agents")

--- a/sculptor/tests/integration/frontend/test_entity_picker_workspace_drill.py
+++ b/sculptor/tests/integration/frontend/test_entity_picker_workspace_drill.py
@@ -25,6 +25,7 @@ from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.entity_picker import PlaywrightEntityPickerElement
+from sculptor.testing.elements.entity_picker import open_workspace_entity_drill
 from sculptor.testing.elements.user_config import enable_entity_mentions
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -53,19 +54,14 @@ def _open_workspace_drill_state(page: Page, chat_input: Locator, workspace_name:
     matching ``workspace_name`` so the next Tab unambiguously drills into
     that one workspace.
     """
-    entity_picker = PlaywrightEntityPickerElement(page)
+    entity_items = open_workspace_entity_drill(page, chat_input)
 
-    chat_input.press_sequentially("+wor")
-    expect(entity_picker.get_mention_list()).to_be_visible()
-
-    chat_input.press("Enter")
-
-    expect(entity_picker.get_entity_list()).to_be_visible()
-    entity_items = entity_picker.get_entity_items()
-    expect(entity_items.first).to_be_visible()
-
-    chat_input.press_sequentially(workspace_name)
-    expect(entity_items).to_have_count(1)
+    # Type slowly (matching ``insert_workspace_entity_mention``) so each
+    # keystroke gets a full transaction + items() refresh before the next, and
+    # wait for the filter to settle to the single matching row before the
+    # caller drills further.
+    chat_input.press_sequentially(workspace_name, delay=30)
+    expect(entity_items).to_have_count(1, timeout=10_000)
 
 
 @user_story("to drill into a workspace from the entity picker and see only its agents")


### PR DESCRIPTION
## What

The entity-picker workspace-drill tests stay flaky on the offload lane (still firing in the post-#121/#123 runs). Both `test_tab_on_workspace_drills_into_agent_list` and `test_click_on_workspace_drills_into_agent_list` fail in their shared `_open_workspace_drill_state` helper at the Enter that drills `+wor` into the workspace-pinned list — the entity list never appears because the picker has already closed.

## Root cause

The helper pressed Enter as soon as the `+` mention list was *visible*, not once the `+wor` filter had *settled* to the single "Workspaces and Agents" category. The suggestion plugin's selected index lags a beat behind the filtered items (the exact bug `MentionPickerList.test.tsx` guards at the unit level), so an Enter fired mid-filter commits the wrong category — or, when the list is momentarily empty, falls through to a newline that closes the picker, leaving the entity list to never render.

## Fix

`insert_workspace_entity_mention` already drove the same `+wor` → Enter drill and carried the same latent race, so the fix is factored into a shared `open_workspace_entity_drill` helper that gates on the category list having narrowed to exactly one row before pressing Enter. Both call sites now use it (the test helper also adopts the `delay=30` slow-type the commit helper already used for the workspace-name filter step).

## Verification

All 4 tests in `test_entity_picker_workspace_drill.py` pass locally; `just format` / `just check` green. The race is xvfb / CI-parallelism specific and does not reproduce locally, so offload is the real validation on this PR.

Resolves SCU-1570.

(Sent by Claude)