### PR TITLE
[SCU-1566] Fix first-message-after-switch scroll flake: re-assert restore after virtualizer settles

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -64,6 +64,33 @@ export const useAlphaScrollPersistence = (
     };
   }, [scrollContainerRef, virtualizer, filteredMessages, setScrollPosition]);
 
+  // Apply the saved scroll position to the container. Resolves the saved anchor
+  // (message index + pixel offset, or distance-from-bottom) against the
+  // virtualizer's *current* item measurements, so calling it again after the
+  // measurements change re-lands at the same logical position.
+  const applyScrollPosition = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el || filteredMessages.length === 0) return;
+
+    if (!scrollPosition || scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
+      // First visit or user was at bottom: scroll to bottom.
+      virtualizer.scrollToIndex(filteredMessages.length - 1, { align: "end" });
+      return;
+    }
+
+    const messageIndex = filteredMessages.findIndex((m) => m.id === scrollPosition.firstVisibleMessageId);
+    if (messageIndex >= 0) {
+      virtualizer.scrollToIndex(messageIndex, { align: "start" });
+      // Apply pixel offset synchronously — scrollToIndex already set scrollTop
+      // so the DOM measurement is available. A rAF here would cause a one-frame
+      // flash at the message-top position before the offset is applied.
+      el.scrollTop += scrollPosition.pixelOffset;
+    } else {
+      // Fallback: use distance from bottom (synchronous for the same reason).
+      el.scrollTop = el.scrollHeight - el.clientHeight - scrollPosition.distanceFromBottom;
+    }
+  }, [scrollContainerRef, virtualizer, filteredMessages, scrollPosition]);
+
   // Restore scroll position on task switch
   const restore = useCallback(() => {
     const el = scrollContainerRef.current;
@@ -73,40 +100,33 @@ export const useAlphaScrollPersistence = (
     cancelPendingRafs(pendingRafsRef.current);
     isRestoringRef.current = true;
 
-    if (!scrollPosition) {
-      // First visit: scroll to bottom
-      virtualizer.scrollToIndex(filteredMessages.length - 1, { align: "end" });
-    } else if (scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
-      // User was at bottom: scroll to bottom
-      virtualizer.scrollToIndex(filteredMessages.length - 1, { align: "end" });
-    } else {
-      // Find message by ID
-      const messageIndex = filteredMessages.findIndex((m) => m.id === scrollPosition.firstVisibleMessageId);
+    // First apply: resolves the anchor against the virtualizer's *estimated*
+    // heights — on a task switch the virtualizer is mid-settle and the items
+    // have not re-measured to their real sizes yet. This prevents a flash of
+    // the outgoing scroll position.
+    applyScrollPosition();
 
-      if (messageIndex >= 0) {
-        virtualizer.scrollToIndex(messageIndex, { align: "start" });
-        // Apply pixel offset synchronously — scrollToIndex already set
-        // scrollTop so the DOM measurement is available.  A rAF here would
-        // cause a one-frame flash at the message-top position before the
-        // offset is applied.
-        el.scrollTop += scrollPosition.pixelOffset;
-      } else {
-        // Fallback: use distance from bottom (synchronous for same reason)
-        el.scrollTop = el.scrollHeight - el.clientHeight - scrollPosition.distanceFromBottom;
-      }
-    }
-
-    // Double-rAF to clear restoration guard after paint settles
+    // Re-assert after the virtualizer has settled. useAlphaVirtualizer's layout
+    // effect runs before this hook's (by call order) and schedules its settle
+    // double-rAF first, so this double-rAF's inner frame fires after it: by then
+    // `isSettlingRef` has cleared and the visible items have re-measured to
+    // their real heights. Re-applying re-resolves the anchor against those
+    // measurements, so the target message lands where intended instead of being
+    // left at a stale estimate-based pixel — which, in a virtualized list, can
+    // scroll the target out of the rendered window entirely (the flake this
+    // fixes). isRestoringRef stays true across the whole window so this
+    // re-assert's scroll events aren't saved back as a new position.
     const id1 = requestAnimationFrame(() => {
       pendingRafsRef.current.delete(id1);
       const id2 = requestAnimationFrame(() => {
         pendingRafsRef.current.delete(id2);
+        applyScrollPosition();
         isRestoringRef.current = false;
       });
       pendingRafsRef.current.add(id2);
     });
     pendingRafsRef.current.add(id1);
-  }, [scrollContainerRef, virtualizer, filteredMessages, scrollPosition]);
+  }, [scrollContainerRef, filteredMessages, applyScrollPosition]);
 
   // Restore scroll position synchronously before paint so the user never
   // sees the old scroll position flash before jumping to the saved one.


### PR DESCRIPTION
## Problem

`test_first_message_visible_after_agent_switch` flakes: after switching tasks/agents, the first message is intermittently not visible.

Root cause is a scroll-restore vs virtualizer-re-measurement race. On a switch, the chat restores the saved scroll position by resolving the saved anchor (message index + pixel offset, or distance-from-bottom) and calling `scrollToIndex`. This ran exactly **once, synchronously**, while the virtualizer was still mid-settle — items were sized from their height *estimates*, not their real measured heights. When the real measurements landed a frame later, item offsets shifted with no re-restore, leaving the target message at a stale estimate-based pixel. In a virtualized list that can scroll the anchor clean out of the rendered window, so the first message isn't visible.

## Fix

Extract the scroll-setting logic into `applyScrollPosition()` and call it **twice**:

1. Once up front (prevents a flash of the outgoing scroll position).
2. Again from the inner frame of `restore()`'s existing double-rAF, **after** the virtualizer has settled and the visible items have re-measured. This re-resolves the same anchor against the now-real measurements so the target lands where intended.

`isRestoringRef` stays true across the whole window so the re-assert's own scroll events aren't saved back as a new position. Ordering is load-bearing: `useAlphaVirtualizer`'s settle layout effect runs before this hook's (by call order) and schedules its settle double-rAF first, so this hook's inner frame fires after settling clears. This is self-contained — no cross-hook plumbing.

## Validation

Offload repro (`test_first_message_visible_after_agent_switch` ×40, `retry_count=0`, `schedule_individual`):

| | flaked |
|---|---|
| baseline (main) | 12/40 |
| this branch | **0/40** |

Part of the SCU-1566 scroll/nav flake cleanup (sibling to the clamp + prompt-nav fixes already shipped).

(Sent by Claude)