### PR TITLE
Make Opus (1M) the default model instead of disabled Fable

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/userConfig.ts
+++ b/sculptor/frontend/src/common/state/atoms/userConfig.ts
@@ -59,9 +59,10 @@ export const defaultModelAtom = atom<string>((get) => {
     return lastUsedModel;
   }
   // Product default when nothing else is selected. Fable is currently disabled
-  // with an indefinite timeline, so the default falls back to Opus (SCU-1576);
-  // Fable stays available in the switcher for if/when it returns.
-  return LlmModel.CLAUDE_4_OPUS_200K;
+  // with an indefinite timeline, so the default falls back to the 1M-context
+  // Opus (CLAUDE_4_OPUS, shown as "Opus (1M)"; SCU-1576). Fable stays available
+  // in the switcher for if/when it returns.
+  return LlmModel.CLAUDE_4_OPUS;
 });
 
 // User identity settings

--- a/sculptor/frontend/src/common/state/atoms/userConfig.ts
+++ b/sculptor/frontend/src/common/state/atoms/userConfig.ts
@@ -58,7 +58,10 @@ export const defaultModelAtom = atom<string>((get) => {
   if (lastUsedModel && isLlmModel(lastUsedModel)) {
     return lastUsedModel;
   }
-  return LlmModel.CLAUDE_FABLE_5;
+  // Product default when nothing else is selected. Fable is currently disabled
+  // with an indefinite timeline, so the default falls back to Opus (SCU-1576);
+  // Fable stays available in the switcher for if/when it returns.
+  return LlmModel.CLAUDE_4_OPUS_200K;
 });
 
 // User identity settings

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -403,12 +403,13 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
                 return message.model_name
         # Fall back to the model selected at agent creation time, then to the
         # product default. Fable is currently disabled with an indefinite
-        # timeline, so the default falls back to Opus (SCU-1576); Fable stays
-        # available in the switcher for if/when it returns.
+        # timeline, so the default falls back to the 1M-context Opus
+        # (CLAUDE_4_OPUS, shown as "Opus (1M)"; SCU-1576); Fable stays available
+        # in the switcher for if/when it returns.
         input_data = self.task.input_data
         if isinstance(input_data, AgentTaskInputsV2) and input_data.default_model is not None:
             return input_data.default_model
-        return LLMModel.CLAUDE_4_OPUS_200K
+        return LLMModel.CLAUDE_4_OPUS
 
     @computed_field
     @property

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -401,11 +401,14 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
         for message in reversed(self._messages):
             if isinstance(message, ChatInputUserMessage) and message.model_name is not None:
                 return message.model_name
-        # Fall back to the model selected at agent creation time, then to CLAUDE_FABLE_5.
+        # Fall back to the model selected at agent creation time, then to the
+        # product default. Fable is currently disabled with an indefinite
+        # timeline, so the default falls back to Opus (SCU-1576); Fable stays
+        # available in the switcher for if/when it returns.
         input_data = self.task.input_data
         if isinstance(input_data, AgentTaskInputsV2) and input_data.default_model is not None:
             return input_data.default_model
-        return LLMModel.CLAUDE_FABLE_5
+        return LLMModel.CLAUDE_4_OPUS_200K
 
     @computed_field
     @property

--- a/sculptor/tests/integration/regression/test_regression_default_model_opus.py
+++ b/sculptor/tests/integration/regression/test_regression_default_model_opus.py
@@ -1,0 +1,46 @@
+"""Regression test: a new workspace defaults to Opus, not Fable.
+
+SCU-1576: Fable was still shipping as the product default model even though it
+is currently disabled with an indefinite timeline. When the "Default model"
+setting (Settings → Agent → Default model) is "Most Recently Used" — the product
+default, where ``userConfig.defaultLlm`` is ``None`` — and the user has not yet
+selected any model (so there is no most-recently-used model either), a newly
+created workspace fell through to the Fable fallback. The default should be Opus
+instead, while Fable remains available in the model switcher for if/when it
+returns.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# The chat-panel model selector renders the model's short name; "Opus" is the
+# short name for CLAUDE_4_OPUS_200K (see frontend modelConstants.ts).
+OPUS_MODEL_NAME = "Opus"
+
+
+@user_story("to have a new workspace default to Opus when I haven't picked a model")
+def test_new_workspace_defaults_to_opus(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """A brand-new workspace defaults to Opus when nothing else is selected.
+
+    Steps:
+    1. Create a brand-new workspace without touching its model selector
+       (``model_name=None``). The "Default model" setting is the product-default
+       "Most Recently Used" (``defaultLlm`` is None) and no model has been used
+       yet, so the default resolves to the product fallback.
+    2. Verify the workspace's model selector shows "Opus" — the product default
+       — rather than the old Fable fallback.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        page,
+        model_name=None,
+        workspace_name="Default Model Workspace",
+    )
+
+    expect(task_page.get_chat_panel().get_model_selector()).to_have_text(OPUS_MODEL_NAME)

--- a/sculptor/tests/integration/regression/test_regression_default_model_opus.py
+++ b/sculptor/tests/integration/regression/test_regression_default_model_opus.py
@@ -1,13 +1,13 @@
-"""Regression test: a new workspace defaults to Opus, not Fable.
+"""Regression test: a new workspace defaults to Opus (1M), not Fable.
 
 SCU-1576: Fable was still shipping as the product default model even though it
 is currently disabled with an indefinite timeline. When the "Default model"
 setting (Settings → Agent → Default model) is "Most Recently Used" — the product
 default, where ``userConfig.defaultLlm`` is ``None`` — and the user has not yet
 selected any model (so there is no most-recently-used model either), a newly
-created workspace fell through to the Fable fallback. The default should be Opus
-instead, while Fable remains available in the model switcher for if/when it
-returns.
+created workspace fell through to the Fable fallback. The default should be the
+1M-context Opus instead, while Fable remains available in the model switcher for
+if/when it returns.
 """
 
 from playwright.sync_api import expect
@@ -16,24 +16,25 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# The chat-panel model selector renders the model's short name; "Opus" is the
-# short name for CLAUDE_4_OPUS_200K (see frontend modelConstants.ts).
-OPUS_MODEL_NAME = "Opus"
+# The chat-panel model selector renders the model's short name; "Opus (1M)" is
+# the short name for CLAUDE_4_OPUS, the 1M-context Opus (see frontend
+# modelConstants.ts). The plain "Opus" short name is the 200K variant.
+OPUS_MODEL_NAME = "Opus (1M)"
 
 
 @user_story("to have a new workspace default to Opus when I haven't picked a model")
 def test_new_workspace_defaults_to_opus(
     sculptor_instance_: SculptorInstance,
 ) -> None:
-    """A brand-new workspace defaults to Opus when nothing else is selected.
+    """A brand-new workspace defaults to Opus (1M) when nothing else is selected.
 
     Steps:
     1. Create a brand-new workspace without touching its model selector
        (``model_name=None``). The "Default model" setting is the product-default
        "Most Recently Used" (``defaultLlm`` is None) and no model has been used
        yet, so the default resolves to the product fallback.
-    2. Verify the workspace's model selector shows "Opus" — the product default
-       — rather than the old Fable fallback.
+    2. Verify the workspace's model selector shows "Opus (1M)" — the product
+       default — rather than the old Fable fallback.
     """
     page = sculptor_instance_.page
 


### PR DESCRIPTION
## Original bug

> Fable is still shipping as the default model even though it is currently disabled with an indefinite timeline. Keep Fable available for if or when it returns, but set the default model back to Opus.

Linear: [SCU-1576 — Make Opus the default model](https://linear.app/imbue/issue/SCU-1576/make-opus-the-default-model)

## Hypotheses considered

1. **Frontend default-model atom falls back to Fable** — when the user has no configured default (`userConfig.defaultLlm` is `None`) and no most-recently-used model, `defaultModelAtom` returned `LlmModel.CLAUDE_FABLE_5`. This is the model the Add Workspace flow sends at agent creation and the model pre-selected in the chat-panel switcher. **REPRODUCED** (failing e2e test + before screenshot).
2. **Backend `CodingAgentTaskView.model` falls back to Fable** — for a task with no message-level model and no creation-time `default_model`, the computed `model` property returned `LLMModel.CLAUDE_FABLE_5`. Same product default, on the server side (reached by API/`sculpt`-created tasks that omit a model). **REPRODUCED** by code inspection; it is the same root constant and is fixed in the same change. Not independently reachable through the UI (the frontend always sends a model at creation), so it is covered by code review rather than a separate test — see Review notes.

Both are facets of one bug — "the product default model is the disabled Fable" — so they are presented as a single reproduced bug below.

## For each reproduced bug

### New workspace defaults to the disabled Fable model

**Repro steps**
1. Launch Sculptor with a fresh profile: the "Default model" setting (Settings → Agent → Default model) is the product default "Most Recently Used" (`userConfig.defaultLlm` is `None`), and no model has been selected yet (no most-recently-used model in local storage).
2. Create a new workspace via the Add Workspace form: type a workspace name (e.g. "Default Model Check") and click **Create workspace**. Do **not** open the model selector.
3. When the workspace's chat panel loads, read the model selector at the bottom-right of the chat input.

**Expected vs actual**
- Expected: the model selector defaults to **Opus (1M)**.
- Actual (before fix): the model selector defaults to **Fable**, which is currently disabled with an indefinite timeline.

**Before**

![Before — model selector defaults to Fable](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1576-proof/scu-1576-before-fable.png)

**Root cause**
Two code paths resolve the default model when the user has neither configured a default nor used a model yet, and both hardcoded Fable. On the frontend, `defaultModelAtom` in `sculptor/frontend/src/common/state/atoms/userConfig.ts` returned `LlmModel.CLAUDE_FABLE_5` as its final fallback after the configured-default and most-recently-used checks; this value is sent to the backend at agent creation and is what the chat-panel switcher shows pre-selected. On the backend, `CodingAgentTaskView.model` in `sculptor/sculptor/web/derived.py` returned `LLMModel.CLAUDE_FABLE_5` when a task carried no message-level model and no creation-time `default_model`. Because Fable was the default, a brand-new agent was pointed at a disabled model.

**Fix**
Point both default fallbacks at `CLAUDE_4_OPUS` — the 1M-context Opus, displayed as **"Opus (1M)"**. (Note the naming: `CLAUDE_4_OPUS` is the 1M model, while `CLAUDE_4_OPUS_200K` is the 200K model whose display short-name is the bare "Opus" — see `modelConstants.ts` and the `sculpt` CLI `MODEL_MAPPING`.) Fable is deliberately left untouched in the `LLMModel` enum, the model-shortname map, the frontend model constants/capabilities, `ModelSelectOptions`, and the `sculpt` CLI mapping, so it remains selectable for if/when it returns — only the no-selection default changes.

The per-turn last-resort fallbacks elsewhere in the code (`ChatInput.tsx`, `useChatData.ts`, `QueuedMessages.tsx`, `AlphaChatInterface.tsx`, `ci_babysitter/coordinator.py`) still use the 200K variant; those fire only when an already-created task is missing a model and are intentionally left as-is. This change is specifically about the product default for a brand-new agent.

**Test**
- Path: `sculptor/tests/integration/regression/test_regression_default_model_opus.py`
- Kind: e2e (Playwright integration). The default is a user-facing UI behaviour, so an e2e test is the right level (no fallback criterion invoked).
- Failing-test commit: `1bc46c6b8b`
- Fix commits: `95c675cac7` (default → Opus), `7171d7139d` (switch the default to the 1M Opus variant per review)

Failing run (before the fix), on the unfixed code — the new-workspace default rendered as `Fable`, failing the assertion (the assertion target was later refined from "Opus" to "Opus (1M)"; the unfixed default fails either way):
```
E       AssertionError: Locator expected to have text 'Opus'
E       Actual value: Fable
sculptor/tests/integration/regression/test_regression_default_model_opus.py:46: AssertionError
============================== 1 failed in 44.86s ==============================
```
Passing run (after the fix, asserting `Opus (1M)`):
```
============================== 1 passed in 12.36s ==============================
```

**After**

![After — model selector defaults to Opus (1M)](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1576-proof/scu-1576-after-opus-1m.png)

Fable remains available in the switcher dropdown (verified live — Opus (1M) is selected by default, Fable is still a selectable option), satisfying the ticket's "keep Fable available" requirement.

## Review notes

- `sculptor/sculptor/web/derived.py` — the backend `Task.model` fallback change is not covered by its own unit test; only the frontend default path is exercised by the e2e test. This branch is reachable only when a task is created with no message-level model and no creation-time `default_model`, which the UI never produces (it always sends a model), so it falls under the testing config's "not reachable from any UI surface" carve-out. The change is a one-constant mirror of the frontend default that the e2e test does cover, so it was left to code review rather than adding a hard-to-construct backend unit test.

---

Verification: `just format`, `just check` (ratchets, typecheck, lint, file hygiene), and `just test-unit` (backend, frontend, foundation, sculpt) all pass on this branch.

(Sent by Claude)
