### PR TITLE
Answer FakePi `pi --version` in the wrapper, skipping Python startup

### DIFF
--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -1256,7 +1256,14 @@ def main(argv: list[str] | None = None) -> int:
     return _run_rpc_loop(parsed.append_system_prompt, session_dir, session_id)
 
 
+# Answer `--version` in the wrapper, before exec'ing Python: `_check_pi_version`
+# allows `pi --version` only a 5s timeout, which the `python -m
+# sculptor.testing.fake_pi` interpreter + `sculptor`-import startup can blow on a
+# contended host, failing the launch. Mirror `fake_pi.main`'s `pi <version>` stderr line.
 _BINARY_WRAPPER_TEMPLATE = """#!/bin/bash
+case "$1" in
+--version|-v) echo "pi {version}" >&2; exit 0;;
+esac
 exec {python} -m sculptor.testing.fake_pi "$@"
 """
 
@@ -1264,14 +1271,20 @@ exec {python} -m sculptor.testing.fake_pi "$@"
 def install_fake_pi_binary(fake_bin_dir: Path) -> Path:
     """Install FakePi as a ``pi`` binary in ``fake_bin_dir``.
 
-    Writes a bash wrapper that execs ``python -m sculptor.testing.fake_pi``
-    with the current interpreter. Returns the absolute path to the wrapper
-    so callers can pin it into ``DependencyPaths.pi`` — pinning the absolute
-    path mirrors ``install_default_claude_stub`` and avoids PATH-ordering
-    races when subprocesses mutate PATH.
+    Writes a bash wrapper that answers ``--version`` directly and otherwise execs
+    ``python -m sculptor.testing.fake_pi`` with the current interpreter. Returns
+    the absolute path to the wrapper so callers can pin it into
+    ``DependencyPaths.pi`` — pinning the absolute path mirrors
+    ``install_default_claude_stub`` and avoids PATH-ordering races when
+    subprocesses mutate PATH.
     """
     binary_path = fake_bin_dir / "pi"
-    binary_path.write_text(_BINARY_WRAPPER_TEMPLATE.format(python=shlex.quote(sys.executable)))
+    binary_path.write_text(
+        _BINARY_WRAPPER_TEMPLATE.format(
+            python=shlex.quote(sys.executable),
+            version=PI_VERSION_RANGE.recommended_version,
+        )
+    )
     binary_path.chmod(0o755)
     return binary_path
 

--- a/sculptor/sculptor/testing/fake_pi_test.py
+++ b/sculptor/sculptor/testing/fake_pi_test.py
@@ -30,6 +30,7 @@ from sculptor.agents.pi_agent.output_processor import ParsedMessageEnd
 from sculptor.agents.pi_agent.output_processor import ParsedMessageUpdate
 from sculptor.agents.pi_agent.output_processor import RpcResponse
 from sculptor.services.dependency_management_service import PI_VERSION_RANGE
+from sculptor.testing.fake_pi import _BINARY_WRAPPER_TEMPLATE
 from sculptor.testing.fake_pi import _parse_args
 from sculptor.testing.fake_pi import install_fake_pi_binary
 
@@ -721,6 +722,35 @@ def test_install_fake_pi_binary_executes_rpc_mode_through_wrapper(tmp_path: Path
     events = _parse_jsonl(result.stdout)
     update = _first_update(events)
     assert update.assistant_message_event.get("delta") == "wrapped"
+
+
+def test_fake_pi_wrapper_answers_version_without_launching_python(tmp_path: Path) -> None:
+    """``pi --version`` is answered by the bash wrapper itself, before it execs
+    Python, so the version probe isn't starved by interpreter + import startup
+    under load (SCU-1571: ``pi --version`` cold-started past ``_check_pi_version``'s
+    5s timeout and failed the agent launch).
+
+    Proven by rendering the wrapper with a non-existent interpreter: ``--version``
+    still returns the pinned version (the wrapper fast-path), while any other
+    invocation reaches the (missing) interpreter and fails.
+    """
+    wrapper = tmp_path / "pi"
+    wrapper.write_text(
+        _BINARY_WRAPPER_TEMPLATE.format(
+            python="/nonexistent/interpreter-should-not-exist",
+            version=PI_VERSION_RANGE.recommended_version,
+        )
+    )
+    wrapper.chmod(0o755)
+
+    version = subprocess.run([str(wrapper), "--version"], capture_output=True, text=True, timeout=10.0, check=False)
+    assert version.returncode == 0
+    assert f"pi {PI_VERSION_RANGE.recommended_version}" in version.stderr
+
+    # Any non-version invocation must still reach the interpreter (here missing),
+    # so the fast-path stays scoped to the version probe only.
+    rpc = subprocess.run([str(wrapper), "--mode", "rpc"], capture_output=True, text=True, timeout=10.0, check=False)
+    assert rpc.returncode != 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Original bug

**SCU-1571** — "Flake cluster: PI capability gating visibility". Several pi tests in `test_pi_capability_gating.py` (`test_stop_button_gated_on_interruption[pi]`, `test_queued_interrupt_gated_on_interruption[pi]`, `test_pi_write_and_edit_render_completed_file_chips`, `test_fast_mode_toggle_gated[pi]`) intermittently time out on offload, waiting 15s/30s for the agent's busy chrome (status pill / thinking indicator / file chips / workspace-ready) that never appears.

## Reproduction

The flake only manifests under offload-scale CPU contention — it does **not** reproduce on an unloaded local machine (confirmed: the full file passes locally, and 4 stressed iterations of the pi busy-state tests passed 8/8). I captured a real failure trace from offload run `27994012108` (`test_stop_button_gated_on_interruption[pi]`):

- Failing action: `expect(STATUS_PILL).to_be_visible` times out at exactly **15.0s**.
- DOM at timeout: no status pill; an `ERROR_BLOCK` with badge `PiVersionMismatchError`. The page shows a red *"The agent is in an error state"* banner — the agent errored on launch instead of going busy.

## Root cause

The FakePi `pi` binary is a bash wrapper that execs `python -m sculptor.testing.fake_pi`, so `pi --version` pays full Python interpreter + `sculptor`-import startup. `PiAgent._check_pi_version` gives that subprocess only a **5.0s timeout**; under offload contention the cold start exceeds it, the process is SIGTERM'd, and the `ProcessError` is re-raised as `PiVersionMismatchError(detected_version="<unknown>")` — so the agent never launches and never goes busy. Backend traceback from the captured artifact:

```
Launching …/fake_bin/pi --version        (×2, ~5.15s apart)
ProcessError: Command failed with non-zero exit code -15   command=`…/fake_bin/pi --version`
_check_pi_version → raise PiVersionMismatchError(detected_version="<unknown>")
TIMING_LOG run_agent_in_environment pre-processing  duration_s=05.07  status=failed
```

Exit `-15` = SIGTERM; `<unknown>` (vs `<unparseable>`) is the timeout/spawn path, not a parse failure. The same run also failed `test_pi_write_and_edit_render_completed_file_chips`, `test_pi_sub_agents`, and `test_pi_session_resume` identically — so this single cause feeds multiple pi flake clusters, not just this one.

## Fix

Answer `--version`/`-v` directly in the FakePi bash wrapper, emitting the same `pi <version>`-to-stderr shape `fake_pi.main` produces, before exec'ing Python. `install_fake_pi_binary` injects `PI_VERSION_RANGE.recommended_version` so the wrapper stays in lockstep with the pin. The version probe no longer pays interpreter/import cost and can't be starved by the 5s timeout under load.

## Proof the fix works

Non-UI (test-infra) fix → failing-then-passing test. A new unit test renders the wrapper with a non-existent interpreter and asserts `--version` is still answered (the fast-path) while `--mode rpc` fails (proving the fast-path's scope).

Before the fix (red):
```
FAILED sculptor/sculptor/testing/fake_pi_test.py::test_fake_pi_wrapper_answers_version_without_launching_python
AssertionError: assert 126 == 0
  (pi: line ...: exec: /nonexistent/interpreter-should-not-exist: cannot execute: No such file or directory)
```

After the fix (green): `fake_pi_test.py` **37 passed**; `just check` and `just test-unit-backend` green.

The real flake-reduction can only be confirmed under offload load (the contention isn't locally reproducible) — this PR's offload CI exercises it.

## Review notes

_(no outstanding review notes — `/code-review-checklist` and `/crispy-comments` were run pre-push; the only finding was a comment trim, which was applied.)_

(Sent by Claude)
