### PR TITLE
Fix flaky test_alpha_scroll_task_switch by settling scroll before scroll-to-top

### DIFF
--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -192,6 +192,42 @@ def scroll_alpha_chat_to_top(page: Page) -> None:
     )
 
 
+def wait_for_alpha_scroll_idle(page: Page, stable_frames: int = 5) -> None:
+    """Wait until the alpha chat's ``scrollTop`` stops changing across frames.
+
+    After a task/agent switch the scroll position is restored asynchronously:
+    the virtualizer re-measures and re-anchors over a settle double-rAF, and
+    ``useAlphaScrollPersistence`` re-applies the saved anchor over its own
+    double-rAF *after* that.  A test that programmatically scrolls immediately
+    after switching can be clobbered by those late corrections (the source of
+    intermittent CI flakes).
+
+    This polls ``scrollTop`` once per animation frame and returns only once it
+    has held the *same* value for ``stable_frames`` consecutive frames — i.e.
+    every queued restore/settle frame has drained.  Any change resets the
+    counter, so the wait can't return mid-restoration even if a correction is
+    still pending when it starts.
+    """
+    page.wait_for_function(
+        f"""(stableFrames) => new Promise((resolve) => {{
+        const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        if (!el) {{ resolve(false); return; }}
+        let last = el.scrollTop;
+        let steady = 0;
+        let budget = 120;
+        const tick = () => {{
+            if (budget-- <= 0) {{ resolve(false); return; }}
+            const now = el.scrollTop;
+            if (now === last) {{ steady++; }} else {{ steady = 0; last = now; }}
+            if (steady >= stableFrames) {{ resolve(true); return; }}
+            requestAnimationFrame(tick);
+        }};
+        requestAnimationFrame(tick);
+    }})""",
+        arg=stable_frames,
+    )
+
+
 def scroll_alpha_chat_by(page: Page, delta: int) -> None:
     """Scroll the alpha chat by a pixel delta (negative = up, positive = down)."""
     page.evaluate(

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_task_switch.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_task_switch.py
@@ -6,6 +6,7 @@ from sculptor.constants import ElementIDs
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_alpha_scroll_position
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
+from sculptor.testing.elements.alpha_chat_view import wait_for_alpha_scroll_idle
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
@@ -41,6 +42,12 @@ def test_scroll_position_restored_on_task_switch(sculptor_instance_: SculptorIns
 
     alpha_chat_view = get_alpha_chat_view(page)
     expect(alpha_chat_view).to_be_visible()
+
+    # Switching to task A restores its saved scroll position (the bottom) over
+    # several animation frames.  Wait for that restoration to fully settle
+    # before scrolling — otherwise a late restore frame can clobber the
+    # scroll-to-top below, which is the source of the CI flake.
+    wait_for_alpha_scroll_idle(page)
 
     # Scroll to the top in task A and wait for scroll to settle
     scroll_alpha_chat_to_top(page)


### PR DESCRIPTION
## Problem

`test_scroll_position_restored_on_task_switch` intermittently times out in CI with `playwright wait_for_function: Timeout 30000ms exceeded`.

On switching to a task, its saved scroll position (here, the bottom) is restored **asynchronously**: `useAlphaScrollPersistence.restore()` re-applies the saved anchor from the inner frame of a double-`requestAnimationFrame`, after the virtualizer has settled. The test scrolls to the top *immediately* after the switch. Under CI load the React commit that fires the restore is delayed, so the late restore frame can run **after** the scroll-to-top and snap the view back to the bottom — so the test's `scrollTop < 10` wait never becomes true and times out at 30s.

The test was effectively racing the restore machinery by scrolling within milliseconds of a programmatic tab switch, which a real user never does.

## Why the deferred restore exists

The deferred re-assert in `useAlphaScrollPersistence` was added to fix `test_first_message_visible_after_agent_switch`: the saved anchor has to be re-resolved against the virtualizer's *real* item measurements once they land a frame later, otherwise the target can be left at a stale estimate-based pixel and scroll out of the rendered window. That deferral is correct and necessary there. Our flake is its dual: a programmatic scroll issued right after a switch can be clobbered by that same deferred frame.

## Fix

Test-only. Add a `wait_for_alpha_scroll_idle()` helper that polls `scrollTop` once per animation frame and returns only after it has held steady for several consecutive frames — i.e. every queued restore/settle frame has drained (any change resets the counter, so it can't return mid-restoration). The test waits for the post-switch restoration to settle before scrolling to the top.

No production scroll behavior is modified — the restore hook is untouched, so this does not regress the first-message-visible-after-switch behavior.

## Validation

- Fixed test: green 8/8 under heavy CPU stress.
- Combined run (`test_alpha_scroll_task_switch` + `test_alpha_scroll_behaviors`): **5/5 passed**, including `test_first_message_visible_after_agent_switch` — confirming the deferred-restore fix is intact.
- `just format` and `just check` clean (lint, typecheck, ratchets, file-hygiene all OK).

## Follow-up (out of scope)

The deferred re-assert guards *saving* via `isRestoringRef` but never cancels on user interaction, so a real user who scrolls within ~2–4 frames of switching tabs could also be yanked back to the restored position. Narrow, but a reasonable follow-up would be to cancel the pending re-assert on genuine user input.

(Sent by Claude)