### PR TITLE
[SCU-1566] Clamp activeIndex on workspace delete + settle prompt-nav scroll

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/workspaces.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/workspaces.test.ts
@@ -392,6 +392,23 @@ describe("activeIndex clamping on workspace deletion", () => {
     });
   });
 
+  it("updateWorkspacesAtom isDeleted branch lands activeIndex on a neighbor when the ACTIVE tab is deleted", () => {
+    // A delete confirmed by the server (e.g. from another client) takes the
+    // same applyClose path as an optimistic delete, so deleting the active tab
+    // must not leave the persisted activeIndex at the invalid sentinel either.
+    const store = seedThreeWorkspacesWithActive(1);
+
+    store.set(updateWorkspacesAtom, [mockWorkspace({ objectId: "ws-b", isDeleted: true })]);
+
+    expect(store.get(tabsAtom)).toEqual({
+      order: [
+        { tabId: "ws-a", agentId: null },
+        { tabId: "ws-c", agentId: null },
+      ],
+      activeIndex: 1,
+    });
+  });
+
   it("closeWorkspaceTabAtom does NOT touch activeIndex for real workspace tabs (close is reversible)", () => {
     const store = seedThreeWorkspacesWithActive(1);
 

--- a/sculptor/frontend/src/common/state/atoms/workspaces.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/workspaces.test.ts
@@ -322,18 +322,46 @@ describe("activeIndex clamping on workspace deletion", () => {
     });
   });
 
-  it("optimisticDeleteWorkspaceAtom resets activeIndex to -1 when the active tab IS the deleted one", () => {
+  it("optimisticDeleteWorkspaceAtom clamps activeIndex to the tab filling the deleted slot when the active tab IS the deleted one", () => {
     const store = seedThreeWorkspacesWithActive(1);
 
     store.set(optimisticDeleteWorkspaceAtom, "ws-b");
 
+    // The active tab was removed; rather than leave activeIndex at the invalid
+    // sentinel (which makes a reload's rootLoader bounce to /ws/new), it is
+    // clamped to a surviving neighbor — the tab that shifts into the deleted
+    // slot (ws-c at index 1). The follow-up navigation refines this further.
     expect(store.get(tabsAtom)).toEqual({
       order: [
         { tabId: "ws-a", agentId: null },
         { tabId: "ws-c", agentId: null },
       ],
-      activeIndex: INVALID_ACTIVE_INDEX,
+      activeIndex: 1,
     });
+  });
+
+  it("optimisticDeleteWorkspaceAtom clamps to the new last tab when the active (and last) tab is deleted", () => {
+    const store = seedThreeWorkspacesWithActive(2);
+
+    store.set(optimisticDeleteWorkspaceAtom, "ws-c");
+
+    expect(store.get(tabsAtom)).toEqual({
+      order: [
+        { tabId: "ws-a", agentId: null },
+        { tabId: "ws-b", agentId: null },
+      ],
+      activeIndex: 1,
+    });
+  });
+
+  it("optimisticDeleteWorkspaceAtom leaves activeIndex invalid when the last remaining tab is deleted", () => {
+    const ws = [mockWorkspace({ objectId: "ws-only", isOpen: true })];
+    const store = seedHydratedStore(ws, ["ws-only"]);
+    store.set(tabsAtom, { order: [{ tabId: "ws-only", agentId: null }], activeIndex: 0 });
+
+    store.set(optimisticDeleteWorkspaceAtom, "ws-only");
+
+    expect(store.get(tabsAtom)).toEqual({ order: [], activeIndex: INVALID_ACTIVE_INDEX });
   });
 
   it("optimisticDeleteWorkspaceAtom decrements activeIndex when the active tab is AFTER the deleted one", () => {

--- a/sculptor/frontend/src/common/state/atoms/workspaces.ts
+++ b/sculptor/frontend/src/common/state/atoms/workspaces.ts
@@ -623,8 +623,25 @@ export const optimisticDeleteWorkspaceAtom = atom(null, (get, set, workspaceId: 
   // arriving before the server confirms deletion doesn't treat it as
   // a "new" workspace and auto-open it as a tab. workspacesArrayAtom
   // filters out null atoms, so it won't appear in the UI.
-  // Remove from tab order so the tab disappears immediately
-  set(tabsAtom, applyClose(get(tabsAtom), workspaceId));
+  // Remove from tab order so the tab disappears immediately.
+  //
+  // When the deleted workspace was the active tab, applyClose leaves
+  // activeIndex at INVALID_ACTIVE_INDEX (-1). The navigation that follows
+  // usually re-points it at a surviving tab, but only synchronously on the
+  // navigateToAgent path; the navigateToWorkspace / new-workspace-fallback
+  // paths defer it to an async effect that can be starved, leaving the
+  // *persisted* tabs state at -1 while tabs still exist. On reload, rootLoader
+  // then reads order[-1] === undefined and bounces to /ws/new instead of
+  // restoring the surviving tab. Clamp to a valid neighbor synchronously so the
+  // persisted state is never invalid; the following navigation refines it.
+  const beforeClose = get(tabsAtom);
+  const removedIndex = beforeClose.order.findIndex((e) => e.tabId === workspaceId);
+  const afterClose = applyClose(beforeClose, workspaceId);
+  const nextTabs =
+    afterClose.activeIndex === INVALID_ACTIVE_INDEX && afterClose.order.length > 0
+      ? { ...afterClose, activeIndex: Math.min(removedIndex, afterClose.order.length - 1) }
+      : afterClose;
+  set(tabsAtom, nextTabs);
   // Track the deletion so components with their own workspace lists
   // (e.g. RecentWorkspaces) can filter it out without a page reload.
   const deleted = new Set(get(deletedWorkspaceIdsAtom));

--- a/sculptor/frontend/src/common/state/atoms/workspaces.ts
+++ b/sculptor/frontend/src/common/state/atoms/workspaces.ts
@@ -153,7 +153,14 @@ const applyClose = (state: TabsState, tabId: string): TabsState => {
   const order = state.order.filter((_, i) => i !== removedIndex);
   let activeIndex = state.activeIndex;
   if (state.activeIndex === removedIndex) {
-    activeIndex = INVALID_ACTIVE_INDEX;
+    // The active tab was closed. Land on the neighbor that shifted into its
+    // slot (or the new last tab if we removed the end) so the persisted state
+    // never points past the end — order[INVALID_ACTIVE_INDEX] is undefined, and
+    // on reload rootLoader reads that as "no MRU pointer" and bounces to
+    // /ws/new even though tabs survive. A subsequent navigation may refine this
+    // to an MRU target; this only guarantees the pointer is always valid.
+    // Only when nothing survives do we fall back to the sentinel.
+    activeIndex = order.length > 0 ? Math.min(removedIndex, order.length - 1) : INVALID_ACTIVE_INDEX;
   } else if (state.activeIndex > removedIndex) {
     activeIndex = state.activeIndex - 1;
   }
@@ -623,25 +630,11 @@ export const optimisticDeleteWorkspaceAtom = atom(null, (get, set, workspaceId: 
   // arriving before the server confirms deletion doesn't treat it as
   // a "new" workspace and auto-open it as a tab. workspacesArrayAtom
   // filters out null atoms, so it won't appear in the UI.
-  // Remove from tab order so the tab disappears immediately.
-  //
-  // When the deleted workspace was the active tab, applyClose leaves
-  // activeIndex at INVALID_ACTIVE_INDEX (-1). The navigation that follows
-  // usually re-points it at a surviving tab, but only synchronously on the
-  // navigateToAgent path; the navigateToWorkspace / new-workspace-fallback
-  // paths defer it to an async effect that can be starved, leaving the
-  // *persisted* tabs state at -1 while tabs still exist. On reload, rootLoader
-  // then reads order[-1] === undefined and bounces to /ws/new instead of
-  // restoring the surviving tab. Clamp to a valid neighbor synchronously so the
-  // persisted state is never invalid; the following navigation refines it.
-  const beforeClose = get(tabsAtom);
-  const removedIndex = beforeClose.order.findIndex((e) => e.tabId === workspaceId);
-  const afterClose = applyClose(beforeClose, workspaceId);
-  const nextTabs =
-    afterClose.activeIndex === INVALID_ACTIVE_INDEX && afterClose.order.length > 0
-      ? { ...afterClose, activeIndex: Math.min(removedIndex, afterClose.order.length - 1) }
-      : afterClose;
-  set(tabsAtom, nextTabs);
+  // Remove from tab order so the tab disappears immediately. When the deleted
+  // workspace was the active tab, applyClose lands activeIndex on a surviving
+  // neighbor so the persisted state never points past the end (which would make
+  // a reload bounce to /ws/new); a following navigation may refine it further.
+  set(tabsAtom, applyClose(get(tabsAtom), workspaceId));
   // Track the deletion so components with their own workspace lists
   // (e.g. RecentWorkspaces) can filter it out without a page reload.
   const deleted = new Set(get(deletedWorkspaceIdsAtom));

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_prompt_nav.py
@@ -129,6 +129,22 @@ def _setup_three_prompt_chat(sculptor_instance_: SculptorInstance):
     # focuses input) without racing an extra scroll.
     page.keyboard.press("Escape")
     _wait_for_no_highlight(page)
+    # The dot-2 click issued an async scrollToIndex to the last user prompt;
+    # Escape clears the highlight synchronously but does NOT wait for that scroll
+    # to land. The prompt-nav keydown hook reads live scrollTop against a 20px
+    # tolerance (isScrolledPastActive), so a first ArrowUp fired before the
+    # scroll settles is misread as "scroll current turn to top" instead of "go to
+    # previous prompt", and the highlight lands on the wrong message. Wait until
+    # the last user prompt (message data-index 4) is pinned at the viewport top,
+    # well within that tolerance, before handing back to the test.
+    page.wait_for_function(
+        """() => {
+            const container = document.querySelector('[data-testid="ALPHA_CHAT_VIEW"]');
+            const item = container && container.querySelector('[data-index="4"]');
+            if (!container || !item) return false;
+            return Math.abs(item.getBoundingClientRect().top - container.getBoundingClientRect().top) < 10;
+        }"""
+    )
     return page, chat_panel
 
 


### PR DESCRIPTION
Two independent flakes from the alpha scroll / prompt-nav cluster (the top unaddressed flake cluster in the latest net).

## 1. Product fix — clamp `activeIndex` when deleting the active workspace
`optimisticDeleteWorkspaceAtom` removed the active tab and left `activeIndex` at the invalid sentinel (`-1`). The follow-up navigation only re-points it *synchronously* on the `navigateToAgent` path; the `navigateToWorkspace` / new-workspace-fallback paths defer it to an async effect that can be starved — so the **persisted** `sculptor-tabs` state keeps a `-1` activeIndex while tabs still exist. On the next reload, `rootLoader` reads `order[-1]` and **bounces to `/ws/new` instead of the surviving tab** (a real user-facing bug).

Fix: clamp to a surviving neighbor in the same synchronous `set`; the following navigation refines it. Updates the existing unit tests (the `-1` behavior was asserted) and adds delete-last / delete-only coverage.

## 2. Test fix — settle the scroll before the first ArrowUp in prompt-nav setup
`_setup_three_prompt_chat`'s dot-click issues an async `scrollToIndex`; `Escape` clears the highlight synchronously but doesn't wait for the scroll to land. The keydown hook reads live `scrollTop` against a 20px tolerance, so a first `ArrowUp` before the scroll settles is misread as "scroll current turn to top". Wait for the last prompt to pin to the viewport top before returning — fixes the whole `_wait_for_highlight_on` group (~5 tests).

## Validation (offload, isolated, `retry_count=0`)
| | flaked |
|---|---|
| prompt-nav (escape / arrow-up / enter) | **0/15 each** (was flaky) |
| clamp | **5/40** (was 11/40) |

The clamp product fix also clears the reload bug. **Deferred follow-ups:** a residual order-settle case in the clamp test (5/40), and the separate scroll-restore flake `test_first_message_visible_after_agent_switch` (a virtualizer re-measurement race — moderate-risk product change).

(Sent by Claude)