### PR TITLE
Bound pi stdin writes so a stalled pi cannot wedge the control loop

### DIFF
--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -262,6 +262,21 @@ _IDLE_WAIT_SECONDS: float = 1.0
 # get_state responses before giving up (see _fetch_models_into_state).
 _MODEL_FETCH_TIMEOUT_SECONDS: float = 10.0
 
+# How long pi may produce NO stdout during a turn before a control command
+# (model switch / context reset) queued behind that turn is failed rather than
+# left to wait on it. Control commands run strictly between turns on the single
+# `_process_message_queue` loop, so a turn that never ends starves them forever —
+# a queued model switch then never completes. pi emits no heartbeat, so total
+# silence is the only wedge signal available — and a long, genuinely-quiet tool
+# (a silent build) is indistinguishable from a wedge. The window is therefore
+# generous, and the response is non-destructive: only the starved command is
+# failed (the user retries, or presses Stop to recover a truly wedged pi via the
+# abort + SIGTERM escalation); the turn and the pi process are left untouched.
+_TURN_STALL_TIMEOUT_SECONDS: float = 120.0
+# Surfaced to the user when a control command is failed because the in-flight
+# turn's pi has gone silent past `_TURN_STALL_TIMEOUT_SECONDS`.
+_STALLED_CONTROL_COMMAND_MESSAGE: str = "The agent is busy or not responding. Stop the current turn and try again."
+
 # Transient-provider-error retry policy. A turn that ends with a known-transient
 # provider failure (overloaded / rate-limit / 5xx / timeout — see
 # `is_transient_provider_error`) is re-prompted up to this many times with
@@ -547,6 +562,12 @@ class PiAgent(DefaultAgentWrapper):
     _input_agent_messages: Queue[ChatInputUserMessage | ClearContextUserMessage | SetModelUserMessage] = PrivateAttr(
         default_factory=Queue
     )
+    # Set whenever a control command (model switch / context reset) is enqueued,
+    # so the turn pump knows to check for one starving behind a stalled turn
+    # (see `_consume_until_turn_end`). A coarse signal — it gates the queue scan
+    # so a turn with nothing waiting never pays for it; it is not kept exactly in
+    # sync with the queue.
+    _control_command_enqueued: Event = PrivateAttr(default_factory=Event)
     _shutdown_event: Event = PrivateAttr(default_factory=Event)
     _message_processing_thread: ObservableThread | None = PrivateAttr(default=None)
     # The pi session id this process resumes / creates (pinned via --session-id);
@@ -742,11 +763,13 @@ class PiAgent(DefaultAgentWrapper):
             # Enqueued on the same FIFO as chat turns so the reset runs strictly
             # between turns (see _handle_clear_context); supports_context_reset.
             self._input_agent_messages.put(message)
+            self._control_command_enqueued.set()
             return True
         if isinstance(message, SetModelUserMessage):
             # Enqueued on the same FIFO as chat turns so the switch runs strictly
             # between turns (see _handle_set_model); supports_model_selection.
             self._input_agent_messages.put(message)
+            self._control_command_enqueued.set()
             return True
         if isinstance(message, ResumeAgentResponseRunnerMessage):
             # The previous pi process died mid-turn: the in-flight chat message
@@ -1721,6 +1744,10 @@ class PiAgent(DefaultAgentWrapper):
         assert process is not None
         out_queue = process.get_queue()
         state = _TurnState(prompt_id=prompt_id)
+        # Wall-clock of pi's most recent stdout line. A turn that produces nothing
+        # for `_TURN_STALL_TIMEOUT_SECONDS` while a control command waits behind it
+        # is treated as stalled (see `_fail_control_commands_starved_by_stall`).
+        last_output_monotonic = time.monotonic()
 
         try:
             while not self._shutdown_event.is_set():
@@ -1729,7 +1756,16 @@ class PiAgent(DefaultAgentWrapper):
                 try:
                     line, is_stdout = out_queue.get(timeout=_STDOUT_QUEUE_POLL_SECONDS)
                 except Empty:
+                    # pi has gone quiet. If it stays silent past the stall window
+                    # while a control command is queued behind this turn, fail
+                    # that command so it does not wait on the turn forever.
+                    if (
+                        self._control_command_enqueued.is_set()
+                        and time.monotonic() - last_output_monotonic > _TURN_STALL_TIMEOUT_SECONDS
+                    ):
+                        self._fail_control_commands_starved_by_stall()
                     continue
+                last_output_monotonic = time.monotonic()
                 if not is_stdout:
                     continue
                 stripped = line.strip()
@@ -1759,6 +1795,58 @@ class PiAgent(DefaultAgentWrapper):
             # agent_end, process exit, raised error, shutdown).
             if state.compaction_open:
                 self._output_messages.put(AutoCompactingDoneAgentMessage(message_id=AgentMessageID()))
+
+    def _fail_control_commands_starved_by_stall(self) -> None:
+        """Fail control commands queued behind a turn whose pi has gone silent.
+
+        Control commands (model switch / context reset) run strictly between
+        turns, so a turn that never ends would leave them waiting forever. When the
+        in-flight turn's pi has produced no output for `_TURN_STALL_TIMEOUT_SECONDS`,
+        resolve any such queued command as a failed request the user can retry
+        rather than letting it block.
+
+        Runs on the message-processing thread — the sole consumer of
+        `_input_agent_messages` — so draining the queue races only with
+        `_push_message` puts. Chat turns drained alongside are put back to keep
+        their order. The current turn and the pi process are left untouched: a
+        genuinely wedged pi is recovered by the user pressing Stop (the abort +
+        SIGTERM escalation); a merely quiet-but-healthy turn keeps running.
+        """
+        # Clear before draining: a control command enqueued concurrently re-sets
+        # the flag, so the next poll rescans rather than missing it.
+        self._control_command_enqueued.clear()
+        requeued: list[ChatInputUserMessage | ClearContextUserMessage | SetModelUserMessage] = []
+        failed_count = 0
+        # Sole-consumer drain (mirrors DefaultAgentWrapper.pop_messages): only this
+        # thread dequeues, so a positive qsize guarantees get_nowait won't block.
+        while self._input_agent_messages.qsize() > 0:
+            message = self._input_agent_messages.get_nowait()
+            if isinstance(message, (ClearContextUserMessage, SetModelUserMessage)):
+                self._fail_stalled_control_command(message)
+                failed_count += 1
+            else:
+                requeued.append(message)
+        for message in requeued:
+            self._input_agent_messages.put(message)
+        if failed_count:
+            logger.warning(
+                "PiAgent failed {} control command(s) starved behind a turn with no pi output for over {}s",
+                failed_count,
+                _TURN_STALL_TIMEOUT_SECONDS,
+            )
+
+    def _fail_stalled_control_command(self, message: ClearContextUserMessage | SetModelUserMessage) -> None:
+        """Resolve one starved control command as a failed request.
+
+        `_handle_user_message` emits the command's RequestStarted and, on the
+        raised `AgentClientError`, its terminal RequestFailure — what the web
+        layer's `await_request_outcome` is blocked on — so the model switch /
+        context reset surfaces an actionable failure instead of hanging.
+        """
+        with self._handle_user_message(message):
+            if isinstance(message, SetModelUserMessage):
+                raise PiSetModelError(_STALLED_CONTROL_COMMAND_MESSAGE, exit_code=None, metadata=None)
+            raise PiContextResetError(_STALLED_CONTROL_COMMAND_MESSAGE, exit_code=None, metadata=None)
 
     def _handle_response_event(self, parsed: RpcResponse, state: _TurnState) -> None:
         """Process a top-level `response` envelope (correlated by `id`, RPC §5.1).

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -28,6 +28,7 @@ from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_ID_STATE_FILE
 from sculptor.agents.pi_agent.agent_wrapper import PiAgent
 from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS
 from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS
+from sculptor.agents.pi_agent.agent_wrapper import _STALLED_CONTROL_COMMAND_MESSAGE
 from sculptor.agents.pi_agent.agent_wrapper import _TurnState
 from sculptor.agents.pi_agent.agent_wrapper import _curate_models
 from sculptor.agents.pi_agent.agent_wrapper import _model_option_from_pi
@@ -1844,6 +1845,97 @@ def test_set_model_runs_after_an_in_flight_chat_turn() -> None:
         agent._shutdown_event.set()
         worker.join(timeout=5.0)
     assert order == ["turn", "set_model"]
+
+
+def _silent_alive_process() -> MagicMock:
+    """A stub process that is alive (`is_finished` False) but emits no stdout,
+    standing in for a pi whose turn has stalled."""
+    process = MagicMock()
+    process.get_queue.return_value = Queue()
+    process.is_finished.return_value = False
+    return process
+
+
+def _run_turn_until(agent: PiAgent, predicate: Callable[[], bool]) -> None:
+    """Drive `_consume_until_turn_end` on a worker thread until `predicate` holds,
+    then shut the turn pump down. A stalled turn never ends on its own, so the
+    test stops it explicitly once the behavior under test has happened."""
+    worker = threading.Thread(target=agent._consume_until_turn_end, args=("p",), daemon=True)
+    worker.start()
+    try:
+        _wait_until(predicate)
+    finally:
+        agent._shutdown_event.set()
+        worker.join(timeout=5.0)
+    assert not worker.is_alive(), "the turn pump did not stop"
+
+
+def test_stalled_turn_fails_a_starved_set_model_instead_of_hanging() -> None:
+    """A turn whose pi goes silent must not starve a queued model switch forever:
+    past the stall window the set_model is failed (and dropped) so the user gets an
+    actionable outcome. The turn and pi process are left running."""
+    agent = _make_agent()
+    agent._process = _silent_alive_process()
+    set_model = SetModelUserMessage(message_id=AgentMessageID(), provider="anthropic", model_id="claude-haiku-4-5")
+    agent._push_message(set_model)
+    with patch("sculptor.agents.pi_agent.agent_wrapper._TURN_STALL_TIMEOUT_SECONDS", 0.2):
+        # The starved set_model is drained and failed, so the input queue empties.
+        _run_turn_until(agent, lambda: agent._input_agent_messages.empty())
+    emitted = _drain(agent._output_messages)
+    failures = [
+        m for m in emitted if isinstance(m, RequestFailureAgentMessage) and m.request_id == set_model.message_id
+    ]
+    assert len(failures) == 1
+    assert _STALLED_CONTROL_COMMAND_MESSAGE in str(failures[0].error.args[0])
+
+
+def test_stalled_turn_fails_a_starved_clear_context() -> None:
+    """The same stall guard covers a queued context reset, not just model switch."""
+    agent = _make_agent()
+    agent._process = _silent_alive_process()
+    clear = ClearContextUserMessage()
+    agent._push_message(clear)
+    with patch("sculptor.agents.pi_agent.agent_wrapper._TURN_STALL_TIMEOUT_SECONDS", 0.2):
+        _run_turn_until(agent, lambda: agent._input_agent_messages.empty())
+    emitted = _drain(agent._output_messages)
+    assert any(isinstance(m, RequestFailureAgentMessage) and m.request_id == clear.message_id for m in emitted)
+
+
+def test_stall_failure_preserves_a_queued_chat_turn() -> None:
+    """Failing a starved control command must not drop a chat turn queued alongside
+    it: the chat is put back to be processed once the turn ends."""
+    agent = _make_agent()
+    agent._process = _silent_alive_process()
+    chat = ChatInputUserMessage(text="next")
+    set_model = SetModelUserMessage(message_id=AgentMessageID(), provider="anthropic", model_id="claude-haiku-4-5")
+    agent._push_message(chat)
+    agent._push_message(set_model)
+    with patch("sculptor.agents.pi_agent.agent_wrapper._TURN_STALL_TIMEOUT_SECONDS", 0.2):
+        # The set_model is failed and dropped; only the chat remains queued.
+        _run_turn_until(agent, lambda: agent._input_agent_messages.qsize() == 1)
+    remaining = [agent._input_agent_messages.get_nowait()]
+    assert remaining == [chat]
+
+
+def test_normal_turn_leaves_a_queued_set_model_for_between_turns_processing() -> None:
+    """A turn that ends normally must NOT fail a model switch queued behind it: the
+    stall guard fires only on prolonged pi silence, so the switch stays queued to
+    apply between turns as usual."""
+    agent = _make_agent()
+    agent._process = _make_process(
+        [
+            _event({"type": "agent_start"}),
+            _event(_text_delta_update("hi", "hi")),
+            _event({"type": "agent_end", "messages": [_assistant_msg("hi")], "willRetry": False}),
+        ]
+    )
+    set_model = SetModelUserMessage(message_id=AgentMessageID(), provider="anthropic", model_id="claude-haiku-4-5")
+    agent._push_message(set_model)
+    # Default stall window (minutes) far exceeds this fast turn, so it never fires.
+    agent._consume_until_turn_end("p")
+    assert agent._input_agent_messages.get_nowait() is set_model
+    emitted = _drain(agent._output_messages)
+    assert not any(isinstance(m, RequestFailureAgentMessage) and m.request_id == set_model.message_id for m in emitted)
 
 
 def _make_start_env(persisted_session_id: str | None = None) -> MagicMock:


### PR DESCRIPTION
## Summary

Fixes SCU-1594: `set_model` (and `/clear`) could hang indefinitely when the pi process stalls.

**Diagnosis correction.** The ticket framed this as an unbounded stdin write, but `RunningProcess.write_stdin` in this repo is non-blocking — it enqueues to a dedicated writer thread, and the pi agent only ever runs on it — so the write never wedges the control loop. (Thanks to the review that caught this.)

**Real cause.** A pi agent's control commands (`set_model`, `/clear`) and chat turns share one between-turns FIFO loop (`_process_message_queue`). A turn drains pi's stdout in `_consume_until_turn_end`, which has no deadline. If pi stays alive but emits nothing (a wedged turn), that loop never returns, so a queued `set_model` is never reached and the web layer's `await_request_outcome` waits on its outcome forever ("Waiting for outcome…").

## Fix

pi sends no heartbeat, so a silent turn is indistinguishable from a long but healthy quiet tool (e.g. a silent build). Killing the turn on silence would risk aborting legitimate work and desyncing Sculptor from a pi that is still running it. So the fix is **non-destructive**:

- `_consume_until_turn_end` tracks the time of pi's last stdout line.
- When the turn's pi has produced no output for `_TURN_STALL_TIMEOUT_SECONDS` (120 s, a single tunable constant) **and** a control command is queued behind it, `_fail_control_commands_starved_by_stall` resolves that command as a failed request with an actionable message ("The agent is busy or not responding. Stop the current turn and try again.").
- The turn and the pi process are **left untouched**. A genuinely wedged pi is recovered by the user pressing **Stop** (the existing abort + SIGTERM escalation); a chat turn queued alongside is put back, not dropped.

A `_control_command_enqueued` flag gates the queue scan so a turn with nothing waiting never pays for it. Healthy streaming turns reset the silence timer continuously, so a control command queued behind them still applies between turns exactly as before.

**Trade-off (intentional):** a model switch / context reset queued during a turn whose pi is genuinely silent for >120 s will fail (recoverable) rather than apply-after. Only a turn that emits nothing at all for the full window is affected, and the threshold is easy to tune.

The earlier stdin-write/lock bound from the first commit — which bounded a non-blocking call — is reverted in favor of this.

## Tests

- `test_stalled_turn_fails_a_starved_set_model_instead_of_hanging` — the headline path.
- `test_stalled_turn_fails_a_starved_clear_context` — the same guard covers context reset.
- `test_stall_failure_preserves_a_queued_chat_turn` — a chat turn queued alongside is not dropped.
- `test_normal_turn_leaves_a_queued_set_model_for_between_turns_processing` — a turn that ends normally does not trigger the guard.

## Verification

- `just format`, `just check` (ratchets / lint / typecheck) — green
- `just test-unit-backend` — green
- pi_agent suite (304 tests) — green

(Sent by Claude)
