### PR TITLE
Add /update-specs skill and refresh docs/specs

### DIFF
--- a/.claude/skills/update-specs/SKILL.md
+++ b/.claude/skills/update-specs/SKILL.md
@@ -135,6 +135,13 @@ truly left over, and batch those questions rather than interrupting per-feature.
 Edit each doc in place, **matching its established format, tone, and structure**. Read enough
 surrounding context in each doc to slot the change in where it belongs, not at the end.
 
+**Describe what the code does today — never what it used to do.** These are living descriptions of the
+current product, not a changelog. Don't leave a trace of the change: no "now …", "no longer …",
+"previously …", "used to …", "formerly …", "renamed from …", "instead of …", or any before/after
+phrasing. The commit history already records what changed; the doc records what *is*. When you revise a
+section, rewrite it so a reader with no knowledge of the old behavior gets an accurate, self-contained
+description — then delete any wording that only makes sense relative to the past.
+
 - **`SPEC.md`** — prose behavior. Add to or revise the relevant feature section; remove text for
   removed features. Keep the descriptive, present-tense product voice. Experimental/off-by-default
   features go in the experimental section, marked as such.

--- a/.claude/skills/update-specs/SKILL.md
+++ b/.claude/skills/update-specs/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: update-specs
+description: |
+  Bring the product specification set under docs/specs/ (SPEC.md,
+  requirements.md, scenarios.md, scenario_coverage.md) up to date with the
+  code that has merged to origin/main since the specs were last refreshed.
+  Reviews the merged PRs since a recorded baseline, filters out non-product
+  churn, and applies the needed edits to each doc — preserving its format and
+  ID scheme. Use periodically to keep the specs from going stale, or when
+  asked to "update the specs" / "refresh docs/specs".
+argument-hint: [baseline-commit (optional; defaults to the recorded baseline)]
+---
+
+# Update the Product Specs
+
+Reconcile the spec set under `docs/specs/` with everything merged to `origin/main` since the specs
+were last refreshed. The job is **review the new commits, decide what changed about the product, and
+edit the docs to match** — nothing more. Do not invent behavior, and do not document implementation
+detail the product docs deliberately omit.
+
+## The doc set
+
+`docs/specs/` holds four long-lived, related documents. Read `docs/specs/README.md` first — it is the
+authority on how they relate. In brief:
+
+| Doc | What it captures | When a change touches it |
+|---|---|---|
+| `SPEC.md` | The narrative product spec: what Sculptor is and how each feature **behaves**, in prose. | A new/changed user-facing capability or behavior. |
+| `requirements.md` | The measurable & contractual facts the prose omits: numeric targets, version/platform bars, persistence/migration guarantees, integration contracts, open questions. (This is the "architecture/requirements" doc — there is no separate `architecture.md`.) | A change that sets or moves a number, a version floor, a contract, or a guarantee. |
+| `scenarios.md` | Every user-facing interaction as a Given/When/Then scenario with a stable `AREA-NNN` ID. | A change to what happens **on screen** for any interaction. |
+| `scenario_coverage.md` | Maps each scenario to the integration test that demonstrates it (Complete / Partial / Missing). | Any scenario you add, change, or remove — and any new/changed test that moves a scenario's status. |
+
+Discover the docs dynamically (`ls docs/specs/*.md`) rather than hard-coding the list, so the skill
+still works if a doc is added or renamed. Apply the per-doc guidance above by matching the doc's role,
+not its exact filename.
+
+## Step 1: Determine the baseline commit
+
+The baseline is the commit the specs were last reconciled against. Everything after it is unreviewed.
+
+1. If the user passed a commit as `$ARGUMENTS`, use that.
+2. Else read `docs/specs/.spec-baseline` — a file holding the baseline SHA on its first line. Use that SHA.
+
+```bash
+head -1 docs/specs/.spec-baseline
+```
+
+If the file is missing, stop and tell the user — the baseline must be seeded first (write the last
+reconciliation commit's SHA to `docs/specs/.spec-baseline`). Don't guess a baseline.
+
+Then fetch and confirm where the baseline sits relative to the current tip:
+
+```bash
+git fetch origin --quiet
+git rev-parse origin/main
+git merge-base --is-ancestor <baseline> origin/main && echo "baseline on main" || echo "WARN: baseline not on main"
+git rev-list --count <baseline>..origin/main
+```
+
+If the baseline is not an ancestor of `origin/main`, stop and ask the user how to proceed (it may be on
+a feature branch or have been rebased away). Reconcile **against `origin/main`**, not the local HEAD,
+unless the user says otherwise.
+
+## Step 2: Enumerate the merged PRs since the baseline
+
+This repo merges with no-fast-forward, so every PR is one merge commit on the first-parent spine. Use
+the **merge commits as the source of truth** for what landed, and the non-merge subjects for detail.
+
+```bash
+# Source of truth — one line per merged PR:
+git log <baseline>..origin/main --merges --first-parent --format='%h %s'
+# Detail — individual commit subjects, for understanding each PR:
+git log <baseline>..origin/main --no-merges --format='%s'
+```
+
+If the lists are large, write them to the scratchpad and read them with the Read tool rather than
+scrolling shell output.
+
+## Step 3: Separate product changes from noise
+
+Most commits do **not** change the product and must not trigger spec edits. Classify each PR.
+
+**Ignore (noise) — does not touch the spec:**
+
+- Comment scrubs and rewording ("Bring … into compliance with review rules", "Prune/Trim … comments").
+- Dependency upgrades (Electron/Node/Python/React/Vite/etc.) and lockfile refreshes.
+- CI / build / release plumbing (release gating, telemetry-key injection, apt-get hardening, CI concurrency, pyre-cache ignore).
+- Test-only changes: new tests, flaky-test fixes, test infra — **with one exception** (see Step 6: they can still move a `scenario_coverage.md` status even when no behavior changed).
+- Style-guide / review-rule / internal-doc edits, version bumps, frozen-schema regeneration.
+
+**Review (product) — may touch the spec.** Apply the inclusion test from the spec's scope discipline:
+
+> Would a user **see**, **name**, or **configure** this? If yes, it likely belongs in the product docs.
+
+New capabilities, new settings, new panels/screens, changed defaults, changed keybindings, new CLI
+flags, changed error/reliability behavior a user would notice, and removed features all qualify.
+
+**Keep implementation detail OUT of the product docs.** Internal services, the task/Environment
+substrate, WebSocket/HTTP transport, Alembic/DB migrations, schema regen, and similar plumbing are
+impl-only — they belong (if anywhere) in `requirements.md` as a contract, never as product narrative.
+
+The signal-to-noise ratio is typically ~10:1 (≈15 product features out of ≈80 PRs). If your "to edit"
+list is much larger than that, you are probably letting noise through — re-apply the filter.
+
+## Step 4: Understand each product change
+
+Branch names embed ticket IDs (`scu-NNNN`) and squashed subjects are descriptive, but **do not write
+spec text from the subject line alone** — it describes the fix, not the resulting behavior. For each
+product PR, read what actually changed:
+
+```bash
+git show --stat <merge-sha>                 # files touched → which area/doc
+git log <merge-sha>^1..<merge-sha>^2 --format='%s'   # the PR's own commits
+git diff <merge-sha>^1..<merge-sha> -- <relevant paths>   # the real change
+```
+
+**Group related PRs into one feature** before editing (e.g. a dozen plugin-system PRs are one new
+product surface, not a dozen edits). Decide, per feature, the *current* user-visible behavior — what
+the product does now, on main — because that is what the spec must describe.
+
+## Step 5: Plan the edits
+
+For each feature, decide which docs are affected and what each edit is. This is mostly a straight
+translation from "what the commits changed" to "what the product now does" — **don't check in with the
+user for routine edits.** Make the changes and let the user review the diff at the end (Step 8).
+
+Only pause to ask the user when there is **genuine ambiguity you cannot resolve from the code and
+docs** — e.g. a default changed but you can't tell which value is now authoritative, or it's unclear
+whether a feature is shipped vs. gated behind an experimental flag and the code doesn't say. Resolve
+everything you can on your own first (read the code, read the surrounding doc); ask only about what's
+truly left over, and batch those questions rather than interrupting per-feature.
+
+## Step 6: Apply the edits
+
+Edit each doc in place, **matching its established format, tone, and structure**. Read enough
+surrounding context in each doc to slot the change in where it belongs, not at the end.
+
+- **`SPEC.md`** — prose behavior. Add to or revise the relevant feature section; remove text for
+  removed features. Keep the descriptive, present-tense product voice. Experimental/off-by-default
+  features go in the experimental section, marked as such.
+- **`requirements.md`** — only when the change sets or moves a measurable target, version/platform
+  bar, persistence/migration guarantee, integration contract, or resolves an open question. Don't
+  restate prose here; record the *fact*.
+- **`scenarios.md`** — Given/When/Then with a stable `AREA-NNN` ID. **Preserve the ID scheme**: reuse
+  the right area prefix (see its "Areas / ID prefixes" table), and **assign the next free number in
+  that area — never renumber existing scenarios**. Every Then must be visible on screen. Delete
+  scenarios for removed behavior; revise in place for changed behavior.
+- **`scenario_coverage.md`** — for every scenario you added/changed/removed, add/update/remove its
+  coverage row, set status (Complete / Partial / Missing) by checking whether an integration test
+  actually drives the action and asserts the visible outcome, and **update the per-area counts in the
+  executive summary table** so the totals stay consistent. A test-only PR that newly covers an
+  existing scenario can move a status here even though no other doc changes.
+
+**Public-visibility rule:** these docs are world-readable. Scrub PII, internal hostnames/service
+names, customer data, and security-sensitive detail, per CLAUDE.md's "Public Visibility" section.
+
+## Step 7: Verify consistency, then record the new baseline
+
+Cross-check that the docs still agree with each other and with the code:
+
+- Every new/changed `scenarios.md` ID has a matching `scenario_coverage.md` row, and the summary
+  counts add up.
+- A feature added to `SPEC.md` is referenced consistently wherever else it's mentioned (CLI table,
+  settings list, experimental section, etc.) — grep the doc for the feature's name.
+- No implementation-only detail leaked into the product narrative.
+- Quickly sanity-check a couple of the riskiest claims against the code (don't trust the commit
+  subject) — e.g. confirm a changed default's actual value, or that a listed CLI model is still
+  selectable.
+
+Then **update the baseline pointer** so the next run starts here:
+
+```bash
+git rev-parse origin/main > docs/specs/.spec-baseline
+```
+
+## Step 8: Hand back, don't commit
+
+Leave the working tree dirty for the user to review — do **not** commit or push (matching the other
+doc-update skills). Summarize what you changed: the baseline range reviewed (`<baseline>..<tip>`, with
+counts), the features that drove edits, the docs touched, the new baseline SHA recorded, and anything
+you intentionally skipped or flagged as uncertain for the user to decide.
+
+## Notes for recurring runs
+
+- The whole point of `.spec-baseline` is that each run only reviews *new* commits. Keep it accurate.
+- Scale effort to the range: a week of commits is a quick pass; a multi-month gap (like the first run)
+  is a large review — work through it feature-group by feature-group.
+- This skill reviews and edits docs; it never changes product code or tests.

--- a/docs/specs/.spec-baseline
+++ b/docs/specs/.spec-baseline
@@ -1,0 +1,5 @@
+e2300a81c86143c8437b3d332e059d17b5b44ec3
+# Commit the docs/specs/ set was last reconciled against.
+# Line 1 (the SHA) is read by the /update-specs skill; everything else is a comment.
+# Baseline: "docs: add product specification set under docs/specs/" (2026-06-18).
+# Update this on each /update-specs run via: git rev-parse origin/main > docs/specs/.spec-baseline

--- a/docs/specs/.spec-baseline
+++ b/docs/specs/.spec-baseline
@@ -1,5 +1,5 @@
-e2300a81c86143c8437b3d332e059d17b5b44ec3
+c6d048e1acc65faaddddb1f44b8dc80e85cb1375
 # Commit the docs/specs/ set was last reconciled against.
 # Line 1 (the SHA) is read by the /update-specs skill; everything else is a comment.
-# Baseline: "docs: add product specification set under docs/specs/" (2026-06-18).
+# Baseline: "Fix Browser panel dropping the first navigation..." (#147, 2026-06-23).
 # Update this on each /update-specs run via: git rev-parse origin/main > docs/specs/.spec-baseline

--- a/docs/specs/.spec-baseline
+++ b/docs/specs/.spec-baseline
@@ -1,5 +1,1 @@
 c6d048e1acc65faaddddb1f44b8dc80e85cb1375
-# Commit the docs/specs/ set was last reconciled against.
-# Line 1 (the SHA) is read by the /update-specs skill; everything else is a comment.
-# Baseline: "Fix Browser panel dropping the first navigation..." (#147, 2026-06-23).
-# Update this on each /update-specs run via: git rev-parse origin/main > docs/specs/.spec-baseline

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -10,7 +10,7 @@ product is, the contracts it upholds, and how its behavior is verified.
   deliberately leaves out: numeric targets, version/platform bars, persistence and migration
   guarantees, integration contracts, and the open questions where the product pins no value yet.
 - **[scenarios.md](scenarios.md)** — every user-facing interaction expressed as a Given/When/Then
-  scenario (~446), the UI-level acceptance layer.
+  scenario, the UI-level acceptance layer.
 - **[scenario_coverage.md](scenario_coverage.md)** — maps each scenario to the integration test that
   demonstrates it (coverage and traceability).
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -253,7 +253,10 @@ Next, Sculptor checks the **dependencies** it needs — chiefly the Claude CLI a
 as a card: a green check with the detected path and version when it's ready, or a warning with an
 **Install** or **Sign in** button when it isn't. Sculptor can install and manage Claude for you
 (showing live install progress) or sign you in, and for anything you'd rather manage yourself you can
-expand a card to override the binary path or switch between a managed install and your system one. A
+expand a card to override the binary path or switch between a managed install and your system one. The
+sign-in flow also supports a **paste-a-code** path for headless or remote setups where a browser
+callback can't reach the app: Sculptor shows the sign-in URL, you approve access, and paste the
+returned authorization code back into the card to finish signing in. A
 **check again** link re-runs the checks. You can't move on until everything required is satisfied.
 
 Finally, you connect your first **repository** (→ §7.2 Workspaces). Point Sculptor at a repo by
@@ -276,11 +279,13 @@ mode and the unisolated **in-place** mode are experimental opt-ins that, once en
 add a mode picker to this form — see §7.12.) Each open workspace is a **tab**.
 
 Inside a workspace, a header **banner** shows where you are: the repo, the workspace's branch (which
-you can copy), and a one-glance **diff summary**. For a repo whose `origin` is on **GitHub or
-GitLab**, the banner also shows the workspace's **target branch** (what its changes are diffed
-against — with a selector to change it and a warning if a PR's target wouldn't match); for other
-repos there is no target-branch concept and the banner simply shows the source branch the workspace
-started from. A non-default mode (clone or in-place) is shown as a strategy badge, and the banner collapses
+you can copy), and a one-glance **diff summary**. The banner also shows the workspace's **target
+branch** — what its changes are diffed against — with a selector to change it and a warning if an
+open PR's target wouldn't match. The selector works for **every repo regardless of remote host**; a
+repo with a remote offers its remote-tracking branches as targets, while a repo with no remote falls
+back to offering the repo's own local branches. (Opening a pull request, by contrast, requires
+a GitHub or GitLab `origin` → §7.6 — the target-branch concept is independent of the PR surface.)
+A non-default mode (clone or in-place) is shown as a strategy badge, and the banner collapses
 progressively as space tightens.
 
 If the project defines a **setup command**, it runs when the workspace is created; its progress and
@@ -314,9 +319,14 @@ explains itself when it can't act — for example when the editor is empty. The 
 span several lines while still sending as one message.
 
 The input toolbar shapes how the agent handles your next message. A **model** picker chooses which
-model answers; an **effort** selector budgets how much thinking it spends per step (Low, Medium, High, Extra High,
-Max — Extra High by default);
-a **fast mode** toggle trades some depth for quicker output; and **plan mode** makes the agent
+model answers — present only for agents whose harness supports model selection (a Claude or Pi chat
+agent), and shown disabled with the current model for those that don't; the list it offers comes from
+the agent's own harness, so a **Claude** agent picks from the Claude models while a **Pi** agent
+surfaces Pi's live catalog grouped by provider, and changing a Pi agent's model takes effect in-session
+(a failed switch leaves the choice unchanged and raises an actionable error toast). An **effort**
+selector budgets how much thinking it spends per step (Low, Medium, High, Extra High, Max — Extra High
+by default); a **fast mode** toggle trades some depth for quicker output on the models that support it
+(the Opus family, including Opus 4.8) and is disabled for the rest; and **plan mode** makes the agent
 investigate and propose a plan for your approval before it changes anything. The **+** button opens a
 menu for adding context — point the agent at specific **files and folders**, attach **images** (you
 can also drag-and-drop or paste them), or start a **skill** (→ §7.8 Skills); with the **Entity
@@ -363,7 +373,8 @@ it (unless its workspace was deleted, in which case it can't be recovered).
 Beyond composing prompts, the chat offers a few conveniences for working in a long conversation:
 recall earlier prompts by pressing the up/down arrows in an empty input, search the transcript
 (Cmd/Ctrl+Shift+F), and switch tool calls between compact pills and expanded rows
-(Cmd/Ctrl+Shift+E).
+(Cmd/Ctrl+Shift+E). Right-clicking an image anywhere in the conversation (a message, the attachment
+preview, or the zoomed lightbox) offers **Copy Image** to put it on your clipboard.
 
 #### 7.3.2 Terminal agents
 
@@ -418,7 +429,8 @@ enabled → §7.12), a plain **Terminal**, and then each **registered terminal a
 name — out of the box that's **"Claude CLI"**, which runs the Claude Code TUI in the workspace (→ §7.3
 Chat). The menu marks your last-used type with a check, Sculptor remembers it, and a plain **+** click
 re-creates that type without opening the menu. **Double-click** a tab to rename it (Enter saves, Escape cancels), drag tabs to **reorder**
-them, and right-click for more: rename, **mark as unread**, delete, plus diagnostics. **Deleting** an
+them, and right-click for more: rename, **mark as unread**, **copy the agent's name**, delete, plus
+diagnostics. **Deleting** an
 agent (after confirming) moves you to the next one, or starts a fresh agent if it was the last.
 
 Because every agent in a workspace works on the same copy of your repo, **siblings share its files
@@ -462,7 +474,7 @@ your local filesystem, opening it in your OS's default app and revealing its con
 
 Clicking a file in the **Changes** tab opens it in the main **diff** view; clicking a file in
 **Browse** opens its read-only contents instead, since an unchanged file has no diff. A scope picker lets you look at only the
-**uncommitted** changes or, when the workspace has a target branch (GitHub/GitLab repos → §7.6),
+**uncommitted** changes or, when the workspace has a target branch (any repo → §7.2),
 **all** changes measured against that target branch, with a count on each option. The diff itself can be shown **side-by-side** or **unified** (inline), with line-wrapping, a
 find-in-file search that highlights matches and counts them ("X of Y") as you step through, and an
 expand control that widens the diff across the whole window. A binary file replaces the diff with an
@@ -493,8 +505,9 @@ shows where the workspace's history forks from its starting point.
 ### 7.6 Pull Requests
 
 The pull-request surface described here appears **only when the workspace's repo has a GitHub or
-GitLab `origin`**; for any other repo there is no target-branch selector and no PR/MR control, and you
-push the branch yourself. Given such a repo, once you've committed work on a workspace branch you can
+GitLab `origin`**; for any other repo there is no PR/MR control and you push the branch yourself. (The
+target-branch selector itself is *not* gated this way — it appears on every repo, → §7.2; only opening
+a PR/MR requires a detected provider.) Given such a repo, once you've committed work on a workspace branch you can
 open a **pull request** (on GitHub) or **merge request** (on GitLab) straight from the workspace's
 top bar — Sculptor stays provider-neutral, so the control reads "Create PR" or "Create MR" to match
 your repo. Clicking it pushes the branch and
@@ -509,7 +522,10 @@ failed," "Approved/Review pending," and so on). Clicking the number opens the re
 The chevron opens a **detail dropdown** with the title and link, checks/pipeline status, approvals and
 reviewer names, and any unresolved comments. If a **CI babysitter** is available, a switch in this
 dropdown lets you pause or resume it — when on, Sculptor keeps an eye on the request's CI for you —
-and the status text updates as you toggle it.
+and the status text updates as you toggle it. When the babysitter *can't* run — for example its
+configured agent type can't be resolved for this workspace — the dropdown surfaces a short
+**disabled reason** in place of the usual status, and for a persistent reason the switch itself is
+forced off and greyed out until the cause is fixed.
 
 When the request is **merged** or **closed**, the button switches to a merge icon reading "PR #N
 merged"/"closed," and clicking it still opens the request in the browser. If a request already exists
@@ -591,7 +607,9 @@ each open workspace. You switch tabs by clicking, cycle through them with keyboa
 keep working even in zen mode), drag to reorder them, and close them with the tab's minimize button, a middle-click,
 or a keyboard shortcut. Workspace tab labels truncate when long and carry a small **status dot**
 reflecting the agent's state; double-clicking a tab renames the workspace inline, and right-clicking
-opens a context menu to rename it, delete it, or close others/all. When too many tabs are open they overflow into a horizontal
+opens a context menu to rename it, delete it, copy its name / branch / workspace id, or close
+others/all. **Cmd+Shift+W** deletes the active workspace (after the same confirmation dialog as the
+menu and palette actions). When too many tabs are open they overflow into a horizontal
 scroller that keeps the active tab in view, and closed workspaces collect into a pill you can reopen
 from. Tabs persist across restarts.
 
@@ -639,8 +657,10 @@ repos with their paths and agent counts and lets you add or remove them and conf
 creation prompt, PR-status polling and its interval (plus a multiplier that throttles polling for
 closed workspaces), the default target branch, the global
 branch-naming pattern, and the branch-deletion policy. CI configures the **CI babysitter** that
-watches pipelines and asks an agent to fix failures — a toggle, a retry cap, and editable prompts for
-pipeline failures and merge conflicts.
+watches pipelines and asks an agent to fix failures — a toggle, a retry cap, a **babysitter-agent
+selector** (which agent type the babysitter drives: the workspace's most-recently-used agent by
+default, or a pinned Claude, Pi, or registered terminal agent that accepts automated prompts), and
+editable prompts for pipeline failures and merge conflicts.
 
 The remaining sections cover the environment and account. **Dependencies** manages the Claude CLI and
 git binaries Sculptor uses — switching between a managed install and a custom path, showing each one's
@@ -660,7 +680,9 @@ organized into **action groups** (the built-in "Sculptor" group — which ships 
 shortcuts — sits first, with any ungrouped actions at the bottom; collapsed group headers carry a count badge). Clicking an action either sends
 its prompt immediately (an auto-submit action, shown with a play icon) or appends it to the chat input
 for you to edit first (a draft action, shown with a text-cursor icon); a hover tooltip previews the
-prompt. While the agent is running, a right-click **Queue message** option on an action lets you queue
+prompt. For a **terminal agent** — which has no chat input — a draft action instead types its prompt
+into the agent's terminal (the PTY) *without* pressing Enter, so you can edit and run it yourself,
+while an auto-submit action types and submits it. While the agent is running, a right-click **Queue message** option on an action lets you queue
 its prompt to run after the current turn rather than sending it immediately. You create, edit, and delete actions through a dialog (Name, Prompt, Group, and an
 auto-submit toggle), manage groups inline (add, rename, delete), and drag actions and groups to
 reorder them or move an action between groups — built-in items can't be edited, deleted, or dragged.
@@ -703,6 +725,9 @@ product makes no finer distinction than that: a feature is either generally avai
   viewer, toggled by the eye icon in the diff toolbar.
 - **Pi agent** — offer the experimental **Pi** agent as a choice when creating an agent (→ §7.4); an
   already-running Pi agent keeps going regardless of the toggle.
+- **Frontend plugins** — enable the experimental plugin system that lets third-party plugins extend
+  Sculptor's own UI (the plugin system below). Off by default; turning it off only fully takes effect
+  after an app reload, since already-loaded plugins aren't torn down live.
 - **Custom backend command** — the entry point for the container / remote backend described below.
 
 The **CI babysitter** (→ §7.6, §7.10) is likewise experimental and off by default.
@@ -719,6 +744,21 @@ The **CI babysitter** (→ §7.6, §7.10) is likewise experimental and off by de
 notably the in-app **Browser** panel (desktop-only), which embeds a browser beside the chat with an
 address bar and back/forward/reload/screenshot controls; outside the desktop app it shows a
 placeholder.
+
+**Frontend plugin system.** With **Frontend plugins** enabled, Sculptor can load third-party
+**plugins** that extend the app's own UI from inside the renderer — contributing new **panels** (which
+show up in the Panels list with a "plugin" badge) and full-screen **overlays**, built against a small
+versioned Sculptor SDK that reuses the host's React, Radix theming, icons, and shared data client so
+they look and behave like native UI. A new **Plugins** section appears in Settings to manage plugin
+**sources**: you add a plugin by dropping its folder into the Sculptor folder's `plugins/` directory
+(picked up on the next launch or via a **Refresh** button) or by adding the **URL** of a plugin
+server (saved and re-fetched on every launch). Each row has an enable/disable switch (mute a plugin
+without removing it) and, while enabled, Settings and Reload controls; user-added URL sources can also
+be removed, while bundled and disk-discovered plugins can't. Sculptor ships a bundled **Linear** example
+plugin and two no-build example plugins (**Sculpty** and **Pomodoro**). Because a plugin runs with the
+**same privileges as Sculptor's own UI** — and a URL source serves whatever code it holds at load time
+— adding a plugin means running that code, so you should only add sources you trust (the plugin trust
+model is documented in `SECURITY.md`; outbound links a plugin opens are restricted to `http(s)`).
 
 **Container / remote execution backend.** Pointing the **custom backend command** at a launcher lets
 Sculptor run agents somewhere other than your host machine — inside a Docker container, on a remote
@@ -745,8 +785,8 @@ The CLI is organized into a handful of command groups, each mapping to a domain 
 |---|---|
 | `sculpt repo` | List and show the **Projects (Repos)** Sculptor knows about — their paths and whether they're accessible. |
 | `sculpt workspace` | Create, list, show, rename, and delete **Workspaces**. Pick the isolation **strategy** (`--strategy`: `worktree`, `clone`, `in-place`); choose the source branch (`--branch`), a name for the workspace's new branch (`--branch-name`), its target (`--target-branch`), and a description (`--name`) at create time; `list` can span all repos (`--all`) or one (`--repo`), and `delete` takes `--yes`/`-y` to skip the prompt. |
-| `sculpt agent` | Manage **Agents** in a workspace: `create` one (with an opening `--prompt`, a `--model`, and a `--name`), list (filter by status, scope with `--all` / `--repo` / `--workspace`), show, `send` a message (with `--model` and repeatable `--file` attachments), check `status`, read `messages` (`--limit`/`--tail`), `interrupt` a running one, rename, and delete. `send`, `status`, and `messages` all accept `--follow` to stream live. Choose the **model** (`haiku`, `sonnet`, `opus`, `fable`, plus the `sonnet[1m]` / `opus[1m]` 1M-context variants). |
-| `sculpt run` | One-shot convenience: from a single prompt, create a workspace **and** an agent in one step, optionally `--follow` its output live. Accepts the same workspace-creation flags as `sculpt workspace create` (`--strategy`, `--branch`, `--target-branch`, …) plus `--model` and `--file`. |
+| `sculpt agent` | Manage **Agents** in a workspace: `create` one (with an opening `--prompt`, a `--model`, a `--name`, and a `--harness`), list (filter by status, scope with `--all` / `--repo` / `--workspace`), show, `send` a message (with `--model` and repeatable `--file` attachments), check `status`, read `messages` (`--limit`/`--tail`), `interrupt` a running one, rename, and delete. `send`, `status`, and `messages` all accept `--follow` to stream live. Choose the **model** (`haiku`, `sonnet`, `opus`, `fable`, plus the `sonnet[1m]` / `opus[1m]` 1M-context variants) and the **harness** (`--harness`: `Claude`, `Pi`, `Terminal`, or a registered terminal agent by display name; omitting it uses your most-recently-used type — the same default the GUI's **+** button applies, and an explicit choice updates that MRU). |
+| `sculpt run` | One-shot convenience: from a single prompt, create a workspace **and** an agent in one step, optionally `--follow` its output live. Accepts the same workspace-creation flags as `sculpt workspace create` (`--strategy`, `--branch`, `--target-branch`, …) plus `--model`, `--file`, and `--harness`. Because `run` always sends a prompt, a terminal/registered harness is rejected here (use `sculpt agent create` for those). |
 | `sculpt signal` | Run from **inside an agent's environment** to report state back to Sculptor — `busy`, `idle`, `waiting`, `files-changed` (refreshes the diff), or `session-id <id>` (which takes the session identifier as an argument). Lets terminal-based agents light up the same status indicators the GUI shows. |
 | `sculpt ui` | Let an agent **drive the app's UI** for the user: `open-file` (open a file or diff tab, with `--mode auto`/`diff`/`file`) and `webview-navigate` / `webview-refresh` (point or reload the in-app Browser panel, e.g. at a generated HTML report). |
 | `sculpt schema` | Print machine-readable **JSON Schemas** for command output (run with no argument to list the available schema names, including a dedicated `error` schema for `--json` failures), so scripts can validate and parse results reliably. |
@@ -884,7 +924,7 @@ and `packaged_electron` (the last combined with `release`) — and by sandbox ne
 `custom_sculptor_folder`), so a test runs only in the environment it requires.
 
 #### 10.4 Scenarios-as-tests methodology
-This spec, the exhaustive **`scenarios.md`** (≈446 Given/When/Then behaviors), and
+This spec, the exhaustive **`scenarios.md`** (Given/When/Then behaviors), and
 **`scenario_coverage.md`** (which maps each scenario to the integration test covering it) together
 form the **English-level acceptance layer**: the spec is the source of truth, the scenarios are
 concrete acceptance checks against it, and the coverage report measures how well the product is

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -200,7 +200,7 @@ the agent is still usable). Several agents can run in one workspace; they share 
 state but each keeps its own conversation and history.
 
 **Task (internal, not a product concept).** An agent is internally backed by a general-purpose
-**task** primitive, now vestigial — the only remaining non-agent task types are test-only. A user
+**task** primitive, vestigial — the only non-agent task types are test-only. A user
 never sees or names a "task"; it survives only as a storage and scheduling detail behind an agent.
 Its internal status, and an agent's TODO-item statuses, are each distinct from the user-visible agent
 status above — don't conflate them.

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -14,7 +14,7 @@ unspecified.
 | Document | Answers | Layer |
 |---|---|---|
 | `SPEC.md` | *What is the product, and how does each feature behave?* | Functional behavior, in prose |
-| `scenarios.md` | *What exactly happens on screen, action by action?* (~446 Given/When/Then) | UI-level acceptance |
+| `scenarios.md` | *What exactly happens on screen, action by action?* (Given/When/Then) | UI-level acceptance |
 | `scenario_coverage.md` | *Which test demonstrates each scenario?* | Coverage / traceability to tests |
 | **`requirements.md`** (this doc) | *What measurable targets, limits, and contracts does the product meet?* | Requirements |
 
@@ -62,7 +62,7 @@ pointers to their spec/scenario home.
 | REQ-FUNC-011 | Command palette & navigation: tabs, Cmd+K / Cmd+P, bottom bar, focus/zen mode, version popover | §7.9 | `SHELL`, `CMDP`, `HELP` | Core |
 | REQ-FUNC-012 | Settings (all sections) | §7.10 | `SET` | Core |
 | REQ-FUNC-013 | Actions & notes; mentions & path autocomplete | §7.11 | `ACT`, `MENT` | Optional |
-| REQ-FUNC-014 | Experimental surface (toggles, experimental skills/panels, container backend) | §7.12 | `SET`, `PANEL` | Experimental |
+| REQ-FUNC-014 | Experimental surface (toggles, experimental skills/panels, frontend plugin system, container backend) | §7.12 | `SET`, `PANEL` | Experimental |
 | REQ-FUNC-015 | `sculpt` CLI: full command surface, `--json`, env-var defaults, cross-surface visibility | §8 | (CLI-level, see §5.4) | Standard |
 
 - **REQ-FUNC-100 (MUST).** Every behavior enumerated in `scenarios.md` is a product requirement; that
@@ -165,9 +165,15 @@ and flags the targets it does not currently define.
 
 ### 2.8 Agent defaults
 
-- **REQ-NFR-070 (MUST).** New-agent defaults: model = **most-recently-used** (no hardcoded default),
-  effort = **Extra High (`xhigh`)**, fast mode = **off** (`sculptor/sculptor/config/user_config.py`). All three
-  are user-overridable in Settings → Agent (`SPEC.md` §7.10).
+- **REQ-NFR-070 (MUST).** New-agent defaults: model = the user's **configured Settings default** if
+  set, else the **most-recently-used** model (recorded whenever the user switches model in chat;
+  `lastUsedModelAtom`, `sculptor/frontend/src/common/state/atoms/userConfig.ts`), else a hardcoded
+  fallback of **`CLAUDE_4_OPUS` ("Opus (1M)")**, the 1M-context Opus variant (Fable, though listed in
+  the switcher, is disabled and so is never the fallback). Effort = **Extra High (`xhigh`)**, fast mode
+  = **off** (`sculptor/sculptor/config/user_config.py`, `sculptor/sculptor/web/derived.py`). All three
+  are user-overridable in Settings → Agent (`SPEC.md` §7.10). **Fast mode** is offered only on models
+  that support it — the Opus 4.x family, including Opus 4.8 (both the 1M and 200K variants) — and is
+  disabled for Sonnet/Haiku/Fable (`sculptor/frontend/src/common/modelCapabilities.ts`).
 
 ---
 
@@ -184,7 +190,7 @@ depends on.
 - **REQ-COMPAT-002 (SHOULD).** Sculptor ships a **Linux x64** build; **Linux arm64** is best-effort /
   non-blocking (`.github/workflows/build-desktop.yml`; `SPEC.md` §11.1).
 - **REQ-COMPAT-003 [Unspecified].** The supported **minimum macOS version** is not stated as a
-  product requirement (CI builds/tests on macOS 14 Sonoma; Electron 37's own floor is macOS 12), and
+  product requirement (CI builds/tests on macOS 14 Sonoma; Electron 42's own floor is macOS 12), and
   the **minimum Linux glibc** is likewise unpinned. → OPEN-5 (§7).
 
 ### 3.2 Toolchain / framework baselines
@@ -194,11 +200,11 @@ packaging Sculptor):
 
 | Component | Pinned value | Source |
 |---|---|---|
-| REQ-COMPAT-010 Python | **>=3.11, <3.13** (pinned 3.11) | `pyproject.toml`, `.python-version` |
-| REQ-COMPAT-011 Node.js | **20.13.1** | `sculptor/frontend/.nvmrc` |
-| REQ-COMPAT-012 Electron | **37.6.0** (Forge **7.8.3**) | `sculptor/frontend/package.json` |
-| REQ-COMPAT-013 uv (Python pkg mgr) | **>=0.7.22** | `pyproject.toml` |
-| REQ-COMPAT-014 TypeScript / React / Jotai / Radix Themes / Vite | **5.5 / 18.3 / 2.9 / 3.1 / 5.4** | `sculptor/frontend/package.json` |
+| REQ-COMPAT-010 Python | **>=3.14, <3.15** (pinned 3.14) | `pyproject.toml`, `.python-version` |
+| REQ-COMPAT-011 Node.js | **24.17.0** | `sculptor/frontend/.nvmrc` |
+| REQ-COMPAT-012 Electron | **42.4.1** (Forge **7.11.2**) | `sculptor/frontend/package.json` |
+| REQ-COMPAT-013 uv (Python pkg mgr) | **>=0.11.22** | `pyproject.toml` |
+| REQ-COMPAT-014 TypeScript / React / Jotai / Radix Themes / Vite | **6.0 / 19.2 / 2.20 / 3.3 / 6.4** | `sculptor/frontend/package.json` |
 
 ### 3.3 Required external binaries
 
@@ -284,8 +290,12 @@ rules behind them.
 
 - **REQ-INT-001 (MUST).** The provider is detected from the `origin` remote hostname (parsing SSH and
   HTTP(S) forms): hostname containing **"github"** → GitHub via **`gh`**; containing **"gitlab"** →
-  GitLab via **`glab`**. Any other host has **no** PR/MR surface and no target-branch concept
-  (`SPEC.md` §7.6; `sculptor/sculptor/web/pr_polling_service.py`).
+  GitLab via **`glab`**. Any other host has **no** PR/MR surface (`SPEC.md` §7.6;
+  `sculptor/sculptor/web/pr_polling_service.py`). The **target-branch** selector is *not* gated on the
+  provider, however — it is host-independent and available on every repo, including repos with no
+  remote (which offer the repo's local branches as targets); only opening a PR/MR requires a detected
+  provider (`SPEC.md` §7.2 / §7.5; `sculptor/sculptor/web/repo_polling_manager.py` target-branch
+  fallback).
 - **REQ-INT-002 (MUST).** Operations performed via the provider CLI: **list** requests for a branch,
   **view** a request's status-check/pipeline rollup, **reviews/approvals**, and **unresolved
   comments/discussions**; **push** the branch and **open** a request; poll status thereafter. (GitHub:
@@ -308,7 +318,12 @@ rules behind them.
 - **REQ-INT-022 (SHOULD).** **Pi** is launched in **`--mode rpc`** with `--session-dir`/`--session-id`
   (same dir+id resumes); multiplexed JSONL channels (`response`, `extension_ui_request`,
   `AgentSessionEvent`); API keys injected from named env vars at startup and **never persisted**; a
-  version mismatch raises a clear error (`sculptor/sculptor/agents/pi_agent/agent_wrapper.py`).
+  version mismatch raises a clear error (`sculptor/sculptor/agents/pi_agent/agent_wrapper.py`). Pi
+  reports a live model catalog and supports **in-session model switching** via a `set_model` RPC
+  between turns (a rejected switch raises `PiSetModelError` → HTTP 400, surfaced as a toast); a turn
+  that ends in a **known-transient provider error** (overload, 429, 5xx/529, timeout) is retried
+  automatically with exponential backoff (up to 4 attempts, honoring a user interrupt during backoff)
+  rather than crashing the agent, exhausting to a re-runnable error message (`output_processor.py`).
 - **REQ-INT-023 (MUST).** A missing binary for either CLI raises a specific, surfaced error
   (`ClaudeBinaryNotFoundError` / `PiBinaryNotFoundError`), not a generic failure.
 
@@ -359,6 +374,17 @@ rules behind them.
 - **REQ-SEC-003 (MUST).** Build & distribution security: the macOS artifact is **signed and notarized**
   (`.dmg`); releases are **tag-driven** with the version checked against build context so a tag build
   cannot publish an inconsistent version (`SPEC.md` §11.2–§11.3).
+- **REQ-SEC-004 (Experimental).** **Frontend-plugin trust model.** The experimental frontend plugin
+  system (off by default, gated on the `enableFrontendPlugins` flag — atom
+  `isFrontendPluginsEnabledAtom`, default `false`) runs plugin code **in the renderer with the same
+  privileges as Sculptor's own UI**; a URL plugin source is re-fetched on every load, so the user
+  trusts whatever it serves at load time. Adding a plugin source is therefore equivalent to running
+  that code, documented in `SECURITY.md`. The SDK's `openExternal` is restricted to **`http(s)`**
+  URLs (`sculptor/frontend/src/plugins/sdk/actions.ts`). In the packaged app the renderer and its
+  plugins are served from a single secure custom origin (`sculptor://app`) rather than `file://`
+  (`sculptor/frontend/src/electron/appProtocol.ts`). Plugins load from the Sculptor folder's
+  `plugins/` directory or user-added URL sources; precedence is local-disk > URL > bundled for the
+  same plugin id (`SPEC.md` §7.12).
 - **REQ-SEC-010 (MUST).** **Telemetry is consent-gated.** Error reporting (Sentry, frontend-only) and
   product analytics (PostHog) are each gated on explicit consent flags
   (`is_error_reporting_enabled`, `is_product_analytics_enabled`, `is_session_recording_enabled`,

--- a/docs/specs/scenario_coverage.md
+++ b/docs/specs/scenario_coverage.md
@@ -31,27 +31,27 @@ Integration tests considered:
 
 | Area | Complete | Partial | Missing | Total |
 |------|---------:|--------:|--------:|------:|
-| SHELL | 22 | 12 | 14 | 48 |
+| SHELL | 24 | 12 | 14 | 50 |
 | ROUTE | 1 | 1 | 4 | 6 |
 | HELP | 0 | 2 | 1 | 3 |
 | HOME | 2 | 4 | 14 | 20 |
-| ADDWS | 7 | 14 | 3 | 24 |
+| ADDWS | 8 | 14 | 3 | 25 |
 | ADDREPO | 1 | 5 | 2 | 8 |
-| ONB | 10 | 10 | 13 | 33 |
-| WS | 39 | 19 | 18 | 76 |
-| CHAT | 21 | 15 | 9 | 45 |
-| MSG | 14 | 12 | 10 | 36 |
-| PANEL | 23 | 19 | 14 | 56 |
+| ONB | 11 | 10 | 13 | 34 |
+| WS | 40 | 20 | 18 | 78 |
+| CHAT | 21 | 16 | 9 | 46 |
+| MSG | 15 | 12 | 10 | 37 |
+| PANEL | 23 | 20 | 14 | 57 |
 | CMDP | 4 | 9 | 18 | 31 |
-| SET | 11 | 16 | 10 | 37 |
+| SET | 11 | 18 | 10 | 39 |
 | DEV | 3 | 1 | 0 | 4 |
 | MENT | 5 | 2 | 3 | 10 |
 | SKILL | 2 | 1 | 0 | 3 |
 | ACT | 2 | 3 | 1 | 6 |
-| **Total** | **167** | **145** | **134** | **446** |
+| **Total** | **173** | **150** | **134** | **457** |
 
-**Under the integration-only standard, 37% of scenarios are completely covered, 33% partially, and
-30% not at all.** (Counts are derived directly from the two sections below.)
+**Under the integration-only standard, 38% of scenarios are completely covered, 33% partially, and
+29% not at all.** (Counts are derived directly from the two sections below.)
 
 The per-scenario detail is split into two sections: **Coverage gaps — Partial & Missing** (every
 scenario needing work, with the test to add) and **Complete coverage** (every scenario already fully
@@ -204,7 +204,7 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | WS-030 | Missing | — | Hover pipeline/review dots; assert tooltip text ("Pipeline running/passed/failed/No pipeline", "Approved/Review pending/No reviewers"). |
 | WS-031 | Missing | — | PR with different target shows "Assign PR"/"Assign MR"; opening offers "Create PR → {target}" and "switch target to {target}". |
 | WS-032 | Partial | test_pr_button_errors.py::test_github_cli_error_variants; ::test_gitlab_cli_error_variants | Assert warning-triangle vs info icon distinction and the remediation-command copy icon turning to a checkmark briefly. |
-| WS-033 | Partial | test_target_branch.py::test_switching_to_all_scope_shows_target_branch_diff; test_pr_management.py::test_banner_hides_pr_ui_for_non_gitlab_origin | Click the selector; assert the dropdown lists remote branches; select one; assert target updates. |
+| WS-033 | Partial | test_target_branch.py::test_switching_to_all_scope_shows_target_branch_diff; test_pr_management.py::test_banner_shows_target_branch_selector_for_non_github_gitlab_origin | Click the selector; assert the dropdown lists branches; select one; assert target updates. |
 | WS-034 | Missing | — | Target differs from PR target → warning color; hover "PR #N targets {branch}"; selecting matching branch updates target. |
 | WS-035 | Missing | — | Click repo segment; assert menu (Open folder, Copy path, Copy relative path, Open in installed apps); each action fires; chosen app remembered. |
 | WS-038 | Partial | test_workspace_banner_overflow.py::test_collapsed_banner_has_no_inert_overflow_menu | Assert collapse priority order at successive widths: PR button → diff summary → repo segment. |
@@ -226,6 +226,7 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | WS-071 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches; ::test_search_bar_does_not_flash_red_while_typing_matching_query | Assert the "0/0" counter with the input turning red when there are no matches. |
 | WS-072 | Partial | test_chat_search_bar.py::test_cmd_f_enter_advances_through_all_matches (Enter nav) | Add Shift+Enter (previous) and up/down arrow navigation. |
 | WS-073 | Missing | — | Press Escape or click close → search bar closes and highlights clear. |
+| WS-077 | Partial | test_ci_babysitter.py::test_plain_terminal_mru_shows_disabled_reason | Assert that a *persistent* disabled reason also forces the dropdown switch off and greys it out (inert). |
 
 ### CHAT
 
@@ -255,6 +256,7 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | CHAT-043 | Partial | test_alpha_ask_user_question.py::test_alpha_auq_pill_dismissed_state | Assert the dimmed-options styling on the dismissed block. |
 | CHAT-044 | Partial | test_alpha_chat_view.py::test_debug_view_displays_blocks | Assert role, id, timestamp, and tool_use/tool_result names per message. |
 | CHAT-045 | Missing | — | Clicking a debug-view timestamp toggles between relative and absolute formats. |
+| CHAT-046 | Partial | test_pi_capability_gating.py::test_pi_model_switcher_offers_pi_models_and_accepts_a_pick; ::test_fresh_pi_agent_switcher_shows_pi_models_without_a_message | Assert the picker is disabled (with the current model) for a terminal agent, and that a harness-rejected Pi switch leaves the selection unchanged and shows an error toast. |
 
 ### MSG
 
@@ -320,6 +322,7 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | PANEL-051 | Partial | test_custom_actions.py::test_create_group_from_settings; ::test_delete_group_deletes_actions_from_settings; ::test_delete_group_deletes_actions_from_panel | Assert inline group rename (Enter/blur confirms) and Escape-cancel on group create. |
 | PANEL-052 | Missing | — | Drag an action/group → drop indicator + order updates; move action between groups; built-in items not draggable. |
 | PANEL-056 | Partial | test_file_browser.py::test_split_view_toggle_persists_across_panel_reopen; ::test_line_wrap_toggle_persists_across_panel_reopen; test_panel_zones.py::test_inner_vertical_split_height_persists_after_navigation | Assert folder-expansion, scroll position, active-tab, view-mode (tree/flat), and diff-scope restored after switching tabs/files and returning. |
+| PANEL-057 | Partial | test_bundled_linear_plugin.py::test_bundled_linear_plugin_loads_and_renders | Assert the plugin-contributed panel is listed with a "plugin" badge in the Panels list (not just that it renders). |
 
 ### CMDP
 
@@ -383,6 +386,8 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | SET-034 | Partial | test_theme_builder.py::test_theme_builder_navigation; ::test_theme_builder_change_accent_color | Exercise changing appearance mode, primary font, code font, and code theme and verify the UI updates. |
 | SET-035 | Partial | test_theme_builder.py::test_theme_builder_change_accent_color; ::test_theme_builder_reset_to_defaults | Cover custom hex entry, the light/dark hex override toggle, invalid-hex-shown-red, and the Gray/Success/Warning/Info swatches. |
 | SET-036 | Missing | — | Click a radius / scaling / panel-background option and assert the live UI updates. |
+| SET-038 | Partial | test_plugins_settings_visibility.py::test_plugins_section_visible_and_toggles_with_switch; test_plugin_loader.py::test_valid_plugin_loads_and_can_be_removed; ::test_plugin_source_can_be_disabled_and_re_enabled | Cover adding a source by URL, the Refresh rescan of the plugins directory, removing a user-added URL source, and the displayed directory path. |
+| SET-039 | Partial | test_ci_babysitter.py::test_settings_selector_lists_only_driveable_harnesses | Assert the selector saves with a toast and is disabled when the babysitter is off. |
 | DEV-001 | Partial | test_tanstack_devtools_panel.py::test_tanstack_devtools_panel_mounts_with_content (panel mounts only) | Cover header Dock/Float/Close controls, floating drag + resize within viewport, docked resize-from-top-edge + pushes content up, and closing hides it. |
 
 ---
@@ -417,6 +422,8 @@ Every scenario an integration test fully covers — it performs the user action 
 | SHELL-039 | test_auto_update_browser.py::test_error_status_shows_error |
 | SHELL-040 | test_auto_update_browser.py::test_dismissed_download_toast_stays_dismissed |
 | SHELL-046 | test_backend_shutdown_stall.py::test_shutdown_stall_recovery_after_timeout; ::test_shutdown_spinner_remains_before_timeout |
+| SHELL-049 | test_workspace_diagnostics_context_menu.py::test_workspace_context_menu_copy_name_branch_id |
+| SHELL-050 | test_workspace_close_vs_delete.py::test_cmd_shift_w_deletes_active_workspace |
 | ROUTE-001 | test_restart_mru.py::test_restart_restores_active_workspace_and_agent; ::test_restart_with_no_mru_lands_on_new |
 
 ### HOME / ADDWS / ADDREPO
@@ -432,6 +439,7 @@ Every scenario an integration test fully covers — it performs the user action 
 | ADDWS-017 | test_add_workspace_agent_type.py::test_first_agent_type_defaults_to_shared_last_used; test_agent_type_menu.py::test_agent_type_menu_creates_terminal_agent_and_remembers_type |
 | ADDWS-021 | test_worktree_create_happy_path.py::test_worktree_create_with_default_branch_name; test_add_workspace_agent_type.py::test_cmd_enter_in_workspace_name_creates_workspace |
 | ADDWS-022 | test_add_workspace_page.py::test_arrow_down_focuses_name_input_when_nothing_focused; ::test_arrow_up_focuses_name_input_when_nothing_focused |
+| ADDWS-025 | test_add_workspace_page.py::test_workspace_form_branch_state_persists_after_navigation |
 | ADDREPO-007 | test_path_autocomplete_keyboard.py::test_enter_on_directory_highlights_first_subentry; ::test_selected_folder_submit_shows_correct_repo_name |
 
 ### ONB / MENT / SKILL / ACT
@@ -448,6 +456,7 @@ Every scenario an integration test fully covers — it performs the user action 
 | ONB-024 | test_onboarding.py::test_onboarding_without_git_installed / test_onboarding_without_claude_installed; ::test_installation_step_skips_add_repo_when_project_exists |
 | ONB-026 | test_onboarding.py::test_full_onboarding_flow; ::test_installation_step_skips_add_repo_when_project_exists |
 | ONB-030 | test_onboarding.py::test_full_onboarding_flow |
+| ONB-034 | test_claude_auth_paste_code.py::test_claude_paste_code_sign_in_succeeds; ::test_claude_paste_code_invalid_code_shows_error |
 | MENT-005 | test_mention_picker_completion.py::test_plus_opens_prefilter_picker; ::test_plus_filters_categories_by_query; ::test_plus_drill_into_files/skills/workspaces/repositories_via_enter; ::test_mention_toolbar_button_opens_picker |
 | MENT-006 | test_at_mention_completion.py; test_at_mention_keyboard_navigation.py; test_at_mention_tab_drill_and_shift_tab.py; test_at_mention_path_mode.py |
 | MENT-007 | test_skill_autocomplete.py; test_pseudo_skills.py; test_slash_command_enter_accepts_suggestion.py; test_mention_picker_completion.py::test_plus_drill_into_skills_via_enter |
@@ -455,7 +464,7 @@ Every scenario an integration test fully covers — it performs the user action 
 | MENT-010 | test_path_autocomplete_keyboard.py::test_enter_on_directory_highlights_first_subentry; ::test_cmd_enter_submits_path; ::test_selected_folder_submit_shows_correct_repo_name; ::test_autocomplete_shows_submit_hint; test_path_tilde_display.py::test_path_autocomplete_shows_tilde_for_home_directory |
 | SKILL-001 | test_skills_panel.py::test_skills_panel_click_inserts_mention_chip; ::test_skills_panel_lists_workspace_skill; ::test_skills_panel_keyboard_navigation_inserts_chip; test_skill_without_frontmatter.py |
 | SKILL-003 | test_skills_panel.py::test_skills_panel_search_filters_list; ::test_skills_panel_keyboard_navigation_inserts_chip; test_skill_autocomplete.py; test_pseudo_skills.py::test_autocomplete_filters_pseudo_skills |
-| ACT-001 | test_custom_actions.py::test_draft_action_populates_and_focuses_chat_input; ::test_builtin_chips; ::test_create_action_from_panel |
+| ACT-001 | test_custom_actions.py::test_draft_action_populates_and_focuses_chat_input; ::test_builtin_chips; ::test_create_action_from_panel; test_terminal_agent_automated_prompts.py (terminal-agent draft types into the PTY without submitting) |
 | ACT-004 | test_custom_actions.py::test_delete_action_from_settings; ::test_delete_group_deletes_actions_from_settings; ::test_delete_group_deletes_actions_from_panel |
 
 ### WS
@@ -485,7 +494,7 @@ Every scenario an integration test fully covers — it performs the user action 
 | WS-041 | test_multi_agent_workspace.py::test_multiple_agent_tabs_shown_for_shared_workspace; ::test_single_agent_shows_one_agent_tab |
 | WS-044 | test_multi_agent_workspace.py::test_create_second_agent_in_existing_workspace |
 | WS-045 | test_agent_type_menu.py::test_agent_type_menu_creates_terminal_agent_and_remembers_type; ::test_agent_type_menu_gates_pi_behind_pi_agent_flag; ::test_registered_terminal_agent_appears_in_menu_and_creates |
-| WS-047 | test_agent_tab_context_menu.py::test_agent_context_menu_has_rename_and_delete; test_agent_diagnostics_context_menu.py::test_agent_diagnostics_disabled_without_session; ::test_agent_diagnostics_copy_session_id_and_transcript_path |
+| WS-047 | test_agent_tab_context_menu.py::test_agent_context_menu_has_rename_and_delete; test_agent_diagnostics_context_menu.py::test_agent_diagnostics_disabled_without_session; ::test_agent_diagnostics_copy_session_id_and_transcript_path; ::test_agent_context_menu_copy_name_and_id |
 | WS-048 | test_agent_tab_context_menu.py::test_agent_context_menu_delete; test_multi_agent_workspace.py::test_workspace_survives_when_other_agents_remain |
 | WS-049 | test_mark_unread.py::test_mark_adjacent_tab_unread; test_read_unread_status.py::test_unread_indicator_when_switching_agents_within_workspace |
 | WS-051 | test_terminal_agent_basic.py::test_terminal_agent_basic |
@@ -501,6 +510,7 @@ Every scenario an integration test fully covers — it performs the user action 
 | WS-074 | test_workspace_setup_command.py::test_setup_config_prompt_deep_links_to_focused_textarea; test_regression_setup_command_backfill.py; test_regression_setup_command_rerun.py::test_setup_rerun_button_runs_command_again |
 | WS-075 | test_btw.py::test_btw_happy_path_while_main_busy |
 | WS-076 | test_btw.py::test_btw_popup_is_draggable; ::test_btw_popup_closes_on_escape; ::test_btw_empty_shows_inline_toast |
+| WS-078 | test_pr_management.py::test_banner_target_branch_lists_local_branches_when_no_remote |
 
 ### CHAT
 
@@ -546,6 +556,7 @@ Every scenario an integration test fully covers — it performs the user action 
 | MSG-028 | test_alpha_chat_chip_row.py::test_chip_popover_opens_on_click; ::test_chip_popover_closes_on_second_click; ::test_chip_popover_swaps_on_different_chip_click; test_alpha_chat_chip_row_advanced.py::test_chip_popover_shows_diff_content; ::test_chip_row_hover_opens_popover |
 | MSG-030 | test_missing_claude_binary.py::test_missing_claude_binary_shows_friendly_error; test_claude_binary_installation.py::test_settings_claude_cli_section_visible; ::test_onboarding_claude_not_found_shows_override |
 | MSG-034 | test_plan_mode.py::test_exit_plan_mode_shows_approval_prompt; ::test_exit_plan_mode_revision_flow; ::test_exit_plan_mode_revision_auto_expands; test_alpha_chat_view.py::test_alpha_exit_plan_mode_approve |
+| MSG-037 | test_copy_image_context_menu.py::test_copy_image_context_menu_scoped_to_chat_content |
 
 ### PANEL
 

--- a/docs/specs/scenarios.md
+++ b/docs/specs/scenarios.md
@@ -683,7 +683,7 @@ The home page and the Add Workspace page share the recent-workspaces list and it
 - **ADDWS-025 — Repo/branch/source-branch selections persist across tab switches**
   - Given: the user chose a repo, source branch, and branch name on the Add Workspace form, then switched tabs.
   - When: the user returns to the same draft.
-  - Then: the previously chosen repo, source branch, and branch name are all restored (not just the name).
+  - Then: the previously chosen repo, source branch, and branch name are all restored.
 
 - **ADDWS-006 — Repo selector dropdown**
   - Given: the repo selector is shown.

--- a/docs/specs/scenarios.md
+++ b/docs/specs/scenarios.md
@@ -130,6 +130,16 @@ behavior**.
   - When: the user chooses Delete and confirms in the dialog.
   - Then: the tab disappears and an adjacent tab/page is shown.
 
+- **SHELL-049 — Copy workspace details from tab context menu**
+  - Given: a workspace tab's context menu is open.
+  - When: the user chooses Copy workspace name, Copy branch, or Copy workspace id.
+  - Then: the chosen value is copied to the clipboard (a confirmation appears briefly).
+
+- **SHELL-050 — Delete the active workspace via keybinding**
+  - Given: a workspace tab is active.
+  - When: the user presses `Cmd+Shift+W`.
+  - Then: the same delete-workspace confirmation dialog opens; confirming removes the workspace and its agents and an adjacent tab/page is shown.
+
 - **SHELL-018 — Close others / Close all from tab menu**
   - Given: multiple tabs open and a tab's context menu is open.
   - When: the user chooses "Close others" or "Close all".
@@ -554,6 +564,11 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: authentication is in progress.
   - Then: a spinner and "authenticating" appear with a help message about running `claude auth login` in a terminal.
 
+- **ONB-034 — Claude card: paste-a-code sign-in**
+  - Given: a headless/remote setup where a browser callback can't reach the app, after the user starts Claude sign-in.
+  - When: the card shows the paste-a-code panel.
+  - Then: the sign-in URL and instructions are shown with a "Paste code here" input; pasting the authorization code and submitting (Enter) completes sign-in.
+
 - **ONB-018 — Claude managed install (progress)**
   - Given: Claude is managed and not installed.
   - When: installation runs (auto-triggered on load or via Install).
@@ -664,6 +679,11 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - Given: the user typed a name and navigated away.
   - When: the user returns to the same draft.
   - Then: the previously typed name is restored.
+
+- **ADDWS-025 — Repo/branch/source-branch selections persist across tab switches**
+  - Given: the user chose a repo, source branch, and branch name on the Add Workspace form, then switched tabs.
+  - When: the user returns to the same draft.
+  - Then: the previously chosen repo, source branch, and branch name are all restored (not just the name).
 
 - **ADDWS-006 — Repo selector dropdown**
   - Given: the repo selector is shown.
@@ -954,6 +974,11 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: the user toggles the babysitter switch.
   - Then: it pauses/resumes and the status text updates.
 
+- **WS-077 — CI babysitter disabled reason in PR dropdown**
+  - Given: the babysitter can't run for this workspace (e.g. its configured agent type can't be resolved) and the PR dropdown is open.
+  - When: the user views the babysitter row.
+  - Then: a short disabled-reason message is shown in place of the usual status; for a persistent reason the switch is forced off and greyed out (inert).
+
 - **WS-029 — Merged/closed PR**
   - Given: the PR was merged or closed.
   - When: viewing the button.
@@ -977,9 +1002,14 @@ The home page and the Add Workspace page share the recent-workspaces list and it
 ## Target branch & repo segment
 
 - **WS-033 — Target-branch selector**
-  - Given: a workspace with a target branch.
+  - Given: any workspace (regardless of remote host).
   - When: viewing the banner.
-  - Then: the target branch name is shown; clicking it opens a dropdown of remote branches, and selecting one updates the target.
+  - Then: the target branch name is shown; clicking it opens a dropdown of branches, and selecting one updates the target.
+
+- **WS-078 — Target-branch selector on a repo with no remote**
+  - Given: a workspace whose repo has no remote configured.
+  - When: the user opens the target-branch selector.
+  - Then: the dropdown offers the repo's local branches (excluding the workspace's own branch), and selecting one updates the target shown in the banner.
 
 - **WS-034 — Target-branch PR mismatch warning**
   - Given: the workspace target differs from an existing PR's target.
@@ -1053,7 +1083,7 @@ The home page and the Add Workspace page share the recent-workspaces list and it
 - **WS-047 — Agent context menu**
   - Given: an agent tab.
   - When: the user right-clicks it.
-  - Then: a menu offers Rename, Mark as unread, Delete, and a Diagnostics submenu (Debug View toggle; copy Claude session id / transcript path / Sculptor transcript path — disabled when unavailable).
+  - Then: a menu offers Rename, Mark as unread, Copy agent name, Delete, and a Diagnostics submenu (Debug View toggle; copy Claude session id / transcript path / Sculptor transcript path — disabled when unavailable).
 
 - **WS-048 — Delete an agent**
   - Given: an agent context menu (or close button) is used.
@@ -1463,6 +1493,11 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: the user clicks a timestamp.
   - Then: it toggles between relative and absolute formats.
 
+- **CHAT-046 — Capability-gated model picker / Pi model catalog**
+  - Given: agents whose harness does and doesn't support model selection.
+  - When: the user opens the model picker on each (a Claude agent, a Pi agent, and a terminal agent).
+  - Then: a Claude agent lists Claude models; a Pi agent lists Pi's own models grouped by provider; a terminal agent shows the picker disabled with the current model; switching a Pi model that the harness rejects leaves the selection unchanged and shows an error toast.
+
 ---
 
 # MSG — Message & tool-content rendering
@@ -1660,6 +1695,11 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - Given: an active chat search.
   - When: messages render.
   - Then: all matches are highlighted, with the active occurrence styled distinctly.
+
+- **MSG-037 — Copy an image from the conversation**
+  - Given: an image is shown in the conversation (in a message, the attachment preview, or the zoomed lightbox).
+  - When: the user right-clicks the image and chooses "Copy Image".
+  - Then: the image is copied to the clipboard.
 
 ---
 
@@ -1964,6 +2004,13 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - Given: the user has set folder-expansion, scroll position, active tab, view mode, diff view type, line-wrapping, and diff scope.
   - When: switching tabs/files and returning.
   - Then: each of these states is restored.
+
+## Plugin panels (experimental)
+
+- **PANEL-057 — Plugin-contributed panel appears with a badge**
+  - Given: Frontend plugins is enabled and a plugin contributing a panel is loaded (e.g. the bundled Linear plugin).
+  - When: the user views the Panels list and opens the plugin's panel.
+  - Then: the panel is listed with a "plugin" badge and renders its content when opened.
 
 ---
 
@@ -2281,6 +2328,11 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: the user toggles the babysitter, sets the retry cap (1–10), or edits the pipeline-failed / merge-conflict prompts.
   - Then: each saves with a toast; the dependent fields disable when the babysitter is off; prompts have reset-to-default.
 
+- **SET-039 — Babysitter agent selector**
+  - Given: the CI section with the babysitter enabled.
+  - When: the user opens the "Babysitter agent" selector.
+  - Then: it offers "Most recently used" (default), Claude, Pi (when enabled), and any registered terminal agent that accepts automated prompts; choosing one saves with a toast; the selector is disabled when the babysitter is off.
+
 ## File browser
 
 - **SET-026 — File-browser settings**
@@ -2306,13 +2358,20 @@ The home page and the Add Workspace page share the recent-workspaces list and it
 
 - **SET-029 — Experimental toggles**
   - Given: the Experimental section.
-  - When: the user toggles any feature (Always interrupt and send, Smooth streaming, Per-workspace panel layout, In-place workspaces, Clone workspaces, Review all, Entity mentions, Rich markdown rendering, Pi agent).
+  - When: the user toggles any feature (Always interrupt and send, Smooth streaming, Per-workspace panel layout, In-place workspaces, Clone workspaces, Review all, Entity mentions, Rich markdown rendering, Pi agent, Frontend plugins).
   - Then: each shows "Setting updated".
 
 - **SET-030 — Custom backend command & timeout**
   - Given: the Experimental/Advanced section.
   - When: the user sets a custom backend command or readiness timeout.
   - Then: each saves with a "restart required" toast.
+
+## Plugins (experimental)
+
+- **SET-038 — Manage plugin sources**
+  - Given: Frontend plugins is enabled, so a Plugins section appears in Settings.
+  - When: the user adds a plugin source by URL, toggles a plugin's enable/disable switch, clicks Refresh to rescan the plugins directory, or removes a user-added URL source.
+  - Then: an added source appears in the list; the switch mutes/unmutes the plugin without removing it; Refresh re-scans drop-in plugins; a user-added URL source can be removed while bundled/disk-discovered ones cannot; the plugins directory path is shown.
 
 ## Actions
 
@@ -2360,7 +2419,7 @@ The home page and the Add Workspace page share the recent-workspaces list and it
 - **ACT-001 — Action chip appearance & trigger**
   - Given: an action chip.
   - When: viewing/clicking it.
-  - Then: it shows a play icon (auto-submit) or text-cursor icon (draft), a tooltip with the prompt on hover, and clicking executes (send or append); disabled chips ignore clicks.
+  - Then: it shows a play icon (auto-submit) or text-cursor icon (draft), a tooltip with the prompt on hover, and clicking executes — for a chat agent, send or append to the chat input; for a terminal agent, type-and-submit (auto-submit) or type into the terminal without submitting (draft); disabled chips ignore clicks.
 
 - **ACT-002 — Action context menu**
   - Given: an action chip.


### PR DESCRIPTION
## What

Adds an `/update-specs` skill that keeps the product spec set under `docs/specs/` (SPEC, requirements, scenarios, scenario_coverage) in sync with code as it lands on `origin/main`, and applies a first reconciliation pass plus some hygiene fixes.

## Why

The spec set was a one-time snapshot and drifted as soon as new work merged. This makes refreshing it a repeatable, scoped operation instead of an ad-hoc re-read of the whole tree.

## Contents

- **New skill** (`.claude/skills/update-specs/SKILL.md`): reviews the PRs merged since a recorded baseline, filters out non-product churn (comment scrubs, deps, CI, tests, version bumps), and edits each doc in place while preserving its format and `AREA-NNN` ID scheme. It reads the baseline from `docs/specs/.spec-baseline` and rewrites it to the current tip when done.
- **Baseline pointer** (`docs/specs/.spec-baseline`): a single commit id scoping the next review.
- **First reconciliation pass**: brings the docs up to date with code merged since the baseline.
- **Present-tense rule**: the skill now requires the docs to describe what the product does today rather than how it changed — they are living descriptions, not a changelog. Two before/after traces that had slipped in were scrubbed.

## Notes

Docs/skill-markdown only — no product code changes.

(Sent by Claude)