### PR TITLE
Retry transient pi provider errors instead of crashing the agent

### DIFF
--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import re
 import time
 from collections.abc import Sequence
@@ -95,6 +96,7 @@ from sculptor.agents.pi_agent.output_processor import ParsedUnknownEvent
 from sculptor.agents.pi_agent.output_processor import RpcResponse
 from sculptor.agents.pi_agent.output_processor import extract_assistant_text
 from sculptor.agents.pi_agent.output_processor import humanize_pi_failure_reason
+from sculptor.agents.pi_agent.output_processor import is_transient_provider_error
 from sculptor.agents.pi_agent.output_processor import parse_rpc_message
 from sculptor.agents.pi_agent.prompt_assembly import build_attachment_instructions
 from sculptor.agents.pi_agent.prompt_assembly import build_image_block
@@ -136,6 +138,7 @@ from sculptor.interfaces.agents.agent import StopAgentUserMessage
 from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
 from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_SHUTDOWN_DUE_TO_EXCEPTION
 from sculptor.interfaces.agents.errors import AgentCrashed
+from sculptor.interfaces.agents.errors import AgentTransientError
 from sculptor.interfaces.agents.errors import PiBinaryNotFoundError
 from sculptor.interfaces.agents.errors import PiContextResetError
 from sculptor.interfaces.agents.errors import PiCrashError
@@ -256,6 +259,17 @@ _IDLE_WAIT_SECONDS: float = 1.0
 # How long the start-time model fetch waits for pi's get_available_models /
 # get_state responses before giving up (see _fetch_models_into_state).
 _MODEL_FETCH_TIMEOUT_SECONDS: float = 10.0
+
+# Transient-provider-error retry policy. A turn that ends with a known-transient
+# provider failure (overloaded / rate-limit / 5xx / timeout — see
+# `is_transient_provider_error`) is re-prompted up to this many times with
+# exponential backoff + jitter before the turn surfaces a non-fatal, retryable
+# AgentTransientError instead of crashing the agent. Backoff for retry N is
+# base*2**(N-1) seconds, capped at the max, with equal jitter so concurrent
+# agents that hit the same provider surge do not retry in lockstep.
+_PI_TRANSIENT_MAX_RETRIES: int = 4
+_PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS: float = 1.0
+_PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS: float = 30.0
 
 # Obsolete model ids pi's get_available_models returns that the switcher must not
 # offer — the whole pre-4 `claude-3-*` family (the live Anthropic catalog still
@@ -498,6 +512,23 @@ def _format_subagent_completion(completion: SubagentCompletion) -> str:
     total = len(completion.children)
     verb = "completed" if completion.status == "completed" else completion.status
     return f"Sub-agents {verb}: {done} done, {failed} failed (of {total})."
+
+
+class _PiTransientTurnError(Exception):
+    """Internal signal that the current turn hit a KNOWN-TRANSIENT provider error.
+
+    Raised from the dispatcher's stopReason-"error" handling when the failure is a
+    retryable provider condition (overloaded / rate-limit / 5xx / timeout), and
+    caught by `_consume_turn_with_transient_retry`, which re-prompts pi with
+    backoff. It never escapes the agent: a successful retry completes the turn
+    normally, and an exhausted retry budget is re-surfaced as the non-fatal,
+    retryable `AgentTransientError`. NOT an `AgentClientError`, so
+    `_handle_user_message` does not intercept it before the retry loop runs.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 class PiAgent(DefaultAgentWrapper):
@@ -1358,12 +1389,10 @@ class PiAgent(DefaultAgentWrapper):
             self._was_interrupted.clear()
             self._interrupt_pending.clear()
             self._cancel_interrupt_escalation()
-            prompt_id = generate_id()
             self._turn_in_flight.set()
             turn_failed = False
-            self._send_rpc(self._build_prompt_payload(prompt_id, message))
             try:
-                self._consume_until_turn_end(prompt_id)
+                self._consume_turn_with_transient_retry(message)
             except BaseException:
                 turn_failed = True
                 raise
@@ -1379,6 +1408,62 @@ class PiAgent(DefaultAgentWrapper):
                 # answer's request resolves instead of pinning the frontend
                 # "thinking" (mirrors Claude).
                 self._finalize_pending_answers(interrupted=turn_failed)
+
+    def _consume_turn_with_transient_retry(self, message: ChatInputUserMessage) -> None:
+        """Drive one user turn, retrying KNOWN-TRANSIENT provider failures with backoff.
+
+        A turn whose assistant run ends in a transient provider error
+        (`_PiTransientTurnError` — overloaded / rate-limit / 5xx / timeout) is
+        re-prompted with exponential backoff + jitter rather than crashing the
+        agent, up to `_PI_TRANSIENT_MAX_RETRIES` times. The re-prompt carries the
+        same content under a fresh prompt id (pi correlates a `prompt` response by
+        id). When the budget is exhausted — or the agent is shutting down — the
+        turn fails with the non-fatal, retryable `AgentTransientError` (surfaced as
+        a RequestFailure the user can re-run) instead of `PiCrashError`. A
+        non-transient error still raises `PiCrashError` from the dispatcher and is
+        not retried here.
+        """
+        payload = self._build_prompt_payload(generate_id(), message)
+        attempt = 0
+        while True:
+            self._send_rpc(payload)
+            try:
+                self._consume_until_turn_end(str(payload["id"]))
+                return
+            except _PiTransientTurnError as transient:
+                if attempt >= _PI_TRANSIENT_MAX_RETRIES or self._shutdown_event.is_set():
+                    raise AgentTransientError(transient.reason, exit_code=None, metadata=None) from transient
+                attempt += 1
+                logger.info(
+                    "PiAgent transient provider error on turn (retry {}/{}); backing off then re-prompting: {}",
+                    attempt,
+                    _PI_TRANSIENT_MAX_RETRIES,
+                    transient.reason,
+                )
+                self._sleep_before_transient_retry(attempt)
+                payload = {**payload, "id": generate_id()}
+
+    def _transient_retry_delay_seconds(self, attempt: int) -> float:
+        """Exponential-backoff-with-equal-jitter delay before transient retry `attempt`.
+
+        Grows as base*2**(attempt-1), capped at the max; equal jitter spreads the
+        delay across [half, full] of that cap so concurrent agents hitting the same
+        provider surge do not retry in lockstep.
+        """
+        capped = min(
+            _PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+            _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS,
+        )
+        return capped / 2 + random.uniform(0.0, capped / 2)
+
+    def _sleep_before_transient_retry(self, attempt: int) -> None:
+        """Block for the backoff delay, interruptible by shutdown.
+
+        Waits on `_shutdown_event` so a stopping agent does not block on a long
+        backoff: a set shutdown returns immediately, and the retry loop then bails
+        to `AgentTransientError`.
+        """
+        self._shutdown_event.wait(timeout=self._transient_retry_delay_seconds(attempt))
 
     def _update_plan_mode_from_message(self, message: ChatInputUserMessage) -> None:
         """Track plan mode across turns from the chat input's toggle flags.
@@ -1749,6 +1834,21 @@ class PiAgent(DefaultAgentWrapper):
         # toolcall_* / start / done) are deliberately discarded.
         logger.debug("PiAgent ignoring assistantMessageEvent variant: {}", inner_type)
 
+    def _raise_for_error_stop_reason(self, message: AgentMessage, state: _TurnState) -> None:
+        """Raise the right failure for an assistant message that ended with stopReason "error".
+
+        A KNOWN-TRANSIENT provider condition (`is_transient_provider_error` on
+        `error_message`) raises `_PiTransientTurnError` so the turn runner retries
+        it with backoff; any other error raises the terminal `PiCrashError`. A
+        failed turn carries no text and no in-stream error event, so pi's real
+        reason lives only on `error_message`; it is lifted (after any assistant
+        text / partial) into a clean, actionable message.
+        """
+        if is_transient_provider_error(message.error_message):
+            raise _PiTransientTurnError(humanize_pi_failure_reason(message.error_message))
+        reason = extract_assistant_text(message) or message.error_message or state.accumulated_text
+        raise PiCrashError(humanize_pi_failure_reason(reason), exit_code=None, metadata=None)
+
     def _handle_message_end(self, parsed: ParsedMessageEnd, state: _TurnState) -> None:
         """Per-message boundary — finalize this assistant message; not a turn boundary.
 
@@ -1766,12 +1866,13 @@ class PiAgent(DefaultAgentWrapper):
         advertised, so the UI collapses partials into a stable final block.
         The accumulator is then reset for the next message; the tool-call
         registry persists (the lane's result events arrive after this reset).
-        A terminal-error `stopReason` raises `PiCrashError`;
-        `stopReason:"aborted"` does too UNLESS an abort is expected (an
-        interrupt is pending, or shutdown) — then it is the interrupted
-        boundary and the partial content is finalized normally. Non-assistant
-        `message_end`s (notably the role="user" prompt echo pi emits at
-        agent-run start) are dropped.
+        A `stopReason:"error"` carrying a known-transient provider failure is
+        retried (see `_raise_for_error_stop_reason`); any other error raises
+        `PiCrashError`, as does an unexpected `stopReason:"aborted"` UNLESS an
+        abort is expected (an interrupt is pending, or shutdown) — then it is the
+        interrupted boundary and the partial content is finalized normally.
+        Non-assistant `message_end`s (notably the role="user" prompt echo pi emits
+        at agent-run start) are dropped.
         """
         # WHY: pi records every message in the session as a message_end — the
         # user's own prompt (echoed at agent-run start), tool results, and
@@ -1786,10 +1887,12 @@ class PiAgent(DefaultAgentWrapper):
         if parsed.message.model:
             logger.info("PiAgent turn produced by model={}", parsed.message.model)
         stop_reason = parsed.message.stop_reason
-        if stop_reason == "error" or (stop_reason == "aborted" and not self._is_abort_expected()):
-            # A failed turn carries no text and no in-stream error event; pi's
-            # real reason lives only on `error_message`. Lift it (after any
-            # assistant text / partial) into a clean, actionable message.
+        if stop_reason == "error":
+            # Transient provider failures retry (see _consume_turn_with_transient_retry);
+            # any other error is terminal.
+            self._raise_for_error_stop_reason(parsed.message, state)
+        if stop_reason == "aborted" and not self._is_abort_expected():
+            # An unexpected abort (no interrupt / shutdown pending) is a pi failure.
             reason = extract_assistant_text(parsed.message) or parsed.message.error_message or state.accumulated_text
             raise PiCrashError(humanize_pi_failure_reason(reason), exit_code=None, metadata=None)
         content = self._build_interleaved_content(parsed.message, state)
@@ -2271,9 +2374,11 @@ class PiAgent(DefaultAgentWrapper):
         command. If `message_end` never fired for the current
         accumulating message (an edge case — e.g. abort mid-stream), the
         accumulated text is finalized here using the partials' IDs so
-        the UI still settles on a stable block. A terminal `stopReason`
-        on any assistant message in the final transcript raises
-        `PiCrashError` — EXCEPT `stopReason:"aborted"` when an abort is
+        the UI still settles on a stable block. A `stopReason:"error"`
+        on any assistant message in the final transcript is retried when it
+        carries a known-transient provider failure (see
+        `_raise_for_error_stop_reason`) and otherwise raises `PiCrashError`; an
+        unexpected `stopReason:"aborted"` raises too, EXCEPT when an abort is
         expected (interrupt pending, or shutdown), which is the interrupted
         boundary and finalizes the partial text instead.
         `willRetry: true` means pi will start another agent run, typically
@@ -2284,11 +2389,14 @@ class PiAgent(DefaultAgentWrapper):
         for message in parsed.messages:
             if message.role != "assistant" or message.stop_reason not in ("error", "aborted"):
                 continue
-            if message.stop_reason == "aborted" and abort_expected:
-                # Expected interrupted boundary: finalize the partial below, don't raise.
-                continue
-            reason = extract_assistant_text(message) or message.error_message or state.accumulated_text
-            raise PiCrashError(humanize_pi_failure_reason(reason), exit_code=None, metadata=None)
+            if message.stop_reason == "aborted":
+                if abort_expected:
+                    # Expected interrupted boundary: finalize the partial below, don't raise.
+                    continue
+                reason = extract_assistant_text(message) or message.error_message or state.accumulated_text
+                raise PiCrashError(humanize_pi_failure_reason(reason), exit_code=None, metadata=None)
+            # stopReason "error": transient provider failures retry, others crash.
+            self._raise_for_error_stop_reason(message, state)
         if state.accumulated_text:
             self._output_messages.put(
                 ResponseBlockAgentMessage(

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1429,7 +1429,7 @@ class PiAgent(DefaultAgentWrapper):
         while True:
             self._send_rpc(payload)
             try:
-                self._consume_until_turn_end(str(payload["id"]))
+                self._consume_until_turn_end(payload["id"])
                 return
             except _PiTransientTurnError as transient:
                 attempt += 1

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1417,11 +1417,11 @@ class PiAgent(DefaultAgentWrapper):
         re-prompted with exponential backoff + jitter rather than crashing the
         agent, up to `_PI_TRANSIENT_MAX_RETRIES` times. The re-prompt carries the
         same content under a fresh prompt id (pi correlates a `prompt` response by
-        id). When the budget is exhausted — or the agent is shutting down — the
-        turn fails with the non-fatal, retryable `AgentTransientError` (surfaced as
-        a RequestFailure the user can re-run) instead of `PiCrashError`. A
-        non-transient error still raises `PiCrashError` from the dispatcher and is
-        not retried here.
+        id). When the budget is exhausted — or the agent is asked to stop (shutdown
+        or a user interrupt) — the turn fails with the non-fatal, retryable
+        `AgentTransientError` (surfaced as a RequestFailure the user can re-run)
+        instead of `PiCrashError`. A non-transient error still raises `PiCrashError`
+        from the dispatcher and is not retried here.
         """
         payload = self._build_prompt_payload(generate_id(), message)
         attempt = 0
@@ -1431,16 +1431,22 @@ class PiAgent(DefaultAgentWrapper):
                 self._consume_until_turn_end(str(payload["id"]))
                 return
             except _PiTransientTurnError as transient:
-                if attempt >= _PI_TRANSIENT_MAX_RETRIES or self._shutdown_event.is_set():
-                    raise AgentTransientError(transient.reason, exit_code=None, metadata=None) from transient
                 attempt += 1
-                logger.info(
-                    "PiAgent transient provider error on turn (retry {}/{}); backing off then re-prompting: {}",
-                    attempt,
-                    _PI_TRANSIENT_MAX_RETRIES,
-                    transient.reason,
-                )
-                self._sleep_before_transient_retry(attempt)
+                # Stop retrying when the budget is spent or we have been asked to
+                # stop — shutdown, or a user interrupt (`_is_abort_expected`).
+                should_give_up = attempt > _PI_TRANSIENT_MAX_RETRIES or self._is_abort_expected()
+                if not should_give_up:
+                    logger.info(
+                        "PiAgent transient provider error on turn (retry {}/{}); backing off then re-prompting: {}",
+                        attempt,
+                        _PI_TRANSIENT_MAX_RETRIES,
+                        transient.reason,
+                    )
+                    self._sleep_before_transient_retry(attempt)
+                    # A Stop or shutdown landed during the backoff: don't re-prompt.
+                    should_give_up = self._is_abort_expected()
+                if should_give_up:
+                    raise AgentTransientError(transient.reason, exit_code=None, metadata=None) from transient
                 payload = {**payload, "id": generate_id()}
 
     def _transient_retry_delay_seconds(self, attempt: int) -> float:
@@ -1457,13 +1463,21 @@ class PiAgent(DefaultAgentWrapper):
         return capped / 2 + random.uniform(0.0, capped / 2)
 
     def _sleep_before_transient_retry(self, attempt: int) -> None:
-        """Block for the backoff delay, interruptible by shutdown.
+        """Block for the backoff delay, woken early by shutdown or a user interrupt.
 
-        Waits on `_shutdown_event` so a stopping agent does not block on a long
-        backoff: a set shutdown returns immediately, and the retry loop then bails
-        to `AgentTransientError`.
+        Polls in short slices so a Stop pressed mid-backoff (which sets
+        `_interrupt_pending`, not `_shutdown_event`) is honored within a poll
+        interval instead of waiting out the full delay; the retry loop then bails
+        to `AgentTransientError`. Waiting on `_shutdown_event` makes a shutdown wake
+        the slice immediately.
         """
-        self._shutdown_event.wait(timeout=self._transient_retry_delay_seconds(attempt))
+        deadline = time.monotonic() + self._transient_retry_delay_seconds(attempt)
+        while not self._is_abort_expected():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0.0:
+                return
+            if self._shutdown_event.wait(timeout=min(remaining, _STDOUT_QUEUE_POLL_SECONDS)):
+                return
 
     def _update_plan_mode_from_message(self, message: ChatInputUserMessage) -> None:
         """Track plan mode across turns from the chat input's toggle flags.

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -96,6 +96,7 @@ from sculptor.agents.pi_agent.output_processor import ParsedUnknownEvent
 from sculptor.agents.pi_agent.output_processor import RpcResponse
 from sculptor.agents.pi_agent.output_processor import extract_assistant_text
 from sculptor.agents.pi_agent.output_processor import humanize_pi_failure_reason
+from sculptor.agents.pi_agent.output_processor import humanize_transient_failure_reason
 from sculptor.agents.pi_agent.output_processor import is_transient_provider_error
 from sculptor.agents.pi_agent.output_processor import parse_rpc_message
 from sculptor.agents.pi_agent.prompt_assembly import build_attachment_instructions
@@ -1856,10 +1857,11 @@ class PiAgent(DefaultAgentWrapper):
         it with backoff; any other error raises the terminal `PiCrashError`. A
         failed turn carries no text and no in-stream error event, so pi's real
         reason lives only on `error_message`; it is lifted (after any assistant
-        text / partial) into a clean, actionable message.
+        text / partial) into a clean, actionable message — the transient case gets
+        retry-oriented guidance so an exhausted-retry failure isn't a raw JSON blob.
         """
         if is_transient_provider_error(message.error_message):
-            raise _PiTransientTurnError(humanize_pi_failure_reason(message.error_message))
+            raise _PiTransientTurnError(humanize_transient_failure_reason(message.error_message))
         reason = extract_assistant_text(message) or message.error_message or state.accumulated_text
         raise PiCrashError(humanize_pi_failure_reason(reason), exit_code=None, metadata=None)
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1433,8 +1433,6 @@ class PiAgent(DefaultAgentWrapper):
                 return
             except _PiTransientTurnError as transient:
                 attempt += 1
-                # Stop retrying when the budget is spent or we have been asked to
-                # stop — shutdown, or a user interrupt (`_is_abort_expected`).
                 should_give_up = attempt > _PI_TRANSIENT_MAX_RETRIES or self._is_abort_expected()
                 if not should_give_up:
                     logger.info(
@@ -1904,8 +1902,6 @@ class PiAgent(DefaultAgentWrapper):
             logger.info("PiAgent turn produced by model={}", parsed.message.model)
         stop_reason = parsed.message.stop_reason
         if stop_reason == "error":
-            # Transient provider failures retry (see _consume_turn_with_transient_retry);
-            # any other error is terminal.
             self._raise_for_error_stop_reason(parsed.message, state)
         if stop_reason == "aborted" and not self._is_abort_expected():
             # An unexpected abort (no interrupt / shutdown pending) is a pi failure.
@@ -2411,7 +2407,6 @@ class PiAgent(DefaultAgentWrapper):
                     continue
                 reason = extract_assistant_text(message) or message.error_message or state.accumulated_text
                 raise PiCrashError(humanize_pi_failure_reason(reason), exit_code=None, metadata=None)
-            # stopReason "error": transient provider failures retry, others crash.
             self._raise_for_error_stop_reason(message, state)
         if state.accumulated_text:
             self._output_messages.put(

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -26,6 +26,8 @@ from sculptor.agents.pi_agent.agent_wrapper import PI_PROBE_SESSION_DIR_NAME
 from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_DIR_NAME
 from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_ID_STATE_FILE
 from sculptor.agents.pi_agent.agent_wrapper import PiAgent
+from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS
+from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS
 from sculptor.agents.pi_agent.agent_wrapper import _TurnState
 from sculptor.agents.pi_agent.agent_wrapper import _curate_models
 from sculptor.agents.pi_agent.agent_wrapper import _model_option_from_pi
@@ -500,6 +502,63 @@ def test_persistent_transient_error_surfaces_retryable_failure_not_crash() -> No
     assert not any(isinstance(m, RequestSuccessAgentMessage) for m in emitted)
     # The agent did not crash: no fatal exception was captured.
     assert agent._exception is None
+
+
+def test_interrupt_during_transient_backoff_stops_retrying() -> None:
+    """A Stop landing during the backoff bails to a retryable failure, with no re-prompt.
+
+    The first run hits a transient overloaded_error; while the harness is backing
+    off, the user interrupts (`_interrupt_pending` is set, simulated here as the
+    backoff's side effect). The loop must give up immediately with a
+    RequestFailure rather than re-prompting and spinning.
+    """
+    agent = _make_agent()
+    overloaded = json.dumps({"type": "overloaded_error", "message": "Overloaded"})
+    # Only one error round is queued: a re-prompt would find an empty/finished
+    # queue, so the assertions below also confirm the loop did not loop again.
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event({"type": "message_end", "message": _assistant_error_msg(overloaded)}),
+        ]
+    )
+
+    def _interrupt_during_backoff(attempt: int) -> None:
+        agent._interrupt_pending.set()
+
+    with patch.object(agent, "_sleep_before_transient_retry", side_effect=_interrupt_during_backoff):
+        agent._run_prompt_turn(ChatInputUserMessage(text="do the thing"))
+
+    emitted = _drain(agent._output_messages)
+    failures = [m for m in emitted if isinstance(m, RequestFailureAgentMessage)]
+    assert len(failures) == 1
+    assert "overloaded" in str(failures[0].error.args[0]).lower()
+    assert not any(isinstance(m, RequestSuccessAgentMessage) for m in emitted)
+
+
+def test_sleep_before_transient_retry_returns_immediately_when_interrupt_pending() -> None:
+    """The backoff is woken by a pending interrupt instead of waiting out the delay."""
+    agent = _make_agent()
+    agent._interrupt_pending.set()
+    with patch.object(agent, "_transient_retry_delay_seconds", return_value=100.0):
+        started = time.monotonic()
+        agent._sleep_before_transient_retry(attempt=1)
+        elapsed = time.monotonic() - started
+    assert elapsed < 1.0
+
+
+@pytest.mark.parametrize("attempt", [1, 2, 3, 4, 8])
+def test_transient_retry_delay_stays_within_equal_jitter_bounds(attempt: int) -> None:
+    """Backoff grows as base*2**(attempt-1), capped, with delay in [cap/2, cap]."""
+    agent = _make_agent()
+    cap = min(
+        _PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+        _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS,
+    )
+    # Sample repeatedly so the jitter range is exercised, not a single draw.
+    for _ in range(20):
+        delay = agent._transient_retry_delay_seconds(attempt)
+        assert cap / 2 <= delay <= cap
 
 
 def test_agent_end_with_aborted_message_raises_pi_crash_error() -> None:

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -467,6 +467,41 @@ def test_transient_overloaded_message_end_is_retried_until_the_turn_recovers() -
     assert successes[0].interrupted is False
 
 
+def test_persistent_transient_error_surfaces_retryable_failure_not_crash() -> None:
+    """When transient retries are exhausted, the turn fails non-fatally (retryable), not crash.
+
+    Every re-prompt hits the same overloaded_error, so the bounded retry budget is
+    exhausted. The turn must surface a RequestFailureAgentMessage (the retryable
+    AgentTransientError path the frontend lets the user re-run) rather than tearing
+    down the agent with PiCrashError.
+    """
+    agent = _make_agent()
+    overloaded = json.dumps({"type": "overloaded_error", "message": "Overloaded"})
+    # Each attempt consumes agent_start + an errored message_end. With the retry
+    # budget patched to 2, the runner makes 3 attempts (initial + 2 retries).
+    error_round = [
+        _event({"type": "agent_start"}),
+        _event({"type": "message_end", "message": _assistant_error_msg(overloaded)}),
+    ]
+    agent._process = _make_process(error_round * 3)
+
+    with (
+        patch("sculptor.agents.pi_agent.agent_wrapper._PI_TRANSIENT_MAX_RETRIES", 2),
+        patch.object(agent, "_transient_retry_delay_seconds", return_value=0.0),
+    ):
+        # Must NOT raise: the exhausted-retry path reports a failed request and the agent keeps running.
+        agent._run_prompt_turn(ChatInputUserMessage(text="do the thing"))
+
+    emitted = _drain(agent._output_messages)
+    failures = [m for m in emitted if isinstance(m, RequestFailureAgentMessage)]
+    assert len(failures) == 1
+    # The failure carries pi's transient reason so the frontend can surface it.
+    assert "overloaded" in str(failures[0].error.args[0]).lower()
+    assert not any(isinstance(m, RequestSuccessAgentMessage) for m in emitted)
+    # The agent did not crash: no fatal exception was captured.
+    assert agent._exception is None
+
+
 def test_agent_end_with_aborted_message_raises_pi_crash_error() -> None:
     agent = _make_agent()
     agent._process = _make_process(

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -128,6 +128,21 @@ def _assistant_msg(text: str, stop_reason: str = "stop") -> dict[str, Any]:
     }
 
 
+def _assistant_error_msg(error_message: str, text: str = "") -> dict[str, Any]:
+    """An assistant message_end that ended in a turn-failure (stopReason "error").
+
+    `error_message` (wire `errorMessage`) carries pi's provider failure reason —
+    the only place a transient provider condition (overloaded/rate-limit/5xx/
+    timeout) is recorded for a turn that fails without an in-stream error event.
+    """
+    return {
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}] if text else [],
+        "stopReason": "error",
+        "errorMessage": error_message,
+    }
+
+
 def _user_msg(text: str) -> dict[str, Any]:
     # A role="user" message carries no stopReason — pi only sets stopReason on
     # generated assistant messages. Mirrors the prompt-echo message pi emits at
@@ -415,6 +430,41 @@ def test_message_end_with_error_stop_reason_raises_pi_crash_error() -> None:
     )
     with pytest.raises(PiCrashError):
         agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+
+def test_transient_overloaded_message_end_is_retried_until_the_turn_recovers() -> None:
+    """A transient provider error at message_end is re-prompted, not fatal.
+
+    The first agent run ends with stopReason "error" carrying an Anthropic
+    `overloaded_error` (~HTTP 529). The harness must retry the turn (re-prompt
+    pi) instead of raising PiCrashError, and the retry's response finalizes the
+    turn normally — so a transient overload no longer tears down the agent.
+    """
+    agent = _make_agent()
+    overloaded = json.dumps({"type": "overloaded_error", "message": "Overloaded"})
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event({"type": "message_end", "message": _assistant_error_msg(overloaded)}),
+            # Retry: pi recovers and completes the turn on the re-prompt.
+            _event({"type": "agent_start"}),
+            _event(_text_delta_update("recovered", "recovered")),
+            _event({"type": "message_end", "message": _assistant_msg("recovered")}),
+            _event({"type": "agent_end", "messages": [_assistant_msg("recovered")], "willRetry": False}),
+        ]
+    )
+
+    agent._run_prompt_turn(ChatInputUserMessage(text="do the thing"))
+
+    emitted = _drain(agent._output_messages)
+    finals = [m for m in emitted if isinstance(m, ResponseBlockAgentMessage)]
+    texts = [block.text for f in finals for block in f.content if isinstance(block, TextBlock)]
+    # The turn completed after the retry instead of crashing.
+    assert "recovered" in texts
+    assert not any(isinstance(m, RequestFailureAgentMessage) for m in emitted)
+    successes = [m for m in emitted if isinstance(m, RequestSuccessAgentMessage)]
+    assert len(successes) == 1
+    assert successes[0].interrupted is False
 
 
 def test_agent_end_with_aborted_message_raises_pi_crash_error() -> None:

--- a/sculptor/sculptor/agents/pi_agent/output_processor.py
+++ b/sculptor/sculptor/agents/pi_agent/output_processor.py
@@ -107,11 +107,7 @@ def humanize_pi_failure_reason(reason: str | None) -> str:
     return _GENERIC_FAILURE_MESSAGE
 
 
-# Provider error-type / message markers (matched case-insensitively in pi's raw
-# failure reason) for transient conditions worth retrying — the provider
-# typically recovers on its own. Anthropic surfaces these as distinct error
-# `type`s: `overloaded_error` (~HTTP 529), `rate_limit_error` (~429), and
-# `api_error` (5xx server errors); request timeouts surface as timeout text.
+# Substrings (matched lowercased) marking a transient provider failure.
 _TRANSIENT_FAILURE_MARKERS = (
     "overloaded_error",
     "overloaded",
@@ -126,11 +122,10 @@ _TRANSIENT_FAILURE_MARKERS = (
     "timeout",
     "timed out",
 )
-# HTTP status codes for the same transient classes: request timeout (408), rate
-# limit (429), 5xx server errors, and Anthropic's "Overloaded" (529).
+# Transient HTTP statuses, including Anthropic's non-standard 529 "Overloaded".
 _TRANSIENT_STATUS_CODES = frozenset({"408", "429", "500", "502", "503", "504", "529"})
-# A standalone 3-digit token, so an embedded status code (e.g. `"status": 529`) is
-# recognized without matching a 3-digit run inside a longer number (model ids, ids).
+# Match a standalone 3-digit token so a status code is recognized without matching
+# three digits inside a longer number or id.
 _THREE_DIGIT_TOKEN_RE = re.compile(r"\b\d{3}\b")
 
 

--- a/sculptor/sculptor/agents/pi_agent/output_processor.py
+++ b/sculptor/sculptor/agents/pi_agent/output_processor.py
@@ -153,6 +153,27 @@ def is_transient_provider_error(error_message: str | None) -> bool:
     return any(token in _TRANSIENT_STATUS_CODES for token in _THREE_DIGIT_TOKEN_RE.findall(text))
 
 
+_TRANSIENT_FAILURE_MESSAGE = (
+    "The model provider is temporarily unavailable (overloaded, rate-limited, or timing out). "
+    + "Sculptor retried automatically — please try again in a moment."
+)
+
+
+def humanize_transient_failure_reason(reason: str | None) -> str:
+    """A friendly, retryable message for a known-transient provider failure.
+
+    Leads with actionable guidance and preserves pi's raw reason on a `Details:`
+    line (mirroring `humanize_pi_failure_reason`) so diagnosis isn't lost. Used
+    when a transient provider error (`is_transient_provider_error`) is surfaced to
+    the user after retries are exhausted, so they see guidance rather than a raw
+    provider JSON blob.
+    """
+    cleaned = (reason or "").strip()
+    if cleaned:
+        return f"{_TRANSIENT_FAILURE_MESSAGE}\n\nDetails: {cleaned}"
+    return _TRANSIENT_FAILURE_MESSAGE
+
+
 def extract_tool_call_blocks(message: AgentMessage) -> list[dict[str, Any]]:
     """Return the `{type:"toolCall",...}` content blocks on a message.
 

--- a/sculptor/sculptor/agents/pi_agent/output_processor.py
+++ b/sculptor/sculptor/agents/pi_agent/output_processor.py
@@ -21,6 +21,7 @@ Reference: the pi RPC protocol notes (pi 0.78.0).
 
 from __future__ import annotations
 
+import re
 from typing import Annotated
 from typing import Any
 from typing import Literal
@@ -104,6 +105,52 @@ def humanize_pi_failure_reason(reason: str | None) -> str:
     if cleaned:
         return cleaned
     return _GENERIC_FAILURE_MESSAGE
+
+
+# Provider error-type / message markers (matched case-insensitively in pi's raw
+# failure reason) for transient conditions worth retrying — the provider
+# typically recovers on its own. Anthropic surfaces these as distinct error
+# `type`s: `overloaded_error` (~HTTP 529), `rate_limit_error` (~429), and
+# `api_error` (5xx server errors); request timeouts surface as timeout text.
+_TRANSIENT_FAILURE_MARKERS = (
+    "overloaded_error",
+    "overloaded",
+    "rate_limit_error",
+    "rate limit",
+    "api_error",
+    "service unavailable",
+    "service_unavailable",
+    "internal server error",
+    "bad gateway",
+    "gateway timeout",
+    "timeout",
+    "timed out",
+)
+# HTTP status codes for the same transient classes: request timeout (408), rate
+# limit (429), 5xx server errors, and Anthropic's "Overloaded" (529).
+_TRANSIENT_STATUS_CODES = frozenset({"408", "429", "500", "502", "503", "504", "529"})
+# A standalone 3-digit token, so an embedded status code (e.g. `"status": 529`) is
+# recognized without matching a 3-digit run inside a longer number (model ids, ids).
+_THREE_DIGIT_TOKEN_RE = re.compile(r"\b\d{3}\b")
+
+
+def is_transient_provider_error(error_message: str | None) -> bool:
+    """Whether pi's recorded turn-failure reason is a KNOWN-TRANSIENT provider condition.
+
+    Transient classes — Anthropic `overloaded_error` (~HTTP 529), `rate_limit_error`
+    (~429), 5xx `api_error`, and request timeouts — are worth retrying because the
+    provider usually recovers on its own. Recognized by the error-type / message
+    markers pi forwards from the provider, or an embedded transient HTTP status
+    code. A reason that matches nothing here — a provider-auth failure, an unknown
+    model, a validation error, or an empty reason — is treated as terminal, NOT
+    transient.
+    """
+    text = (error_message or "").lower()
+    if not text.strip():
+        return False
+    if any(marker in text for marker in _TRANSIENT_FAILURE_MARKERS):
+        return True
+    return any(token in _TRANSIENT_STATUS_CODES for token in _THREE_DIGIT_TOKEN_RE.findall(text))
 
 
 def extract_tool_call_blocks(message: AgentMessage) -> list[dict[str, Any]]:

--- a/sculptor/sculptor/agents/pi_agent/output_processor_test.py
+++ b/sculptor/sculptor/agents/pi_agent/output_processor_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import humanize_pi_failure_reason
+from sculptor.agents.pi_agent.output_processor import humanize_transient_failure_reason
 from sculptor.agents.pi_agent.output_processor import is_transient_provider_error
 
 
@@ -79,3 +80,18 @@ def test_transient_provider_errors_are_recognized(error_message: str) -> None:
 def test_terminal_errors_are_not_classified_transient(error_message: str | None) -> None:
     """Auth / unknown-model / validation / empty reasons are terminal, not retryable."""
     assert not is_transient_provider_error(error_message)
+
+
+def test_humanize_transient_failure_leads_with_retry_guidance_and_keeps_detail() -> None:
+    raw = '{"type": "overloaded_error", "message": "Overloaded"}'
+    out = humanize_transient_failure_reason(raw)
+    assert "try again" in out.lower()
+    # The raw provider reason is preserved as detail so debugging isn't lost.
+    assert raw in out
+
+
+def test_humanize_transient_failure_empty_reason_is_clean() -> None:
+    out = humanize_transient_failure_reason("")
+    assert out
+    assert "try again" in out.lower()
+    assert humanize_transient_failure_reason(None) == out

--- a/sculptor/sculptor/agents/pi_agent/output_processor_test.py
+++ b/sculptor/sculptor/agents/pi_agent/output_processor_test.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import humanize_pi_failure_reason
+from sculptor.agents.pi_agent.output_processor import is_transient_provider_error
 
 
 def test_agent_message_maps_camelcase_error_message() -> None:
@@ -40,3 +43,39 @@ def test_humanize_empty_reason_gives_clean_generic_not_placeholder() -> None:
     assert out
     assert "pi message ended in error" not in out
     assert humanize_pi_failure_reason(None) == out
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        '{"type": "overloaded_error", "message": "Overloaded"}',
+        '{"type": "error", "error": {"type": "overloaded_error"}}',
+        '{"type": "rate_limit_error", "message": "rate limit exceeded"}',
+        '{"type": "api_error", "message": "Internal server error"}',
+        "Request timed out after 600s",
+        "Provider returned status 503",
+        "429 Too Many Requests",
+    ],
+)
+def test_transient_provider_errors_are_recognized(error_message: str) -> None:
+    """overloaded / rate-limit / 5xx / timeout conditions classify as retryable."""
+    assert is_transient_provider_error(error_message)
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        None,
+        "",
+        "   ",
+        "oops",
+        "401 Authentication Fails, Your api key: ****0000 is invalid",
+        '{"type": "authentication_error"}',
+        '{"type": "invalid_request_error", "message": "max_tokens too large"}',
+        "Model not found: deepseek/deepseek-v4-flash",
+        "API error 400: Could not process image",
+    ],
+)
+def test_terminal_errors_are_not_classified_transient(error_message: str | None) -> None:
+    """Auth / unknown-model / validation / empty reasons are terminal, not retryable."""
+    assert not is_transient_provider_error(error_message)


### PR DESCRIPTION
## Original bug

Linear SCU-1557. The pi harness treated any assistant message ending with `stopReason: "error"` as a fatal `PiCrashError` with no retry/backoff, so a single transient Anthropic `overloaded_error` (~HTTP 529) could tear down an entire agent run. The observed crash happened when an overload arrived just as the agent resumed after the user answered an `ask_user_question`.

## Root cause

`_handle_message_end` (and the parallel check in `_handle_agent_end`) in `sculptor/sculptor/agents/pi_agent/agent_wrapper.py` raised `PiCrashError` unconditionally on `stopReason == "error"`. Because `PiCrashError` is an `AgentCrashed` (not an `AgentClientError`), it propagated out of the message-processing thread and tore the agent down. A transient/retryable provider condition was indistinguishable from a genuine failure — the provider error JSON sits on `parsed.message.error_message` but was unused.

## Fix

- Classify the failure reason (`is_transient_provider_error` in `output_processor.py`): `overloaded_error` (~529), `rate_limit_error` (~429), 5xx `api_error`, and request timeouts are recognized as transient, by error-type/message markers and embedded HTTP status codes.
- A transient error re-prompts the current turn with bounded exponential backoff + equal jitter (`_consume_turn_with_transient_retry`), up to a fixed retry budget; a successful retry completes the turn normally.
- When the budget is exhausted, the turn surfaces a non-fatal, retryable `AgentTransientError` (→ `RequestFailureAgentMessage`, which the user can re-run) instead of `AgentCrashed`.
- Genuinely terminal errors (auth, unknown model, validation) still raise `PiCrashError` as before.

### Follow-up improvements (separate commits)

- **Honor user interrupt during backoff** — the retry loop bails, and the backoff wakes, on a pending interrupt (not just shutdown); the backoff polls in short slices and re-checks after sleeping, so a Stop is honored promptly and never triggers a stray re-prompt.
- **Friendlier exhausted-retry message** — an exhausted transient retry surfaces retry-oriented guidance with the raw reason on a `Details:` line, instead of a raw provider JSON blob.

## Tests

Backend unit tests. The transient pi-RPC provider-error path cannot be reproduced through the UI or `fake_claude` (matching the repo's "impossible" e2e criteria), so it is unit-tested following the existing `_make_process`/RPC-event patterns:

- `agent_wrapper_test.py`: failing-then-passing regression (a transient overload is retried and the turn recovers); a persistent transient error surfaces a retryable `RequestFailure`, not a crash; interrupt-during-backoff bail; interruptible sleep; delay jitter bounds.
- `output_processor_test.py`: transient vs. terminal classification; the friendly humanizer.

Failing-test commit: `7c9616b` · Fix commit: `afcd418`

Proof of work (non-UI bug → failing-then-passing test output).

Before (on the failing-test commit, pre-fix):

```
sculptor/.../agent_wrapper.py:_handle_message_end
    raise PiCrashError(humanize_pi_failure_reason(reason), ...)
PiCrashError: ('{"type": "overloaded_error", "message": "Overloaded"}', None, None)
1 failed
```

After (final state): full backend unit suite `1838 passed, 3 skipped`; `ruff` + `pyrefly` (0 errors) + `just ratchets` all clean.

## Review notes

Two findings from the self-review that are inherent to re-prompting and want real-pi/integration verification — both degrade gracefully (no crash):

- The retry re-prompts when the transient surfaces at `message_end`, possibly before the errored run's trailing `agent_end` is drained; a stale `agent_end` could burn one extra retry.
- Re-prompting may duplicate the user turn in pi's session (pi exposes no "continue this generation" RPC) — the same hazard the `ResumeAgentResponseRunnerMessage` handler already notes.

(Sent by Claude)
