### PR TITLE
Open Settings with its workspace tab from Configure panels (SCU-1581)

### DIFF
--- a/sculptor/frontend/src/common/NavigateUtils.ts
+++ b/sculptor/frontend/src/common/NavigateUtils.ts
@@ -11,6 +11,7 @@ type ImbueNavigationFunctions = {
   navigateToHome: () => void;
   navigateToGlobalSettings: (section?: string) => void;
   navigateToRepoSetupCommand: (projectId: string) => void;
+  navigateToPanelSettings: (panelId: string) => void;
   navigateToComponentGallery: () => void;
   navigateToRoot: () => void;
 };
@@ -67,6 +68,12 @@ export const useImbueNavigate = (): ImbueNavigationFunctions => {
     navigateToRepoSetupCommand: useCallback(
       (projectId: string): void => {
         navigate(`/settings?section=repositories&focusRepo=${encodeURIComponent(projectId)}`);
+      },
+      [navigate],
+    ),
+    navigateToPanelSettings: useCallback(
+      (panelId: string): void => {
+        navigate(`/settings?section=PANELS&panel=${encodeURIComponent(panelId)}`);
       },
       [navigate],
     ),

--- a/sculptor/frontend/src/common/state/hooks/useOpenSettings.ts
+++ b/sculptor/frontend/src/common/state/hooks/useOpenSettings.ts
@@ -8,23 +8,33 @@ import { SETTINGS_TAB_ID } from "~/components/workspaceTabIds.ts";
 type OpenSettings = {
   (section?: string): void;
   (section: "repositories", focusRepoId: string): void;
+  (section: "PANELS", focusPanelId: string): void;
 };
 
+/**
+ * The single correct way to open the global Settings page: it both creates the
+ * Settings pseudo-workspace-tab and navigates to the requested section, so no
+ * caller has to remember to do the former. Callers must route through here
+ * rather than navigating to `/settings` directly (see SCU-1581).
+ */
 export const useOpenSettings = (): OpenSettings => {
-  const { navigateToGlobalSettings, navigateToRepoSetupCommand } = useImbueNavigate();
+  const { navigateToGlobalSettings, navigateToRepoSetupCommand, navigateToPanelSettings } = useImbueNavigate();
   const ensurePseudoTab = useSetAtom(ensurePseudoTabAtom);
 
   return useMemo<OpenSettings>(() => {
     function openSettings(section?: string): void;
     function openSettings(section: "repositories", focusRepoId: string): void;
-    function openSettings(section?: string, focusRepoId?: string): void {
+    function openSettings(section: "PANELS", focusPanelId: string): void;
+    function openSettings(section?: string, focusId?: string): void {
       ensurePseudoTab(SETTINGS_TAB_ID);
-      if (focusRepoId !== undefined) {
-        navigateToRepoSetupCommand(focusRepoId);
+      if (focusId !== undefined && section === "repositories") {
+        navigateToRepoSetupCommand(focusId);
+      } else if (focusId !== undefined && section === "PANELS") {
+        navigateToPanelSettings(focusId);
       } else {
         navigateToGlobalSettings(section);
       }
     }
     return openSettings;
-  }, [ensurePseudoTab, navigateToGlobalSettings, navigateToRepoSetupCommand]);
+  }, [ensurePseudoTab, navigateToGlobalSettings, navigateToRepoSetupCommand, navigateToPanelSettings]);
 };

--- a/sculptor/frontend/src/components/TopBar.tsx
+++ b/sculptor/frontend/src/components/TopBar.tsx
@@ -9,16 +9,18 @@ import { useKeybindingDisplayText } from "../common/keybindings/hooks.ts";
 import { useImbueNavigate } from "../common/NavigateUtils.ts";
 import { ensurePseudoTabAtom } from "../common/state/atoms/workspaces.ts";
 import { useHelpDialog } from "../common/state/hooks/useHelpDialog.ts";
+import { useOpenSettings } from "../common/state/hooks/useOpenSettings.ts";
 import { getTitleBarLeftPadding } from "../electron/utils.ts";
 import { ClosedWorkspacesPill } from "./ClosedWorkspacesPill.tsx";
 import { useCommandPalette } from "./CommandPalette";
 import { TooltipIconButton } from "./TooltipIconButton.tsx";
 import styles from "./TopBar.module.scss";
-import { HOME_TAB_ID, SETTINGS_TAB_ID } from "./workspaceTabIds.ts";
+import { HOME_TAB_ID } from "./workspaceTabIds.ts";
 import { WorkspaceTabs } from "./WorkspaceTabs.tsx";
 
 export const TopBar = (): ReactElement => {
-  const { navigateToGlobalSettings, navigateToHome } = useImbueNavigate();
+  const { navigateToHome } = useImbueNavigate();
+  const openSettings = useOpenSettings();
   const { toggle: toggleCommandPalette } = useCommandPalette();
   const { showHelpDialog } = useHelpDialog();
   // Read the live binding from the registry so the tooltip stays accurate
@@ -35,9 +37,8 @@ export const TopBar = (): ReactElement => {
   }, [ensurePseudoTab, navigateToHome]);
 
   const handleOpenSettings = useCallback((): void => {
-    ensurePseudoTab(SETTINGS_TAB_ID);
-    navigateToGlobalSettings();
-  }, [ensurePseudoTab, navigateToGlobalSettings]);
+    openSettings();
+  }, [openSettings]);
 
   return (
     <Flex

--- a/sculptor/frontend/src/components/panels/PanelContextMenu.tsx
+++ b/sculptor/frontend/src/components/panels/PanelContextMenu.tsx
@@ -1,8 +1,8 @@
 import { ContextMenu } from "@radix-ui/themes";
 import type { ReactElement, ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { ElementIds } from "~/api";
+import { useOpenSettings } from "~/common/state/hooks/useOpenSettings.ts";
 import { ZONE_DISPLAY_NAMES } from "~/components/panels/constants.ts";
 import { usePanelActions, usePanelById, usePanelsByZone } from "~/components/panels/hooks.ts";
 import type { PanelId, ZoneId } from "~/components/panels/types.ts";
@@ -27,7 +27,7 @@ export const PanelContextMenu = ({
   const panelDef = usePanelById(panelId);
   const panelsByZone = usePanelsByZone();
   const { movePanel } = usePanelActions();
-  const navigate = useNavigate();
+  const openSettings = useOpenSettings();
 
   const isDisabled = (targetZone: ZoneId): boolean =>
     targetZone === zoneId || isZoneMoveDisabled({ panelId, targetZone, panelsByZone });
@@ -38,7 +38,7 @@ export const PanelContextMenu = ({
   };
 
   const handleConfigurePanels = (): void => {
-    navigate(`/settings?section=PANELS&panel=${encodeURIComponent(panelId)}`);
+    openSettings("PANELS", panelId);
   };
 
   return (

--- a/sculptor/tests/integration/frontend/test_panels_settings.py
+++ b/sculptor/tests/integration/frontend/test_panels_settings.py
@@ -18,6 +18,7 @@ import pytest
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
+from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 from sculptor.testing.pages.settings_page import PlaywrightSettingsPage
 from sculptor.testing.playwright_utils import blur_active_element
 from sculptor.testing.playwright_utils import navigate_to_settings_page
@@ -200,6 +201,46 @@ def test_configure_panels_deep_link(sculptor_instance_: SculptorInstance) -> Non
     settings_page = PlaywrightSettingsPage(page=page)
     panels = settings_page.click_on_panels()
     expect(panels.get_panel_row("files")).to_be_visible()
+
+
+@user_story("to have 'Configure panels…' open Settings as a persistent workspace tab")
+def test_configure_panels_creates_persistent_settings_tab(sculptor_instance_: SculptorInstance) -> None:
+    """Opening Settings via a panel's "Configure panels…" item must create the
+    Settings pseudo-workspace-tab in the workspace tab bar.
+
+    Regression test for SCU-1581: the context-menu handler navigated straight
+    to /settings without calling `ensurePseudoTab(SETTINGS_TAB_ID)`, so Settings
+    opened with no tab in the tab bar — a broken state. We assert the Settings
+    tab appears, and that it is a real tab by confirming it survives switching
+    back to the workspace tab (a merely route-derived tab would disappear).
+    """
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page, prompt="Hello")
+
+    layout = PlaywrightProjectLayoutPage(page)
+    zones = PlaywrightPanelZonesElement(page=page)
+
+    # Open Settings via the panel context menu's "Configure panels…" item.
+    files_icon = zones.get_files_icon()
+    expect(files_icon).to_be_visible()
+    files_icon.click(button="right")
+    configure_item = zones.get_configure_context_menu_item()
+    expect(configure_item).to_be_visible()
+    configure_item.click()
+
+    # "Configure panels…" must open Settings as a tab in the workspace tab bar.
+    settings_tab = layout.get_settings_tab()
+    expect(settings_tab).to_be_visible()
+
+    # Switch back to the workspace tab and wait for the tab bar to settle.
+    workspace_tab = layout.get_workspace_tabs().first
+    expect(workspace_tab).to_be_visible()
+    workspace_tab.click()
+    expect(workspace_tab).to_have_attribute("aria-selected", "true")
+
+    # The Settings tab must still be present: "Configure panels…" opened it as a
+    # real pseudo-tab, so leaving the /settings route does not close it.
+    expect(settings_tab).to_be_visible()
 
 
 @user_story("to drag a panel icon in the layout diagram to move it to another zone")


### PR DESCRIPTION
## Original bug

From [SCU-1581](https://linear.app/imbue/issue/SCU-1581/configure-panels-opens-settings-without-its-workspace-tab-add-a-shared):

> Right-click a panel icon → "Configure panels" opens the correct Settings page, but it doesn't create the pseudo-workspace-tab for Settings, leaving the Settings page in a weird/broken state. Two parts:
>
> 1. Fix the "Configure panels" path so opening Settings also creates the pseudo-workspace-tab (the caller is in `PanelContextMenu.tsx`).
> 2. No caller should have to remember how to open Settings correctly — route every entry point through a **common helper**. There's already a `useOpenSettings` hook (`common/state/hooks/useOpenSettings.ts`); make it the single correct way to open Settings (creating the pseudo-tab and selecting the page) and convert callers to it.

## Hypotheses considered

1. **"Configure panels…" opens Settings without creating the Settings pseudo-workspace-tab, so no Settings tab appears in the workspace tab bar** — REPRODUCED. (The ticket was specific; this was the single grounded hypothesis, and it reproduced exactly.)

## For each reproduced bug

### "Configure panels…" opens Settings with no tab in the workspace tab bar

**Repro steps**
1. Launch Sculptor and open a workspace (wait for the agent to be ready).
2. Right-click a panel icon in the sidebar — e.g. the **Files** panel icon.
3. In the context menu, click **Configure panels…**.
4. Look at the workspace tab bar at the top.

**Expected vs actual**
- Expected: Settings opens as a tab in the workspace tab bar (the same as clicking the gear icon), and that tab persists when you switch to another tab.
- Actual: the Settings page opens, but **no Settings tab appears** in the tab bar. There is no real, persistent Settings tab — leaving Settings in the broken state the ticket describes.

**Before**

![Before — no Settings tab in the tab bar after Configure panels](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1581-proof/scu-1581-before.png)

The tab bar shows the Home icon, the "Test Workspace 1" tab, and the "+" button — but no Settings tab, even though the Settings page is open.

**Root cause**

`PanelContextMenu.handleConfigurePanels` called `useNavigate()` directly with `/settings?section=PANELS&panel=<id>`, which changes the route but never calls `ensurePseudoTab(SETTINGS_TAB_ID)`. `WorkspaceTabs` only renders a persistent Settings tab when `SETTINGS_TAB_ID` is present in `effectiveOpenTabIds`; the `|| isSettingsRoute` fallback in the tab list does not yield a real, persistent tab, and — unlike the home route, which has a dedicated `useEffect` that calls `ensurePseudoTab(HOME_TAB_ID)` — there is no settings equivalent. So navigating to `/settings` without creating the pseudo-tab leaves Settings open with no tab. The `useOpenSettings` hook already creates the pseudo-tab correctly, but this caller bypassed it.

**Fix**

Make `useOpenSettings` the single correct way to open Settings and route the entry points through it, so no caller has to remember to create the pseudo-tab. To preserve the panel-focus deep link while still creating the tab, a `"PANELS"` overload was added to `useOpenSettings` plus a `navigateToPanelSettings` helper in `NavigateUtils` that builds the same `?section=PANELS&panel=<id>` URL. `PanelContextMenu` now calls `openSettings("PANELS", panelId)`, and `TopBar`'s gear button drops its duplicated `ensurePseudoTab` + `navigate` in favor of `openSettings()`. The tab-*switching* call sites in `WorkspaceTabs`/`useWorkspaceTabActions` were intentionally left as-is: they navigate among already-open tabs (peers of `navigateToHome`/`navigateToComponentGallery`), not "open Settings" entry points.

**Test**
- Path: `sculptor/tests/integration/frontend/test_panels_settings.py`
- Kind: e2e (Playwright integration). Behavioral assertion (the Settings tab appears and persists across a tab switch), not layout — so an integration test is correct here per `.sculptor/testing.md`.
- Failing-test commit: `40adacf208`
- Fix commit: `1dbc080802`

The new `test_configure_panels_creates_persistent_settings_tab` failed on the pre-fix code (`Locator expected to be visible … waiting for get_by_test_id("SETTINGS_TAB")`) and passes after the fix. The existing `test_configure_panels_deep_link` still passes, confirming the panel-focus deep link is preserved.

**After**

![After — Settings tab present in the tab bar after Configure panels](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1581-proof/scu-1581-after.png)

The tab bar now shows a real **Settings** tab (gear icon, active, with a close button) after "Configure panels…".

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
