### PR TITLE
Pin Node via nvm in frontend launch recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -596,6 +596,7 @@ _patch-electron-app-name label:
 [group("dev")]
 frontend:
     #!/usr/bin/env bash
+    {{ nvm_use }}
     just _patch-electron-app-name "Sculptor (from source)"
     cd "{{justfile_directory()}}/sculptor/frontend"
     env SCULPTOR_ICON_LABEL="src" \
@@ -608,6 +609,7 @@ frontend:
 frontend-container:
     #!/usr/bin/env bash
     set -euo pipefail
+    {{ nvm_use }}
     REPO_ROOT="{{justfile_directory()}}"
     IMAGE_NAME="sculptor-backend-dev"
     SCRIPT="$REPO_ROOT/container/run-backend-in-container.sh"
@@ -644,6 +646,7 @@ frontend-container:
 frontend-custom:
     #!/usr/bin/env bash
     set -euo pipefail
+    {{ nvm_use }}
     REPO_ROOT="{{justfile_directory()}}"
     PORT="${SCULPTOR_API_PORT:-5050}"
 


### PR DESCRIPTION
## Problem

`just start` could fail to launch the frontend with a Node version error even right after a clean `just install`. The three Electron launch recipes — `frontend`, `frontend-container`, and `frontend-custom` — ran `pnpm run electron:start` without first switching to the project's pinned Node version. They inherited whatever Node was active in the shell.

After the toolchain moved to Node 24, any machine whose default Node was older would launch Electron under the wrong version and crash, even though the dependencies themselves were installed correctly — `install-frontend` already applies the shared `nvm_use` pin, as do `format`, `lint`, `tsc`, and `storybook`. The launch path was the only place missing it.

## Fix

Add the `nvm_use` snippet to all three launch recipes so the run path pins the same Node version as install/build/lint. No dependency reinstall is needed; this only changes which Node the Electron process runs under.

The snippet self-brackets `set +u`/`set -u`, so it is safe under the `set -euo pipefail` already present in `frontend-container` and `frontend-custom`.

## Testing

- `just format` — OK
- `just check` — OK (includes `shellcheck` over the recipes, typecheck, lint, ratchets)
- Manually confirmed `just start` now launches the frontend under the pinned Node version.

(Sent by Claude)