### PR TITLE
Don't carry a model on terminal agents (SCU-1580)

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/tasks.ts
+++ b/sculptor/frontend/src/common/state/atoms/tasks.ts
@@ -96,8 +96,9 @@ export const taskStatusAtomFamily = atomFamily<string, Atom<TaskStatus | undefin
   atom((get) => get(taskAtomFamily(taskId))?.status),
 );
 
+// Terminal agents carry no model (`model` is null); treat that the same as "unknown".
 export const taskModelAtomFamily = atomFamily<string, Atom<string | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.model),
+  atom((get) => get(taskAtomFamily(taskId))?.model ?? undefined),
 );
 
 // A stable reference for the "no backend list" case, so the derived atom below

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -1975,7 +1975,8 @@ def create_workspace_agent(
                 agent_config=agent_config,
                 git_hash=initial_commit_hash,
                 system_prompt=project.default_system_prompt,
-                default_model=agent_request.model,
+                # Terminal agents don't carry a model — Sculptor doesn't control it (SCU-1580).
+                default_model=None if is_terminal_agent_config(agent_config) else agent_request.model,
             ),
             current_state=initial_task_state,
         )

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -222,6 +222,44 @@ def test_create_task_creates_task(
     assert len(response.json()) == 1
 
 
+def test_terminal_agent_does_not_carry_a_model(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    """Terminal agents must not carry a model (SCU-1580).
+
+    Sculptor doesn't control the model for terminal agents, so creating one must
+    not stamp a ``default_model`` onto its task, and the agent view that
+    ``sculpt agent list`` (and the frontend) read must report no model — even
+    when the creation request happens to carry a model value.
+    """
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        workspace = _create_workspace(transaction, test_services, test_project)
+
+    response = client.post(
+        f"/api/v1/workspaces/{workspace.object_id}/agents",
+        json=model_dump(
+            CreateAgentRequest(
+                agent_type=AgentTypeName.TERMINAL,
+                model=LLMModel.CLAUDE_4_OPUS,
+            ),
+            is_camel_case=True,
+        ),
+    )
+    assert response.status_code == 200, response.text
+
+    # The view the CLI / frontend consume must report no model for a terminal agent.
+    assert response.json()["model"] is None
+
+    # The deeper fix: creation must not persist a model on the terminal agent's task.
+    task_id = TaskID(response.json()["id"])
+    with user_session.open_transaction(test_services) as transaction:
+        created_task = test_services.task_service.get_task(task_id, transaction)
+    assert created_task is not None
+    assert isinstance(created_task.input_data, AgentTaskInputsV2)
+    assert created_task.input_data.default_model is None
+
+
 def test_create_task_returns_422_when_missing_required_attribute(
     client: TestClient, test_services: CompleteServiceCollection, test_project: Project
 ) -> None:

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -396,7 +396,11 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
 
     @computed_field
     @property
-    def model(self) -> LLMModel:
+    def model(self) -> LLMModel | None:
+        # Terminal agents have no chat and Sculptor does not control their model,
+        # so they carry no model at all — report None rather than a fallback (SCU-1580).
+        if is_terminal_agent_config(self.task_input.agent_config):
+            return None
         # Use the most recent chat message that carried an explicit model selection.
         for message in reversed(self._messages):
             if isinstance(message, ChatInputUserMessage) and message.model_name is not None:

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -91,7 +91,10 @@ def resolve_workspace(workspace: str | None, client: Client, json_output: bool) 
     cli_error("--workspace is required (or set SCULPT_WORKSPACE_ID)", json_output=json_output)
 
 
-def _format_model_name(model_value: str) -> str:
+def _format_model_name(model_value: str | None) -> str:
+    # Terminal agents carry no model; render a placeholder rather than a name.
+    if not model_value:
+        return "-"
     lower = model_value.lower()
     if "opus" in lower:
         return "opus"
@@ -191,7 +194,8 @@ def create(
             id=result.id,
             title=_get_task_title(result),
             status=result.status.value,
-            model=result.model.value,
+            # `agent create` always makes a chat agent, so a model is always present.
+            model=result.model.value if result.model else "",
             workspace_id=result.workspace_id,
             created_at=result.created_at.isoformat(),
         )
@@ -200,7 +204,7 @@ def create(
 
     typer.echo(f"Agent created: {result.id}")
     typer.echo(f"Status: {result.status.value}")
-    typer.echo(f"Model: {result.model.value}")
+    typer.echo(f"Model: {result.model.value if result.model else '-'}")
 
 
 @agent_app.command("list")
@@ -347,7 +351,7 @@ def show(
         f"Agent: {snapshot.task_id}",
         f"Title: {snapshot.title or 'Untitled'}",
         f"Status: {snapshot.status}",
-        f"Model: {snapshot.model}",
+        f"Model: {snapshot.model or '-'}",
         f"Interface: {snapshot.interface}",
         f"Created: {format_datetime(created_dt)}",
         f"Updated: {format_datetime(updated_dt)}",

--- a/tools/sculpt/sculpt/commands/data_types.py
+++ b/tools/sculpt/sculpt/commands/data_types.py
@@ -105,7 +105,7 @@ class AgentListItem(BaseModel):
     id: str = Field(description="Unique agent ID")
     title: str = Field(description="Agent title")
     status: str = Field(description="Agent infrastructure status")
-    model: str = Field(description="LLM model identifier")
+    model: str | None = Field(description="LLM model identifier (null for terminal agents)")
     workspace_id: str = Field(description="Parent workspace ID")
     created_at: str = Field(description="ISO 8601 datetime of creation")
 
@@ -116,7 +116,7 @@ class AgentShowOutput(BaseModel):
     id: str = Field(description="Unique agent ID")
     title: str = Field(description="Agent title")
     status: str = Field(description="Agent infrastructure status")
-    model: str = Field(description="LLM model identifier")
+    model: str | None = Field(description="LLM model identifier (null for terminal agents)")
     interface: str = Field(description="Agent interface type")
     created_at: str = Field(description="ISO 8601 datetime of creation")
     updated_at: str = Field(description="ISO 8601 datetime of last update")

--- a/tools/sculpt/sculpt/ws_client.py
+++ b/tools/sculpt/sculpt/ws_client.py
@@ -40,7 +40,8 @@ class AgentSnapshot(pydantic.BaseModel):
     error_detail: str | None
     updated_at: str
     title: str | None
-    model: str
+    # Terminal agents carry no model (Sculptor doesn't control it), so this is None for them.
+    model: str | None
     interface: str
     project_id: str
     workspace_id: str
@@ -124,7 +125,7 @@ def _snapshot_from_view(
         error_detail=view.get("errorDetail"),
         updated_at=view.get("updatedAt", ""),
         title=view.get("title"),
-        model=view.get("model", ""),
+        model=view.get("model"),
         interface=view.get("interface", ""),
         project_id=view.get("projectId", ""),
         workspace_id=view.get("workspaceId", ""),

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -342,6 +342,27 @@ class TestAgentList:
 
     @patch("sculpt.commands.agent.fetch_all_agents")
     @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    @respx.mock
+    def test_list_terminal_agent_reports_no_model(self, _mock_token: Any, mock_fetch: Any, runner: CliRunner) -> None:
+        """Terminal agents carry no model (SCU-1580): the list must not invent one."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        mock_fetch.return_value = [_make_snapshot(model=None)]
+
+        # Table output renders a placeholder, never a model name.
+        result = runner.invoke(app, ["agent", "list", "-w", "ws_test123"])
+        assert result.exit_code == 0
+        assert "opus" not in result.output
+        assert "sonnet" not in result.output
+
+        # JSON output reports the model as null.
+        result = runner.invoke(app, ["agent", "list", "-w", "ws_test123", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["model"] is None
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
     def test_list_all(self, _mock_token: Any, mock_fetch: Any, runner: CliRunner) -> None:
         mock_fetch.return_value = [_make_snapshot()]
 
@@ -798,6 +819,7 @@ class TestAgentSend:
 def _make_snapshot(
     task_id: str = "tsk_abc123def456",
     status: str = "RUNNING",
+    model: str | None = "CLAUDE-4-SONNET",
     current_activity: str | None = None,
     last_activity: str | None = None,
     waiting_detail: str | None = None,
@@ -823,7 +845,7 @@ def _make_snapshot(
         error_detail=error_detail,
         updated_at="2026-01-15T10:35:00Z",
         title="Test task",
-        model="CLAUDE-4-SONNET",
+        model=model,
         interface="TERMINAL",
         project_id=project_id,
         workspace_id=workspace_id,


### PR DESCRIPTION
## Original bug

> `sculpt agent list` reports a model for terminal agents even though a model isn't applicable to them. The surface symptom is the CLI output, but the deeper issue is in agent creation: we set a model on a terminal agent at all, even though Sculptor doesn't control the model for terminal agents. Fix: don't assign a model when creating a terminal agent, and don't report one for it (in `sculpt agent list` or elsewhere). Confirm nothing downstream relies on terminal agents having a model set.

Linear: [SCU-1580](https://linear.app/imbue/issue/SCU-1580)

## Hypotheses considered

1. **Terminal agents carry a model, surfaced by the task view that `sculpt agent list` reads** — REPRODUCED. Creation stamped the request's model as `default_model`, and `CodingAgentTaskView.model` reported it (falling back to `CLAUDE_FABLE_5` when unset), so a terminal agent always reported a model.

## For each reproduced bug

### Terminal agents carry a model

**Repro steps**

1. Create a terminal agent (`POST /api/v1/workspaces/{id}/agents` with `agent_type=TERMINAL`; the request may carry a `model`, e.g. from the "+"-button flow inheriting the previously-viewed agent's model).
2. Read the agent back — via `sculpt agent list` / `sculpt agent show`, or the task view the server serializes (`GET /api/v1/workspaces/{id}/agents`).
3. Observe the reported model.

In the regression test this is driven directly against the API: create a terminal agent with `model=CLAUDE_4_OPUS`, then assert the returned view's `model` and the persisted task's `default_model`.

**Expected vs actual**
- Expected: a terminal agent reports **no model** (`model: null`), and no `default_model` is persisted on its task — Sculptor does not control the model for terminal agents.
- Actual: the view reported `CLAUDE-4-OPUS` (or `CLAUDE_FABLE_5` as a fallback when nothing was stamped), and `sculpt agent list` showed that model.

**Before** (failing test, pre-fix)

```
>       assert response.json()["model"] is None
E       AssertionError: assert 'CLAUDE-4-OPUS' is None

sculptor/sculptor/web/app_basic_test.py:255: AssertionError
FAILED sculptor/sculptor/web/app_basic_test.py::test_terminal_agent_does_not_carry_a_model
```

**Root cause**

Two places conspired. In `create_workspace_agent` (`sculptor/sculptor/web/app.py`), the prompt-less creation path set `default_model=agent_request.model` unconditionally, so a terminal agent's task persisted a model. Separately, `CodingAgentTaskView.model` (`sculptor/sculptor/web/derived.py`) — the single computed field that both `sculpt agent list` and the frontend read — never returned `None`: it used the most recent chat message's model, then `default_model`, then fell back to `LLMModel.CLAUDE_FABLE_5`. Because terminal agents have no chat messages, the view returned the stamped model and, even with nothing stamped, the `CLAUDE_FABLE_5` fallback — so fixing creation alone would not have stopped the report.

**Fix**

`CodingAgentTaskView.model` now returns `None` for terminal agents (guarded by `is_terminal_agent_config(self.task_input.agent_config)`), making the view the authoritative "no model" source for both the CLI and the frontend. `create_workspace_agent` no longer stamps `default_model` on terminal agents. The supporting surfaces follow the now-nullable model: the sculpt CLI's `AgentSnapshot`/`AgentListItem`/`AgentShowOutput` and its table/JSON renderers accept a null model (rendered as `-`), and the frontend's `taskModelAtomFamily` coalesces null to `undefined` to keep its existing "unknown model" contract. Downstream readers already tolerate a model-less terminal agent: the CI babysitter skips terminal agents when selecting a model, the first-run intro message is gated to non-terminal agents, and `is_smooth_streaming_supported` treats `None` as unsupported.

**Test**
- Path: `sculptor/sculptor/web/app_basic_test.py::test_terminal_agent_does_not_carry_a_model` (backend endpoint test via FastAPI `TestClient`), plus `tools/sculpt/tests/unit/test_agent.py::TestAgentList::test_list_terminal_agent_reports_no_model` (sculpt CLI rendering).
- Kind: backend/CLI, not Playwright e2e. The symptom surface (`sculpt agent list`) is a CLI-only entrypoint and a terminal agent's model is not rendered anywhere in the Playwright UI, so it is not reachable from a UI surface — the "impossible to reproduce through the UI" criterion in `.sculptor/testing.md`. The endpoint test asserts the exact view the CLI serializes **and** the persisted `default_model`, covering both the reporting and the creation halves.
- Failing-test commit: `5c7544c722`
- Fix commit: `51c99c454c`

**After** (passing test, post-fix)

```
sculptor/sculptor/web/app_basic_test.py::test_terminal_agent_does_not_carry_a_model PASSED
1 passed in 2.17s
```

The sculpt CLI test passes too (`test_list_terminal_agent_reports_no_model`: table shows `-`, JSON reports `model: null`), and the full `just check` + `just test-unit` gate is green.

## Deferred follow-ups

- [SCU-1582](https://linear.app/imbue/issue/SCU-1582) — `CodingAgentTaskView.interface` always returns `TaskInterface.API`, even for terminal agents, so `sculpt agent show` prints `Interface: API` for a terminal agent. Same class of "a terminal agent misreports itself in `sculpt`" as this bug, but out of scope here.

## Review notes

A self-review pass (`/code-review-checklist`) ran over `5c7544c722...51c99c454c`. The one actionable finding — unrelated `ruff format` churn in `tools/sculpt/sculpt/commands/agent.py` and `tools/sculpt/tests/unit/test_agent.py` — was fixed before publishing (those files now contain only the logical changes). Remaining notes, intentional and not acted on:

- `tools/sculpt/sculpt/commands/agent.py` — the `else ""` / `else "-"` branches in `agent create` output are effectively unreachable (`agent create` only ever makes a chat agent, which always has a model); they exist to satisfy the now-optional generated client type and are commented as such.
- The task-view `model` field changes from required to nullable in the API contract, and `sculpt agent ... --json` `model` can now be `null`. This is the intended behavior change; frontend and backend ship together (generated clients regenerate), so no migration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
