### PR TITLE
[SCU-1591] Eliminate deprecation & hidden warnings from build/check/test commands

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -25,3 +25,14 @@ search_path = [
 ]
 
 python_version = "3.11"
+
+# Colocated unit tests (`*_test.py`) deliberately assert on literal runtime state
+# (e.g. `assert agent._is_in_plan_mode is False`). Pyrefly over-narrows such an
+# attribute to a literal type after an earlier assignment and then flags the
+# assertion as an "always true/false" comparison — a false positive, since it
+# cannot see the mutation that happens through the method call under test.
+# Disable only that check for test files; it stays active for production code.
+[[sub_config]]
+matches = "**/*_test.py"
+[sub_config.errors]
+unnecessary-comparison = false

--- a/sculptor/frontend/src/styles/_scrollbar.scss
+++ b/sculptor/frontend/src/styles/_scrollbar.scss
@@ -18,7 +18,7 @@
 // changes — the track width stays constant.
 
 @mixin thin-scrollbar($direction: vertical, $size: null, $autohide: true) {
-  $resolved-size: if($size, $size, var(--scrollbar-size));
+  $resolved-size: $size or var(--scrollbar-size);
 
   @if $direction == vertical {
     &::-webkit-scrollbar {
@@ -38,7 +38,11 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: if($autohide, transparent, var(--scrollbar-thumb-color));
+    @if $autohide {
+      background-color: transparent;
+    } @else {
+      background-color: var(--scrollbar-thumb-color);
+    }
     border-radius: var(--scrollbar-thumb-radius);
     transition: background-color var(--duration-fast);
   }

--- a/sculptor/pyproject.toml
+++ b/sculptor/pyproject.toml
@@ -117,6 +117,10 @@ dev = [
     "syrupy",
     "tabulate>=0.9.0",
     "ty>=0.0.4",
+    "types-PyYAML",
+    "types-cachetools",
+    "types-psutil",
+    "types-requests",
     "websocket-client>=1.5.1",
 ]
 

--- a/sculptor/pytest.ini
+++ b/sculptor/pytest.ini
@@ -6,7 +6,7 @@ filterwarnings =
     ignore::DeprecationWarning:notebook.*:
     ignore::DeprecationWarning:nptyping.*:
     ignore::DeprecationWarning:starlette.*:
-    ignore:Using .httpx. with .starlette.testclient. is deprecated
+    ignore:Using .httpx. with .starlette.testclient. is deprecated:starlette.exceptions.StarletteDeprecationWarning
     ignore::DeprecationWarning:uvicorn.*:
     ignore::DeprecationWarning:websockets.*:
     ignore:.*record_property is incompatible with junit_family.*::pytest.PytestWarning

--- a/sculptor/pytest.ini
+++ b/sculptor/pytest.ini
@@ -6,6 +6,7 @@ filterwarnings =
     ignore::DeprecationWarning:notebook.*:
     ignore::DeprecationWarning:nptyping.*:
     ignore::DeprecationWarning:starlette.*:
+    ignore:Using .httpx. with .starlette.testclient. is deprecated
     ignore::DeprecationWarning:uvicorn.*:
     ignore::DeprecationWarning:websockets.*:
     ignore:.*record_property is incompatible with junit_family.*::pytest.PytestWarning

--- a/sculptor/sculptor/agents/default/claude_code_sdk/diff_tracker.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/diff_tracker.py
@@ -324,7 +324,7 @@ def create_unified_diff(
             # --no-index: compare files outside of git repo
             # --binary: handle binary files
             result = concurrency_group.run_process_to_completion(
-                command=["git", "diff", "--no-index", "--binary", str(old_dir), str(new_dir)],
+                command=["git", "diff", "--no-index", "--binary", old_dir, new_dir],
                 is_checked_after=False,
                 timeout=10.0,
             )
@@ -333,7 +333,7 @@ def create_unified_diff(
             if result.returncode not in (0, 1):
                 raise GitCommandFailure(
                     f"git diff returned unexpected code {result.returncode}: stdout={result.stdout}, stderr={result.stderr}",
-                    command=["git", "diff", "--no-index", "--binary", str(old_dir), str(new_dir)],
+                    command=["git", "diff", "--no-index", "--binary", old_dir, new_dir],
                     returncode=result.returncode,
                     stdout=result.stdout,
                     stderr=result.stderr,

--- a/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/process_manager_test.py
@@ -46,7 +46,7 @@ from sculptor.state.messages import LLMModel
 def local_environment(
     test_root_concurrency_group: ConcurrencyGroup,
 ) -> Generator[AgentExecutionEnvironment, None, None]:
-    workspace_dir = LOCAL_WORKSPACE_DIR / str(uuid4().hex)
+    workspace_dir = LOCAL_WORKSPACE_DIR / uuid4().hex
     workspace_dir.mkdir(parents=True, exist_ok=True)
     repo_dir = workspace_dir / "repo"
     repo_dir.mkdir(parents=True, exist_ok=True)

--- a/sculptor/sculptor/foundation/async_monkey_patches_test.py
+++ b/sculptor/sculptor/foundation/async_monkey_patches_test.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Any
 from typing import Callable
 from typing import Generator
-from typing import Iterator
+from typing import NoReturn
 
 import pytest
 from loguru import logger
@@ -16,7 +16,7 @@ class IncorrectErrorsLoggedDuringTesting(Exception):
 
 
 @contextmanager
-def check_logged_errors(check_func: Callable[[list[str]], None]) -> Iterator[None]:
+def check_logged_errors(check_func: Callable[[list[str]], None]) -> Generator[None, None, None]:
     """Context manager that monkey patches logger._log to accumulate error messages instead of logging them.
     Then it runs the check function on the accumulated errors."""
     # pyrefly: ignore [missing-attribute]
@@ -69,7 +69,7 @@ def at_least_check_maker(expected_errors_set: set[str]) -> Callable[[list[str]],
 
 
 @contextmanager
-def expect_at_least_logged_errors(expected_errors: set[str]) -> Iterator[None]:
+def expect_at_least_logged_errors(expected_errors: set[str]) -> Generator[None, None, None]:
     """Context manager that monkey patches logger._log to accumulate error messages instead of logging them.
     Checks that all expected errors are in the accumulated errors, in no particular order."""
     check_func = at_least_check_maker(expected_errors)
@@ -95,7 +95,7 @@ def exact_check_maker(expected_errors: list[str]) -> Callable[[list[str]], None]
 
 
 @contextmanager
-def expect_exact_logged_errors(expected_errors: list[str]) -> Iterator[None]:
+def expect_exact_logged_errors(expected_errors: list[str]) -> Generator[None, None, None]:
     """Context manager that monkey patches logger._log to accumulate error messages instead of logging them.
     Checks that all expected errors are in the accumulated errors, in the same order."""
     check_func = exact_check_maker(expected_errors)
@@ -103,10 +103,15 @@ def expect_exact_logged_errors(expected_errors: list[str]) -> Iterator[None]:
         yield
 
 
+def _raise_zero_division() -> NoReturn:
+    """Raise a ZeroDivisionError to exercise error-handling paths."""
+    raise ZeroDivisionError("division by zero")
+
+
 def test_log_exception() -> None:
     with expect_exact_logged_errors(["Test log_exception"]):
         try:
-            x = 1 / 0
+            _raise_zero_division()
         except Exception as e:
             log_exception(e, "Test log_exception")
             assert True
@@ -118,7 +123,7 @@ def test_log_exception_with_priority() -> None:
     # ensure_core_log_levels_configured auto-used in conftest
     with expect_exact_logged_errors(["Test log_exception"]):
         try:
-            x = 1 / 0
+            _raise_zero_division()
         except Exception as e:
             log_exception(e, "Test log_exception", priority=ExceptionPriority.LOW_PRIORITY)
             assert True

--- a/sculptor/sculptor/foundation/concurrency_group_test.py
+++ b/sculptor/sculptor/foundation/concurrency_group_test.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 from threading import Event
 from typing import Any
+from typing import NoReturn
 from unittest import mock
 from unittest.mock import Mock
 
@@ -27,6 +28,11 @@ LARGE_SLEEP = 1.0
 def _small_sleep_and_return_1() -> int:
     time.sleep(0.1)
     return 1
+
+
+def _raise_zero_division() -> NoReturn:
+    """Raise a ZeroDivisionError to exercise thread-failure paths."""
+    raise ZeroDivisionError("division by zero")
 
 
 def test_concurrency_group_shortly_waits_for_threads_to_finish() -> None:
@@ -95,7 +101,7 @@ def test_failed_threads_raise_when_probed(mock_log_exception: mock.MagicMock) ->
     i = 0
     with pytest.raises(ConcurrencyExceptionGroup) as exception_info:
         with ConcurrencyGroup(name="outer") as cg:
-            thread = cg.start_new_thread(target=lambda: 1 / 0)
+            thread = cg.start_new_thread(target=_raise_zero_division)
             cg.raise_if_any_strands_or_ancestors_failed_or_is_shutting_down()
             i += 1
     assert exception_info.value.only_exception_is_instance_of(ZeroDivisionError)
@@ -110,7 +116,7 @@ def test_failed_threads_raise_when_exiting(mock_log_exception: mock.MagicMock) -
     i = 0
     with pytest.raises(ConcurrencyExceptionGroup) as exception_info:
         with ConcurrencyGroup(name="outer") as cg:
-            thread = cg.start_new_thread(target=lambda: 1 / 0)
+            thread = cg.start_new_thread(target=_raise_zero_division)
             i += 1
     assert exception_info.value.only_exception_is_instance_of(ZeroDivisionError)
     assert i == 1
@@ -120,7 +126,7 @@ def test_failed_threads_raise_when_exiting(mock_log_exception: mock.MagicMock) -
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 def test_failed_threads_do_not_raise_when_suppressed(mock_log_exception: mock.MagicMock) -> None:
     with ConcurrencyGroup(name="outer") as cg:
-        thread = cg.start_new_thread(target=lambda: 1 / 0, suppressed_exceptions=(ZeroDivisionError,))
+        thread = cg.start_new_thread(target=_raise_zero_division, suppressed_exceptions=(ZeroDivisionError,))
         cg.raise_if_any_strands_or_ancestors_failed_or_is_shutting_down()
 
 
@@ -128,7 +134,7 @@ def test_failed_threads_do_not_raise_when_suppressed(mock_log_exception: mock.Ma
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 def test_failed_threads_do_not_raise_when_explicitly_unchecked(mock_log_exception: mock.MagicMock) -> None:
     with ConcurrencyGroup(name="outer") as cg:
-        thread = cg.start_new_thread(target=lambda: 1 / 0, is_checked=False)
+        thread = cg.start_new_thread(target=_raise_zero_division, is_checked=False)
         cg.raise_if_any_strands_or_ancestors_failed_or_is_shutting_down()
 
 
@@ -205,7 +211,7 @@ def test_all_failure_modes_get_combined(tmp_path: Path) -> None:
             process2 = cg.run_process_in_background(["bash", "-c", "exit 1"], is_checked_by_group=True)
             # Avoid explicitly calling wait() on process2 to test that the probing in the exit works.
             time.sleep(SMALL_SLEEP)
-            i = 1 / 0
+            _raise_zero_division()
     assert len(exception_info.value.exceptions) == 3
     assert any(isinstance(e, ProcessError) for e in exception_info.value.exceptions)
     assert any(isinstance(e, ZeroDivisionError) for e in exception_info.value.exceptions)
@@ -269,7 +275,7 @@ def test_nesting_across_threads_raises_timeout_when_child_group_does_not_finish_
 
 def _create_nested_failing_concurrency_group(concurrency_group: ConcurrencyGroup, thread_started_event: Event) -> None:
     with concurrency_group.make_concurrency_group(name="inner") as cg:
-        cg.start_new_thread(target=lambda: 1 / 0)
+        cg.start_new_thread(target=_raise_zero_division)
         thread_started_event.set()
 
 
@@ -453,7 +459,7 @@ def test_new_resources_cannot_be_created_when_ancestor_has_failed_strands(mock_l
         with ConcurrencyGroup(name="outer") as cg_outer:
             with pytest.raises(ConcurrencyExceptionGroup) as exception_info_inner:
                 with cg_outer.make_concurrency_group(name="inner") as cg_inner:
-                    outer_failed_thread = cg_outer.start_new_thread(target=lambda: 1 / 0)
+                    outer_failed_thread = cg_outer.start_new_thread(target=_raise_zero_division)
                     with pytest.raises(ZeroDivisionError):
                         outer_failed_thread.join()
                     with pytest.raises(ConcurrencyExceptionGroup):

--- a/sculptor/sculptor/foundation/fixed_traceback.py
+++ b/sculptor/sculptor/foundation/fixed_traceback.py
@@ -35,4 +35,4 @@ class FixedTraceback(Traceback):
 
     @classmethod
     def from_dict(cls, dct: dict[str, Any]) -> Self:
-        return cast(cls, super().from_dict(dct))
+        return super().from_dict(dct)

--- a/sculptor/sculptor/foundation/nested_evolver.py
+++ b/sculptor/sculptor/foundation/nested_evolver.py
@@ -162,7 +162,7 @@ class _Evolver(Generic[_T]):
                 name: chill(child) for name, child in self._value.child_evolver_by_name.items()
             }
             assert attr.has(self._value.attr_value.__class__)
-            return cast(_T, attr.evolve(cast(Any, cast(_AttrValue, self._value).attr_value), **new_children))
+            return cast(_T, attr.evolve(cast(Any, self._value.attr_value), **new_children))
         elif isinstance(self._value, _PydanticModelValue):
             return cast(
                 _T,

--- a/sculptor/sculptor/foundation/processes/local_process_kill_now_test.py
+++ b/sculptor/sculptor/foundation/processes/local_process_kill_now_test.py
@@ -11,7 +11,6 @@ depends on real signals and process-group semantics.
 import os
 import shlex
 import signal
-import tempfile
 import time
 from pathlib import Path
 from queue import Queue
@@ -49,7 +48,7 @@ def _wait_until_dead(pid: int, timeout: float = 5.0) -> bool:
     return False
 
 
-def test_kill_now_escalates_sigterm_then_sigkill_across_the_process_group() -> None:
+def test_kill_now_escalates_sigterm_then_sigkill_across_the_process_group(tmp_path: Path) -> None:
     """A SIGTERM-ignoring process group survives ``kill_now(SIGTERM)`` but is
     fully reaped — leader AND a SIGTERM-ignoring descendant — by
     ``kill_now(SIGKILL)``.
@@ -58,8 +57,8 @@ def test_kill_now_escalates_sigterm_then_sigkill_across_the_process_group() -> N
     trap SIGTERM, so Stop must escalate to SIGKILL on the whole group, issued
     directly (``killpg``) rather than via the worker thread's shutdown path.
     """
-    leader_pid_path = Path(tempfile.mktemp(prefix="scu1340_leader_", suffix=".pid"))
-    child_pid_path = Path(tempfile.mktemp(prefix="scu1340_child_", suffix=".pid"))
+    leader_pid_path = tmp_path / "scu1340_leader.pid"
+    child_pid_path = tmp_path / "scu1340_child.pid"
     leader_pid: int | None = None
     child_pid: int | None = None
     try:

--- a/sculptor/sculptor/services/btw_service/api_test.py
+++ b/sculptor/sculptor/services/btw_service/api_test.py
@@ -50,7 +50,7 @@ from sculptor.web.data_types import StreamingUpdateSourceTypes
 def local_environment(
     test_root_concurrency_group: ConcurrencyGroup,
 ) -> Generator[AgentExecutionEnvironment, None, None]:
-    workspace_dir = LOCAL_WORKSPACE_DIR / str(uuid4().hex)
+    workspace_dir = LOCAL_WORKSPACE_DIR / uuid4().hex
     workspace_dir.mkdir(parents=True, exist_ok=True)
     repo_dir = workspace_dir / "repo"
     repo_dir.mkdir(parents=True, exist_ok=True)

--- a/sculptor/sculptor/services/data_model_service/sql_implementation.py
+++ b/sculptor/sculptor/services/data_model_service/sql_implementation.py
@@ -20,6 +20,7 @@ from typing import ParamSpec
 from typing import TypeVar
 
 import sqlalchemy
+import sqlalchemy.exc
 from filelock import BaseFileLock
 from filelock import Timeout
 from filelock import UnixFileLock

--- a/sculptor/sculptor/services/dependency_management_service.py
+++ b/sculptor/sculptor/services/dependency_management_service.py
@@ -434,8 +434,6 @@ class DependencyManagementService(Service):
                 return self._resolve_git_path()
             case Dependency.PI:
                 return self._resolve_pi_path()
-            case Dependency():
-                raise ValueError(f"Unhandled dependency: {tool}")
             case _ as unreachable:
                 assert_never(unreachable)
 
@@ -476,8 +474,6 @@ class DependencyManagementService(Service):
                     logger.info("Invalid custom Claude binary path: {!r}, ignoring", custom_value)
                     return None
                 return shutil.which(custom_value)
-            case BinaryMode():
-                raise ValueError(f"Unhandled claude binary mode: {mode}")
             case _ as unreachable:
                 assert_never(unreachable)
 

--- a/sculptor/sculptor/services/workspace_service/api.py
+++ b/sculptor/sculptor/services/workspace_service/api.py
@@ -2,7 +2,7 @@ from abc import ABC
 from abc import abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Generator
 from typing import Literal
 
 from sculptor.database.models import Project
@@ -222,7 +222,7 @@ class WorkspaceService(Service, ABC):
         concurrency_group: ConcurrencyGroup,
         root_progress_handle: RootProgressHandle,
         shutdown_event: ReadOnlyEvent,
-    ) -> Iterator[AgentExecutionEnvironment]:
+    ) -> Generator[AgentExecutionEnvironment, None, None]:
         """
         Set up the environment for a workspace.
 

--- a/sculptor/sculptor/services/workspace_service/default_implementation.py
+++ b/sculptor/sculptor/services/workspace_service/default_implementation.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Generator
 from typing import Self
 from typing import cast
 
@@ -560,7 +560,7 @@ class DefaultWorkspaceService(WorkspaceService):
     # Environment Lifecycle
 
     @contextmanager
-    def _environment_setup_lock(self, workspace_id: WorkspaceID) -> Iterator[None]:
+    def _environment_setup_lock(self, workspace_id: WorkspaceID) -> Generator[None, None, None]:
         """Per-workspace lock for environment setup.
 
         This prevents two tasks in the same workspace from racing to create
@@ -683,7 +683,7 @@ class DefaultWorkspaceService(WorkspaceService):
         concurrency_group: ConcurrencyGroup,
         root_progress_handle: RootProgressHandle,
         shutdown_event: ReadOnlyEvent,
-    ) -> Iterator[AgentExecutionEnvironment]:
+    ) -> Generator[AgentExecutionEnvironment, None, None]:
         """Set up the environment for a workspace and wrap it for agent use."""
         environment = self._create_or_resume_environment(
             project=project,

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_environment.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_environment.py
@@ -355,7 +355,7 @@ class LocalEnvironment(Environment):
         process = run_background(
             command,
             cwd=workdir,
-            env={k: str(v) for k, v in env.items() if v is not None},
+            env={k: v for k, v in env.items() if v is not None},
             is_checked=is_checked,
             timeout=timeout,
             shutdown_event=shutdown_event,
@@ -382,7 +382,7 @@ class LocalEnvironment(Environment):
         else:
             merged = {**self._project_env_vars, **os.environ}
         merged.pop("CLAUDECODE", None)
-        env = {k: str(v) for k, v in merged.items() if v is not None}
+        env = {k: v for k, v in merged.items() if v is not None}
         logger.info("Starting setup subprocess in workspace: {}", self.workspace_path)
         process = subprocess.Popen(
             ["bash", "-l", "-c", command],

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_environment_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_environment_test.py
@@ -24,7 +24,7 @@ from sculptor.testing.local_git_repo import LocalGitRepo
 
 @pytest.fixture
 def local_environment(test_root_concurrency_group: ConcurrencyGroup) -> Generator[LocalEnvironment, None, None]:
-    workspace_dir = LOCAL_WORKSPACE_DIR / str(uuid4().hex)
+    workspace_dir = LOCAL_WORKSPACE_DIR / uuid4().hex
     workspace_dir.mkdir(parents=True, exist_ok=True)
     # Create a repo directory to simulate the user's repo
     repo_dir = workspace_dir / "repo"

--- a/sculptor/sculptor/tasks/handlers/run_agent/conftest.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/conftest.py
@@ -70,7 +70,7 @@ def environment(
     """
     code_dir, _ = initial_commit_repo
     # Create workspace directory for state/artifacts
-    workspace_dir = LOCAL_WORKSPACE_DIR / str(uuid4().hex)
+    workspace_dir = LOCAL_WORKSPACE_DIR / uuid4().hex
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
     environment = LocalEnvironment.create(

--- a/sculptor/sculptor/tasks/handlers/run_agent/setup.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/setup.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 from queue import Queue
 from threading import Thread
 from typing import Generator
-from typing import Iterator
 from typing import cast
 
 from loguru import logger
@@ -100,7 +99,7 @@ def title_prediction_context(
     settings: SculptorSettings,
     concurrency_group: ConcurrencyGroup,
     root_progress_handle: RootProgressHandle,
-) -> Iterator[tuple[list[TaskTitle], Thread | None]]:
+) -> Generator[tuple[list[TaskTitle], Thread | None], None, None]:
     """Start title prediction thread if needed."""
     title_result: list[TaskTitle] = []
     title_thread = None

--- a/sculptor/sculptor/tasks/handlers/run_terminal_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_terminal_agent/v1_test.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from typing import Generator
-from typing import Iterator
 from typing import cast
 from unittest.mock import patch
 from uuid import uuid4
@@ -92,7 +91,7 @@ def environment(
     test_root_concurrency_group: ConcurrencyGroup,
 ) -> Generator[LocalEnvironment, None, None]:
     code_dir, _ = initial_commit_repo
-    workspace_dir = LOCAL_WORKSPACE_DIR / str(uuid4().hex)
+    workspace_dir = LOCAL_WORKSPACE_DIR / uuid4().hex
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
     environment = LocalEnvironment.create(
@@ -200,7 +199,7 @@ def test_outer_handler_emits_acquired_and_released_messages(
     )
 
     @contextmanager
-    def fake_environment_context(self: DefaultWorkspaceService, **kwargs: Any) -> Iterator[Any]:
+    def fake_environment_context(self: DefaultWorkspaceService, **kwargs: Any) -> Generator[Any, None, None]:
         yield agent_env
 
     def fake_inner(**kwargs: Any) -> None:

--- a/sculptor/sculptor/utils/build_test.py
+++ b/sculptor/sculptor/utils/build_test.py
@@ -69,7 +69,7 @@ def test_get_sculpt_bin_dir_warns_loudly_when_target_missing(tmp_path: Path) -> 
     finally:
         logger.remove(handler_id)
 
-    assert any("sculpt" in str(message).lower() for message in warnings), (
+    assert any("sculpt" in message.lower() for message in warnings), (
         "must log a loud warning when the sculpt target is missing"
     )
 

--- a/sculptor/sculptor/utils/logs.py
+++ b/sculptor/sculptor/utils/logs.py
@@ -198,9 +198,12 @@ def _patch_log_context_in_place(
     record: "loguru.Record", format_task_id: Callable[[str], str] = format_task_id
 ) -> None:
     record["extra"]["full_location"] = fix_full_location(record)
-    task_id: str | None = record["extra"].get("task_id", None)
+    # `record["extra"]` is untyped, and these values are typed-ID objects (e.g. TaskID),
+    # not `str` — so the `str()` coercions below are load-bearing. The locals are left
+    # unannotated rather than mis-annotated as `str | None`.
+    task_id = record["extra"].get("task_id", None)
     if task_id is None:
-        request_id: str | None = record["extra"].get("request_id", "")
+        request_id = record["extra"].get("request_id", "")
         formatted_context = str(request_id) if request_id else ""
         record["extra"]["formatted_context"] = f" [{formatted_context}]"
     else:

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -25,6 +25,7 @@ from typing import TypeVar
 from uuid import uuid4
 
 import anyio
+import anyio.to_thread
 import psutil
 import typeid.errors
 from fastapi import Depends
@@ -2632,7 +2633,7 @@ def await_message_response(
     message_id: AgentMessageID,
     task_id: TaskID,
     services: CompleteServiceCollection,
-) -> Iterator[None]:
+) -> Generator[None, None, None]:
     with services.task_service.subscribe_to_task(task_id) as updates_queue:
         yield
         logger.debug("Waiting for response to message {} in task {}", message_id, task_id)
@@ -2652,7 +2653,7 @@ def await_request_outcome(
     message_id: AgentMessageID,
     task_id: TaskID,
     services: CompleteServiceCollection,
-) -> Iterator[list[PersistentRequestCompleteAgentMessage]]:
+) -> Generator[list[PersistentRequestCompleteAgentMessage], None, None]:
     """Like `await_message_response`, but captures the terminal request message.
 
     Yields a one-element list the caller reads after the block to inspect the
@@ -2739,7 +2740,7 @@ def get_config_status(
         has_email=bool(user_config.user_email) and check_is_user_email_field_valid(user_config),
         has_privacy_consent=user_config.is_privacy_policy_consented,
         has_project=has_project,
-        has_dependencies_passing=bool(deps_passing),
+        has_dependencies_passing=deps_passing,
     )
 
 
@@ -2760,9 +2761,9 @@ def save_user_email(
         user_config,
         {
             "user_email": email_config_request.user_email,
-            "user_id": create_user_id(str(email_config_request.user_email)),
+            "user_id": create_user_id(email_config_request.user_email),
             "user_full_name": email_config_request.full_name,
-            "organization_id": create_organization_id(str(email_config_request.user_email)),
+            "organization_id": create_organization_id(email_config_request.user_email),
             # Saving user email counts as consenting to the Policy email
             "is_privacy_policy_consented": True,
             # Telemetry choice comes from the welcome-step checkbox
@@ -4006,8 +4007,8 @@ def get_health_check(request: Request) -> HealthCheckResponse:
     dependencies_status = services.dependency_management_service.get_status()
 
     return HealthCheckResponse(
-        version=str(version.__version__),
-        git_sha=str(version.__git_sha__),
+        version=version.__version__,
+        git_sha=version.__git_sha__,
         python_version=sys.version.split()[0],
         platform=platform.system(),
         platform_version=platform.release(),

--- a/sculptor/sculptor/web/typed_artifact_data_test.py
+++ b/sculptor/sculptor/web/typed_artifact_data_test.py
@@ -92,4 +92,4 @@ def test_unknown_object_type_still_raises_500(monkeypatch: pytest.MonkeyPatch) -
         with pytest.raises(HTTPException) as exc:
             _invoke(monkeypatch, raw)
     assert exc.value.status_code == 500
-    assert "SomeNewArtifact" in str(exc.value.detail)
+    assert "SomeNewArtifact" in exc.value.detail

--- a/sculptor/sculptor/web/upload_diagnostics.py
+++ b/sculptor/sculptor/web/upload_diagnostics.py
@@ -40,8 +40,8 @@ def _collect_server_diagnostics(
     free_gb = (_get_disk_bytes_free() or _ASSUMED_FREE_BYTES_WHEN_UNKNOWN) / _BYTES_PER_GIBIBYTE
 
     result: dict[str, str | float | int | None] = {
-        "version": str(version.__version__),
-        "git_sha": str(version.__git_sha__),
+        "version": version.__version__,
+        "git_sha": version.__git_sha__,
         "python_version": sys.version.split()[0],
         "platform": platform.system(),
         "platform_version": platform.release(),

--- a/uv.lock
+++ b/uv.lock
@@ -1412,6 +1412,10 @@ dev = [
     { name = "syrupy" },
     { name = "tabulate" },
     { name = "ty" },
+    { name = "types-cachetools" },
+    { name = "types-psutil" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
     { name = "websocket-client" },
 ]
 
@@ -1469,6 +1473,10 @@ dev = [
     { name = "syrupy" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "ty", specifier = ">=0.0.4" },
+    { name = "types-cachetools" },
+    { name = "types-psutil" },
+    { name = "types-pyyaml" },
+    { name = "types-requests" },
     { name = "websocket-client", specifier = ">=1.5.1" },
 ]
 
@@ -1703,6 +1711,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/59/44409a8fc06b444ab1a6f71dcb29d49a6e17e02424345eb51b051bebb345/types_awscrt-0.34.1.tar.gz", hash = "sha256:559aa04250f6a419a617dfb788f3e10903aaf74700ef23e521b64a411b83b803", size = 19062, upload-time = "2026-06-05T04:40:10.689Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/b1/214b12162b452ed6acd230065e6c587cde6b96871e3ce6d653f40888f8df/types_awscrt-0.34.1-py3-none-any.whl", hash = "sha256:20c752b6031544d8f694803c35174aee129f1be5ddf886ae46d22f7ffd9b7d75", size = 45688, upload-time = "2026-06-05T04:40:09.198Z" },
+]
+
+[[package]]
+name = "types-cachetools"
+version = "7.0.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/14/1e4fca2b250dbc75be9f0beab083acb3cd1151711e1031eb4a854dfd71be/types_cachetools-7.0.0.20260518.tar.gz", hash = "sha256:7730014e4fef0c6f01e2cd0f980f8ce6d1b1d2472c8459c1f382348ec1a6b435", size = 10072, upload-time = "2026-05-18T06:02:20.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/e0/767be6b60859fd2edc4512fabdedbce703fc8d4ec5007b31abaf37a51c6c/types_cachetools-7.0.0.20260518-py3-none-any.whl", hash = "sha256:997b356870915f8bbc9b2cdb4e7271c01d487996fdac2a9c8e91cc5b1261b3d1", size = 9500, upload-time = "2026-05-18T06:02:19.042Z" },
+]
+
+[[package]]
+name = "types-psutil"
+version = "7.2.2.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/f1/6901857281d4e8d792492e1495eef6f4f01318a3b6a066486d81000a4511/types_psutil-7.2.2.20260518.tar.gz", hash = "sha256:9f825f631463a5b4d26f19f63aebc9ec25f01140d655026f3ad8a67841f9b331", size = 26660, upload-time = "2026-05-18T06:05:09.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/eb/f726339668879819599c74c2e1f0cab760912a4159046942bdae2ad37bd6/types_psutil-7.2.2.20260518-py3-none-any.whl", hash = "sha256:6a3d697665754a60d7b5a41d5a2cff12b53f5e0676d77810cd28ba5e14cb4049", size = 32820, upload-time = "2026-05-18T06:05:08.321Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`just refresh` (the SCSS build), `just check`, and `just test-unit` emitted a number of deprecation and lint warnings — a few visible, most hidden behind pyrefly's default output. This makes all three commands run warning-free.

## Why

The warnings were latent noise: 84 SCSS deprecation warnings on every build, 64 pyrefly warning-level diagnostics suppressed by default (`0 errors (70 suppressed, 64 warnings not shown)`), and 8 third-party pytest deprecation warnings. Clearing them keeps the dev commands' output signal-only and surfaces real problems sooner.

## Changes

**SCSS build (`just refresh`)**
- Replace the deprecated Sass global `if()` in `_scrollbar.scss` with `or` (null-coalesce) and `@if`/`@else`. A single source reported once per importer → 84 warnings gone.

**pyrefly (`just check`) — 64 hidden warnings**
- Remove 22 redundant `str()`/`bool()` conversions.
- Annotate `@contextmanager` returns as `Generator[X, None, None]` instead of `Iterator[X]` (typeshed's preferred form) — 10.
- Replace deliberate `1/0` thread-failure test triggers with a named `_raise_zero_division()` helper — 9.
- Drop 2 redundant `cast()` and 2 unreachable `case` arms (the exhaustive `assert_never` stays); make 2 implicit imports explicit; switch 2 `tempfile.mktemp` uses to the `tmp_path` fixture.
- Add `types-PyYAML` / `types-psutil` / `types-requests` / `types-cachetools` dev deps for 8 `untyped-import` warnings.
- Disable pyrefly's `unnecessary-comparison` check for `*_test.py` via a scoped `[[sub_config]]` (7 false positives where it over-narrows test assertions); the check stays active for production code.

**pytest (`just test-unit`) — 8 warnings**
- Filter the third-party Starlette/httpx TestClient deprecation warning in `pytest.ini`, matching the file's existing third-party filters.

## Verification

`just format`, `just check` (pyrefly `--min-severity warn` → 0 diagnostics), `just refresh` (SCSS clean), and `just test-unit` (all suites pass, 0 warnings) all run clean.

## Note

One `str()` removal in `logs.py` initially broke task logging — the `str | None` annotation was wrong (the runtime value is a `TaskID`, which is not subscriptable). It was caught during verification; the coercion was restored and the misleading annotation dropped with an explanatory comment.

(Sent by Claude)
