### PR TITLE
Fix Edit-command deep-link landing on the last-open Settings page

### DIFF
--- a/sculptor/frontend/src/common/NavigateUtils.ts
+++ b/sculptor/frontend/src/common/NavigateUtils.ts
@@ -59,7 +59,7 @@ export const useImbueNavigate = (): ImbueNavigationFunctions => {
     ),
     navigateToRepoSetupCommand: useCallback(
       (projectId: string): void => {
-        navigate(`/settings?section=repositories&focusRepo=${encodeURIComponent(projectId)}`);
+        navigate(`/settings?section=REPOSITORIES&focusRepo=${encodeURIComponent(projectId)}`);
       },
       [navigate],
     ),

--- a/sculptor/frontend/src/common/state/hooks/useOpenSettings.ts
+++ b/sculptor/frontend/src/common/state/hooks/useOpenSettings.ts
@@ -5,9 +5,12 @@ import { useImbueNavigate } from "~/common/NavigateUtils.ts";
 import { ensurePseudoTabAtom } from "~/common/state/atoms/workspaces.ts";
 import { SETTINGS_TAB_ID } from "~/components/workspaceTabIds.ts";
 
+// `section` is a `SettingsSection` id from `~/pages/settings/sections.ts`.
+// `SettingsPage` matches the `?section=` query param against those ids
+// case-sensitively, so these literals MUST stay uppercase to match (SCU-1599).
 type OpenSettings = {
   (section?: string): void;
-  (section: "repositories", focusRepoId: string): void;
+  (section: "REPOSITORIES", focusRepoId: string): void;
   (section: "PANELS", focusPanelId: string): void;
 };
 
@@ -23,11 +26,11 @@ export const useOpenSettings = (): OpenSettings => {
 
   return useMemo<OpenSettings>(() => {
     function openSettings(section?: string): void;
-    function openSettings(section: "repositories", focusRepoId: string): void;
+    function openSettings(section: "REPOSITORIES", focusRepoId: string): void;
     function openSettings(section: "PANELS", focusPanelId: string): void;
     function openSettings(section?: string, focusId?: string): void {
       ensurePseudoTab(SETTINGS_TAB_ID);
-      if (focusId !== undefined && section === "repositories") {
+      if (focusId !== undefined && section === "REPOSITORIES") {
         navigateToRepoSetupCommand(focusId);
       } else if (focusId !== undefined && section === "PANELS") {
         navigateToPanelSettings(focusId);

--- a/sculptor/frontend/src/pages/workspace/components/SetupConfigPrompt.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/SetupConfigPrompt.tsx
@@ -14,9 +14,9 @@ export const SetupConfigPrompt = (): ReactElement => {
 
   const handleOpenSettings = useCallback((): void => {
     if (projectId !== null) {
-      openSettings("repositories", projectId);
+      openSettings("REPOSITORIES", projectId);
     } else {
-      openSettings("repositories");
+      openSettings("REPOSITORIES");
     }
   }, [projectId, openSettings]);
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/SetupStatusCard.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/SetupStatusCard.tsx
@@ -172,9 +172,9 @@ export const SetupStatusCard = ({ workspaceId }: SetupStatusCardProps): ReactEle
 
   const handleEdit = useCallback((): void => {
     if (project?.objectId) {
-      openSettings("repositories", project.objectId);
+      openSettings("REPOSITORIES", project.objectId);
     } else {
-      openSettings("repositories");
+      openSettings("REPOSITORIES");
     }
   }, [project?.objectId, openSettings]);
 

--- a/sculptor/tests/integration/frontend/test_workspace_setup_command.py
+++ b/sculptor/tests/integration/frontend/test_workspace_setup_command.py
@@ -159,7 +159,10 @@ def test_setup_edit_button_switches_section_when_other_page_was_last_open(
 
     # Make a non-Repositories section the last-opened one. The active section is
     # persisted, so without a real switch the Edit deep-link would simply land here.
+    # Confirm the switch landed (the Repositories textarea is gone) so a silently
+    # dropped click can't turn this into a false-negative.
     settings_page.click_on_general()
+    expect(repos.get_setup_command_input()).not_to_be_visible()
 
     start_task_and_wait_for_ready(sculptor_page=page)
 

--- a/sculptor/tests/integration/frontend/test_workspace_setup_command.py
+++ b/sculptor/tests/integration/frontend/test_workspace_setup_command.py
@@ -132,6 +132,49 @@ def test_setup_edit_button_deep_links_to_focused_textarea(sculptor_instance_: Sc
     expect(textarea).to_be_focused()
 
 
+@user_story("to land on the repositories page even when another settings page was last open")
+def test_setup_edit_button_switches_section_when_other_page_was_last_open(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Clicking the pencil edit button must switch Settings to Repositories even when a
+    *different* section was the last one open.
+
+    Regression test for SCU-1599: the "Edit command" deep-link navigated to
+    ``?section=repositories`` (lowercase), but ``SettingsPage`` matches the query
+    param against the canonical ``SettingsSection`` ids (uppercase
+    ``REPOSITORIES``). The lowercase value never matched, so the active section
+    was left untouched and Settings just showed whatever page was last opened.
+
+    The existing deep-link tests above don't catch this: they leave Repositories
+    as the last-opened section while configuring the command, so the section
+    "happens" to already be correct. Here we deliberately open General last, so
+    only an actual section switch can land the user on Repositories.
+    """
+    page = sculptor_instance_.page
+
+    settings_page = navigate_to_settings_page(page=page)
+    repos = settings_page.click_on_repositories()
+    repos.expand_repo_config()
+    repos.set_setup_command('echo "SCULPTOR_SETUP_MARKER_QUICKEDIT"')
+
+    # Make a non-Repositories section the last-opened one. The active section is
+    # persisted, so without a real switch the Edit deep-link would simply land here.
+    settings_page.click_on_general()
+
+    start_task_and_wait_for_ready(sculptor_page=page)
+
+    setup = PlaywrightSetupStatusElement(page=page)
+    expect(setup.get_card()).to_be_visible()
+    setup.get_edit_button().click()
+
+    # The deep-link must switch to Repositories: the focused repo auto-expands and
+    # focuses its setup-command textarea. With the bug the page stays on General
+    # and this textarea is never rendered.
+    textarea = repos.get_setup_command_input()
+    expect(textarea).to_be_visible()
+    expect(textarea).to_be_focused()
+
+
 @user_story("to land on the focused textarea from the configure-CTA")
 def test_setup_config_prompt_deep_links_to_focused_textarea(sculptor_instance_: SculptorInstance) -> None:
     """Clicking the SetupConfigPrompt CTA should deep-link to settings with the matching

--- a/sculptor/tests/integration/frontend/test_workspace_setup_command.py
+++ b/sculptor/tests/integration/frontend/test_workspace_setup_command.py
@@ -125,7 +125,7 @@ def test_setup_edit_button_deep_links_to_focused_textarea(sculptor_instance_: Sc
     expect(setup.get_card()).to_be_visible()
     setup.get_edit_button().click()
 
-    expect(page).to_have_url(re.compile(r".*section=repositories.*focusRepo=.*"))
+    expect(page).to_have_url(re.compile(r".*section=REPOSITORIES.*focusRepo=.*"))
 
     textarea = repos.get_setup_command_input()
     expect(textarea).to_be_visible()
@@ -192,7 +192,7 @@ def test_setup_config_prompt_deep_links_to_focused_textarea(sculptor_instance_: 
     expect(setup.get_config_prompt()).to_be_visible()
     setup.get_config_settings_link().click()
 
-    expect(page).to_have_url(re.compile(r".*section=repositories.*focusRepo=.*"))
+    expect(page).to_have_url(re.compile(r".*section=REPOSITORIES.*focusRepo=.*"))
 
     textarea = repos.get_setup_command_input()
     expect(textarea).to_be_visible()


### PR DESCRIPTION
## Original bug

[SCU-1599](https://linear.app/imbue/issue/SCU-1599) — "Edit command" opens the last Settings page instead of the setup-command page:

> On the chat intro's workspace setup row, clicking "Edit command" opens the Settings tab but not on the correct page to edit the setup command — it just shows whatever Settings page was last opened. It should deep-link to the repo's setup-command page.
>
> The "Edit command" button lives in the chat-intro setup row (`SetupStatusCard.tsx` / `AlphaChatIntro.tsx` / `SetupConfigPrompt.tsx`); the target page is the repos/setup-command section (`settings/components/ReposSection.tsx` / `RepoRow.tsx`). It should call the shared open-Settings helper (`useOpenSettings`, introduced in SCU-1581) with the target page, rather than hand-rolling navigation.

## Hypotheses considered

1. **The Edit-command buttons hand-roll navigation instead of routing through `useOpenSettings`** — **DISCARDED**. Both the pencil button in `SetupStatusCard.tsx` and the CTA in `SetupConfigPrompt.tsx` already call `useOpenSettings("repositories", projectId)`. Navigation is not hand-rolled, so the ticket's suggested remedy was already in place.
2. **The deep-link's `?section=` token doesn't match what `SettingsPage` looks for, so the section never switches** — **REPRODUCED**. `useOpenSettings` / `navigateToRepoSetupCommand` emitted `section=repositories` (lowercase), but `SettingsPage` matches the param against the canonical `SettingsSection` ids, which are uppercase (`REPOSITORIES`). The match failed and the active section was left untouched.

## For each reproduced bug

### "Edit command" lands on the last-open Settings page instead of Repositories

**Repro steps**

1. Open **Settings → Repositories**, expand the repo's **Configure** section, set a workspace setup command (e.g. `echo SCULPTOR_SETUP_MARKER`), and click away to save.
2. Still in Settings, click **General** in the sidebar — so General becomes the last-opened section (its active section is persisted).
3. Create a workspace. On the agent page, the chat-intro **Setup** row shows the setup status card with a pencil **Edit command** button.
4. Click the pencil **Edit command** button.
5. Observe: the URL becomes `…/settings?section=repositories&focusRepo=…`, but Settings displays the **General** page — not the Repositories setup-command page.

**Expected vs actual**

- Expected: clicking **Edit command** opens Settings on the **Repositories** page, with the repo auto-expanded and its setup-command textarea focused.
- Actual: Settings opens on whatever section was last viewed (General, here). The deep-link is silently ignored.

**Before**

![Before — Edit command lands on General](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1599-proof/scu1599-before.png)

The address bar reads `?section=repositories&focusRepo=…`, yet the page shows **General** (Theme / Software Updates) — the last-opened section. The Repositories setup-command field is nowhere on screen.

**Root cause**

`SettingsPage.tsx` reads `?section=` and applies it only when it is a recognized `SettingsSection` id: `Object.values(SettingsSection).includes(sectionParam)`. Those ids are uppercase (`SettingsSection.REPOSITORIES === "REPOSITORIES"`). The repo-setup deep-link, however, was produced with a lowercase literal — `navigateToRepoSetupCommand` navigated to `?section=repositories`, and `useOpenSettings` keyed its repo branch on `section === "repositories"`. Because `"repositories"` is not in the uppercase id set, `setActiveSection` was never called, so the page kept rendering the persisted last-opened section. The sibling `PANELS` deep-link already used the matching uppercase `"PANELS"` token, which is why panel deep-linking worked and repositories did not. `ReposSection`'s `focusRepo` auto-expand logic was never the problem — it just needs the Repositories section to actually render first.

**Fix**

Emit the canonical uppercase `"REPOSITORIES"` token everywhere the repo-setup deep-link is produced: the `useOpenSettings` overload signatures and its runtime `section === …` guard, the `navigateToRepoSetupCommand` URL, and the two callers (`SetupStatusCard`, `SetupConfigPrompt`). This makes the repositories path behave exactly like the already-working `PANELS` path, so `SettingsPage`'s id match succeeds and the section switches. A short comment on the `useOpenSettings` types now records that these literals must match `SettingsSection` ids case-sensitively. I aligned the producer with the canonical id (rather than making the consumer lowercase-tolerant) so there is one casing convention shared with `PANELS`, not a special case for repositories.

**Test**

- Path: `sculptor/tests/integration/frontend/test_workspace_setup_command.py::test_setup_edit_button_switches_section_when_other_page_was_last_open`
- Kind: e2e (Playwright integration test)
- Failing-test commit: `6f9a308ddc5e1269affc0b907953ea5bb988f195`
- Fix commit: `41f85e3e4956b2a806be40bfc5e63af297bfcc58`
- Test-hardening commit (self-review follow-up): `17a777efa1`

The two pre-existing deep-link tests pass even with the bug present, because they leave Repositories as the last-opened section while configuring the command — so the section "happens" to already be correct and only the URL (which is set regardless) is asserted. The new test deliberately opens **General** last, so only a real section switch can land on Repositories. Failing run (before the fix): `expect(textarea).to_be_visible()` timed out after 30s waiting for `SETTINGS_WORKSPACE_SETUP_COMMAND_INPUT` — the Repositories section never rendered. Passing run (after the fix): `1 passed in 11.92s`. The two existing deep-link tests had their URL regex updated from `section=repositories` to `section=REPOSITORIES` to match the corrected URL; both still pass (full file: `8 passed`).

**After**

![After — Edit command lands on Repositories with the textarea focused](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1599-proof/scu1599-after.png)

The same **Edit command** click now lands on the **Repositories** page (`?section=REPOSITORIES`), with the repo auto-expanded and its setup-command textarea (`echo SCULPTOR_SETUP_MARKER`) focused — the intended deep-link target.

## Review notes

_(no outstanding review notes)_ — the self-review (`/code-review-checklist`) surfaced one finding: the regression test didn't confirm the section actually left Repositories before continuing, so a silently dropped click could have made it a false-negative. That was acted on in commit `17a777efa1` (assert the Repositories textarea is gone after switching to General). All other categories were clean.

(Sent by Claude)
