### PR TITLE
Recover idle-but-RUNNING pi agent on Stop

### DIFF
--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -60,6 +60,7 @@ from pydantic import ValidationError
 
 from sculptor.agents.default.agent_wrapper import DefaultAgentWrapper
 from sculptor.agents.default.utils import get_state_file_contents
+from sculptor.agents.default.utils import get_turn_request_id
 from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
 from sculptor.agents.pi_agent.backchannel import build_ask_user_question_data
 from sculptor.agents.pi_agent.backchannel import extension_ui_response_body
@@ -523,6 +524,13 @@ class PiAgent(DefaultAgentWrapper):
     # escalation so an interrupt that races in between turns never SIGTERMs an
     # idle (but healthy) pi.
     _turn_in_flight: Event = PrivateAttr(default_factory=Event)
+    # The request id of the chat turn currently being processed (its
+    # RequestStarted was emitted; the matching terminal RequestSuccess may not
+    # have been). The interrupt path keys its reconciling RequestSuccess on this
+    # when no turn is in flight, so an idle-but-RUNNING agent — a turn orphaned
+    # without a terminal completion (e.g. a prior process death) — still settles
+    # on Stop. Mirrors ClaudeProcessManager._in_flight_request_id.
+    _in_flight_request_id: AgentMessageID | None = PrivateAttr(default=None)
     # Set when an interrupt has been requested and we are waiting for pi's
     # abort-induced boundary. The dispatcher consults it so `stopReason:"aborted"`
     # finalizes the partial response instead of raising `PiCrashError`.
@@ -1247,6 +1255,10 @@ class PiAgent(DefaultAgentWrapper):
         turn keeps draining inside `_handle_user_message` until pi's `agent_end`;
         if that never arrives, the escalation ladder SIGTERMs pi so the
         process-exit fallback in `_consume_until_turn_end` still resolves the turn.
+
+        When no turn is in flight the abort is a no-op (pi is idle) and no
+        turn-end will arrive, so Stop instead reconciles any orphaned in-flight
+        request directly — the idle-but-RUNNING escape hatch.
         """
         self._was_interrupted.set()
         self._interrupt_pending.set()
@@ -1259,6 +1271,32 @@ class PiAgent(DefaultAgentWrapper):
             self.concurrency_group.start_new_thread(
                 target=self._await_interrupt_escalation,
                 args=(cancel,),
+            )
+        else:
+            # The abort above is a no-op with pi idle, and no turn-end will
+            # arrive to resolve the request, so reconcile any orphaned turn here.
+            self._resolve_in_flight_request_as_interrupted()
+
+    def _resolve_in_flight_request_as_interrupted(self) -> None:
+        """Emit a terminal RequestSuccess(interrupted=True) for the in-flight
+        request, if any, so the frontend's in-progress chat message resolves
+        instead of staying stuck "thinking".
+
+        Used by the interrupt path when no turn is draining pi's stdout: the
+        turn's own terminal message can no longer be relied upon (it was never
+        emitted, or its process is gone). No-ops when no request is being
+        tracked (`_in_flight_request_id is None`). Mirrors
+        ClaudeProcessManager._resolve_in_flight_request_as_interrupted.
+        """
+        in_flight_request_id = self._in_flight_request_id
+        if in_flight_request_id is not None:
+            self._output_messages.put(
+                RequestSuccessAgentMessage(
+                    message_id=AgentMessageID(),
+                    request_id=in_flight_request_id,
+                    error=None,
+                    interrupted=True,
+                )
             )
 
     def _await_interrupt_escalation(self, cancel: Event) -> None:
@@ -1350,6 +1388,11 @@ class PiAgent(DefaultAgentWrapper):
         self._awaiting_reaction_deadline = time.monotonic() + _REACTION_WINDOW_SECONDS
 
     def _run_prompt_turn(self, message: ChatInputUserMessage) -> None:
+        # Track this turn's request id so an interrupt arriving with no turn in
+        # flight can reconcile it (see _resolve_in_flight_request_as_interrupted).
+        # Never cleared on turn end: a turn orphaned without a terminal completion
+        # leaves this set so Stop can still settle it.
+        self._in_flight_request_id = get_turn_request_id(message)
         self._update_plan_mode_from_message(message)
         with self._handle_user_message(message):
             # A fresh turn starts un-interrupted: clear interrupt state left by an

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1276,6 +1276,14 @@ class PiAgent(DefaultAgentWrapper):
             # The abort above is a no-op with pi idle, and no turn-end will
             # arrive to resolve the request, so reconcile any orphaned turn here.
             self._resolve_in_flight_request_as_interrupted()
+            # The reconciliation emits its own terminal RequestSuccess directly,
+            # so no in-flight turn will consume these flags. A chat turn resets
+            # interrupt state at its start, but the between-turns control paths
+            # read it via `_handle_user_message` without resetting it — so clear
+            # it here, or a lingering flag mislabels the next such request as
+            # interrupted.
+            self._was_interrupted.clear()
+            self._interrupt_pending.clear()
 
     def _resolve_in_flight_request_as_interrupted(self) -> None:
         """Emit a terminal RequestSuccess(interrupted=True) for the in-flight

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -580,6 +580,57 @@ def test_interrupt_with_no_turn_in_flight_resolves_stuck_request() -> None:
     assert resolved[0].interrupted is True
 
 
+def test_idle_interrupt_does_not_poison_next_clear_context() -> None:
+    """An interrupt with no turn in flight must not leave interrupt state set.
+
+    A chat turn resets interrupt state at its start, but the between-turns
+    control paths (/clear, set_model) do not — they only read it via
+    `_handle_user_message`. So a lingering `_was_interrupted` from an idle
+    interrupt would wrongly mark the next /clear's RequestSuccess as interrupted.
+    """
+    env = _clear_env()
+    agent = _make_agent(env)
+    agent._session_id = "old-session"
+    agent._in_flight_request_id = AgentMessageID()
+    process = _make_process(
+        [
+            _event(
+                {
+                    "type": "response",
+                    "command": "new_session",
+                    "success": True,
+                    "id": "cmd-new",
+                    "data": {"cancelled": False},
+                }
+            ),
+            _event(
+                {
+                    "type": "response",
+                    "command": "get_state",
+                    "success": True,
+                    "id": "cmd-state",
+                    "data": {"sessionId": "new-session", "messageCount": 0},
+                }
+            ),
+        ]
+    )
+    agent._process = process
+
+    # Idle interrupt (no turn in flight): reconciles the orphaned request.
+    agent._request_interrupt()
+
+    clear = ClearContextUserMessage(message_id=AgentMessageID())
+    with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-new", "cmd-state"]):
+        agent._handle_clear_context(clear)
+
+    emitted = _drain(agent._output_messages)
+    clear_successes = [
+        m for m in emitted if isinstance(m, RequestSuccessAgentMessage) and m.request_id == clear.message_id
+    ]
+    assert len(clear_successes) == 1
+    assert clear_successes[0].interrupted is False
+
+
 def test_aborted_agent_end_with_interrupt_pending_finalizes_without_crash() -> None:
     """`stopReason:"aborted"` on agent_end is the expected boundary when interrupt-pending — finalize, don't raise."""
     agent = _make_agent()

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -465,8 +465,12 @@ def test_push_message_interrupt_is_handled_and_sends_abort() -> None:
     interrupt = InterruptProcessUserMessage()
     handled = agent._push_message(interrupt)
     assert handled is True
-    assert agent._was_interrupted.is_set()
-    assert agent._interrupt_pending.is_set()
+    # With no turn in flight, the interrupt has nothing to escalate against and
+    # emits its own terminal directly, so it disarms the interrupt flags rather
+    # than leaving them set to mislabel a later between-turns request — handled
+    # via `_handle_user_message`, which reads but does not reset them.
+    assert not agent._was_interrupted.is_set()
+    assert not agent._interrupt_pending.is_set()
     assert _abort_was_written(process)
     # The interrupt request itself must be completed (request_id == the interrupt
     # message id) — `await_message_response` blocks the /interrupt POST until then,

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -549,6 +549,37 @@ def test_interrupt_with_no_turn_in_flight_does_not_poison_next_turn() -> None:
     assert successes[0].interrupted is False
 
 
+def test_interrupt_with_no_turn_in_flight_resolves_stuck_request() -> None:
+    """SCU-1560: Stop on an idle-but-RUNNING agent must resolve the orphaned turn.
+
+    When a turn's RequestStarted was emitted but no terminal RequestSuccess ever
+    followed (e.g. the prior process died mid-turn), the task stays RUNNING with
+    no turn actively draining pi's stdout. Pressing Stop must NOT be a silent
+    no-op: it must emit RequestSuccess(interrupted=True) for the in-flight
+    request so the task settles to READY, instead of the status pill bouncing
+    "Stopping" -> "Thinking" with nothing changed.
+
+    Mirrors Claude's interrupt_current_message no-op branch
+    (process_manager.py:_resolve_in_flight_request_as_interrupted).
+    """
+    agent = _make_agent()
+    agent._process = MagicMock()
+    # A turn is in flight from the frontend's point of view (RequestStarted with
+    # no terminal completion) but no turn is actively draining pi's stdout.
+    in_flight_id = AgentMessageID()
+    agent._in_flight_request_id = in_flight_id
+    assert not agent._turn_in_flight.is_set()
+
+    handled = agent._push_message(InterruptProcessUserMessage())
+
+    assert handled is True
+    emitted = _drain(agent._output_messages)
+    # The orphaned chat request is resolved, so derived state moves RUNNING -> READY.
+    resolved = [m for m in emitted if isinstance(m, RequestSuccessAgentMessage) and m.request_id == in_flight_id]
+    assert len(resolved) == 1
+    assert resolved[0].interrupted is True
+
+
 def test_aborted_agent_end_with_interrupt_pending_finalizes_without_crash() -> None:
     """`stopReason:"aborted"` on agent_end is the expected boundary when interrupt-pending — finalize, don't raise."""
     agent = _make_agent()


### PR DESCRIPTION
## Original bug

**Linear: SCU-1560** — *pi harness: allow Stop/Interrupt to recover an idle-but-RUNNING agent.*

When a pi task is `outcome=RUNNING` but no turn is in flight, pressing Stop was a no-op: the interrupt resolved immediately as `RequestSuccess(interrupted=False)`, the status pill flipped "Stopping…" then back to "Thinking…", and nothing changed. The user had no way out — three consecutive Stop attempts each produced `RequestSuccess(interrupted=False)` and left the agent wedged.

## Reproduction

The wedged state is an *idle-but-RUNNING* agent: a chat turn whose `RequestStarted` was emitted but whose terminal `RequestSuccess` never followed (e.g. the prior agent process died mid-turn), so the message-processing thread is idle while the request stays open.

1. Get a pi agent into that state (a turn orphaned without a terminal completion, message-processing thread idle).
2. Press Stop.
3. Observe: the interrupt resolves as `RequestSuccess(interrupted=False)` for the interrupt's own request only; the orphaned chat request stays open, so the task remains `RUNNING` and the pill bounces "Stopping" → "Thinking".

This is internal harness state that cannot be driven deterministically through the UI (it depends on a mid-turn process-death race), so it is covered by a backend unit test rather than a Playwright e2e test — see Test below.

## Hypothesis (code path)

`PiAgent._request_interrupt` (`sculptor/sculptor/agents/pi_agent/agent_wrapper.py`) only armed escalation `if self._turn_in_flight.is_set()`. With the agent idle, the `abort` sent to pi is a no-op and nothing ever resolves the orphaned request. Because that chat request has no completion, `web/derived.py` keeps the task `RUNNING` (`is_ready` is false — the chat message's id isn't in `request_finished_messages`), and `useAgentStatus.ts` re-derives "thinking" from `taskStatus === RUNNING && workingUserMessageId !== null`. The pill bounces and the agent stays wedged.

## Fix

Track the in-flight chat request id (`PiAgent._in_flight_request_id`, set in `_run_prompt_turn` via `get_turn_request_id`, never cleared on turn end so an orphaned turn stays recoverable). When an interrupt arrives with no turn in flight, reconcile that request directly via a new `_resolve_in_flight_request_as_interrupted()` helper, which emits `RequestSuccess(interrupted=True)`. The orphaned request now has a completion, so `derived.py` computes `READY` and the pill settles "Stopped" → idle with no bounce — Stop is a reliable escape hatch.

This deliberately mirrors the Claude harness, which already handles the identical case in `claude_code_sdk/process_manager.py` (`interrupt_current_message`'s dead-worker no-op branch / `_resolve_in_flight_request_as_interrupted`), so the two harnesses stay structurally consistent.

**Acceptance criteria**
- Pressing Stop on an idle-but-RUNNING pi agent reliably moves it to READY ✅
- The status pill does not bounce "Stopping → Thinking" without effect ✅

## Proof the fix works

TDD: a regression test was committed first and fails without the fix.

- **Failing-test commit:** `71da882` — *Add failing test for Stop on idle-but-RUNNING pi agent*
- **Fix commit:** `d44db24` — *Recover idle-but-RUNNING pi agent on Stop*

Before the fix (`test_interrupt_with_no_turn_in_flight_resolves_stuck_request`):

```
>       assert len(resolved) == 1
E       assert 0 == 1
E        +  where 0 = len([])
FAILED ...::test_interrupt_with_no_turn_in_flight_resolves_stuck_request
1 failed in 0.23s
```

After the fix (full pi_agent wrapper suite):

```
$ uv run --project sculptor pytest sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py -q
170 passed in 2.43s
```

Full gate green: `just format`, `just check` (lint/types/ratchets), `just test-unit` (backend, frontend, foundation, sculpt).

## Review notes

Self-reviewed with `/code-review-checklist`; no findings warranted a follow-up commit. Two LOW observations were consciously declined, each mirroring established Claude behavior: re-resolving an already-completed request id is harmless (readiness keys on the presence of any completion) and is UI-gated (Stop is only surfaced while the pill is cancellable); and the `None` / process-gone guards are trivial and already mirror the Claude helper.

(Sent by Claude)
