### PR TITLE
[SCU-1603] Add runtime viztracer control and thread-dump for a live backend

### DIFF
--- a/docs/development/tracing.md
+++ b/docs/development/tracing.md
@@ -14,9 +14,11 @@ Add the `--trace-to=<path>` flag when starting Sculptor:
 sculptor --trace-to=/tmp/sculptor.json
 ```
 
-The path is taken literally — relative or absolute. The flag's presence is
-the only on/off control; there is no separate env var or runtime toggle.
-When the flag is absent, no tracing code runs and overhead is near zero.
+The path is taken literally — relative or absolute. This traces from the
+earliest possible point (it captures backend import time) and writes once on
+clean shutdown. To instead arm/disarm a backend that is already running, see
+"Ad-hoc tracing on a running backend" below. When neither is active, no
+tracing code runs and overhead is near zero.
 
 When Sculptor is launched via Electron, pass the flag through the standard
 arg-forwarding prefix:
@@ -28,6 +30,54 @@ sculptor-electron --sculptor=--trace-to=/tmp/sculptor.json
 Electron's main process picks up the flag from its own argv (so it can wire
 up Node-side tracing before any windows are created) and forwards it to the
 spawned Python backend.
+
+## Ad-hoc tracing on a running backend (no restart)
+
+The `--trace-to` flag traces from boot and writes once, on clean shutdown.
+When you instead need to profile a backend that is *already running* — most
+importantly a signed production build, which `py-spy`/`lldb` cannot attach to
+because of the hardened runtime — arm and disarm viztracer at runtime over
+HTTP:
+
+```sh
+sculpt trace start          # arm; prints the output path it will write to
+# ...reproduce the slow path...
+sculpt trace stop           # stop, flush the Chrome-JSON file, print its path
+sculpt trace status         # is a trace running right now?
+```
+
+This works in-process, so it needs no debugger entitlement and no signals.
+The file lands under `{LOG_PATH}/traces/trace-<timestamp>.json`
+(`~/.sculptor/internal/logs/traces/` in a normal install); open it at
+<https://ui.perfetto.dev> as usual.
+
+The underlying endpoints are `POST /api/v1/trace/start`,
+`POST /api/v1/trace/stop`, and `GET /api/v1/trace/status`. Unlike
+`/api/v1/trace/batch`, they **require the session token** (see the security
+note below); `sculpt` supplies it automatically.
+
+Two limitations of a runtime-armed trace versus a boot-time `--trace-to` run:
+
+- **Backend Python only.** The renderer and Electron main decide whether to
+  forward their events by reading `window.__SCULPTOR_TRACING__`, which is
+  injected once at page load. A trace armed after boot therefore captures the
+  backend process alone — which is exactly what you want when profiling a live
+  backend, but means no renderer/Electron lanes appear in the file.
+- **No import-time spans.** Boot and import durations already happened; the
+  capture covers only what runs between `start` and `stop`.
+
+### Just dump thread stacks
+
+When the backend merely looks *wedged* and you want an instant snapshot rather
+than a profile:
+
+```sh
+sculpt debug threads        # Python traceback for every live thread
+```
+
+This hits `GET /api/v1/debug/threads`, which renders `sys._current_frames()`.
+It is greenlet-safe (no signals, no C-stack walk — the reason the old
+`faulthandler`/`SIGUSR1` route was dropped) and effectively free.
 
 ## What you get
 
@@ -116,6 +166,23 @@ surface and the dev-only flag gating; flagged here so a future change that
 broadens the network surface (e.g. exposing the backend on a non-loopback
 address while tracing is on) knows to add per-event size limits.
 
+## Security note on the trace-control and debug endpoints
+
+`POST /api/v1/trace/start`, `POST /api/v1/trace/stop`,
+`GET /api/v1/trace/status`, and `GET /api/v1/debug/threads` are **not**
+exempt from `SessionTokenMiddleware` — they require the session token,
+because each is a more powerful primitive than the fire-and-forget
+`/trace/batch` ingest:
+
+- `start` allocates viztracer's ring buffer (hundreds of MB to ~2.5 GB) and
+  writes a file. The output path is **not** caller-supplied — it is always a
+  timestamped file under `{LOG_PATH}/traces` — specifically so the token
+  holder cannot use the trace writer as an arbitrary-file-write primitive.
+  `tracer_entries` is bounded server-side to cap the memory lever.
+- `debug/threads` exposes Python stacks (function names, file paths), the
+  same class of information a trace file contains; treat its output like a
+  code dump.
+
 ## Future augmentations
 
 Out of scope for v1, in rough priority order:
@@ -133,9 +200,14 @@ Out of scope for v1, in rough priority order:
   in SQLAlchemy sessions, etc.) make this unsafe as a default.
 - **Cross-source clock synchronization** via a handshake protocol.
 - **Live trace snapshot endpoint** (`GET`) so developers can sample a
-  running process without stopping it. v1 only writes at process exit;
-  fetching mid-run would require transcoding viztracer's native buffer to
+  running process *without* stopping it. Runtime arm/disarm (above) already
+  lets you trace a live process, but you must `stop` to get the file;
+  snapshotting mid-run would require transcoding viztracer's native buffer to
   Chrome JSON on the fly, which fights the library's internals.
+- **Renderer/Electron capture for runtime-armed traces.** A trace armed after
+  boot is backend-only because the renderer reads its on/off flag once at page
+  load; a status-poll or push would let the frontend start forwarding events
+  mid-session.
 - **Named "category" hot-path spans** for LLM, SQL, git, per-message-type
   WebSocket handlers, and FastAPI routes — we currently rely on
   viztracer's auto-captured function names.
@@ -143,7 +215,5 @@ Out of scope for v1, in rough priority order:
   follow-up will add it.
 - **Selective subprocess filtering** (e.g. trace agent processes but skip
   short-lived git utilities).
-- **Runtime start/stop control** — explicitly out of scope; lifecycle is
-  whole-process only.
 - **End-user-facing tracing UX** (badges, banners, in-app "download trace"
   affordances).

--- a/docs/development/tracing.md
+++ b/docs/development/tracing.md
@@ -37,13 +37,14 @@ The `--trace-to` flag traces from boot and writes once, on clean shutdown.
 When you instead need to profile a backend that is *already running* — most
 importantly a signed production build, which `py-spy`/`lldb` cannot attach to
 because of the hardened runtime — arm and disarm viztracer at runtime over
-HTTP:
+HTTP. These commands live under `sculpt debug` because they exist for Sculptor
+development only, not as end-user functionality:
 
 ```sh
-sculpt trace start          # arm; prints the output path it will write to
+sculpt debug trace start    # arm; prints the output path it will write to
 # ...reproduce the slow path...
-sculpt trace stop           # stop, flush the Chrome-JSON file, print its path
-sculpt trace status         # is a trace running right now?
+sculpt debug trace stop     # stop, flush the Chrome-JSON file, print its path
+sculpt debug trace status   # is a trace running right now?
 ```
 
 This works in-process, so it needs no debugger entitlement and no signals.

--- a/sculptor/sculptor/utils/tracing.py
+++ b/sculptor/sculptor/utils/tracing.py
@@ -33,6 +33,7 @@ import json
 import os
 import shutil
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
 from typing import Any
@@ -62,6 +63,14 @@ MAX_BUFFERED_EXTERNAL_EVENTS = 100_000
 # materialize anyway.
 DEFAULT_TRACER_ENTRIES = 50_000_000
 
+# Smaller default ring buffer for ad-hoc tracing armed at runtime (via the
+# trace-control HTTP endpoint / `sculpt trace start`) rather than at boot.
+# Runtime arming targets steady-state interactive work, whose event rate is
+# far below the boot peak the 50M buffer is sized for, so a fifth of the
+# entries (~500 MB) still covers a generous capture window while keeping the
+# resident footprint reasonable on a machine running a real workload.
+DEFAULT_ADHOC_TRACER_ENTRIES = 10_000_000
+
 # Required keys on every Chrome-JSON event we accept. Events missing either
 # field are dropped; the rest of the batch is still ingested. This is cheap
 # insurance against a renderer regression silently corrupting every trace
@@ -86,6 +95,21 @@ _dropped_event_count = 0
 _invalid_event_count = 0
 
 
+@dataclass(frozen=True)
+class TraceWriteResult:
+    """Outcome of a completed trace flush, returned by ``stop_and_write_trace``.
+
+    ``path`` is the file the combined Chrome-JSON trace was written to.
+    The counts are the number of backend (viztracer) and external (renderer /
+    Electron-main) events the file contains, exposed so the trace-control HTTP
+    endpoint can report how much was captured without re-reading the file.
+    """
+
+    path: Path
+    backend_event_count: int
+    external_event_count: int
+
+
 def is_tracing_enabled() -> bool:
     return _trace_to_path is not None
 
@@ -94,19 +118,39 @@ def get_trace_to_path() -> Path | None:
     return _trace_to_path
 
 
-def start_tracing(output_path: Path) -> None:
-    """Start viztracer. Idempotent — safe to call twice."""
+def get_buffered_external_event_count() -> int:
+    """Number of external (renderer / Electron-main) events currently buffered
+    and awaiting the next flush. Read under the lock so the count is consistent
+    with concurrent ``add_external_events`` writers."""
+    with _external_events_lock:
+        return len(_external_events)
+
+
+def start_tracing(output_path: Path, tracer_entries: int | None = None) -> None:
+    """Start viztracer, writing the combined trace to ``output_path`` when it is
+    later stopped. ``tracer_entries`` sizes viztracer's in-memory ring buffer;
+    ``None`` uses ``DEFAULT_TRACER_ENTRIES`` (resolved at call time so tests can
+    monkeypatch the constant).
+
+    Idempotent — a second call while a trace is already running is a no-op (it
+    does NOT change the path or buffer size). After ``stop_and_write_trace``
+    has flushed and torn down a session, calling this again arms a fresh one,
+    which is what makes the runtime arm/disarm cycle (`sculpt trace start` then
+    `stop` then `start`) work.
+    """
     global _trace_to_path, _tracer, _internal_trace_path
     if _tracer is not None:
         return
     from viztracer import VizTracer
 
+    if tracer_entries is None:
+        tracer_entries = DEFAULT_TRACER_ENTRIES
     _trace_to_path = output_path.resolve()
     tmp_dir = Path(tempfile.mkdtemp(prefix="sculptor_viztrace_"))
     _internal_trace_path = tmp_dir / "viztracer.json"
     _tracer = VizTracer(
         output_file=str(_internal_trace_path),
-        tracer_entries=DEFAULT_TRACER_ENTRIES,
+        tracer_entries=tracer_entries,
         log_func_args=False,
         log_print=False,
         minimize_memory=True,
@@ -223,19 +267,28 @@ def _flush_event_batch(batch: Sequence[dict[str, Any]], f: IO[str], is_first_bat
     f.write(payload)
 
 
-def stop_and_write_trace() -> None:
+def stop_and_write_trace() -> TraceWriteResult | None:
     """Stop viztracer, merge with buffered external events, and write the
-    combined Chrome-JSON file to the configured `--trace-to` path.
+    combined Chrome-JSON file to the configured trace path. Returns a
+    ``TraceWriteResult`` describing the written file, or ``None`` if no trace
+    was active.
 
     The output is stream-written one event at a time rather than building a
     single dict in memory, so peak memory at exit is just viztracer's parsed
     events plus one in-flight serializer call.
+
+    After a successful (or failed) flush the module's trace state is reset to
+    the disarmed state, so a subsequent ``start_tracing`` arms a fresh session.
+    This is what makes runtime arm/disarm cycling work; it also means the
+    shutdown-time caller must read ``get_trace_to_path()`` BEFORE calling this
+    (or use the returned result), since the global is cleared here.
     """
+    global _trace_to_path, _tracer, _internal_trace_path, _dropped_event_count, _invalid_event_count
     trace_to_path = _trace_to_path
     tracer = _tracer
     internal_trace_path = _internal_trace_path
     if trace_to_path is None or tracer is None or internal_trace_path is None:
-        return
+        return None
 
     try:
         tracer.stop()
@@ -276,8 +329,23 @@ def stop_and_write_trace() -> None:
             # On success, the tmp file has been renamed away and this is a
             # no-op. On failure, drop the partial `.tmp` so we don't leak it.
             tmp_path.unlink(missing_ok=True)
+        return TraceWriteResult(
+            path=trace_to_path,
+            backend_event_count=len(viztracer_events),
+            external_event_count=len(buffered),
+        )
     finally:
         # Always clean up the viztracer temp dir, even on partial-write
         # failure. The user-facing trace file at trace_to_path is intentionally
         # NOT cleaned up — that's the artifact they came here for.
         shutil.rmtree(internal_trace_path.parent, ignore_errors=True)
+        # Disarm: drop references to the stopped tracer and clear the path so
+        # the module is ready to arm a fresh session. Dropping the only
+        # reference to the VizTracer also lets it be garbage-collected; the
+        # next start_tracing builds a new instance (viztracer's global
+        # __viz_tracer__ pointer is simply overwritten).
+        _tracer = None
+        _trace_to_path = None
+        _internal_trace_path = None
+        _dropped_event_count = 0
+        _invalid_event_count = 0

--- a/sculptor/sculptor/utils/tracing_test.py
+++ b/sculptor/sculptor/utils/tracing_test.py
@@ -88,6 +88,54 @@ def test_start_tracing_is_idempotent(tmp_path: Path) -> None:
     tracing.stop_and_write_trace()
 
 
+def test_stop_returns_result_with_counts(tmp_path: Path) -> None:
+    out = tmp_path / "trace.json"
+    tracing.start_tracing(out)
+    tracing.add_external_events(
+        [
+            {"ph": "X", "name": "renderer.a", "ts": 0, "dur": 1},
+            {"ph": "X", "name": "renderer.b", "ts": 1, "dur": 1},
+        ],
+        tracing.RENDERER_PID,
+    )
+    result = tracing.stop_and_write_trace()
+    assert result is not None
+    assert result.path == out.resolve()
+    assert result.external_event_count == 2
+    # viztracer always records at least its own frames, so this is non-zero.
+    assert result.backend_event_count > 0
+
+
+def test_stop_when_disabled_returns_none() -> None:
+    assert tracing.stop_and_write_trace() is None
+
+
+def test_rearm_after_stop_starts_fresh_session(tmp_path: Path) -> None:
+    """The whole point of runtime arm/disarm: after a flush the module must be
+    ready to arm a brand-new session to a different file. Pins that
+    stop_and_write_trace resets state and that a second start builds a fresh
+    tracer rather than no-opping (which is what the idempotency guard would do
+    if the prior tracer were not cleared)."""
+    first = tmp_path / "first.json"
+    tracing.start_tracing(first)
+    first_tracer = tracing._tracer
+    assert tracing.stop_and_write_trace() is not None
+    # Disarmed and reset.
+    assert tracing.is_tracing_enabled() is False
+    assert tracing.get_trace_to_path() is None
+    assert tracing._tracer is None
+
+    second = tmp_path / "second.json"
+    tracing.start_tracing(second)
+    assert tracing.is_tracing_enabled() is True
+    assert tracing._tracer is not None
+    assert tracing._tracer is not first_tracer
+    assert tracing.get_trace_to_path() == second.resolve()
+    result = tracing.stop_and_write_trace()
+    assert result is not None and result.path == second.resolve()
+    assert first.exists() and second.exists()
+
+
 def test_temp_directory_cleaned_up_after_write(tmp_path: Path) -> None:
     out = tmp_path / "trace.json"
     tracing.start_tracing(out)

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import contextlib
+import datetime
 import json
 import logging
 import mimetypes
@@ -10,7 +11,9 @@ import queue
 import re
 import subprocess
 import sys
+import threading
 import time
+import traceback
 import urllib.parse
 from asyncio import CancelledError
 from importlib import resources
@@ -37,6 +40,7 @@ from fastapi import UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse
+from fastapi.responses import PlainTextResponse
 from fastapi.responses import StreamingResponse
 from fastapi.websockets import WebSocket
 from fastapi.websockets import WebSocketDisconnect
@@ -162,10 +166,16 @@ from sculptor.utils.build import get_sculptor_folder
 from sculptor.utils.build import is_packaged
 from sculptor.utils.errors import is_irrecoverable_exception
 from sculptor.utils.timeout import log_runtime
+from sculptor.utils.tracing import DEFAULT_ADHOC_TRACER_ENTRIES
+from sculptor.utils.tracing import DEFAULT_TRACER_ENTRIES
 from sculptor.utils.tracing import ELECTRON_MAIN_PID
 from sculptor.utils.tracing import RENDERER_PID
 from sculptor.utils.tracing import add_external_events
+from sculptor.utils.tracing import get_buffered_external_event_count
+from sculptor.utils.tracing import get_trace_to_path
 from sculptor.utils.tracing import is_tracing_enabled
+from sculptor.utils.tracing import start_tracing
+from sculptor.utils.tracing import stop_and_write_trace
 from sculptor.web.access_log_filter import should_suppress_access_log
 from sculptor.web.auth import SESSION_TOKEN_HEADER_NAME
 from sculptor.web.auth import SessionTokenMiddleware
@@ -4369,6 +4379,138 @@ def post_trace_batch(payload: TraceBatchRequest) -> None:
     if not is_tracing_enabled():
         return
     add_external_events(payload.events, _TRACE_SOURCE_TO_PID[payload.source])
+
+
+class TraceStartRequest(SerializableModel):
+    """Knobs for arming an ad-hoc backend trace at runtime.
+
+    There is intentionally no ``output_path`` field: the file is always written
+    under a fixed server-owned directory (see ``post_trace_start``). These
+    endpoints require the session token, but constraining the path keeps an
+    attacker who obtains the token from using the trace writer as an
+    arbitrary-file-write primitive."""
+
+    # None → DEFAULT_ADHOC_TRACER_ENTRIES. Bounded server-side; the ring buffer
+    # costs ~50 bytes/entry of resident memory, so an unbounded value would be
+    # an OOM lever.
+    tracer_entries: int | None = None
+
+
+class TraceStatusResponse(SerializableModel):
+    enabled: bool
+    output_path: str | None
+    buffered_external_events: int
+
+
+class TraceStopResponse(SerializableModel):
+    output_path: str
+    backend_event_count: int
+    external_event_count: int
+
+
+def _adhoc_trace_dir(settings: SculptorSettings) -> Path:
+    return Path(settings.LOG_PATH) / "traces"
+
+
+@router.post("/api/v1/trace/start")
+def post_trace_start(
+    payload: TraceStartRequest,
+    settings: SculptorSettings = Depends(get_settings),
+) -> TraceStatusResponse:
+    """Arm viztracer on the running backend, writing to a fresh timestamped
+    file under ``{LOG_PATH}/traces``. 409 if a trace is already running.
+
+    Renderer / Electron-main events are only captured if the renderer learned
+    tracing was on at boot (it reads ``window.__SCULPTOR_TRACING__`` once);
+    a trace armed at runtime therefore captures backend Python only, which is
+    the point of this endpoint — profiling a live (e.g. production) backend
+    without a restart. Requires the session token (not exempt like
+    ``/trace/batch``)."""
+    if is_tracing_enabled():
+        raise HTTPException(
+            status_code=409,
+            detail="A trace is already running. Stop it first with POST /api/v1/trace/stop.",
+        )
+
+    tracer_entries = payload.tracer_entries if payload.tracer_entries is not None else DEFAULT_ADHOC_TRACER_ENTRIES
+    if tracer_entries <= 0 or tracer_entries > DEFAULT_TRACER_ENTRIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"tracer_entries must be in 1..{DEFAULT_TRACER_ENTRIES}",
+        )
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_path = _adhoc_trace_dir(settings) / f"trace-{timestamp}.json"
+    start_tracing(output_path, tracer_entries=tracer_entries)
+    # Report the resolved path that start_tracing stored, so it matches what
+    # /trace/status and /trace/stop later report (start_tracing resolves it,
+    # e.g. /tmp -> /private/tmp on macOS).
+    resolved_path = get_trace_to_path()
+    logger.info("Ad-hoc trace armed, output -> {} (tracer_entries={})", resolved_path, tracer_entries)
+    return TraceStatusResponse(
+        enabled=True,
+        output_path=str(resolved_path),
+        buffered_external_events=get_buffered_external_event_count(),
+    )
+
+
+@router.post("/api/v1/trace/stop")
+def post_trace_stop() -> TraceStopResponse:
+    """Stop the running trace, flush the combined Chrome-JSON file to disk, and
+    return where it landed plus how much was captured. 409 if no trace is
+    running. The backend is left disarmed and ready to be armed again."""
+    if not is_tracing_enabled():
+        raise HTTPException(
+            status_code=409,
+            detail="No trace is running. Start one first with POST /api/v1/trace/start.",
+        )
+    result = stop_and_write_trace()
+    if result is None:
+        # Defensive: is_tracing_enabled() was true above, so a None here means
+        # the tracer state was torn down concurrently (e.g. process shutdown
+        # raced this request). Surface it rather than returning a bogus path.
+        raise HTTPException(status_code=409, detail="Trace was torn down before it could be written.")
+    logger.info("Ad-hoc trace written to {}", result.path)
+    return TraceStopResponse(
+        output_path=str(result.path),
+        backend_event_count=result.backend_event_count,
+        external_event_count=result.external_event_count,
+    )
+
+
+@router.get("/api/v1/trace/status")
+def get_trace_status() -> TraceStatusResponse:
+    """Report whether a trace is currently running and, if so, where it will be
+    written and how many external events are buffered so far."""
+    path = get_trace_to_path()
+    return TraceStatusResponse(
+        enabled=is_tracing_enabled(),
+        output_path=str(path) if path is not None else None,
+        buffered_external_events=get_buffered_external_event_count(),
+    )
+
+
+@router.get("/api/v1/debug/threads", response_class=PlainTextResponse)
+def get_debug_threads() -> PlainTextResponse:
+    """Dump a Python traceback for every live thread, as plain text.
+
+    Uses ``sys._current_frames()`` rather than ``faulthandler``/signals: it
+    reads Python frame objects and never walks the C stack, so it is safe with
+    greenlet (which manipulates the C stack for coroutine switching and makes
+    faulthandler's stack walk crash). A cheap, instant escape hatch for
+    inspecting a wedged backend without arming a full trace. Requires the
+    session token."""
+    lines: list[str] = []
+    lines.append(f"Thread dump at {datetime.datetime.now().isoformat()}")
+    lines.append("=" * 72)
+    lines.append("")
+    thread_names = {t.ident: t.name for t in threading.enumerate()}
+    for thread_id, frame in sys._current_frames().items():
+        name = thread_names.get(thread_id, "<unknown>")
+        lines.append(f"Thread {thread_id} ({name}):")
+        lines.extend(traceback.format_stack(frame))
+        lines.append("")
+    return PlainTextResponse("\n".join(lines))
 
 
 # Dummy routes to include WebSocket types in OpenAPI schema

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -4439,7 +4439,10 @@ def post_trace_start(
             detail=f"tracer_entries must be in 1..{DEFAULT_TRACER_ENTRIES}",
         )
 
-    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    # Microsecond precision (%f), not just seconds: a stop-then-immediate-start
+    # within the same second would otherwise reuse this path, and stop's
+    # os.replace would silently overwrite the previous session's trace.
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     output_path = _adhoc_trace_dir(settings) / f"trace-{timestamp}.json"
     start_tracing(output_path, tracer_entries=tracer_entries)
     # Report the resolved path that start_tracing stored, so it matches what
@@ -4500,17 +4503,19 @@ def get_debug_threads() -> PlainTextResponse:
     faulthandler's stack walk crash). A cheap, instant escape hatch for
     inspecting a wedged backend without arming a full trace. Requires the
     session token."""
-    lines: list[str] = []
-    lines.append(f"Thread dump at {datetime.datetime.now().isoformat()}")
-    lines.append("=" * 72)
-    lines.append("")
+    chunks: list[str] = [
+        f"Thread dump at {datetime.datetime.now().isoformat()}\n",
+        "=" * 72 + "\n\n",
+    ]
     thread_names = {t.ident: t.name for t in threading.enumerate()}
     for thread_id, frame in sys._current_frames().items():
         name = thread_names.get(thread_id, "<unknown>")
-        lines.append(f"Thread {thread_id} ({name}):")
-        lines.extend(traceback.format_stack(frame))
-        lines.append("")
-    return PlainTextResponse("\n".join(lines))
+        chunks.append(f"Thread {thread_id} ({name}):\n")
+        # traceback.format_stack returns lines that already end in "\n", so
+        # join them with "" — using "\n".join here would double every newline.
+        chunks.extend(traceback.format_stack(frame))
+        chunks.append("\n")
+    return PlainTextResponse("".join(chunks))
 
 
 # Dummy routes to include WebSocket types in OpenAPI schema

--- a/sculptor/sculptor/web/middleware.py
+++ b/sculptor/sculptor/web/middleware.py
@@ -34,7 +34,6 @@ from sculptor.services.workspace_service.legacy_cleanup import cleanup_obsolete_
 from sculptor.utils.build import get_sculptor_folder
 from sculptor.utils.migration import ensure_sculptor_folder_ready
 from sculptor.utils.shutdown import GLOBAL_SHUTDOWN_EVENT
-from sculptor.utils.tracing import get_trace_to_path
 from sculptor.utils.tracing import is_tracing_enabled
 from sculptor.utils.tracing import stop_and_write_trace
 from sculptor.web.auth import UserSession
@@ -280,11 +279,12 @@ def _write_trace_if_enabled() -> None:
     if not is_tracing_enabled():
         return
     try:
-        stop_and_write_trace()
-        logger.info(
-            "Trace written to {}. Open https://ui.perfetto.dev and drop this file there to view.",
-            get_trace_to_path(),
-        )
+        result = stop_and_write_trace()
+        if result is not None:
+            logger.info(
+                "Trace written to {}. Open https://ui.perfetto.dev and drop this file there to view.",
+                result.path,
+            )
     except Exception as e:
         logger.opt(exception=e).error("Failed to write trace file")
 

--- a/sculptor/sculptor/web/trace_endpoint_test.py
+++ b/sculptor/sculptor/web/trace_endpoint_test.py
@@ -199,6 +199,9 @@ def test_debug_threads_dumps_stacks(client: TestClient) -> None:
     # At least the thread serving this request should appear.
     assert "Thread " in body
     assert "File " in body  # traceback frames render "File ..., line ..."
+    # traceback.format_stack lines already end in "\n"; the dump must not
+    # double them up into blank lines between every frame (a "\n".join bug).
+    assert "\n\n\n" not in body
 
 
 def test_trace_file_written_on_lifespan_shutdown(

--- a/sculptor/sculptor/web/trace_endpoint_test.py
+++ b/sculptor/sculptor/web/trace_endpoint_test.py
@@ -135,6 +135,72 @@ def test_post_trace_batch_with_session_token_still_works(
     assert response.status_code == 204
 
 
+def test_trace_start_status_stop_roundtrip(client: TestClient) -> None:
+    """Arm via HTTP, confirm status reflects it, stop, and confirm the file is
+    written and the backend is left disarmed and ready to re-arm."""
+    # Responses serialize with camelCase aliases (SerializableModel).
+    start = client.post("/api/v1/trace/start", json={})
+    assert start.status_code == 200, start.text
+    output_path = Path(start.json()["outputPath"])
+    assert start.json()["enabled"] is True
+
+    status = client.get("/api/v1/trace/status")
+    assert status.status_code == 200
+    assert status.json()["enabled"] is True
+    assert status.json()["outputPath"] == str(output_path)
+
+    stop = client.post("/api/v1/trace/stop")
+    assert stop.status_code == 200, stop.text
+    assert stop.json()["outputPath"] == str(output_path)
+    assert stop.json()["backendEventCount"] > 0
+    assert output_path.exists()
+
+    after = client.get("/api/v1/trace/status")
+    assert after.json()["enabled"] is False
+    assert after.json()["outputPath"] is None
+
+
+def test_trace_start_conflicts_when_already_running(client: TestClient) -> None:
+    assert client.post("/api/v1/trace/start", json={}).status_code == 200
+    try:
+        second = client.post("/api/v1/trace/start", json={})
+        assert second.status_code == 409
+    finally:
+        client.post("/api/v1/trace/stop")
+
+
+def test_trace_stop_conflicts_when_not_running(client: TestClient) -> None:
+    assert client.post("/api/v1/trace/stop").status_code == 409
+
+
+def test_trace_start_rejects_out_of_range_tracer_entries(client: TestClient) -> None:
+    assert client.post("/api/v1/trace/start", json={"tracer_entries": 0}).status_code == 422
+    assert client.post("/api/v1/trace/start", json={"tracer_entries": 10**12}).status_code == 422
+    # The rejected starts must not have armed anything.
+    assert client.get("/api/v1/trace/status").json()["enabled"] is False
+
+
+def test_trace_control_endpoints_require_session_token(
+    client_with_session_token_required: TestClient,
+) -> None:
+    """Unlike /trace/batch, the control endpoints are NOT auth-exempt: an
+    arbitrary-file-write + multi-GB-alloc primitive must sit behind the token."""
+    assert client_with_session_token_required.post("/api/v1/trace/start", json={}).status_code == 403
+    assert client_with_session_token_required.post("/api/v1/trace/stop").status_code == 403
+    assert client_with_session_token_required.get("/api/v1/trace/status").status_code == 403
+    assert client_with_session_token_required.get("/api/v1/debug/threads").status_code == 403
+
+
+def test_debug_threads_dumps_stacks(client: TestClient) -> None:
+    response = client.get("/api/v1/debug/threads")
+    assert response.status_code == 200
+    body = response.text
+    assert "Thread dump at" in body
+    # At least the thread serving this request should appear.
+    assert "Thread " in body
+    assert "File " in body  # traceback frames render "File ..., line ..."
+
+
 def test_trace_file_written_on_lifespan_shutdown(
     test_settings: SculptorSettings,
     test_already_started_services: CompleteServiceCollection,

--- a/tools/sculpt/sculpt/commands/debug.py
+++ b/tools/sculpt/sculpt/commands/debug.py
@@ -1,11 +1,16 @@
 """Low-level diagnostics against a running Sculptor backend.
 
-    sculpt debug threads        # print a Python traceback for every thread
+**For Sculptor development only — not end-user functionality.** These commands
+exist to debug and profile the Sculptor backend itself; they are not part of
+the product surface and may change or disappear without notice.
 
-This is the lightweight alternative to a full trace when the backend looks
-wedged: it returns an instant snapshot of every thread's Python stack via
-``sys._current_frames()`` (greenlet-safe — no signals, no C-stack walk).
-Requires the session token, which ``get_authenticated_client`` resolves.
+    sculpt debug threads              # print a Python traceback for every thread
+    sculpt debug trace start|stop|status   # profile the backend (viztracer)
+
+``threads`` is the lightweight alternative to a full trace when the backend
+looks wedged: it returns an instant snapshot of every thread's Python stack via
+``sys._current_frames()`` (greenlet-safe — no signals, no C-stack walk). All
+commands require the session token, which ``get_authenticated_client`` resolves.
 """
 
 import httpx
@@ -13,10 +18,14 @@ import typer
 
 from sculpt.auth import get_authenticated_client
 from sculpt.auth import get_default_base_url
+from sculpt.commands.trace import trace_app
 from sculpt.formatting import cli_error
 from sculpt.formatting import handle_connection_error
 
-debug_app = typer.Typer(help="Low-level diagnostics for a running Sculptor backend.")
+debug_app = typer.Typer(
+    help="Diagnostics for a running Sculptor backend. For Sculptor development only — not end-user functionality."
+)
+debug_app.add_typer(trace_app, name="trace")
 
 _OUTPUT_OPTION = typer.Option(None, "--output", "-o", help="Write the dump to this file instead of stdout.")
 

--- a/tools/sculpt/sculpt/commands/debug.py
+++ b/tools/sculpt/sculpt/commands/debug.py
@@ -31,7 +31,7 @@ _OUTPUT_OPTION = typer.Option(None, "--output", "-o", help="Write the dump to th
 
 
 @debug_app.command("threads")
-def threads(output: str = _OUTPUT_OPTION) -> None:
+def threads(output: str | None = _OUTPUT_OPTION) -> None:
     """Dump a Python traceback for every live backend thread."""
     client = get_authenticated_client(get_default_base_url())
     try:

--- a/tools/sculpt/sculpt/commands/debug.py
+++ b/tools/sculpt/sculpt/commands/debug.py
@@ -1,0 +1,39 @@
+"""Low-level diagnostics against a running Sculptor backend.
+
+    sculpt debug threads        # print a Python traceback for every thread
+
+This is the lightweight alternative to a full trace when the backend looks
+wedged: it returns an instant snapshot of every thread's Python stack via
+``sys._current_frames()`` (greenlet-safe — no signals, no C-stack walk).
+Requires the session token, which ``get_authenticated_client`` resolves.
+"""
+
+import httpx
+import typer
+
+from sculpt.auth import get_authenticated_client
+from sculpt.auth import get_default_base_url
+from sculpt.formatting import cli_error
+from sculpt.formatting import handle_connection_error
+
+debug_app = typer.Typer(help="Low-level diagnostics for a running Sculptor backend.")
+
+_OUTPUT_OPTION = typer.Option(None, "--output", "-o", help="Write the dump to this file instead of stdout.")
+
+
+@debug_app.command("threads")
+def threads(output: str = _OUTPUT_OPTION) -> None:
+    """Dump a Python traceback for every live backend thread."""
+    client = get_authenticated_client(get_default_base_url())
+    try:
+        response = client.get_httpx_client().get("/api/v1/debug/threads")
+    except (httpx.ConnectError, httpx.ConnectTimeout):
+        handle_connection_error()
+    if response.status_code >= 400:
+        cli_error(f"Request failed with status {response.status_code}", detail=response.text)
+    if output is not None:
+        with open(output, "w") as f:
+            f.write(response.text)
+        typer.echo(f"Thread dump written to {output}")
+    else:
+        typer.echo(response.text)

--- a/tools/sculpt/sculpt/commands/trace.py
+++ b/tools/sculpt/sculpt/commands/trace.py
@@ -1,12 +1,14 @@
 """Arm/disarm the backend's viztracer profiler at runtime.
 
-Thin wrappers over the trace-control HTTP endpoints so a developer can profile
-a running (including a signed, production) backend without restarting it or
-passing ``--trace-to`` at launch:
+**For Sculptor development only — not end-user functionality.** Registered as a
+subgroup of ``sculpt debug`` (see ``debug.py``). Thin wrappers over the
+trace-control HTTP endpoints so a developer can profile a running (including a
+signed, production) backend without restarting it or passing ``--trace-to`` at
+launch:
 
-    sculpt trace start         # arm
+    sculpt debug trace start         # arm
     ...reproduce the slow thing...
-    sculpt trace stop          # flush the Chrome-JSON file, print its path
+    sculpt debug trace stop          # flush the Chrome-JSON file, print its path
 
 Drop the resulting file into https://ui.perfetto.dev to inspect it. Unlike the
 ``/api/v1/trace/batch`` ingest endpoint, these require the session token, which
@@ -23,7 +25,7 @@ from sculpt.auth import get_default_base_url
 from sculpt.formatting import cli_error
 from sculpt.formatting import handle_connection_error
 
-trace_app = typer.Typer(help="Profile a running Sculptor backend (viztracer).")
+trace_app = typer.Typer(help="Profile a running Sculptor backend with viztracer (Sculptor development only).")
 
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON")
 
@@ -64,7 +66,7 @@ def start(
         return
     # The backend serializes responses with camelCase aliases (SerializableModel).
     typer.echo(f"Tracing armed. Output will be written to:\n  {result['outputPath']}")
-    typer.echo("Reproduce the slow path, then run `sculpt trace stop`.")
+    typer.echo("Reproduce the slow path, then run `sculpt debug trace stop`.")
 
 
 @trace_app.command("stop")

--- a/tools/sculpt/sculpt/commands/trace.py
+++ b/tools/sculpt/sculpt/commands/trace.py
@@ -1,0 +1,93 @@
+"""Arm/disarm the backend's viztracer profiler at runtime.
+
+Thin wrappers over the trace-control HTTP endpoints so a developer can profile
+a running (including a signed, production) backend without restarting it or
+passing ``--trace-to`` at launch:
+
+    sculpt trace start         # arm
+    ...reproduce the slow thing...
+    sculpt trace stop          # flush the Chrome-JSON file, print its path
+
+Drop the resulting file into https://ui.perfetto.dev to inspect it. Unlike the
+``/api/v1/trace/batch`` ingest endpoint, these require the session token, which
+``get_authenticated_client`` resolves automatically.
+"""
+
+import json
+
+import httpx
+import typer
+
+from sculpt.auth import get_authenticated_client
+from sculpt.auth import get_default_base_url
+from sculpt.formatting import cli_error
+from sculpt.formatting import handle_connection_error
+
+trace_app = typer.Typer(help="Profile a running Sculptor backend (viztracer).")
+
+_JSON_OPTION = typer.Option(False, "--json", help="Output as JSON")
+
+
+def _request(method: str, path: str, json_output: bool, body: dict | None = None) -> dict:
+    """Make an authenticated request to a trace-control endpoint and return the
+    decoded JSON body. Exits with a friendly message on connection failure or a
+    non-2xx response (the backend sends a useful ``detail`` on 409/422)."""
+    client = get_authenticated_client(get_default_base_url())
+    try:
+        response = client.get_httpx_client().request(method, path, json=body)
+    except (httpx.ConnectError, httpx.ConnectTimeout):
+        handle_connection_error(json_output)
+    if response.status_code >= 400:
+        detail = ""
+        try:
+            detail = response.json().get("detail", "")
+        except (json.JSONDecodeError, ValueError):
+            detail = response.text
+        cli_error(f"Request failed with status {response.status_code}", detail=detail, json_output=json_output)
+    return response.json()
+
+
+@trace_app.command("start")
+def start(
+    tracer_entries: int = typer.Option(
+        None,
+        "--tracer-entries",
+        help="Ring-buffer size (entries). Larger = longer capture window, more memory. Defaults to the backend's ad-hoc default.",
+    ),
+    json_output: bool = _JSON_OPTION,
+) -> None:
+    """Arm viztracer on the running backend."""
+    body = {"tracer_entries": tracer_entries} if tracer_entries is not None else {}
+    result = _request("POST", "/api/v1/trace/start", json_output, body=body)
+    if json_output:
+        typer.echo(json.dumps(result))
+        return
+    # The backend serializes responses with camelCase aliases (SerializableModel).
+    typer.echo(f"Tracing armed. Output will be written to:\n  {result['outputPath']}")
+    typer.echo("Reproduce the slow path, then run `sculpt trace stop`.")
+
+
+@trace_app.command("stop")
+def stop(json_output: bool = _JSON_OPTION) -> None:
+    """Stop tracing and flush the combined trace file to disk."""
+    result = _request("POST", "/api/v1/trace/stop", json_output)
+    if json_output:
+        typer.echo(json.dumps(result))
+        return
+    typer.echo(f"Trace written to:\n  {result['outputPath']}")
+    typer.echo(f"  {result['backendEventCount']} backend events, {result['externalEventCount']} external events.")
+    typer.echo("Open https://ui.perfetto.dev and drop the file there to view.")
+
+
+@trace_app.command("status")
+def status(json_output: bool = _JSON_OPTION) -> None:
+    """Report whether a trace is currently running."""
+    result = _request("GET", "/api/v1/trace/status", json_output)
+    if json_output:
+        typer.echo(json.dumps(result))
+        return
+    if result["enabled"]:
+        typer.echo(f"Tracing is RUNNING. Output -> {result['outputPath']}")
+        typer.echo(f"  {result['bufferedExternalEvents']} external events buffered.")
+    else:
+        typer.echo("Tracing is not running.")

--- a/tools/sculpt/sculpt/commands/trace.py
+++ b/tools/sculpt/sculpt/commands/trace.py
@@ -51,7 +51,7 @@ def _request(method: str, path: str, json_output: bool, body: dict | None = None
 
 @trace_app.command("start")
 def start(
-    tracer_entries: int = typer.Option(
+    tracer_entries: int | None = typer.Option(
         None,
         "--tracer-entries",
         help="Ring-buffer size (entries). Larger = longer capture window, more memory. Defaults to the backend's ad-hoc default.",

--- a/tools/sculpt/sculpt/main.py
+++ b/tools/sculpt/sculpt/main.py
@@ -1,10 +1,12 @@
 import typer
 
 from sculpt.commands.agent import agent_app
+from sculpt.commands.debug import debug_app
 from sculpt.commands.repo import repo_app
 from sculpt.commands.run import run_cmd
 from sculpt.commands.schema import schema_app
 from sculpt.commands.signal import signal_app
+from sculpt.commands.trace import trace_app
 from sculpt.commands.ui import ui_app
 from sculpt.commands.workspace import workspace_app
 
@@ -19,6 +21,8 @@ app.add_typer(agent_app, name="agent")
 app.add_typer(repo_app, name="repo")
 app.add_typer(schema_app, name="schema")
 app.add_typer(signal_app, name="signal")
+app.add_typer(trace_app, name="trace")
+app.add_typer(debug_app, name="debug")
 app.add_typer(ui_app, name="ui")
 app.command("run")(run_cmd)
 

--- a/tools/sculpt/sculpt/main.py
+++ b/tools/sculpt/sculpt/main.py
@@ -6,7 +6,6 @@ from sculpt.commands.repo import repo_app
 from sculpt.commands.run import run_cmd
 from sculpt.commands.schema import schema_app
 from sculpt.commands.signal import signal_app
-from sculpt.commands.trace import trace_app
 from sculpt.commands.ui import ui_app
 from sculpt.commands.workspace import workspace_app
 
@@ -21,7 +20,6 @@ app.add_typer(agent_app, name="agent")
 app.add_typer(repo_app, name="repo")
 app.add_typer(schema_app, name="schema")
 app.add_typer(signal_app, name="signal")
-app.add_typer(trace_app, name="trace")
 app.add_typer(debug_app, name="debug")
 app.add_typer(ui_app, name="ui")
 app.command("run")(run_cmd)

--- a/tools/sculpt/tests/unit/test_trace.py
+++ b/tools/sculpt/tests/unit/test_trace.py
@@ -29,7 +29,7 @@ def test_trace_start_prints_output_path(runner: CliRunner) -> None:
         return_value=Response(200, json={"enabled": True, "outputPath": "/logs/traces/t.json", "bufferedExternalEvents": 0})
     )
 
-    result = runner.invoke(app, ["trace", "start"])
+    result = runner.invoke(app, ["debug", "trace", "start"])
 
     assert result.exit_code == 0, result.stderr
     assert route.called
@@ -45,7 +45,7 @@ def test_trace_start_forwards_tracer_entries(runner: CliRunner) -> None:
         return_value=Response(200, json={"enabled": True, "outputPath": "/x.json", "bufferedExternalEvents": 0})
     )
 
-    result = runner.invoke(app, ["trace", "start", "--tracer-entries", "12345"])
+    result = runner.invoke(app, ["debug", "trace", "start", "--tracer-entries", "12345"])
 
     assert result.exit_code == 0, result.stderr
     assert json.loads(route.calls.last.request.content) == {"tracer_entries": 12345}
@@ -60,7 +60,7 @@ def test_trace_stop_reports_counts(runner: CliRunner) -> None:
         )
     )
 
-    result = runner.invoke(app, ["trace", "stop"])
+    result = runner.invoke(app, ["debug", "trace", "stop"])
 
     assert result.exit_code == 0, result.stderr
     assert "/logs/traces/t.json" in result.stdout
@@ -75,7 +75,7 @@ def test_trace_stop_surfaces_409_detail(runner: CliRunner) -> None:
         return_value=Response(409, json={"detail": "No trace is running."})
     )
 
-    result = runner.invoke(app, ["trace", "stop"])
+    result = runner.invoke(app, ["debug", "trace", "stop"])
 
     assert result.exit_code == 1
     assert "409" in result.stderr
@@ -88,7 +88,7 @@ def test_trace_status_json_passthrough(runner: CliRunner) -> None:
     payload = {"enabled": True, "outputPath": "/x.json", "bufferedExternalEvents": 3}
     respx.get(f"{_BASE_URL}/api/v1/trace/status").mock(return_value=Response(200, json=payload))
 
-    result = runner.invoke(app, ["trace", "status", "--json"])
+    result = runner.invoke(app, ["debug", "trace", "status", "--json"])
 
     assert result.exit_code == 0, result.stderr
     assert json.loads(result.stdout) == payload

--- a/tools/sculpt/tests/unit/test_trace.py
+++ b/tools/sculpt/tests/unit/test_trace.py
@@ -1,0 +1,107 @@
+"""Unit tests for the sculpt trace and debug command groups."""
+
+import json
+
+import pytest
+import respx
+from httpx import Response
+from sculpt.main import app
+from typer.testing import CliRunner
+
+_BASE_URL = "http://localhost:5050"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _mock_session(base_url: str = _BASE_URL) -> None:
+    respx.get(f"{base_url}/api/v1/session-token").mock(
+        return_value=Response(204, headers={"set-cookie": "x-session-token=test123"})
+    )
+
+
+@respx.mock
+def test_trace_start_prints_output_path(runner: CliRunner) -> None:
+    _mock_session()
+    route = respx.post(f"{_BASE_URL}/api/v1/trace/start").mock(
+        return_value=Response(200, json={"enabled": True, "outputPath": "/logs/traces/t.json", "bufferedExternalEvents": 0})
+    )
+
+    result = runner.invoke(app, ["trace", "start"])
+
+    assert result.exit_code == 0, result.stderr
+    assert route.called
+    # No tracer_entries provided → empty body, so the backend default applies.
+    assert json.loads(route.calls.last.request.content) == {}
+    assert "/logs/traces/t.json" in result.stdout
+
+
+@respx.mock
+def test_trace_start_forwards_tracer_entries(runner: CliRunner) -> None:
+    _mock_session()
+    route = respx.post(f"{_BASE_URL}/api/v1/trace/start").mock(
+        return_value=Response(200, json={"enabled": True, "outputPath": "/x.json", "bufferedExternalEvents": 0})
+    )
+
+    result = runner.invoke(app, ["trace", "start", "--tracer-entries", "12345"])
+
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(route.calls.last.request.content) == {"tracer_entries": 12345}
+
+
+@respx.mock
+def test_trace_stop_reports_counts(runner: CliRunner) -> None:
+    _mock_session()
+    respx.post(f"{_BASE_URL}/api/v1/trace/stop").mock(
+        return_value=Response(
+            200, json={"outputPath": "/logs/traces/t.json", "backendEventCount": 42, "externalEventCount": 7}
+        )
+    )
+
+    result = runner.invoke(app, ["trace", "stop"])
+
+    assert result.exit_code == 0, result.stderr
+    assert "/logs/traces/t.json" in result.stdout
+    assert "42 backend events" in result.stdout
+    assert "7 external events" in result.stdout
+
+
+@respx.mock
+def test_trace_stop_surfaces_409_detail(runner: CliRunner) -> None:
+    _mock_session()
+    respx.post(f"{_BASE_URL}/api/v1/trace/stop").mock(
+        return_value=Response(409, json={"detail": "No trace is running."})
+    )
+
+    result = runner.invoke(app, ["trace", "stop"])
+
+    assert result.exit_code == 1
+    assert "409" in result.stderr
+    assert "No trace is running." in result.stderr
+
+
+@respx.mock
+def test_trace_status_json_passthrough(runner: CliRunner) -> None:
+    _mock_session()
+    payload = {"enabled": True, "outputPath": "/x.json", "bufferedExternalEvents": 3}
+    respx.get(f"{_BASE_URL}/api/v1/trace/status").mock(return_value=Response(200, json=payload))
+
+    result = runner.invoke(app, ["trace", "status", "--json"])
+
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout) == payload
+
+
+@respx.mock
+def test_debug_threads_prints_dump(runner: CliRunner) -> None:
+    _mock_session()
+    dump = "Thread dump at 2026-01-01\nThread 1 (MainThread):\n"
+    respx.get(f"{_BASE_URL}/api/v1/debug/threads").mock(return_value=Response(200, text=dump))
+
+    result = runner.invoke(app, ["debug", "threads"])
+
+    assert result.exit_code == 0, result.stderr
+    assert "Thread dump at" in result.stdout
+    assert "MainThread" in result.stdout


### PR DESCRIPTION
## What

Adds an in-process control surface to profile or inspect a **running** Sculptor backend — including a signed production build — on demand, with no restart, no entitlements, and no signals.

New authed HTTP endpoints:

- `POST /api/v1/trace/start` — arm viztracer (optional `tracer_entries`); writes to `{LOG_PATH}/traces/trace-<timestamp>.json`. 409 if already running.
- `POST /api/v1/trace/stop` — stop, merge buffered external events, flush the combined Chrome-JSON trace; returns the path + event counts.
- `GET /api/v1/trace/status` — whether a trace is running, where it will land, buffered external-event count.
- `GET /api/v1/debug/threads` — every live thread's Python stack via `sys._current_frames()` (greenlet-safe; no signals, no C-stack walk — the reason the old `faulthandler`/`SIGUSR1` route was unusable).

CLI wrappers: `sculpt trace start|stop|status` and `sculpt debug threads`.

## Why

The `--trace-to` flag only traces from boot and only writes on clean shutdown, so it can't profile a process that's already running. External profilers (py-spy, lldb) can't attach to the shipped backend because of the macOS hardened runtime. An in-process control surface sidesteps the entitlement wall entirely. Drop the resulting file into ui.perfetto.dev.

```sh
sculpt trace start          # arm
# ...reproduce the slow path...
sculpt trace stop           # flush; prints the file path + counts
sculpt debug threads        # instant stack snapshot, no profiling overhead
```

## Notes

- `tracing.py`: `stop_and_write_trace()` now returns a `TraceWriteResult` and resets module state so sessions can re-arm; `start_tracing()` takes an optional `tracer_entries` with a smaller ad-hoc default.
- **Security:** the control/debug endpoints require the session token (unlike the auth-exempt `/trace/batch`); the output path is server-chosen (fixed dir), not caller-supplied, so the token can't be used as an arbitrary-file-write primitive, and `tracer_entries` is bounds-checked.
- **Limitation:** a runtime-armed trace captures backend Python only — the renderer reads its on/off flag once at page load. Documented in `docs/development/tracing.md`.

## Testing

`just format`, `just check` (lint/typecheck/ratchets/codegen), full backend unit suite, and full sculpt unit suite all pass. New tests: `tracing_test.py` (re-arm + return value), `web/trace_endpoint_test.py` (start/stop/status roundtrip, conflicts, bounds, auth, thread dump), `tools/sculpt/tests/unit/test_trace.py`.

SCU-1603

(Sent by Claude)