### PR TITLE
Focus a terminal agent's pane when its tab is selected

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/AgentTerminalPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/AgentTerminalPanel.tsx
@@ -26,6 +26,9 @@ export const AgentTerminalPanel = ({ taskId }: AgentTerminalPanelProps): ReactEl
     isVisible: true,
     fontSize: 13,
     lineHeight: 1.1,
+    // The terminal is this agent's only input surface and the pane remounts
+    // on every tab switch, so it must take keyboard focus immediately (SCU-1578).
+    focusOnVisible: true,
   });
 
   return (

--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
@@ -692,14 +692,12 @@ export const useTerminal = ({
   // sees its first visible frame and never grants focus, leaving the user
   // unable to type without first clicking into the pane (SCU-1578). The
   // terminal is the agent's only input surface, so there is no chat input to
-  // steal focus from. Gating on `isXtermReady` avoids racing the async xterm
-  // creation (which defers until the container has dimensions).
+  // steal focus from. `isXtermReady` is the readiness signal: it flips true
+  // only after `xterm.open()` has created the helper textarea, so the focus
+  // target exists in the DOM and we can focus synchronously.
   useEffect(() => {
     if (!focusOnVisible || !isVisible || !isXtermReady) return;
-    const handle = requestAnimationFrame(() => {
-      xtermRef.current?.focus();
-    });
-    return (): void => cancelAnimationFrame(handle);
+    xtermRef.current?.focus();
   }, [focusOnVisible, isVisible, isXtermReady]);
 
   // ── Clear-terminal keybinding (focus-gated) ────────────────────────

--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
@@ -318,6 +318,12 @@ type UseTerminalArgs = {
    * customGlyphs rendering stretches box-drawing characters to the full
    * cell, so TUI borders stay seamless at line heights above 1. */
   lineHeight?: number;
+  /** When true, focus the terminal as soon as it is visible and ready —
+   * including the initial mount. Terminal *agents* set this: their pane is
+   * remounted on every tab switch and the terminal is the agent's only input
+   * surface, so it must take keyboard focus immediately. Workspace terminals
+   * leave it false so they don't steal focus from the chat input on load. */
+  focusOnVisible?: boolean;
 };
 
 type UseTerminalResult = {
@@ -330,6 +336,7 @@ export const useTerminal = ({
   onOutput,
   fontSize = 12,
   lineHeight = 1,
+  focusOnVisible = false,
 }: UseTerminalArgs): UseTerminalResult => {
   const terminalContainerRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
@@ -678,6 +685,25 @@ export const useTerminal = ({
     };
   }, [isVisible, handleResize]);
 
+  // Focus the terminal as soon as it is visible and ready — including the
+  // initial mount — when the caller opts in via `focusOnVisible`. Terminal
+  // agents do: switching to a terminal agent's tab remounts this hook (the
+  // pane is keyed by agent id), so the `hasBeenVisibleRef` guard above always
+  // sees its first visible frame and never grants focus, leaving the user
+  // unable to type without first clicking into the pane (SCU-1578). The
+  // terminal is the agent's only input surface, so there is no chat input to
+  // steal focus from. Gating on `isXtermReady` avoids racing the async xterm
+  // creation (which defers until the container has dimensions).
+  useEffect(() => {
+    if (!focusOnVisible || !isVisible || !isXtermReady) return;
+    const handle = requestAnimationFrame(() => {
+      xtermRef.current?.focus();
+    });
+    return (): void => cancelAnimationFrame(handle);
+  }, [focusOnVisible, isVisible, isXtermReady]);
+
+  // ── Clear-terminal keybinding (focus-gated) ────────────────────────
+  //
   // Mirrors the `interrupt_agent` pattern in ChatInput.tsx — we read the
   // resolved binding from the keybindings registry and attach a window-level
   // keydown listener that only fires when this terminal instance has

--- a/sculptor/tests/integration/frontend/test_terminal_agent_focus.py
+++ b/sculptor/tests/integration/frontend/test_terminal_agent_focus.py
@@ -76,7 +76,7 @@ def test_terminal_agent_tab_switch_focuses_terminal(sculptor_instance_: Sculptor
     # The terminal pane must auto-focus on tab switch (SCU-1578). Without the
     # fix the freshly-mounted panel never grabs focus, so the user has to click
     # into it before typing.
-    expect(agent_terminal_textarea).to_be_focused(timeout=10_000)
+    expect(agent_terminal_textarea).to_be_focused()
 
     # Prove the user-facing guarantee, not just the focus snapshot: type a probe
     # with the GLOBAL keyboard (routes to document.activeElement) and confirm it

--- a/sculptor/tests/integration/frontend/test_terminal_agent_focus.py
+++ b/sculptor/tests/integration/frontend/test_terminal_agent_focus.py
@@ -1,0 +1,87 @@
+"""Regression test: switching to a terminal agent's tab must focus its pane.
+
+A terminal agent's main panel is a PTY terminal that occupies the chat space.
+The terminal is the agent's only input surface, so selecting its tab should
+place keyboard focus into the terminal immediately — the user must be able to
+type without first clicking into the pane (SCU-1578).
+"""
+
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.agent_tab import PlaywrightAgentTabBarElement
+from sculptor.testing.elements.terminal import expect_chat_replaces_terminal_panel
+from sculptor.testing.elements.terminal import get_agent_terminal_panel
+from sculptor.testing.elements.terminal import get_agent_terminal_textarea
+from sculptor.testing.elements.terminal import type_with_global_keyboard
+from sculptor.testing.elements.terminal import wait_for_xterm_substring
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+
+def _create_terminal_agent(agent_tab_bar: PlaywrightAgentTabBarElement) -> None:
+    agent_tab_bar.open_agent_type_menu()
+    agent_tab_bar.get_agent_type_menu_item_terminal().click()
+
+
+def _wait_for_terminal_ready(page: Page) -> None:
+    """Wait until the agent terminal's xterm is mounted and the shell is up.
+
+    The backend PTY may still be spawning when the panel mounts (the
+    WebSocket retries 4404 closes every 2s), so give the prompt a moment
+    after the textarea attaches.
+    """
+    expect(get_agent_terminal_textarea(page)).to_be_attached()
+    page.wait_for_timeout(3_000)
+
+
+@user_story("to start typing in a terminal agent immediately after selecting its tab")
+def test_terminal_agent_tab_switch_focuses_terminal(sculptor_instance_: SculptorInstance) -> None:
+    """Selecting a terminal agent's tab auto-focuses its terminal pane.
+
+    Steps:
+    1. Create a workspace with a chat agent (tab 1).
+    2. Create a terminal agent (tab 2); creating it navigates to the new tab.
+    3. Switch away to the chat agent — the terminal pane unmounts and gives up
+       keyboard focus.
+    4. Switch back to the terminal agent's tab.
+    5. The terminal pane must hold keyboard focus, and a probe typed with the
+       global keyboard (which routes to ``document.activeElement``) must land in
+       the xterm buffer — proving typing works without clicking into the pane.
+    """
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Terminal Focus WS")
+    agent_tab_bar = PlaywrightAgentTabBarElement(page)
+    agent_tabs = agent_tab_bar.get_agent_tabs()
+    expect(agent_tabs).to_have_count(1)
+
+    _create_terminal_agent(agent_tab_bar)
+    expect(agent_tabs).to_have_count(2)
+    terminal_tab = agent_tab_bar.get_agent_tab_by_name("Terminal 1").first
+    expect(terminal_tab).to_be_visible()
+    _wait_for_terminal_ready(page)
+
+    # Switch away to the chat agent — the terminal pane unmounts (chat input
+    # replaces it), so the terminal no longer owns keyboard focus.
+    agent_tabs.first.click()
+    expect_chat_replaces_terminal_panel(page)
+
+    # Switch back to the terminal agent's tab.
+    terminal_tab.click()
+    expect(get_agent_terminal_panel(page)).to_be_visible()
+    agent_terminal_textarea = get_agent_terminal_textarea(page)
+    expect(agent_terminal_textarea).to_be_attached()
+
+    # The terminal pane must auto-focus on tab switch (SCU-1578). Without the
+    # fix the freshly-mounted panel never grabs focus, so the user has to click
+    # into it before typing.
+    expect(agent_terminal_textarea).to_be_focused(timeout=10_000)
+
+    # Prove the user-facing guarantee, not just the focus snapshot: type a probe
+    # with the GLOBAL keyboard (routes to document.activeElement) and confirm it
+    # reaches the shell. The leading throwaway chars absorb any keystrokes xterm
+    # may drop right as input begins.
+    probe_marker = "TAB_SWITCH_FOCUS_OK"
+    type_with_global_keyboard(page, "zzz " + probe_marker)
+    wait_for_xterm_substring(page, probe_marker)


### PR DESCRIPTION
## Original bug

[SCU-1578](https://linear.app/imbue/issue/SCU-1578/auto-focus-the-terminal-agents-chat-pane-on-tab-switch)

> When using terminal agents, switching between workspace or agent tabs should automatically place keyboard focus into the active terminal agent's chat (terminal) pane. Today the focus isn't moved on tab switch, so the user has to click into the pane before they can type. Expected: selecting a tab whose agent is a terminal agent immediately focuses its terminal/chat input, so typing works right away.

## Hypotheses considered

1. **The terminal agent's pane is never focused on tab switch because `useTerminal` skips focusing on its first visible frame, and a tab switch always remounts the agent pane.** — **REPRODUCED** (root cause below).
2. *Workspace-tab switches to a terminal agent are a separate code path needing a separate fix.* — **DISCARDED** — switching workspace tabs into a terminal agent hits the same `AgentTerminalPanel` remount path, so hypothesis 1's fix covers it; not a distinct bug.

## For each reproduced bug

### Terminal agent pane is not focused when its tab is selected

**Repro steps**

1. Create a workspace (it opens with a Claude chat agent as tab 1).
2. Add a terminal agent via the agent-type menu (the `+` chevron → **Terminal**). Creating it navigates to the new terminal tab (tab 2).
3. Switch to the Claude agent tab — the terminal pane unmounts and the chat input replaces it.
4. Switch back to the terminal agent's tab.
5. Without clicking into the pane, start typing.

**Expected vs actual**

- Expected: after step 4 the terminal pane holds keyboard focus, so the keystrokes in step 5 go straight to the shell.
- Actual: the terminal pane is not focused; keystrokes in step 5 are dropped (they land on the tab button / nothing). The user must click into the pane before typing.

**Before**

This bug only manifests in the **production** React build, so the dev-server screenshot harness (`/auto-qa-changes`, which serves the Vite dev server) cannot reproduce it — see "A note on evidence" below. The faithful reproduction is the production-build integration test, which fails on the unfixed code with the terminal textarea never becoming the active element:

```
>       expect(agent_terminal_textarea).to_be_focused(timeout=10_000)
E       AssertionError: Locator expected to be focused
E       Actual value: inactive
E       Call log:
E         - Expect "to_be_focused" with timeout 10000ms
E         - waiting for get_by_test_id("AGENT_TERMINAL_PANEL").get_by_label("Terminal input")
E           14 × locator resolved to <textarea ... class="xterm-helper-textarea"></textarea>
E              - unexpected value "inactive"
sculptor/tests/integration/frontend/test_terminal_agent_focus.py:79: AssertionError
========================= 1 failed in 68.31s (0:01:08) =========================
```

(The committed test uses the default 30s timeout; this first run, before the self-review pass, used a 10s timeout — the outcome is identical: the terminal stays `inactive`.)

**Root cause**

A terminal agent's full-pane terminal is rendered as `<AgentTerminalPanel key={taskID}>` in `ChatPanelContent.tsx`, keyed by agent id. Selecting a different tab therefore unmounts the old panel and mounts a fresh one, which mounts a fresh `useTerminal` hook (`sculptor/frontend/src/pages/workspace/panels/useTerminal.ts`). That hook deliberately suppresses focusing the terminal on its first visible frame — tracked by `hasBeenVisibleRef` — so the workspace's bottom terminal doesn't steal focus from the chat input when a workspace first loads. For a terminal *agent*, every tab switch is that first visible frame (the panel was just remounted), so `hasBeenVisibleRef` is always `false` and the terminal is never granted focus, leaving the user unable to type without first clicking into the pane.

**Fix**

Added an opt-in `focusOnVisible` flag to `useTerminal`. When set, a dedicated effect focuses the xterm as soon as it is visible and ready — including the initial mount — gated on `isXtermReady` so it focuses only after `xterm.open()` has created the helper textarea in the DOM (no `requestAnimationFrame` timing hack, no race against the async xterm creation). `AgentTerminalPanel` opts in, because the terminal is a terminal agent's only input surface and there is no chat input to steal focus from. The workspace bottom terminal leaves the flag at its `false` default and keeps its existing behavior unchanged.

**Test**

- Path: `sculptor/tests/integration/frontend/test_terminal_agent_focus.py`
- Kind: e2e (Playwright integration test). It creates a terminal agent, switches away to the chat agent, switches back, asserts the terminal pane is focused, and then proves the user-facing guarantee by typing a probe with the global keyboard (which routes to `document.activeElement`) and confirming it lands in the xterm buffer.
- Failing-test commit: `2af0cda78e03be94f37781e5fdb91ebf61d631e1`
- Fix commit: `67a02c431423db6de99c326d1b8390cea6d143a5`
- Self-review follow-up commit: `43bbbaecd3` (focus synchronously; use the default test timeout)

**After**

With the fix, the same production-build integration test passes:

```
========================= 1 passed in 68.37s (0:01:08) =========================
```

Sibling terminal-agent tests (`test_terminal_agent_basic.py` — create, shell round-trip, tab switch, content-leak; `test_registered_terminal_agent.py`; `test_ask_user_question_focus.py`) also pass, confirming no regression to the bottom-terminal focus behavior or the tab-switch flows.

## A note on evidence (why no screenshots)

This bug reproduces only in the **production** React build. The Vite dev server runs `<React.StrictMode>`, whose dev-only double-invoke of effects re-runs the focus effect a second time with `hasBeenVisibleRef` already `true` (refs persist across the StrictMode remount), which *accidentally* focuses the terminal and masks the bug in dev. I verified this directly: in the dev harness, after a clean tab switch, `document.activeElement` is the `xterm-helper-textarea` (focus works), while the production-build integration test shows it `inactive`.

Because the only screenshot harness available (`/auto-qa-changes`) serves the dev build, a "before" screenshot from it would falsely show the bug already fixed — it would mislead a reviewer rather than document the bug. The faithful, unambiguous evidence for this production-only focus bug is the failing-then-passing integration test above, which runs against the production build that ships to users.

## Review notes

- **`no_layout_only_tests` / behavioural coverage** — the test asserts focus *and* that typed keystrokes reach the shell buffer (behaviour), not layout. No action needed.
- **`no_sleep_then_assert` (LOW, declined)** — the `_wait_for_terminal_ready` helper uses `page.wait_for_timeout(3_000)` to let the backend PTY spawn. It is copied verbatim from the sibling `test_terminal_agent_basic.py` helper, is followed by a `.click()` and retrying `expect()` calls (not a non-retrying snapshot assertion), so it is not the flagged anti-pattern. Kept for consistency with the established sibling helper.


(Sent by Claude)
