### PR TITLE
Fix Browser panel dropping the first navigation typed before the webview attaches

### DIFF
--- a/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
@@ -33,6 +33,12 @@ export const useBrowserWebview = (
   // slot. The ref holds the running value so partial updates can merge.
   const statusRef = useRef<BrowserViewStatus>({ ...INITIAL_STATUS, currentUrl: initialUrl });
 
+  // A navigation requested before the guest <webview> has fired did-attach.
+  // loadURL throws "WebView must be attached to the DOM and the dom-ready
+  // event emitted" until then, so navigate() stashes the URL here instead of
+  // losing it, and handleDidAttach replays it once the guest attaches.
+  const pendingNavigationUrlRef = useRef<string | null>(null);
+
   // Latest-ref pattern: the event-listener effect runs once with [], so it
   // captures the originally-passed callbacks. Reading via ref keeps it
   // pointing at the most recent props on every event.
@@ -88,6 +94,14 @@ export const useBrowserWebview = (
       const id = webview.getWebContentsId();
       setWebContentsId(id);
       publishStatus({ webContentsId: id });
+      // Replay a navigation requested before the guest attached (loadURL
+      // would have thrown then). This also overrides the initial
+      // src="about:blank" load so the user's first typed URL wins.
+      const pendingUrl = pendingNavigationUrlRef.current;
+      if (pendingUrl !== null) {
+        pendingNavigationUrlRef.current = null;
+        webview.loadURL(pendingUrl).catch(() => {});
+      }
     };
 
     webview.addEventListener("did-navigate", handleDidNavigate);
@@ -139,7 +153,15 @@ export const useBrowserWebview = (
 
   const navigate = useCallback((url: string): void => {
     const webview = webviewRef.current;
-    if (!webview) return;
+    // Until the guest has fired did-attach (webContentsId still null),
+    // loadURL throws and the navigation is silently lost. Stash the URL so
+    // handleDidAttach can replay it once the guest attaches — mirroring the
+    // agent-command gate in BrowserViewSlot. Last write wins, so the user's
+    // most recent typed URL is the one that loads.
+    if (!webview || statusRef.current.webContentsId === null) {
+      pendingNavigationUrlRef.current = url;
+      return;
+    }
     webview.loadURL(url).catch(() => {});
   }, []);
 


### PR DESCRIPTION
## Problem

In the Electron Browser panel, the first navigation a user types is silently dropped if the workspace's `<webview>` hasn't attached yet — the panel stays stuck on its initial `about:blank`. This is easy to hit right after switching to a freshly-created workspace, whose webview is created on the tab-switch and may not have fired `did-attach` by the time the user types a URL and presses Enter.

It also makes `test_browser_panel.py` flaky in CI with the "about:blank" signature (most visibly `test_browser_panel_in_page_state_preserved_across_workspace_switch`), because attach can take well over 10s under xvfb + software rendering.

## Root cause

The user-typed toolbar path calls `loadURL` the instant Enter is pressed:

```ts
const navigate = (url) => {
  const webview = webviewRef.current;
  if (!webview) return;
  webview.loadURL(url).catch(() => {});
};
```

Before the guest `<webview>` fires `did-attach`, `loadURL` throws *"WebView must be attached to the DOM and the dom-ready event emitted"*, and the `.catch(() => {})` swallows it — so the navigation is lost.

The agent-command path already guards this exact race in `BrowserViewSlot` (it gates on `webContentsId` and replays the command once the webview attaches). The user-typed path never got the same treatment. That asymmetry is the bug.

## Fix

Make `navigate()` robust to the attach race, mirroring the proven agent-command gate:

- When the webview is not yet attached (`webContentsId === null`), stash the requested URL in a ref instead of calling `loadURL` and swallowing the rejection.
- The `did-attach` handler replays the stashed URL once the guest attaches, overriding the initial `about:blank` load.
- Last write wins, so the user's most recent typed URL is the one that loads.

One file changed (+23/−1), well-commented to explain the attach race.

## Testing

- `just format`, `just check` (typecheck, lint, ratchets, file hygiene), and `just test-unit` (backend, frontend, foundation, sculpt) all pass.
- The reproducer is the existing electron integration test `test_browser_panel.py::test_browser_panel_in_page_state_preserved_across_workspace_switch`, which runs via the offload electron CI job; this change removes its attach-timing flakiness.

(Sent by Claude)