### PR TITLE
[SCU-1585] Don't render a disabled panel when a plugin is unloaded

### DIFF
--- a/sculptor/frontend/src/components/panels/PanelRegistryProvider.test.tsx
+++ b/sculptor/frontend/src/components/panels/PanelRegistryProvider.test.tsx
@@ -273,6 +273,69 @@ describe("PanelRegistryProvider — reconciliation (removing panels)", () => {
     }
   });
 
+  it("skips a disabled panel when falling back after the active panel is removed", () => {
+    const store = createStore();
+    // top-left order is [disabled, enabled, active]; the disabled panel sits
+    // ahead of the enabled one. Removing the active panel must fall back to the
+    // enabled panel, never the disabled one (which would render despite being
+    // toggled off).
+    const disabledPanel: PanelDefinition = {
+      ...INFO_PANEL,
+      id: "disabledPanel",
+      defaultZone: "top-left",
+      defaultEnabled: false,
+    };
+    const enabledPanel: PanelDefinition = { ...INFO_PANEL, id: "enabledPanel", defaultZone: "top-left" };
+    const activePanel: PanelDefinition = { ...INFO_PANEL, id: "activePanel", defaultZone: "top-left" };
+
+    const seededLayout: DefaultPanelLayout = {
+      zoneAssignments: { disabledPanel: "top-left", enabledPanel: "top-left", activePanel: "top-left" },
+      activePanelPerZone: { "top-left": "activePanel" },
+      zoneVisibility: { "top-left": true },
+      zoneOrder: { "top-left": ["disabledPanel", "enabledPanel", "activePanel"] },
+    };
+
+    const { rerender } = renderProvider({
+      store,
+      panels: [disabledPanel, enabledPanel, activePanel],
+      defaultLayout: seededLayout,
+    });
+
+    expect(store.get(activePanelPerZoneAtom)["top-left"]).toBe("activePanel");
+
+    // Remove the active panel — fallback must land on the enabled panel, even
+    // though the disabled panel comes first in the zone's order.
+    rerender({ store, panels: [disabledPanel, enabledPanel], defaultLayout: seededLayout });
+    expect(store.get(activePanelPerZoneAtom)["top-left"]).toBe("enabledPanel");
+  });
+
+  it("clears the active panel when the only remaining panels in the zone are disabled", () => {
+    const store = createStore();
+    const disabledPanel: PanelDefinition = {
+      ...INFO_PANEL,
+      id: "disabledPanel",
+      defaultZone: "top-left",
+      defaultEnabled: false,
+    };
+    const activePanel: PanelDefinition = { ...INFO_PANEL, id: "activePanel", defaultZone: "top-left" };
+
+    const seededLayout: DefaultPanelLayout = {
+      zoneAssignments: { disabledPanel: "top-left", activePanel: "top-left" },
+      activePanelPerZone: { "top-left": "activePanel" },
+      zoneVisibility: { "top-left": true },
+      zoneOrder: { "top-left": ["disabledPanel", "activePanel"] },
+    };
+
+    const { rerender } = renderProvider({
+      store,
+      panels: [disabledPanel, activePanel],
+      defaultLayout: seededLayout,
+    });
+
+    rerender({ store, panels: [disabledPanel], defaultLayout: seededLayout });
+    expect(store.get(activePanelPerZoneAtom)["top-left"]).toBeUndefined();
+  });
+
   it("falls back to the next remaining panel in the zone when the active panel is removed", () => {
     const store = createStore();
     // Seed a zone with two panels, panelA active.

--- a/sculptor/frontend/src/components/panels/PanelRegistryProvider.tsx
+++ b/sculptor/frontend/src/components/panels/PanelRegistryProvider.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from "react";
 
 import {
   activePanelPerZoneAtom,
+  panelEnabledAtom,
   panelRegistryAtom,
   zoneAssignmentsAtom,
   zoneOrderAtom,
@@ -32,6 +33,7 @@ export const PanelRegistryProvider = ({
 
   const zoneAssignments = useAtomValue(zoneAssignmentsAtom);
   const zoneOrder = useAtomValue(zoneOrderAtom);
+  const panelEnabled = useAtomValue(panelEnabledAtom);
   const setZoneAssignments = useSetAtom(zoneAssignmentsAtom);
   const setActivePanelPerZone = useSetAtom(activePanelPerZoneAtom);
   const setZoneVisibility = useSetAtom(zoneVisibilityAtom);
@@ -95,11 +97,21 @@ export const PanelRegistryProvider = ({
           newOrder[zone as ZoneId] = order.filter((id) => !staleSet.has(id));
         }
       }
+
+      // The fallback must skip disabled panels: a panel can sit in a zone's
+      // order while toggled off (e.g. the Browser panel, defaultEnabled:false).
+      // Picking it would render a panel the user never enabled, so fall back to
+      // the first *enabled* sibling instead (matching panelsInZoneAtom).
+      const isEnabled = (panelId: PanelId): boolean => {
+        const def = panels.find((p) => p.id === panelId);
+        if (def?.isBuiltin ?? false) return true;
+        return panelEnabled[panelId] ?? def?.defaultEnabled ?? true;
+      };
       setActivePanelPerZone((prev) => {
         const cleaned = { ...prev };
         for (const [zone, panelId] of Object.entries(cleaned)) {
           if (panelId && staleSet.has(panelId)) {
-            const remaining = (newOrder[zone as ZoneId] ?? []).filter((id) => !staleSet.has(id));
+            const remaining = (newOrder[zone as ZoneId] ?? []).filter((id) => !staleSet.has(id) && isEnabled(id));
             cleaned[zone as ZoneId] = remaining[0] as PanelId | undefined;
           }
         }
@@ -127,7 +139,16 @@ export const PanelRegistryProvider = ({
 
     setZoneAssignments(newAssignments);
     setZoneOrder(newOrder);
-  }, [defaultLayout, panels, zoneAssignments, zoneOrder, setZoneAssignments, setActivePanelPerZone, setZoneOrder]);
+  }, [
+    defaultLayout,
+    panels,
+    zoneAssignments,
+    zoneOrder,
+    panelEnabled,
+    setZoneAssignments,
+    setActivePanelPerZone,
+    setZoneOrder,
+  ]);
 
   return <>{children}</>;
 };

--- a/sculptor/frontend/src/components/panels/atoms.test.ts
+++ b/sculptor/frontend/src/components/panels/atoms.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { UserConfig } from "~/api";
 import { userConfigAtom } from "~/common/state/atoms/userConfig.ts";
 import {
+  activePanelInZoneAtom,
+  activePanelPerZoneAtom,
   createPanelStore,
   didZenImplyFocusModeAtom,
   focusModeActiveAtom,
@@ -18,6 +20,7 @@ import {
   savedSideVisibilityAtom,
   zenModeActiveAtom,
   zoneAssignmentsAtom,
+  zoneOrderAtom,
   zoneVisibilityAtom,
 } from "~/components/panels/atoms.ts";
 import type { PanelDefinition } from "~/components/panels/types.ts";
@@ -54,6 +57,58 @@ const TEST_PANELS: ReadonlyArray<PanelDefinition> = [
 
 beforeEach(() => localStorage.clear());
 afterEach(() => localStorage.clear());
+
+describe("activePanelInZoneAtom", () => {
+  const ENABLED_PANEL: PanelDefinition = {
+    id: "enabled",
+    displayName: "Enabled",
+    description: "Test panel",
+    icon: Circle,
+    defaultZone: "top-right",
+    defaultShortcut: "",
+    component: () => createElement("div"),
+  };
+  const DISABLED_PANEL: PanelDefinition = {
+    id: "disabled",
+    displayName: "Disabled",
+    description: "Test panel",
+    icon: Circle,
+    defaultZone: "top-right",
+    defaultShortcut: "",
+    component: () => createElement("div"),
+    defaultEnabled: false,
+  };
+
+  it("resolves the active panel when it is enabled", () => {
+    const store = createPanelStore([ENABLED_PANEL, DISABLED_PANEL]);
+    store.set(zoneAssignmentsAtom, { enabled: "top-right", disabled: "top-right" });
+    store.set(zoneOrderAtom, { "top-right": ["disabled", "enabled"] });
+    store.set(activePanelPerZoneAtom, { "top-right": "enabled" });
+
+    expect(store.get(activePanelInZoneAtom("top-right"))?.id).toBe("enabled");
+  });
+
+  it("never resolves to a disabled panel, even when it is the persisted active one", () => {
+    // Stale localStorage can name a panel the user has since toggled off.
+    // Rendering it would show a panel that is off; fall back to the first
+    // enabled panel in the zone instead.
+    const store = createPanelStore([ENABLED_PANEL, DISABLED_PANEL]);
+    store.set(zoneAssignmentsAtom, { enabled: "top-right", disabled: "top-right" });
+    store.set(zoneOrderAtom, { "top-right": ["disabled", "enabled"] });
+    store.set(activePanelPerZoneAtom, { "top-right": "disabled" });
+
+    expect(store.get(activePanelInZoneAtom("top-right"))?.id).toBe("enabled");
+  });
+
+  it("returns undefined when the zone has no enabled panels", () => {
+    const store = createPanelStore([DISABLED_PANEL]);
+    store.set(zoneAssignmentsAtom, { disabled: "top-right" });
+    store.set(zoneOrderAtom, { "top-right": ["disabled"] });
+    store.set(activePanelPerZoneAtom, { "top-right": "disabled" });
+
+    expect(store.get(activePanelInZoneAtom("top-right"))).toBeUndefined();
+  });
+});
 
 describe("isSideVisibleAtom", () => {
   it("returns true when any zone in the side is visible", () => {

--- a/sculptor/frontend/src/components/panels/atoms.ts
+++ b/sculptor/frontend/src/components/panels/atoms.ts
@@ -216,9 +216,18 @@ const activePanelInZoneAtomMap = new Map<ZoneId, Atom<PanelDefinition | undefine
     atom<PanelDefinition | undefined>((get) => {
       const registry = get(panelRegistryAtom);
       const activePanel = get(activePanelPerZoneAtom);
+      const enabled = get(panelEnabledAtom);
+      const isEnabled = (def: PanelDefinition): boolean =>
+        (def.isBuiltin ?? false) || (enabled[def.id] ?? def.defaultEnabled ?? true);
+
       const panelId = activePanel[zoneId];
-      if (!panelId) return undefined;
-      return registry.find((p) => p.id === panelId);
+      const active = panelId ? registry.find((p) => p.id === panelId) : undefined;
+      // Never render a disabled panel, even if it is the persisted active one
+      // (stale localStorage can point at a panel the user has since toggled
+      // off). Fall back to the first enabled panel in the zone instead.
+      if (active && isEnabled(active)) return active;
+      const fallbackId = get(panelsInZoneAtomMap.get(zoneId)!)[0];
+      return fallbackId ? registry.find((p) => p.id === fallbackId) : undefined;
     }),
   ]),
 );

--- a/sculptor/sculptor/testing/elements/panel_zones.py
+++ b/sculptor/sculptor/testing/elements/panel_zones.py
@@ -60,15 +60,19 @@ class PlaywrightPanelZonesElement:
     def get_file_browser_panel(self) -> Locator:
         return self._page.get_by_test_id(ElementIDs.FILE_BROWSER_PANEL)
 
-    def activate_plugin_panel(self, plugin_id: str) -> None:
-        """Click a plugin-contributed panel's sidebar icon to make it the active
-        panel in its zone.
+    def get_plugin_panel_icon(self, plugin_id: str) -> Locator:
+        """Locator for a plugin-contributed panel's sidebar icon.
 
         Plugin panels render `data-panel-icon=<id>` with no ElementIDs testid
         (unlike built-in panels, which are in PANEL_ICON_TEST_IDS), so they're
         located by that attribute.
         """
-        icon = self._page.locator(f'[data-panel-icon="{plugin_id}"]')
+        return self._page.locator(f'[data-panel-icon="{plugin_id}"]')
+
+    def activate_plugin_panel(self, plugin_id: str) -> None:
+        """Click a plugin-contributed panel's sidebar icon to make it the active
+        panel in its zone."""
+        icon = self.get_plugin_panel_icon(plugin_id)
         expect(icon).to_be_visible()
         icon.click()
 

--- a/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
+++ b/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
@@ -1,26 +1,29 @@
-"""Integration test for panel open-state after a plugin panel is unloaded.
+"""Integration tests for panel open-state when a plugin's panel is unloaded.
 
 When a plugin contributes a panel and that panel is the *active* one in its
-zone, unloading the plugin (turning it off) must fall back to an **enabled**
-sibling panel — never to a panel the user has disabled.
+zone, turning the plugin off — or turning it off then on again — must never
+leave a panel the user has disabled (e.g. the Browser panel) rendered in that
+zone.
 
 The reproducer mirrors a real user setup: the bundled Linear plugin docks its
 panel in the top-right zone (alongside the built-in, disabled-by-default
-Browser panel). If the disabled Browser panel happens to sit ahead of the
-remaining enabled panels in that zone's order, unloading the active Linear
-panel used to select Browser as the fallback and actually render it — even
-though the user never enabled it. This drives that exact arrangement through
-the UI and asserts the fallback lands on an enabled panel instead.
+Browser panel). With the disabled Browser panel ordered ahead of the remaining
+enabled panel, unloading the active Linear panel used to select Browser as the
+fallback and actually render it. These tests drive that arrangement through the
+UI and assert the zone falls back to an enabled panel instead — both for a
+plain disable and for a disable-then-re-enable cycle.
 """
 
 from pathlib import Path
 
+from playwright.sync_api import Page
 from playwright.sync_api import expect
 
 from sculptor.services.user_config.user_config import load_config
 from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
 from sculptor.testing.elements.panels import ensure_right_area_visible
+from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.resources import _default_sculptor_folder_populator
@@ -39,6 +42,34 @@ def _enable_frontend_plugins_populator(folder_path: Path) -> None:
     save_config(config, config_path)
 
 
+def _open_linear_with_disabled_browser_ahead(
+    page: Page, task_page: PlaywrightTaskPage, zones: PlaywrightPanelZonesElement
+) -> None:
+    """Order the disabled Browser panel ahead of an enabled panel in top-right,
+    then open the Linear plugin panel as the active one in that zone.
+
+    The default top-right order is [actions, skills, browser]; moving the two
+    enabled built-ins out and one back (each move appends to the target zone's
+    order) leaves [browser (disabled), linear-issue, skills (enabled)] — so the
+    disabled Browser panel is the first sibling after Linear is removed.
+    """
+    settings_page = navigate_to_settings_page(page=page)
+    plugins = settings_page.click_on_plugins()
+    plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
+
+    panels = settings_page.click_on_panels()
+    panels.set_panel_zone("skills", "bottom-right")
+    panels.set_panel_zone("actions", "bottom-right")
+    panels.set_panel_zone("skills", "top-right")
+
+    task_page.get_workspace_tabs().first.click()
+    ensure_right_area_visible(page)
+    zones.activate_plugin_panel("linear-issue")
+    expect(zones.get_top_right_zone()).to_be_visible()
+    # The disabled Browser panel must not be showing while Linear is active.
+    expect(task_page.get_browser_panel_root()).not_to_be_visible()
+
+
 @custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 @user_story("to keep a disabled panel hidden when I turn off a plugin whose panel was open")
 def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
@@ -51,31 +82,7 @@ def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
 
         task_page = start_task_and_wait_for_ready(page, prompt="panel persistence", workspace_name="Panels WS")
         zones = PlaywrightPanelZonesElement(page)
-        browser_panel = task_page.get_browser_panel_root()
-        skills_panel = task_page.get_skills_panel()
-
-        # The bundled Linear plugin auto-loads and docks a panel in top-right.
-        settings_page = navigate_to_settings_page(page=page)
-        plugins = settings_page.click_on_plugins()
-        plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
-
-        # Arrange the top-right order so the disabled Browser panel sits *before*
-        # the remaining enabled panel. The default order is
-        # [actions, skills, browser]; moving the two enabled built-ins out and
-        # one back (each move appends to the target zone's order) leaves
-        # [browser (disabled), linear-issue, skills (enabled)].
-        panels = settings_page.click_on_panels()
-        panels.set_panel_zone("skills", "bottom-right")
-        panels.set_panel_zone("actions", "bottom-right")
-        panels.set_panel_zone("skills", "top-right")
-
-        # Open the Linear panel so it is the active top-right panel.
-        task_page.get_workspace_tabs().first.click()
-        ensure_right_area_visible(page)
-        zones.activate_plugin_panel("linear-issue")
-        expect(zones.get_top_right_zone()).to_be_visible()
-        # The disabled Browser panel must not be showing while Linear is active.
-        expect(browser_panel).not_to_be_visible()
+        _open_linear_with_disabled_browser_ahead(page, task_page, zones)
 
         # Turn the plugin off while its panel is the active one.
         settings_page = navigate_to_settings_page(page=page)
@@ -86,5 +93,37 @@ def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
         # Back in the workspace, the zone must fall back to the enabled Skills
         # panel — never the disabled Browser panel.
         task_page.get_workspace_tabs().first.click()
-        expect(browser_panel).not_to_be_visible()
-        expect(skills_panel).to_be_visible()
+        expect(task_page.get_browser_panel_root()).not_to_be_visible()
+        expect(task_page.get_skills_panel()).to_be_visible()
+
+
+@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
+@user_story("to keep a disabled panel hidden after I toggle a plugin off and back on")
+def test_toggling_plugin_off_then_on_does_not_open_a_disabled_panel(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+) -> None:
+    """Disabling and then re-enabling a plugin (both from the settings page)
+    must not leave a disabled panel (e.g. Browser) rendered in the zone where
+    the plugin panel had been active."""
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        page = instance.page
+
+        task_page = start_task_and_wait_for_ready(page, prompt="panel persistence", workspace_name="Panels WS")
+        zones = PlaywrightPanelZonesElement(page)
+        _open_linear_with_disabled_browser_ahead(page, task_page, zones)
+
+        # Toggle the plugin off and then back on, both within the settings page.
+        settings_page = navigate_to_settings_page(page=page)
+        plugins = settings_page.click_on_plugins()
+        plugins.set_enabled(LINEAR_SOURCE, enabled=False)
+        plugins.expect_disabled(LINEAR_SOURCE)
+        plugins.set_enabled(LINEAR_SOURCE, enabled=True)
+        plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
+
+        # Back in the workspace, the disabled Browser panel must not be showing;
+        # the zone shows the enabled Skills panel and the re-loaded Linear panel
+        # is available again in the sidebar.
+        task_page.get_workspace_tabs().first.click()
+        expect(task_page.get_browser_panel_root()).not_to_be_visible()
+        expect(task_page.get_skills_panel()).to_be_visible()
+        expect(zones.get_plugin_panel_icon("linear-issue")).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
+++ b/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
@@ -1,0 +1,91 @@
+"""Integration test for panel open-state after a plugin panel is unloaded.
+
+When a plugin contributes a panel and that panel is the *active* one in its
+zone, unloading the plugin (turning it off) must fall back to an **enabled**
+sibling panel — never to a panel the user has disabled.
+
+The reproducer mirrors a real user setup: the bundled Linear plugin docks its
+panel in the top-right zone (alongside the built-in, disabled-by-default
+Browser panel). If the disabled Browser panel happens to sit ahead of the
+remaining enabled panels in that zone's order, unloading the active Linear
+panel used to select Browser as the fallback and actually render it — even
+though the user never enabled it. This drives that exact arrangement through
+the UI and asserts the fallback lands on an enabled panel instead.
+"""
+
+from pathlib import Path
+
+from playwright.sync_api import expect
+
+from sculptor.constants import ElementIDs
+from sculptor.services.user_config.user_config import load_config
+from sculptor.services.user_config.user_config import save_config
+from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
+from sculptor.testing.elements.panels import ensure_right_area_visible
+from sculptor.testing.playwright_utils import navigate_to_settings_page
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.resources import _default_sculptor_folder_populator
+from sculptor.testing.resources import custom_sculptor_folder_populator
+from sculptor.testing.sculptor_instance import SculptorInstanceFactory
+from sculptor.testing.user_stories import user_story
+
+LINEAR_SOURCE = "/plugins/linear-issue"
+
+
+def _enable_frontend_plugins_populator(folder_path: Path) -> None:
+    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
+    _default_sculptor_folder_populator(folder_path)
+    config_path = folder_path / "internal" / "config.toml"
+    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
+    save_config(config, config_path)
+
+
+@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
+@user_story("to keep a disabled panel hidden when I turn off a plugin whose panel was open")
+def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+) -> None:
+    """Turning off a plugin whose panel is the active one must fall back to an
+    enabled sibling, not render a disabled panel (e.g. Browser)."""
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        page = instance.page
+
+        task_page = start_task_and_wait_for_ready(page, prompt="panel persistence", workspace_name="Panels WS")
+        zones = PlaywrightPanelZonesElement(page)
+        browser_panel = page.get_by_test_id(ElementIDs.BROWSER_PANEL)
+        skills_panel = page.get_by_test_id(ElementIDs.SKILLS_PANEL)
+
+        # The bundled Linear plugin auto-loads and docks a panel in top-right.
+        settings_page = navigate_to_settings_page(page=page)
+        plugins = settings_page.click_on_plugins()
+        plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
+
+        # Arrange the top-right order so the disabled Browser panel sits *before*
+        # the remaining enabled panel. The default order is
+        # [actions, skills, browser]; moving the two enabled built-ins out and
+        # one back (each move appends to the target zone's order) leaves
+        # [browser (disabled), linear-issue, skills (enabled)].
+        panels = settings_page.click_on_panels()
+        panels.set_panel_zone("skills", "bottom-right")
+        panels.set_panel_zone("actions", "bottom-right")
+        panels.set_panel_zone("skills", "top-right")
+
+        # Open the Linear panel so it is the active top-right panel.
+        task_page.get_workspace_tabs().first.click()
+        ensure_right_area_visible(page)
+        zones.activate_plugin_panel("linear-issue")
+        expect(zones.get_top_right_zone()).to_be_visible()
+        # The disabled Browser panel must not be showing while Linear is active.
+        expect(browser_panel).not_to_be_visible()
+
+        # Turn the plugin off while its panel is the active one.
+        settings_page = navigate_to_settings_page(page=page)
+        plugins = settings_page.click_on_plugins()
+        plugins.set_enabled(LINEAR_SOURCE, enabled=False)
+        plugins.expect_disabled(LINEAR_SOURCE)
+
+        # Back in the workspace, the zone must fall back to the enabled Skills
+        # panel — never the disabled Browser panel.
+        task_page.get_workspace_tabs().first.click()
+        expect(browser_panel).not_to_be_visible()
+        expect(skills_panel).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
+++ b/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
 from sculptor.services.user_config.user_config import load_config
 from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
@@ -52,8 +51,8 @@ def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
 
         task_page = start_task_and_wait_for_ready(page, prompt="panel persistence", workspace_name="Panels WS")
         zones = PlaywrightPanelZonesElement(page)
-        browser_panel = page.get_by_test_id(ElementIDs.BROWSER_PANEL)
-        skills_panel = page.get_by_test_id(ElementIDs.SKILLS_PANEL)
+        browser_panel = task_page.get_browser_panel_root()
+        skills_panel = task_page.get_skills_panel()
 
         # The bundled Linear plugin auto-loads and docks a panel in top-right.
         settings_page = navigate_to_settings_page(page=page)


### PR DESCRIPTION
## What
When a plugin that contributes a panel is turned off (or reloaded) while its panel is the **active** one in a zone, the zone's active-panel fallback could select a **disabled** sibling panel and render it. In practice, turning off the Linear plugin showed the disabled-by-default Browser panel where the Linear panel had been.

## Root cause
`PanelRegistryProvider`'s reconciliation picked the new active panel as the first entry in the zone's order, ignoring enabled state. `activePanelInZoneAtom` then rendered whatever the active id pointed at — also without checking enabled state.

## Fix
- The reconciliation fallback now selects the first **enabled** remaining panel in the zone, and clears the active panel when none remain enabled (so the zone hides, as before).
- `activePanelInZoneAtom` never resolves to a disabled panel — defense in depth that also heals layout state already persisted in the broken shape.

## Testing
- New Playwright e2e (`test_panel_open_state_after_plugin_unload.py`): orders the disabled Browser panel ahead of an enabled panel, opens the Linear panel, turns the plugin off, and asserts the zone falls back to the enabled Skills panel. Fails before the fix, passes after.
- Unit tests for the reconciliation fallback (skip disabled, clear when all disabled) and the `activePanelInZoneAtom` guard.
- `just format`, `just check` (lint + types + ratchets), and the frontend unit suite pass.

## Before / After
Top-right zone after turning the Linear plugin off (its panel had been active):
- **Before:** the disabled Browser panel renders ("Browser panel requires the desktop app").
- **After:** the zone falls back to the enabled Skills panel.

Screenshots are attached to the linked ticket.

Linear: [SCU-1585](https://linear.app/imbue/issue/SCU-1585/disabled-panel-renders-after-unloading-a-plugins-panel)

(Sent by Claude)
