### PR TITLE
Resume an orphaned ask_user_question answer after a crash/restore

### DIFF
--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -55,6 +55,7 @@ from sculptor.interfaces.agents.agent import PersistentUserMessageUnion
 from sculptor.interfaces.agents.agent import RequestFailureAgentMessage
 from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestStoppedAgentMessage
+from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
 from sculptor.interfaces.agents.agent import StopAgentUserMessage
 from sculptor.interfaces.agents.agent import UnexpectedErrorRunnerMessage
@@ -381,6 +382,14 @@ def _run_agent_in_environment(
         # one of those things is to figure out what the last user chat message was that we *started* processing
         # this is in case we never *finished* processing it, so that the agent can resume from where it left off
         initial_in_flight_user_chat_message_id: AgentMessageID | None = None
+        # An orphaned answer: a UserQuestionAnswerMessage that was delivered to a
+        # now-dead agent process (its RequestStarted is in history) but whose turn
+        # never completed cleanly. On resume the agent has already recorded the
+        # answer (e.g. pi persists it as a toolResult) and has no open dialog, so
+        # re-delivering it raw is a stale dialog the harness skips — dropping the
+        # answer and leaving the request perpetually in-flight. Resuming it instead
+        # settles that dangling request (see _send_user_input_message).
+        initial_in_flight_user_question_answer_message_id: AgentMessageID | None = None
         # Track whether the agent emitted any visible response for the in-flight chat
         # message. If it didn't, there's nothing for Claude to "resume" from — we'd
         # rather just resend the original prompt than send a "continue where you left
@@ -395,6 +404,8 @@ def _run_agent_in_environment(
                         last_user_chat_message_id = message.request_id
                         initial_in_flight_user_chat_message_id = message.request_id
                         is_partial_agent_response = False
+                    elif isinstance(persistent_message, UserQuestionAnswerMessage):
+                        initial_in_flight_user_question_answer_message_id = message.request_id
                     # add the user message to the history as well
                     persistent_message_history.append(persistent_user_message_by_id[message.request_id])
             if isinstance(message, PersistentRequestCompleteAgentMessage):
@@ -403,6 +414,15 @@ def _run_agent_in_environment(
                     was_killed = _get_killed_exit_code(message)
                     if not was_killed:
                         initial_in_flight_user_chat_message_id = None
+                # Only a clean (non-interrupted) success means the answer's turn
+                # actually finished — clear it so it isn't resumed. An interrupted
+                # success, a failure, or a kill all leave the answer orphaned (its
+                # toolResult is recorded but nothing drove the follow-up turn), so
+                # keep it for resume.
+                if message.request_id == initial_in_flight_user_question_answer_message_id and (
+                    isinstance(message, RequestSuccessAgentMessage) and not message.interrupted
+                ):
+                    initial_in_flight_user_question_answer_message_id = None
             # used above so that we can figure out which user messages started being processed so far
             if isinstance(message, PersistentUserMessage):
                 persistent_user_message_by_id[message.message_id] = message
@@ -435,6 +455,7 @@ def _run_agent_in_environment(
             agent_wrapper,
             queued_user_input_messages.pop(0),
             initial_in_flight_user_chat_message_id,
+            initial_in_flight_user_question_answer_message_id,
         )
     while True:
         # if we have been trying to shut down for too long, it is time for more drastic measures.
@@ -568,6 +589,7 @@ def _run_agent_in_environment(
                         agent_wrapper,
                         queued_answer,
                         initial_in_flight_user_chat_message_id,
+                        initial_in_flight_user_question_answer_message_id,
                     )
                 else:
                     user_input_message_being_processed = None
@@ -578,6 +600,7 @@ def _run_agent_in_environment(
                     agent_wrapper,
                     queued_user_input_messages.pop(0),
                     initial_in_flight_user_chat_message_id,
+                    initial_in_flight_user_question_answer_message_id,
                 )
 
         # get any new user message(s)
@@ -611,6 +634,7 @@ def _run_agent_in_environment(
                         agent_wrapper,
                         message,
                         initial_in_flight_user_chat_message_id,
+                        initial_in_flight_user_question_answer_message_id,
                     )
                 else:
                     queued_user_input_messages.append(message)
@@ -641,6 +665,7 @@ def _send_user_input_message(
     agent_wrapper: Agent,
     message: InputMessageT,
     initial_in_flight_user_chat_message_id: AgentMessageID | None,
+    initial_in_flight_user_question_answer_message_id: AgentMessageID | None,
 ) -> InputMessageT:
     user_input_message_being_processed = message
     # if this message was one that we left off on last time,
@@ -648,6 +673,15 @@ def _send_user_input_message(
     # this allows the agent to use whatever in-flight response it had
     # (which prevents the user from losing a bunch of work if they shut down or sculptor crashed)
     # this is especially important as agents start to have much longer response times
+    #
+    # Do NOT re-persist a resumed message here. We only convert a message that is
+    # being resumed after a restart, which means it already has a RequestStarted in
+    # the log and was therefore already saved when it was first sent. Calling
+    # create_message again would write a second saved_agent_message row with the
+    # same object_id; replay then projects that id into both completed_chat_messages
+    # and queued_chat_messages, so it renders as a sent message AND a stuck queued
+    # message that never clears (and the duplicate React key corrupts the
+    # virtualized list).
     if user_input_message_being_processed.message_id == initial_in_flight_user_chat_message_id and isinstance(
         user_input_message_being_processed, ChatInputUserMessage
     ):
@@ -657,14 +691,21 @@ def _send_user_input_message(
             fast_mode=user_input_message_being_processed.fast_mode,
             effort=user_input_message_being_processed.effort,
         )
-        # Do NOT re-persist the message here. We only reach this branch for the
-        # in-flight message being resumed after a restart, which means it already
-        # has a RequestStarted in the log and was therefore already saved when it
-        # was first sent. Calling create_message again would write a second
-        # saved_agent_message row with the same object_id; replay then projects
-        # that id into both completed_chat_messages and queued_chat_messages, so
-        # it renders as a sent message AND a stuck queued message that never
-        # clears (and the duplicate React key corrupts the virtualized list).
+        agent_wrapper.push_message(resume_message)
+    elif (
+        user_input_message_being_processed.message_id == initial_in_flight_user_question_answer_message_id
+        and isinstance(user_input_message_being_processed, UserQuestionAnswerMessage)
+    ):
+        # An orphaned answer: it was delivered to a now-dead agent process and its
+        # turn never finished. Re-delivering it raw hits a fresh agent with no open
+        # dialog (the answer is already recorded in the resumed session), which the
+        # harness stale-skips — dropping the answer and leaving the request
+        # perpetually in-flight. Resume it instead so the dangling request settles.
+        # UserQuestionAnswerMessage carries no model/effort, so the resume defaults
+        # those (it only continues the turn, it does not start a fresh prompt).
+        resume_message = ResumeAgentResponseRunnerMessage(
+            for_user_message_id=user_input_message_being_processed.message_id,
+        )
         agent_wrapper.push_message(resume_message)
     else:
         agent_wrapper.push_message(user_input_message_being_processed)

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -696,13 +696,10 @@ def _send_user_input_message(
         user_input_message_being_processed.message_id == initial_in_flight_user_question_answer_message_id
         and isinstance(user_input_message_being_processed, UserQuestionAnswerMessage)
     ):
-        # An orphaned answer: it was delivered to a now-dead agent process and its
-        # turn never finished. Re-delivering it raw hits a fresh agent with no open
-        # dialog (the answer is already recorded in the resumed session), which the
-        # harness stale-skips — dropping the answer and leaving the request
-        # perpetually in-flight. Resume it instead so the dangling request settles.
+        # Resume the orphaned answer (tracked during replay) instead of re-delivering
+        # it raw, which a fresh agent with no open dialog stale-skips.
         # UserQuestionAnswerMessage carries no model/effort, so the resume defaults
-        # those (it only continues the turn, it does not start a fresh prompt).
+        # those: it continues the turn, it does not start a fresh prompt.
         resume_message = ResumeAgentResponseRunnerMessage(
             for_user_message_id=user_input_message_being_processed.message_id,
         )

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -1143,6 +1143,180 @@ def test_send_user_input_message_resumes_only_the_orphaned_answer() -> None:
     assert live_call.args[0] is live, "a live answer must be delivered raw, not converted to a resume"
 
 
+def test_orphaned_answer_with_interrupted_completion_is_still_resumed(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """An answer whose only completion is interrupted stays orphaned and resumes.
+
+    A post-answer shutdown can leave the answer with RequestStarted +
+    RequestSuccess(interrupted=True): the deferred per-turn success fired during
+    teardown, but the follow-up turn was never driven. That is not a finished turn,
+    so the resume replay must keep treating the answer as orphaned and convert it
+    to a ResumeAgentResponseRunnerMessage. Clearing it on the interrupted
+    completion would fall back to raw re-delivery, which a fresh agent stale-skips
+    — re-introducing the bug on the next restart.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"q": "a"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
+        tool_use_id="t1",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    # Crash-mid-answer history where the answer's deferred success fired interrupted
+    # during teardown: RequestStarted + RequestSuccess(interrupted=True), no clean
+    # completion and no follow-up turn.
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            answer,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+            RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id, interrupted=True),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordAnswerOrResumeAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()  # Fire immediately so the loop sends Stop after the first send.
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(answer,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert fake_agent.pushed_answer_or_resume, "Expected the loop to dispatch the orphaned answer"
+    first_push = fake_agent.pushed_answer_or_resume[0]
+    assert isinstance(first_push, ResumeAgentResponseRunnerMessage), (
+        f"interrupted answer completion must keep the orphan resumable; got {type(first_push).__name__}"
+    )
+    assert first_push.for_user_message_id == answer.message_id
+
+
+def test_answer_with_clean_completion_is_not_resumed(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A cleanly-completed answer is cleared from orphan tracking, not resumed.
+
+    A clean (non-interrupted) RequestSuccess means the answer's turn actually
+    finished, so the replay must clear it. If such an answer still reaches the
+    resume loop it is delivered raw (its dialog round is genuinely over), never
+    converted to a resume — the negative side of the clearing condition.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"q": "a"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
+        tool_use_id="t1",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    # The answer's turn finished cleanly: RequestStarted + RequestSuccess(interrupted=False).
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            answer,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+            RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id, interrupted=False),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordAnswerOrResumeAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()  # Fire immediately so the loop sends Stop after the first send.
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(answer,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert fake_agent.pushed_answer_or_resume, "Expected the loop to dispatch the answer"
+    first_push = fake_agent.pushed_answer_or_resume[0]
+    assert isinstance(first_push, UserQuestionAnswerMessage), (
+        f"a cleanly-completed answer must not be resumed; got {type(first_push).__name__}"
+    )
+
+
 class _CompletingResumeAgent(DefaultAgentWrapper):
     """Fake agent that COMPLETES resumed turns, keyed on ``for_user_message_id``.
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -946,6 +946,158 @@ def test_resuming_in_flight_message_does_not_persist_a_duplicate(
     )
 
 
+class _RecordAnswerOrResumeAgent(DefaultAgentWrapper):
+    """Fake agent that records whether the loop dispatched a raw answer or a resume.
+
+    Mirrors ``_RecordOnlyAgent`` but for the crash-mid-answer restore path: it
+    records pushed ``UserQuestionAnswerMessage`` and
+    ``ResumeAgentResponseRunnerMessage`` so a test can assert which one the loop
+    sent for an orphaned answer. On the ``StopAgentUserMessage`` the v1 loop pushes
+    when it observes ``shutdown_event``, it emits a ``RequestStoppedAgentMessage``
+    for the most recent dispatched request and sets ``_exit_code = SIGTERM`` so the
+    next iteration early-exits into ``_handle_completed_agent``.
+    """
+
+    _pushed_answer_or_resume: list[UserQuestionAnswerMessage | ResumeAgentResponseRunnerMessage] = PrivateAttr(
+        default_factory=list
+    )
+    _last_request_id: AgentMessageID | None = PrivateAttr(default=None)
+
+    def _start(self) -> None: ...
+
+    def _terminate(self, force_kill_seconds: float) -> None: ...
+
+    def wait(self, timeout: float) -> int:
+        return self._exit_code if self._exit_code is not None else 0
+
+    @property
+    def pushed_answer_or_resume(self) -> list[UserQuestionAnswerMessage | ResumeAgentResponseRunnerMessage]:
+        return self._pushed_answer_or_resume
+
+    def _push_message(self, message: Message) -> bool:
+        if isinstance(message, UserQuestionAnswerMessage):
+            self._pushed_answer_or_resume.append(message)
+            self._last_request_id = message.message_id
+            return True
+        if isinstance(message, ResumeAgentResponseRunnerMessage):
+            self._pushed_answer_or_resume.append(message)
+            self._last_request_id = message.for_user_message_id
+            return True
+        if isinstance(message, StopAgentUserMessage):
+            request_id = self._last_request_id
+            assert request_id is not None, "Stop arrived before any answer/resume message"
+            try:
+                raise AgentClientError("Killed by SIGTERM", exit_code=AGENT_EXIT_CODE_FROM_SIGTERM)
+            except AgentClientError as exc:
+                err = SerializedException.build(exc, exc.__traceback__)
+            self._output_messages.put(
+                RequestStoppedAgentMessage(
+                    message_id=AgentMessageID(),
+                    request_id=request_id,
+                    error=err,
+                )
+            )
+            self._exit_code = AGENT_EXIT_CODE_FROM_SIGTERM
+            return True
+        return False
+
+
+def test_orphaned_question_answer_is_resumed_not_stale_skipped(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """SCU-1558: a question answer whose turn died mid-flight must be RESUMED on
+    restart, not re-delivered raw.
+
+    A crash mid-question-answer leaves the ``UserQuestionAnswerMessage`` with a
+    ``RequestStarted`` but no completion -- the per-turn ``RequestSuccess`` is
+    deferred to the turn boundary, which the crash never reaches. Reconciliation
+    keeps the orphaned answer in the queue, so the resume loop re-dispatches it.
+
+    On restart the pi process has already recorded the answer as a ``toolResult``
+    and has no open dialog, so re-delivering the answer raw is reported as a stale
+    dialog and dropped (``_deliver_question_answer`` emits ``RequestSkipped``): no
+    turn is driven and the request never settles, leaving a perpetually-busy agent.
+
+    The loop must instead convert the orphaned answer to a
+    ``ResumeAgentResponseRunnerMessage`` -- the same contract it already honors for
+    an orphaned chat message -- so the dangling request settles.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Which option?": "the first one"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
+        tool_use_id="t1",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    # Persist the crash-mid-answer history: the chat turn started and produced a
+    # partial response, then the user's answer was delivered (RequestStarted) but
+    # its turn never completed -- no completion message for either request.
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            answer,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordAnswerOrResumeAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()  # Fire immediately so the loop sends Stop after the first send.
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(answer,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert fake_agent.pushed_answer_or_resume, "Expected the loop to dispatch the orphaned answer"
+    first_push = fake_agent.pushed_answer_or_resume[0]
+    assert isinstance(first_push, ResumeAgentResponseRunnerMessage), (
+        f"orphaned answer must be resumed, not re-delivered raw (which is stale-skipped); got {type(first_push).__name__}"
+    )
+    assert first_push.for_user_message_id == answer.message_id
+
+
 class _CompletingResumeAgent(DefaultAgentWrapper):
     """Fake agent that COMPLETES resumed turns, keyed on ``for_user_message_id``.
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -55,6 +55,7 @@ from sculptor.tasks.handlers.run_agent.v1 import AgentPaused
 from sculptor.tasks.handlers.run_agent.v1 import _build_agent_path
 from sculptor.tasks.handlers.run_agent.v1 import _run_agent_in_environment
 from sculptor.tasks.handlers.run_agent.v1 import _save_messages
+from sculptor.tasks.handlers.run_agent.v1 import _send_user_input_message
 from sculptor.tasks.handlers.run_agent.v1 import _update_task_state
 
 
@@ -1096,6 +1097,50 @@ def test_orphaned_question_answer_is_resumed_not_stale_skipped(
         f"orphaned answer must be resumed, not re-delivered raw (which is stale-skipped); got {type(first_push).__name__}"
     )
     assert first_push.for_user_message_id == answer.message_id
+
+
+def test_send_user_input_message_resumes_only_the_orphaned_answer() -> None:
+    """Only the answer tracked as orphaned converts to a resume; any other is raw.
+
+    Guards the boundary of the SCU-1558 fix: a live answer (one not left in flight
+    by a previous, crashed run) must still reach the harness as a raw
+    UserQuestionAnswerMessage so it is delivered to the open dialog. Converting it
+    to a resume would silently drop the user's actual answer.
+    """
+    orphaned = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"q": "a"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
+        tool_use_id="t1",
+    )
+    live = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"q": "b"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="t2"),
+        tool_use_id="t2",
+    )
+
+    orphaned_agent = MagicMock()
+    _send_user_input_message(
+        orphaned_agent,
+        orphaned,
+        None,
+        orphaned.message_id,
+    )
+    (orphaned_call,) = orphaned_agent.push_message.call_args_list
+    sent_for_orphaned = orphaned_call.args[0]
+    assert isinstance(sent_for_orphaned, ResumeAgentResponseRunnerMessage)
+    assert sent_for_orphaned.for_user_message_id == orphaned.message_id
+
+    live_agent = MagicMock()
+    _send_user_input_message(
+        live_agent,
+        live,
+        None,
+        orphaned.message_id,
+    )
+    (live_call,) = live_agent.push_message.call_args_list
+    assert live_call.args[0] is live, "a live answer must be delivered raw, not converted to a resume"
 
 
 class _CompletingResumeAgent(DefaultAgentWrapper):

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -955,8 +955,9 @@ class _RecordAnswerOrResumeAgent(DefaultAgentWrapper):
     ``ResumeAgentResponseRunnerMessage`` so a test can assert which one the loop
     sent for an orphaned answer. On the ``StopAgentUserMessage`` the v1 loop pushes
     when it observes ``shutdown_event``, it emits a ``RequestStoppedAgentMessage``
-    for the most recent dispatched request and sets ``_exit_code = SIGTERM`` so the
-    next iteration early-exits into ``_handle_completed_agent``.
+    for the most recent dispatched request and sets ``_exit_code =
+    AGENT_EXIT_CODE_FROM_SIGTERM`` so the next iteration early-exits into
+    ``_handle_completed_agent``.
     """
 
     _pushed_answer_or_resume: list[UserQuestionAnswerMessage | ResumeAgentResponseRunnerMessage] = PrivateAttr(


### PR DESCRIPTION
## Original bug

Linear: **SCU-1558** — "pi harness: recover an orphaned ask_user_question answer after a crash/restore (don't stale-skip it)".

When a pi agent crashes mid-question-answer and the task is restored, the user's answer was silently dropped and **no new turn was ever driven** — the agent made no further progress and the answer was lost. On restore, pi has already recorded the answer as a `toolResult`, so re-delivery was reported as a stale dialog and skipped:

```
_deliver_question_answer: PiAgent received question answer with no pending dialog (stale); skipping.
```

The task sat in `outcome=RUNNING` with an idle agent (perpetually "busy").

## Reproduction

This is a backend resume/restore-path bug with no UI surface — it only manifests under an OS-level crash mid-answer plus a backend restart, which Playwright cannot produce, and the buggy code path (the resume/replay dispatch) is internal. So it is proven with a backend unit test rather than screenshots.

1. A turn asks an `ask_user_question`; the user submits an answer.
2. The harness delivers the answer (emits `RequestStarted` for it, defers its `RequestSuccess` to the turn boundary); pi records the answer as a `toolResult`.
3. The turn crashes before the turn boundary, so the answer's deferred `RequestSuccess` never fires — the `UserQuestionAnswerMessage` is left with a `RequestStarted` and no completion.
4. On restore, reconciliation keeps the orphaned answer in the queue and the resume loop re-dispatches it.

## Hypothesis (root cause)

In `sculptor/sculptor/tasks/handlers/run_agent/v1.py`, the harness-agnostic resume loop only tracked an orphaned `ChatInputUserMessage` (`initial_in_flight_user_chat_message_id`) and converted it to a `ResumeAgentResponseRunnerMessage`. It had no handling for an orphaned `UserQuestionAnswerMessage`, so it re-sent the answer **raw**. A freshly relaunched agent has no open dialog (the answer is already recorded in the resumed session), so `_deliver_question_answer` stale-skips it (`RequestSkipped`) and the request never settles.

## Fix

In the resume replay, track an orphaned answer: a `UserQuestionAnswerMessage` with a `RequestStarted` in history and no clean, non-interrupted `RequestSuccess`. In `_send_user_input_message`, convert that orphaned answer to a `ResumeAgentResponseRunnerMessage` — the same contract already honored for an orphaned chat message — so the harness emits `RequestSuccess(interrupted=True)` and the dangling request settles (the UI is no longer perpetually busy). A live, newly-arriving answer is **not** tracked as orphaned and is still delivered raw to its open dialog.

The clearing condition is deliberately asymmetric from the chat path: only a clean (non-interrupted) `RequestSuccess` clears the orphan. An interrupted success, a failure, or a kill keep it orphaned, so a later restart still resumes it rather than falling back to the stale-skipped raw re-delivery.

## Proof the fix works

Non-UI bug → failing-then-passing test output.

- Failing-test commit: `1da79e3`
- Fix commit: `e393c1b`

Before the fix (red):

```
FAILED sculptor/sculptor/tasks/handlers/run_agent/v1_test.py::test_orphaned_question_answer_is_resumed_not_stale_skipped
AssertionError: orphaned answer must be resumed, not re-delivered raw (which is stale-skipped); got UserQuestionAnswerMessage
```

After the fix (green) — the regression test, the dispatch-boundary guard, and the replay-side clearing-condition tests (each mutation-checked to fail under a broken condition):

```
sculptor/sculptor/tasks/handlers/run_agent/v1_test.py::test_orphaned_question_answer_is_resumed_not_stale_skipped PASSED
sculptor/sculptor/tasks/handlers/run_agent/v1_test.py::test_send_user_input_message_resumes_only_the_orphaned_answer PASSED
sculptor/sculptor/tasks/handlers/run_agent/v1_test.py::test_orphaned_answer_with_interrupted_completion_is_still_resumed PASSED
sculptor/sculptor/tasks/handlers/run_agent/v1_test.py::test_answer_with_clean_completion_is_not_resumed PASSED
4 passed
```

`just check` and `just test-unit-backend` are green on the rebased base.

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
