### PR TITLE
[SCU-1584] Linear plugin: show sub-issue links and persist ticket open state

### DIFF
--- a/sculptor/frontend/plugins/linear-issue/src/components/IssueDetails.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/IssueDetails.tsx
@@ -4,16 +4,19 @@ import { ExternalLink, GitPullRequest } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { isPullRequestAttachment, type LinearIssue, prLabel } from "../linear/client.ts";
-import { TicketBadge } from "./TicketBadge.tsx";
-
-// How many sub-issues to render before collapsing the rest into "+N more".
-const MAX_SUBISSUES_SHOWN = 10;
+import { SubIssues } from "./SubIssues.tsx";
 
 /** The expanded body of a ticket: metadata, markdown description, and links out. */
-export const IssueDetails = ({ issue }: { issue: LinearIssue }): ReactElement => {
+export const IssueDetails = ({
+  issue,
+  subIssuesOpen,
+  onToggleSubIssues,
+}: {
+  issue: LinearIssue;
+  subIssuesOpen: boolean;
+  onToggleSubIssues: () => void;
+}): ReactElement => {
   const prLinks = issue.attachments.filter(isPullRequestAttachment);
-  const shownChildren = issue.children.slice(0, MAX_SUBISSUES_SHOWN);
-  const hiddenChildCount = issue.children.length - shownChildren.length;
   return (
     <Flex direction="column" gap="3" pt="2">
       <Flex align="center" gap="2" wrap="wrap">
@@ -35,31 +38,7 @@ export const IssueDetails = ({ issue }: { issue: LinearIssue }): ReactElement =>
         </Box>
       )}
 
-      {issue.children.length > 0 && (
-        <Flex direction="column" gap="2">
-          <Text size="1" color="gray" weight="medium">
-            Sub-issues
-          </Text>
-          <Flex gap="2" wrap="wrap" align="center">
-            {shownChildren.map((child) => (
-              <TicketBadge
-                key={child.identifier}
-                identifier={child.identifier}
-                title={child.title}
-                url={child.url}
-                state={child.state}
-              />
-            ))}
-            {hiddenChildCount > 0 && (
-              // The parent's Linear page lists every sub-issue, so send the
-              // overflow there rather than truncating silently.
-              <Button size="1" variant="ghost" color="gray" onClick={() => openExternal(issue.url)}>
-                +{hiddenChildCount} more
-              </Button>
-            )}
-          </Flex>
-        </Flex>
-      )}
+      <SubIssues issue={issue} isOpen={subIssuesOpen} onToggle={onToggleSubIssues} />
 
       <Flex gap="2" wrap="wrap">
         <Button size="1" variant="soft" onClick={() => openExternal(issue.url)}>

--- a/sculptor/frontend/plugins/linear-issue/src/components/IssueDetails.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/IssueDetails.tsx
@@ -4,10 +4,16 @@ import { ExternalLink, GitPullRequest } from "lucide-react";
 import type { ReactElement } from "react";
 
 import { isPullRequestAttachment, type LinearIssue, prLabel } from "../linear/client.ts";
+import { TicketBadge } from "./TicketBadge.tsx";
+
+// How many sub-issues to render before collapsing the rest into "+N more".
+const MAX_SUBISSUES_SHOWN = 10;
 
 /** The expanded body of a ticket: metadata, markdown description, and links out. */
 export const IssueDetails = ({ issue }: { issue: LinearIssue }): ReactElement => {
   const prLinks = issue.attachments.filter(isPullRequestAttachment);
+  const shownChildren = issue.children.slice(0, MAX_SUBISSUES_SHOWN);
+  const hiddenChildCount = issue.children.length - shownChildren.length;
   return (
     <Flex direction="column" gap="3" pt="2">
       <Flex align="center" gap="2" wrap="wrap">
@@ -27,6 +33,32 @@ export const IssueDetails = ({ issue }: { issue: LinearIssue }): ReactElement =>
         <Box>
           <Markdown content={issue.description} />
         </Box>
+      )}
+
+      {issue.children.length > 0 && (
+        <Flex direction="column" gap="2">
+          <Text size="1" color="gray" weight="medium">
+            Sub-issues
+          </Text>
+          <Flex gap="2" wrap="wrap" align="center">
+            {shownChildren.map((child) => (
+              <TicketBadge
+                key={child.identifier}
+                identifier={child.identifier}
+                title={child.title}
+                url={child.url}
+                state={child.state}
+              />
+            ))}
+            {hiddenChildCount > 0 && (
+              // The parent's Linear page lists every sub-issue, so send the
+              // overflow there rather than truncating silently.
+              <Button size="1" variant="ghost" color="gray" onClick={() => openExternal(issue.url)}>
+                +{hiddenChildCount} more
+              </Button>
+            )}
+          </Flex>
+        </Flex>
       )}
 
       <Flex gap="2" wrap="wrap">

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearPanel.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearPanel.tsx
@@ -40,17 +40,19 @@ export const LinearPanel = (): ReactElement => {
             const id = ticket.issue.identifier;
             // A user toggle wins; otherwise open the primary, and open a lone
             // ticket of any source so a single result is never left collapsed.
-            const isOpen = overrides[id] ?? (ticket.isPrimary || tickets.length === 1);
+            const defaultOpen = ticket.isPrimary || tickets.length === 1;
+            const isOpen = overrides[id] ?? defaultOpen;
             // Sub-issues stay collapsed until asked for, keeping the body compact.
-            const subIssuesOpen = subOverrides[id] ?? false;
+            const subIssuesDefaultOpen = false;
+            const subIssuesOpen = subOverrides[id] ?? subIssuesDefaultOpen;
             return (
               <TicketSection
                 key={id}
                 ticket={ticket}
                 isOpen={isOpen}
-                onToggle={() => setExpanded(id, !isOpen)}
+                onToggle={() => setExpanded(id, !isOpen, defaultOpen)}
                 subIssuesOpen={subIssuesOpen}
-                onToggleSubIssues={() => setSubExpanded(id, !subIssuesOpen)}
+                onToggleSubIssues={() => setSubExpanded(id, !subIssuesOpen, subIssuesDefaultOpen)}
                 onUnpin={unpin}
               />
             );

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearPanel.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearPanel.tsx
@@ -3,6 +3,7 @@ import { PanelHeader, useCurrentWorkspace, usePluginSetting } from "@sculptor/pl
 import { RefreshCw } from "lucide-react";
 import type { ReactElement } from "react";
 
+import { useExpandedIds } from "../linear/useExpandedIds.ts";
 import { useLinearTickets } from "../linear/useLinearTickets.ts";
 import { usePinnedIds } from "../linear/usePinnedIds.ts";
 import { EmptyState } from "./EmptyState.tsx";
@@ -19,6 +20,7 @@ export const LinearPanel = (): ReactElement => {
   const workspaceId = useCurrentWorkspace((workspace) => workspace?.id ?? null);
   const [apiKey] = usePluginSetting("apiKey");
   const { pinnedIds, pin, unpin } = usePinnedIds(workspaceId);
+  const { overrides, setExpanded } = useExpandedIds(workspaceId);
   const { tickets, isFetching, isError, error, refetch } = useLinearTickets({ apiKey, branch, pinnedIds });
 
   const refreshAction = apiKey ? (
@@ -31,15 +33,21 @@ export const LinearPanel = (): ReactElement => {
     if (tickets.length > 0) {
       return (
         <Flex direction="column" gap="2">
-          {tickets.map((ticket) => (
-            <TicketSection
-              // Include isPrimary so a ticket that becomes (or stops being) the
-              // workspace's primary remounts and re-derives its default open state.
-              key={`${ticket.issue.identifier}:${ticket.isPrimary}`}
-              ticket={ticket}
-              onUnpin={unpin}
-            />
-          ))}
+          {tickets.map((ticket) => {
+            const id = ticket.issue.identifier;
+            // A user toggle wins; otherwise open the primary, and open a lone
+            // ticket of any source so a single result is never left collapsed.
+            const isOpen = overrides[id] ?? (ticket.isPrimary || tickets.length === 1);
+            return (
+              <TicketSection
+                key={id}
+                ticket={ticket}
+                isOpen={isOpen}
+                onToggle={() => setExpanded(id, !isOpen)}
+                onUnpin={unpin}
+              />
+            );
+          })}
         </Flex>
       );
     }

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearPanel.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearPanel.tsx
@@ -21,6 +21,9 @@ export const LinearPanel = (): ReactElement => {
   const [apiKey] = usePluginSetting("apiKey");
   const { pinnedIds, pin, unpin } = usePinnedIds(workspaceId);
   const { overrides, setExpanded } = useExpandedIds(workspaceId);
+  // A separate map for each ticket's sub-issue disclosure, keyed by the same
+  // ticket identifier but namespaced so it can't collide with the section map.
+  const { overrides: subOverrides, setExpanded: setSubExpanded } = useExpandedIds(workspaceId, "subissues");
   const { tickets, isFetching, isError, error, refetch } = useLinearTickets({ apiKey, branch, pinnedIds });
 
   const refreshAction = apiKey ? (
@@ -38,12 +41,16 @@ export const LinearPanel = (): ReactElement => {
             // A user toggle wins; otherwise open the primary, and open a lone
             // ticket of any source so a single result is never left collapsed.
             const isOpen = overrides[id] ?? (ticket.isPrimary || tickets.length === 1);
+            // Sub-issues stay collapsed until asked for, keeping the body compact.
+            const subIssuesOpen = subOverrides[id] ?? false;
             return (
               <TicketSection
                 key={id}
                 ticket={ticket}
                 isOpen={isOpen}
                 onToggle={() => setExpanded(id, !isOpen)}
+                subIssuesOpen={subIssuesOpen}
+                onToggleSubIssues={() => setSubExpanded(id, !subIssuesOpen)}
                 onUnpin={unpin}
               />
             );

--- a/sculptor/frontend/plugins/linear-issue/src/components/SubIssues.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/SubIssues.tsx
@@ -1,0 +1,65 @@
+import { Box, Button, Flex, Text } from "@radix-ui/themes";
+import { openExternal } from "@sculptor/plugin-sdk";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { ReactElement } from "react";
+
+import type { LinearIssue } from "../linear/client.ts";
+import { TicketBadge } from "./TicketBadge.tsx";
+
+// How many sub-issues to render before collapsing the rest into "+N more".
+const MAX_SUBISSUES_SHOWN = 10;
+
+/**
+ * A light, collapsible disclosure of an issue's sub-issues: a header that just
+ * counts them, expanding to a slightly-indented list of sub-issue badges. Keeps
+ * the ticket body compact until the reader asks for the nesting. Open state is
+ * owned and persisted by the panel (so it survives the panel remounting);
+ * renders nothing when the issue has no sub-issues.
+ */
+export const SubIssues = ({
+  issue,
+  isOpen,
+  onToggle,
+}: {
+  issue: LinearIssue;
+  isOpen: boolean;
+  onToggle: () => void;
+}): ReactElement | null => {
+  const count = issue.children.length;
+  if (count === 0) return null;
+  const shown = issue.children.slice(0, MAX_SUBISSUES_SHOWN);
+  const hidden = count - shown.length;
+  return (
+    <Flex direction="column" gap="2">
+      <Flex align="center" gap="1" onClick={onToggle} style={{ cursor: "pointer", width: "fit-content" }}>
+        {isOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        <Text size="1" color="gray">
+          {count} sub-issue{count === 1 ? "" : "s"}
+        </Text>
+      </Flex>
+      {isOpen && (
+        // A faint left border + indent reads as nesting under the parent ticket.
+        <Box pl="3" style={{ borderLeft: "1px solid var(--gray-4)", marginLeft: "var(--space-1)" }}>
+          <Flex gap="2" wrap="wrap" align="center">
+            {shown.map((child) => (
+              <TicketBadge
+                key={child.identifier}
+                identifier={child.identifier}
+                title={child.title}
+                url={child.url}
+                state={child.state}
+              />
+            ))}
+            {hidden > 0 && (
+              // The parent's Linear page lists every sub-issue, so send the
+              // overflow there rather than truncating silently.
+              <Button size="1" variant="ghost" color="gray" onClick={() => openExternal(issue.url)}>
+                +{hidden} more
+              </Button>
+            )}
+          </Flex>
+        </Box>
+      )}
+    </Flex>
+  );
+};

--- a/sculptor/frontend/plugins/linear-issue/src/components/TicketBadge.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/TicketBadge.tsx
@@ -1,0 +1,39 @@
+import { Badge, Text } from "@radix-ui/themes";
+import { openExternal } from "@sculptor/plugin-sdk";
+import type { ReactElement } from "react";
+
+import type { LinearState } from "../linear/client.ts";
+import { StateDot } from "./StateDot.tsx";
+
+/**
+ * A clickable badge linking to another Linear ticket — the panel's shape for a
+ * "reference back to a ticket" (sub-issues today; parent/related/mentions
+ * later). It shows the identifier and title, with a status dot when the ticket's
+ * workflow state is known. `state` is optional precisely so the same badge can
+ * front references we have the status for inline and ones whose status would be
+ * fetched separately.
+ */
+export const TicketBadge = ({
+  identifier,
+  title,
+  url,
+  state,
+}: {
+  identifier: string;
+  title: string;
+  url: string;
+  state: LinearState | null;
+}): ReactElement => (
+  <Badge
+    size="2"
+    variant="soft"
+    color="gray"
+    onClick={() => openExternal(url)}
+    title={state ? `${identifier} · ${state.name}` : identifier}
+    style={{ cursor: "pointer", maxWidth: "100%" }}
+  >
+    {state && <StateDot color={state.color} />}
+    <Text style={{ fontFamily: "var(--code-font-family)", flexShrink: 0 }}>{identifier}</Text>
+    <Text truncate>{title}</Text>
+  </Badge>
+);

--- a/sculptor/frontend/plugins/linear-issue/src/components/TicketBadge.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/TicketBadge.tsx
@@ -23,17 +23,31 @@ export const TicketBadge = ({
   title: string;
   url: string;
   state: LinearState | null;
-}): ReactElement => (
-  <Badge
-    size="2"
-    variant="soft"
-    color="gray"
-    onClick={() => openExternal(url)}
-    title={state ? `${identifier} · ${state.name}` : identifier}
-    style={{ cursor: "pointer", maxWidth: "100%" }}
-  >
-    {state && <StateDot color={state.color} />}
-    <Text style={{ fontFamily: "var(--code-font-family)", flexShrink: 0 }}>{identifier}</Text>
-    <Text truncate>{title}</Text>
-  </Badge>
-);
+}): ReactElement => {
+  const open = (): void => openExternal(url);
+  return (
+    // Radix `Badge` renders a <span>, so it carries no button semantics on its
+    // own; this is an interactive link, so add the role, focusability, and
+    // keyboard activation a real button would have.
+    <Badge
+      size="2"
+      variant="soft"
+      color="gray"
+      role="button"
+      tabIndex={0}
+      onClick={open}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          open();
+        }
+      }}
+      title={state ? `${identifier} · ${state.name}` : identifier}
+      style={{ cursor: "pointer", maxWidth: "100%" }}
+    >
+      {state && <StateDot color={state.color} />}
+      <Text style={{ fontFamily: "var(--code-font-family)", flexShrink: 0 }}>{identifier}</Text>
+      <Text truncate>{title}</Text>
+    </Badge>
+  );
+};

--- a/sculptor/frontend/plugins/linear-issue/src/components/TicketSection.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/TicketSection.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { ChevronDown, ChevronRight, X } from "lucide-react";
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 
 import type { PanelTicket } from "../linear/sources.ts";
 import { IssueDetails } from "./IssueDetails.tsx";
@@ -9,17 +9,20 @@ import { StateDot } from "./StateDot.tsx";
 
 /**
  * A collapsible issue: a header (id, state, title, source badges) that toggles
- * the details. The primary (workspace) ticket is accented and expanded by
- * default; pinned tickets get an unpin control.
+ * the details. Open/closed is controlled by the panel, which derives the
+ * default and persists user toggles; pinned tickets get an unpin control.
  */
 export const TicketSection = ({
   ticket,
+  isOpen,
+  onToggle,
   onUnpin,
 }: {
   ticket: PanelTicket;
+  isOpen: boolean;
+  onToggle: () => void;
   onUnpin: (identifier: string) => void;
 }): ReactElement => {
-  const [isOpen, setIsOpen] = useState<boolean>(ticket.isPrimary);
   const { issue } = ticket;
   const canUnpin = ticket.sources.includes("pinned");
 
@@ -31,7 +34,7 @@ export const TicketSection = ({
         borderRadius: "var(--radius-3)",
       }}
     >
-      <Flex align="center" gap="2" p="2" onClick={() => setIsOpen((open) => !open)} style={{ cursor: "pointer" }}>
+      <Flex align="center" gap="2" p="2" onClick={() => onToggle()} style={{ cursor: "pointer" }}>
         {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         <Text size="1" color="gray" style={{ fontFamily: "var(--code-font-family)", flexShrink: 0 }}>
           {issue.identifier}

--- a/sculptor/frontend/plugins/linear-issue/src/components/TicketSection.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/TicketSection.tsx
@@ -16,11 +16,15 @@ export const TicketSection = ({
   ticket,
   isOpen,
   onToggle,
+  subIssuesOpen,
+  onToggleSubIssues,
   onUnpin,
 }: {
   ticket: PanelTicket;
   isOpen: boolean;
   onToggle: () => void;
+  subIssuesOpen: boolean;
+  onToggleSubIssues: () => void;
   onUnpin: (identifier: string) => void;
 }): ReactElement => {
   const { issue } = ticket;
@@ -65,7 +69,7 @@ export const TicketSection = ({
       </Flex>
       {isOpen && (
         <Box px="2" pb="2">
-          <IssueDetails issue={issue} />
+          <IssueDetails issue={issue} subIssuesOpen={subIssuesOpen} onToggleSubIssues={onToggleSubIssues} />
         </Box>
       )}
     </Box>

--- a/sculptor/frontend/plugins/linear-issue/src/linear/client.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/client.test.ts
@@ -1,8 +1,40 @@
 import { describe, expect, it } from "vitest";
 
-import { isPullRequestAttachment, type LinearAttachment, prLabel } from "./client.ts";
+import { isPullRequestAttachment, type LinearAttachment, normalizeIssue, prLabel } from "./client.ts";
 
 const attachment = (url: string): LinearAttachment => ({ url, sourceType: "github", title: null });
+
+// A raw issue as Linear returns it, with connections still wrapped in `{ nodes }`.
+// Typed loosely so a test can omit a connection to exercise the absent-field path.
+const rawIssue = (overrides: Record<string, unknown> = {}): Parameters<typeof normalizeIssue>[0] =>
+  ({
+    identifier: "SCU-1",
+    title: "Parent",
+    url: "https://linear.app/x/issue/SCU-1",
+    description: null,
+    priorityLabel: null,
+    state: null,
+    assignee: null,
+    attachments: { nodes: [] },
+    children: { nodes: [] },
+    ...overrides,
+  }) as Parameters<typeof normalizeIssue>[0];
+
+describe("normalizeIssue", () => {
+  it("flattens sub-issues out of the children connection", () => {
+    const child = {
+      identifier: "SCU-2",
+      title: "Child",
+      url: "https://linear.app/x/issue/SCU-2",
+      state: { name: "Todo", type: "unstarted", color: "#fff" },
+    };
+    expect(normalizeIssue(rawIssue({ children: { nodes: [child] } })).children).toEqual([child]);
+  });
+
+  it("defaults children to [] when the connection is absent", () => {
+    expect(normalizeIssue(rawIssue({ children: undefined })).children).toEqual([]);
+  });
+});
 
 describe("isPullRequestAttachment", () => {
   it("matches GitHub pull and GitLab merge-request URLs", () => {

--- a/sculptor/frontend/plugins/linear-issue/src/linear/client.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/client.ts
@@ -5,6 +5,17 @@ const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 /** A link Linear holds against an issue (a PR, a design, a doc, …). */
 export type LinearAttachment = { url: string; sourceType: string | null; title: string | null };
 
+/** A Linear workflow state (e.g. "In Progress"), with its display color. */
+export type LinearState = { name: string; type: string; color: string };
+
+/** A sub-issue, narrowed to what a ticket badge renders (id, title, status). */
+export type LinearChild = {
+  identifier: string;
+  title: string;
+  url: string;
+  state: LinearState | null;
+};
+
 /** A Linear issue, narrowed to the fields the panel renders. */
 export type LinearIssue = {
   identifier: string;
@@ -12,9 +23,11 @@ export type LinearIssue = {
   url: string;
   description: string | null;
   priorityLabel: string | null;
-  state: { name: string; type: string; color: string } | null;
+  state: LinearState | null;
   assignee: { displayName: string } | null;
   attachments: ReadonlyArray<LinearAttachment>;
+  /** Direct sub-issues, capped by the `children` selection in ISSUE_FIELDS. */
+  children: ReadonlyArray<LinearChild>;
 };
 
 /** Lightweight issue shape for quick-search results. */
@@ -25,7 +38,10 @@ export type LinearIssueSummary = {
 };
 
 // Shared selection for a fully-rendered issue, so every fetch path (branch,
-// identifier, PR-linked) returns the same shape.
+// identifier, PR-linked) returns the same shape. Sub-issues are fetched with a
+// generous cap so the panel can show an accurate "+N more" beyond the first
+// few it renders; a ticket with more children than this would undercount.
+const CHILDREN_FETCH_LIMIT = 50;
 const ISSUE_FIELDS = `
   identifier
   title
@@ -35,11 +51,16 @@ const ISSUE_FIELDS = `
   state { name type color }
   assignee { displayName }
   attachments { nodes { url sourceType title } }
+  children(first: ${CHILDREN_FETCH_LIMIT}) { nodes { identifier title url state { name type color } } }
 `;
 
-type RawIssue = Omit<LinearIssue, "attachments"> & { attachments: { nodes: Array<LinearAttachment> } };
+type RawIssue = Omit<LinearIssue, "attachments" | "children"> & {
+  attachments: { nodes: Array<LinearAttachment> };
+  children: { nodes: Array<LinearChild> };
+};
 
-const normalizeIssue = (raw: RawIssue): LinearIssue => ({
+/** Flatten Linear's nested connections (`{ nodes }`) into the panel's flat shape. */
+export const normalizeIssue = (raw: RawIssue): LinearIssue => ({
   identifier: raw.identifier,
   title: raw.title,
   url: raw.url,
@@ -48,6 +69,7 @@ const normalizeIssue = (raw: RawIssue): LinearIssue => ({
   state: raw.state,
   assignee: raw.assignee,
   attachments: raw.attachments?.nodes ?? [],
+  children: raw.children?.nodes ?? [],
 });
 
 // Single POST helper with shared auth + error handling. `signal` is the

--- a/sculptor/frontend/plugins/linear-issue/src/linear/sources.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/sources.test.ts
@@ -12,6 +12,7 @@ const issue = (identifier: string): LinearIssue => ({
   state: null,
   assignee: null,
   attachments: [],
+  children: [],
 });
 
 describe("mergeTickets", () => {

--- a/sculptor/frontend/plugins/linear-issue/src/linear/useExpandedIds.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/useExpandedIds.ts
@@ -13,14 +13,17 @@ export type ExpandedState = {
 };
 
 /**
- * Per-workspace ticket open/closed overrides, persisted via the plugin-settings
- * SDK as a JSON object under a per-workspace key. Persisting (rather than React
- * state) is what lets a manually-toggled section survive the panel remounting.
+ * Per-workspace open/closed overrides, persisted via the plugin-settings SDK as
+ * a JSON object under a per-workspace key. Persisting (rather than React state)
+ * is what lets a manually-toggled section survive the panel remounting.
+ * `namespace` separates independent collapsible groups (e.g. the ticket
+ * sections vs. each ticket's sub-issue disclosure) so their keys can't collide
+ * — both are keyed by a Linear identifier, but they live in different maps.
  * `workspaceId` may be null in contexts without a workspace, where overrides
  * share a single fallback bucket.
  */
-export const useExpandedIds = (workspaceId: string | null): ExpandedState => {
-  const [raw, setRaw] = usePluginSetting(`expanded:${workspaceId ?? "none"}`);
+export const useExpandedIds = (workspaceId: string | null, namespace = "expanded"): ExpandedState => {
+  const [raw, setRaw] = usePluginSetting(`${namespace}:${workspaceId ?? "none"}`);
 
   const overrides = useMemo<Readonly<Record<string, boolean>>>(() => {
     if (!raw) return {};

--- a/sculptor/frontend/plugins/linear-issue/src/linear/useExpandedIds.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/useExpandedIds.ts
@@ -9,7 +9,14 @@ export type ExpandedState = {
    * being frozen into persisted state.
    */
   overrides: Readonly<Record<string, boolean>>;
-  setExpanded: (identifier: string, open: boolean) => void;
+  /**
+   * Record the user's open/closed choice. `defaultOpen` is the panel's derived
+   * default for this id: when the choice matches it, the override is *deleted*
+   * rather than written, so only true deviations persist and a later change to
+   * the default rule isn't frozen out by a stored value that merely echoed the
+   * old default.
+   */
+  setExpanded: (identifier: string, open: boolean, defaultOpen: boolean) => void;
 };
 
 /**
@@ -41,8 +48,14 @@ export const useExpandedIds = (workspaceId: string | null, namespace = "expanded
   }, [raw]);
 
   const setExpanded = useCallback(
-    (identifier: string, open: boolean): void => {
-      setRaw(JSON.stringify({ ...overrides, [identifier]: open }));
+    (identifier: string, open: boolean, defaultOpen: boolean): void => {
+      const next = { ...overrides };
+      if (open === defaultOpen) {
+        delete next[identifier];
+      } else {
+        next[identifier] = open;
+      }
+      setRaw(JSON.stringify(next));
     },
     [overrides, setRaw],
   );

--- a/sculptor/frontend/plugins/linear-issue/src/linear/useExpandedIds.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/useExpandedIds.ts
@@ -1,0 +1,48 @@
+import { usePluginSetting } from "@sculptor/plugin-sdk";
+import { useCallback, useMemo } from "react";
+
+export type ExpandedState = {
+  /**
+   * Explicit open/closed choices the user has made, keyed by ticket
+   * identifier. Tickets absent here fall back to the panel's derived default —
+   * this stores only deviations from it, so the default can evolve without
+   * being frozen into persisted state.
+   */
+  overrides: Readonly<Record<string, boolean>>;
+  setExpanded: (identifier: string, open: boolean) => void;
+};
+
+/**
+ * Per-workspace ticket open/closed overrides, persisted via the plugin-settings
+ * SDK as a JSON object under a per-workspace key. Persisting (rather than React
+ * state) is what lets a manually-toggled section survive the panel remounting.
+ * `workspaceId` may be null in contexts without a workspace, where overrides
+ * share a single fallback bucket.
+ */
+export const useExpandedIds = (workspaceId: string | null): ExpandedState => {
+  const [raw, setRaw] = usePluginSetting(`expanded:${workspaceId ?? "none"}`);
+
+  const overrides = useMemo<Readonly<Record<string, boolean>>>(() => {
+    if (!raw) return {};
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+      const result: Record<string, boolean> = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "boolean") result[key] = value;
+      }
+      return result;
+    } catch {
+      return {};
+    }
+  }, [raw]);
+
+  const setExpanded = useCallback(
+    (identifier: string, open: boolean): void => {
+      setRaw(JSON.stringify({ ...overrides, [identifier]: open }));
+    },
+    [overrides, setRaw],
+  );
+
+  return { overrides, setExpanded };
+};


### PR DESCRIPTION
## Summary

Expands the bundled `linear-issue` plugin in two ways:

- **Sub-issue links.** Each ticket's expanded view now lists its direct sub-issues as clickable status badges (state dot + identifier + title) that open the sub-issue in Linear. The first 10 are shown, then a "+N more" link to the parent's Linear page. Sub-issues are fetched on the existing issue queries — a `children` selection added to the shared field set — so no extra network requests are made.
- **Consistent, persistent open state.** The panel now owns each ticket section's open/closed state and derives a default (open the primary branch ticket, or a lone result of any source), while persisting explicit user toggles per workspace so they survive the panel remounting. This removes the previous remount-key hack and the branch-open/pinned-closed inconsistency.

Also adds a reusable `TicketBadge` component whose status is optional, so it can later front other cross-ticket references.

## Deferred

Surfacing description-mentioned tickets and a batched status-only query (for references whose status isn't already in hand) — held for a follow-up that needs more thought on consolidating the GraphQL queries.

## Testing

- `just check` (typecheck, lint, ratchets, file hygiene) — green
- frontend unit tests — green; added `normalizeIssue` cases for `children` flattening

Ticket: SCU-1584

(Sent by Claude)