### PR TITLE
Fix Browser panel dark theme leaking into plain page content

### DIFF
--- a/sculptor/frontend/src/pages/workspace/panels/browser/BrowserViewSlot.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/BrowserViewSlot.tsx
@@ -95,8 +95,17 @@ export const BrowserViewSlot = ({ workspaceId }: { workspaceId: string }): React
   const partition = `persist:sculptor-browser-${workspaceId}`;
   const initialSrc = initialUrl === "" ? "about:blank" : initialUrl;
 
-  const style: CSSProperties =
-    placement.visible && placement.bounds !== null
+  // The <webview> guest renders with a transparent base, so a plain/unstyled
+  // page (whose <body> has no background of its own) lets whatever is behind
+  // the webview show through — namely Sculptor's themed app background. In dark
+  // mode that paints the guest's default black text on a dark backdrop, which
+  // is unreadable (SCU-1577). Give the element an opaque white background so
+  // transparent pages render against the browser's normal white canvas,
+  // independent of the Sculptor theme; pages with their own background paint
+  // over it as usual.
+  const style: CSSProperties = {
+    backgroundColor: "#ffffff",
+    ...(placement.visible && placement.bounds !== null
       ? {
           position: "fixed",
           left: placement.bounds.x,
@@ -104,7 +113,8 @@ export const BrowserViewSlot = ({ workspaceId }: { workspaceId: string }): React
           width: placement.bounds.width,
           height: placement.bounds.height,
         }
-      : { display: "none" };
+      : { display: "none" }),
+  };
 
   // Only the focused workspace's slot carries the BROWSER_WEBVIEW test id.
   const testId = isFocused ? ElementIds.BROWSER_WEBVIEW : undefined;


### PR DESCRIPTION
## Original bug

[SCU-1577](https://linear.app/imbue/issue/SCU-1577) (from a user report):

> "if i'm in dark mode and i open browser tab then a plain html website gets the wrong style and the text is hard to read. works fine in light mode."

In dark mode, a plain/unstyled HTML page loaded in the Browser panel inherits the wrong colors — the app's dark background bleeds in behind webview content that has no styling of its own — making text unreadable. Light mode is fine. (Distinct from the file-viewer dark-mode tickets SCU-1307 / SCU-1432.)

## Hypotheses considered

1. **The app's `color-scheme: dark` leaks into the `<webview>` via CSS inheritance, darkening the guest's base canvas** — *DISCARDED.* The `<webview>` element does compute `color-scheme: dark` (inherited from the Radix `.radix-themes` ancestor), but pinning it to `color-scheme: normal` changed the computed property while the composited background stayed dark (`rgb(25,25,25)`). So the embedder's color-scheme is not what paints the dark backdrop for an Electron `<webview>` guest.
2. **The guest's `prefers-color-scheme` is dark (OS/native theme), so Chromium renders the plain page dark** — *DISCARDED.* Measured `matchMedia('(prefers-color-scheme: dark)').matches === false` inside the guest. The leak tracks the *app* theme, not the OS — exactly as the ticket describes.
3. **The `<webview>` guest renders with a transparent base, so the themed app background shows through behind transparent-body pages** — *REPRODUCED.* The guest's `<body>` computes `rgba(0,0,0,0)` (transparent) and the guest surface is transparent where the page has no background; the composited pixel the user sees is the dark Sculptor app background behind it, with the guest's default black text on top.

## For each reproduced bug

### Plain page in the Browser panel is unreadable in dark mode

**Repro steps**
1. Launch Sculptor (default theme is dark).
2. Start a workspace and wait for it to be ready.
3. Settings → Panels → enable the **Browser** panel, then go back to the workspace.
4. Open the Browser panel and navigate the address bar to a plain, unstyled HTML page (e.g. the integration fixture `…/index.html`, which is just a heading and two links with no CSS).
5. Observe the rendered page in dark mode.

**Expected vs actual**
- Expected: the plain page renders against the browser's normal white canvas (black text on white), readable regardless of the Sculptor theme.
- Actual: the plain page renders on the dark app background; black heading text and dark-blue links sit on a near-black backdrop and are nearly unreadable.

**Before**

![before — plain page unreadable on dark backdrop in the Browser panel](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1577-proof/scu-1577-before.png)

(Full window for context: [scu-1577-before-full.png](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1577-proof/scu-1577-before-full.png) — the app is in dark mode throughout.)

**Root cause**

The Browser panel's `<webview>` (rendered in `BrowserViewSlot.tsx`) is given no background, and an Electron `<webview>` guest renders with a transparent base. A plain page whose `<body>` declares no background of its own therefore lets whatever is painted behind the webview show through — namely Sculptor's themed app background. In dark mode that backdrop is dark, while the guest's default text color is black, so the page is black-on-dark and unreadable. In light mode the app backdrop is light, which is why the same page looks fine there. Diagnostics confirmed the chain: app appearance `dark`, guest `prefers-color-scheme` `false`, guest `body` background `rgba(0,0,0,0)`, and the composited pixel behind the page measured `rgb(25,25,25)`.

**Fix**

Give the `<webview>` element an opaque white background (`backgroundColor: "#ffffff"`) in its inline style, so transparent pages render against the browser's normal white canvas independent of the Sculptor theme. Pages that set their own background simply paint over it as usual, so themed sites are unaffected. White is intentionally hardcoded rather than a theme token: a token would be dark in dark mode and reintroduce the bug. Two alternatives were rejected — `color-scheme: normal` on the element had no effect on the composited backdrop (see Hypothesis 1), and `webContents.setBackgroundColor(...)` is not available on the guest `WebContents` in this Electron version (it throws `TypeError: … is not a function`, which breaks webview attachment).

**Test**
- Path: none — purely visual bug.
- Kind: no automated test. Per `.sculptor/testing.md`, purely visual bugs MUST NOT have automated tests (asserting rendered colors is a layout/computed-style read); they are verified with before/after screenshots. The dark backdrop here comes from compositing a transparent guest over the host and is not observable via any DOM/computed-style assertion — only a screenshot captures it.
- Fix commit: `32a39ce0de`
- Verification: a temporary Electron diagnostic harness drove the real Browser panel to the plain fixture page in dark mode and sampled the composited pixel behind the page. Before the fix it measured `rgb(25,25,25)`; after the fix `rgb(255,255,255)`, with the app still in dark mode (`app_appearance: "dark"`). The harness was removed before committing.

**After**

![after — plain page readable on white canvas; app chrome stays dark](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1577-proof/scu-1577-after.png)

(Full window for context: [scu-1577-after-full.png](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1577-proof/scu-1577-after-full.png) — the surrounding app chrome remains dark; only the webview content area is now white and readable.)

## Review notes

_(no outstanding review notes — the self-review pass via `/code-review-checklist` flagged only the intentional hardcoded `#ffffff`, which is required to be theme-independent and is documented in the code comment; `just check` accepts it.)_

(Sent by Claude)
