### PR TITLE
Skip CI Babysitter prompts while another workspace agent is busy

### DIFF
--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
@@ -56,8 +56,7 @@ from sculptor.state.messages import LLMModel
 from sculptor.state.messages import Message
 from sculptor.web.data_types import StreamingUpdateSourceTypes
 from sculptor.web.derived import PrStatusInfo
-from sculptor.web.derived import TaskStatus
-from sculptor.web.derived import derive_agent_task_status
+from sculptor.web.derived import is_agent_busy_or_waiting
 from sculptor.web.derived import scan_terminal_signal_state
 from sculptor.web.pr_polling_service import PrPollingService
 from sculptor.web.terminal_input import TerminalDeliveryResult
@@ -84,14 +83,6 @@ _TRANSIENT_REASON_UNREACHABLE = "Couldn't reach the terminal agent's prompt; wil
 # unit tests run fast.
 _TERMINAL_READINESS_BACKSTOP_SECONDS = 30.0
 _TERMINAL_READINESS_POLL_SECONDS = 0.5
-
-# Statuses that mean an agent is mid-flight and the babysitter must not inject a
-# prompt yet (SCU-1601): BUILDING/RUNNING are the blue "working" states and
-# WAITING is the yellow "needs your input" state. READY (idle), ERROR, and
-# REQUEST_ERROR are at-rest — a stopped or errored agent does not block, so a
-# wedged agent can never park the babysitter indefinitely. A SUCCEEDED task maps
-# to READY and is likewise not blocking.
-_BUSY_OR_WAITING_STATUSES = frozenset({TaskStatus.BUILDING, TaskStatus.RUNNING, TaskStatus.WAITING})
 
 
 @dataclass(frozen=True)
@@ -364,18 +355,20 @@ class CIBabysitterCoordinator(Service):
     def _are_all_workspace_agents_idle(self, state: CIBabysitterState) -> bool:
         """True when no non-babysitter agent in the workspace is busy or waiting.
 
-        Reads each agent's *live* messages so the status matches what the UI
-        shows (the babysitter's own task is excluded by
-        ``_workspace_agent_tasks_most_recent_first``). Any agent in a
-        busy/waiting state (see ``_BUSY_OR_WAITING_STATUSES``) makes the
-        workspace not-idle and the babysitter holds off (SCU-1601). A workspace
-        with no prior agent is trivially idle.
+        Reads each agent's *live* messages and asks ``is_agent_busy_or_waiting``,
+        which keys off the same agent status (WORKING/WAITING) the UI shows — so
+        the gate and the status dot never disagree. The babysitter's own task is
+        excluded by ``_workspace_agent_tasks_most_recent_first``. Any
+        busy/waiting agent makes the workspace not-idle and the babysitter holds
+        off (SCU-1601); an idle, errored, or completed agent does not block, so a
+        wedged agent can never park the babysitter indefinitely. A workspace with
+        no prior agent is trivially idle.
         """
         with self._data_model_service.open_transaction(RequestID()) as transaction:
             tasks = self._workspace_agent_tasks_most_recent_first(state.workspace_id, state.project_id, transaction)
         for task in tasks:
             messages = self._task_service.get_live_messages_for_task(task.object_id)
-            if derive_agent_task_status(task, messages) in _BUSY_OR_WAITING_STATUSES:
+            if is_agent_busy_or_waiting(task, messages):
                 return False
         return True
 

--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
@@ -260,21 +260,13 @@ class CIBabysitterCoordinator(Service):
             try:
                 item = self._queue.get(timeout=_CONSUMER_QUEUE_TIMEOUT_SECONDS)
             except Empty:
-                item = None
-            if isinstance(item, PrStatusInfo):
-                try:
-                    self._handle_status(item)
-                except Exception:
-                    logger.exception("CIBabysitterCoordinator: error handling PrStatusInfo for {}", item.workspace_id)
-            # Re-check deferred dispatches on every tick — including idle ticks,
-            # since the polling service only re-pushes a status on change, so a
-            # still-failing pipeline never re-arrives to retrigger the gate. This
-            # is what lets a deferred prompt fire within ~1s of every agent in
-            # the workspace going idle (SCU-1601).
+                continue
+            if not isinstance(item, PrStatusInfo):
+                continue
             try:
-                self._process_deferred_dispatches()
+                self._handle_status(item)
             except Exception:
-                logger.opt(exception=True).error("CIBabysitterCoordinator: error processing deferred dispatches")
+                logger.exception("CIBabysitterCoordinator: error handling PrStatusInfo for {}", item.workspace_id)
 
     def _handle_status(self, new: PrStatusInfo) -> None:
         state = self._ensure_state(new.workspace_id)
@@ -311,46 +303,13 @@ class CIBabysitterCoordinator(Service):
                     # The transient reason reflects a one-off hiccup; once the
                     # cycle resolves it no longer applies.
                     state.transient_disabled_reason = None
-                    # A passing pipeline cancels any prompt deferred for the
-                    # now-resolved failure (SCU-1601).
-                    self._clear_pending_dispatch(state)
             elif transition in (Transition.MR_MERGED, Transition.MR_CLOSED):
                 with self._lock:
                     state.retired = True
                     state.transient_disabled_reason = None
-                    # A merged/closed PR retires the babysitter; drop any
-                    # deferred prompt so it can't fire after retirement.
-                    self._clear_pending_dispatch(state)
         for transition in transitions:
             if transition in (Transition.PIPELINE_FAILED, Transition.MERGE_CONFLICT):
                 self._dispatch_prompt(state, transition, new)
-
-    def _clear_pending_dispatch(self, state: CIBabysitterState) -> None:
-        """Drop a deferred dispatch. The caller MUST hold ``self._lock``."""
-        state.pending_dispatch_transition = None
-        state.pending_dispatch_status = None
-
-    def _process_deferred_dispatches(self) -> None:
-        """Re-attempt every dispatch that was deferred because an agent was busy.
-
-        Called on each consumer-loop tick. ``_dispatch_prompt`` re-runs the
-        all-agents-idle gate, so this is a no-op for a workspace whose agents are
-        still busy and a real dispatch the moment they all go idle (SCU-1601).
-        """
-        with self._lock:
-            pending: list[tuple[CIBabysitterState, Transition, PrStatusInfo]] = []
-            for state in self._state.values():
-                transition = state.pending_dispatch_transition
-                status = state.pending_dispatch_status
-                if transition is not None and status is not None:
-                    pending.append((state, transition, status))
-        for state, transition, status in pending:
-            try:
-                self._dispatch_prompt(state, transition, status)
-            except Exception:
-                logger.opt(exception=True).error(
-                    "CIBabysitterCoordinator: error re-dispatching deferred prompt for {}", state.workspace_id
-                )
 
     def _are_all_workspace_agents_idle(self, state: CIBabysitterState) -> bool:
         """True when no non-babysitter agent in the workspace is busy or waiting.
@@ -359,10 +318,9 @@ class CIBabysitterCoordinator(Service):
         which keys off the same agent status (WORKING/WAITING) the UI shows — so
         the gate and the status dot never disagree. The babysitter's own task is
         excluded by ``_workspace_agent_tasks_most_recent_first``. Any
-        busy/waiting agent makes the workspace not-idle and the babysitter holds
-        off (SCU-1601); an idle, errored, or completed agent does not block, so a
-        wedged agent can never park the babysitter indefinitely. A workspace with
-        no prior agent is trivially idle.
+        busy/waiting agent makes the workspace not-idle, so the babysitter skips
+        this failure (SCU-1601); an idle, errored, or completed agent does not
+        count. A workspace with no prior agent is trivially idle.
         """
         with self._data_model_service.open_transaction(RequestID()) as transaction:
             tasks = self._workspace_agent_tasks_most_recent_first(state.workspace_id, state.project_id, transaction)
@@ -407,24 +365,22 @@ class CIBabysitterCoordinator(Service):
         # All-agents-idle gate (SCU-1601). Never inject a fix prompt while another
         # agent in the workspace is busy or waiting for input — the babysitter
         # runs as its own agent, so two agents would then edit the same workspace
-        # at once. Computing agent status does DB I/O, so it runs outside the
-        # lock. When an agent is busy, record this transition as pending and bail;
-        # the consumer loop's _process_deferred_dispatches re-checks each tick and
-        # dispatches once every agent is idle. The deferral counts no retry and
-        # sets no dedup, so re-checking re-enters this method cleanly.
+        # at once. Computing agent status does DB I/O, so it runs outside the lock.
+        #
+        # When the workspace isn't idle we DROP this failure rather than queueing
+        # it for later: pouncing the instant the user's agent finishes a turn is
+        # more disruptive than a missed prompt, and the user's own work may have
+        # already made the CI result moot. A still-relevant pipeline failure
+        # re-arms naturally on the next push (a new pipeline_id is a fresh
+        # PIPELINE_FAILED edge); a persistent merge conflict re-arms when it next
+        # clears and recurs. The drop counts no retry and sets no dedup.
         if not self._are_all_workspace_agents_idle(state):
-            with self._lock:
-                state.pending_dispatch_transition = transition
-                state.pending_dispatch_status = new
             logger.info(
-                "CIBabysitterCoordinator: deferring {} for workspace={} — another agent is busy/waiting",
+                "CIBabysitterCoordinator: skipping {} for workspace={} — another agent is busy/waiting",
                 transition,
                 state.workspace_id,
             )
             return
-        # Every agent is idle: this dispatch supersedes any earlier deferral.
-        with self._lock:
-            self._clear_pending_dispatch(state)
 
         if transition is Transition.PIPELINE_FAILED:
             prompt_text = config.ci_babysitter.pipeline_failed_prompt

--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator.py
@@ -56,6 +56,8 @@ from sculptor.state.messages import LLMModel
 from sculptor.state.messages import Message
 from sculptor.web.data_types import StreamingUpdateSourceTypes
 from sculptor.web.derived import PrStatusInfo
+from sculptor.web.derived import TaskStatus
+from sculptor.web.derived import derive_agent_task_status
 from sculptor.web.derived import scan_terminal_signal_state
 from sculptor.web.pr_polling_service import PrPollingService
 from sculptor.web.terminal_input import TerminalDeliveryResult
@@ -82,6 +84,14 @@ _TRANSIENT_REASON_UNREACHABLE = "Couldn't reach the terminal agent's prompt; wil
 # unit tests run fast.
 _TERMINAL_READINESS_BACKSTOP_SECONDS = 30.0
 _TERMINAL_READINESS_POLL_SECONDS = 0.5
+
+# Statuses that mean an agent is mid-flight and the babysitter must not inject a
+# prompt yet (SCU-1601): BUILDING/RUNNING are the blue "working" states and
+# WAITING is the yellow "needs your input" state. READY (idle), ERROR, and
+# REQUEST_ERROR are at-rest — a stopped or errored agent does not block, so a
+# wedged agent can never park the babysitter indefinitely. A SUCCEEDED task maps
+# to READY and is likewise not blocking.
+_BUSY_OR_WAITING_STATUSES = frozenset({TaskStatus.BUILDING, TaskStatus.RUNNING, TaskStatus.WAITING})
 
 
 @dataclass(frozen=True)
@@ -259,13 +269,21 @@ class CIBabysitterCoordinator(Service):
             try:
                 item = self._queue.get(timeout=_CONSUMER_QUEUE_TIMEOUT_SECONDS)
             except Empty:
-                continue
-            if not isinstance(item, PrStatusInfo):
-                continue
+                item = None
+            if isinstance(item, PrStatusInfo):
+                try:
+                    self._handle_status(item)
+                except Exception:
+                    logger.exception("CIBabysitterCoordinator: error handling PrStatusInfo for {}", item.workspace_id)
+            # Re-check deferred dispatches on every tick — including idle ticks,
+            # since the polling service only re-pushes a status on change, so a
+            # still-failing pipeline never re-arrives to retrigger the gate. This
+            # is what lets a deferred prompt fire within ~1s of every agent in
+            # the workspace going idle (SCU-1601).
             try:
-                self._handle_status(item)
+                self._process_deferred_dispatches()
             except Exception:
-                logger.exception("CIBabysitterCoordinator: error handling PrStatusInfo for {}", item.workspace_id)
+                logger.opt(exception=True).error("CIBabysitterCoordinator: error processing deferred dispatches")
 
     def _handle_status(self, new: PrStatusInfo) -> None:
         state = self._ensure_state(new.workspace_id)
@@ -302,13 +320,64 @@ class CIBabysitterCoordinator(Service):
                     # The transient reason reflects a one-off hiccup; once the
                     # cycle resolves it no longer applies.
                     state.transient_disabled_reason = None
+                    # A passing pipeline cancels any prompt deferred for the
+                    # now-resolved failure (SCU-1601).
+                    self._clear_pending_dispatch(state)
             elif transition in (Transition.MR_MERGED, Transition.MR_CLOSED):
                 with self._lock:
                     state.retired = True
                     state.transient_disabled_reason = None
+                    # A merged/closed PR retires the babysitter; drop any
+                    # deferred prompt so it can't fire after retirement.
+                    self._clear_pending_dispatch(state)
         for transition in transitions:
             if transition in (Transition.PIPELINE_FAILED, Transition.MERGE_CONFLICT):
                 self._dispatch_prompt(state, transition, new)
+
+    def _clear_pending_dispatch(self, state: CIBabysitterState) -> None:
+        """Drop a deferred dispatch. The caller MUST hold ``self._lock``."""
+        state.pending_dispatch_transition = None
+        state.pending_dispatch_status = None
+
+    def _process_deferred_dispatches(self) -> None:
+        """Re-attempt every dispatch that was deferred because an agent was busy.
+
+        Called on each consumer-loop tick. ``_dispatch_prompt`` re-runs the
+        all-agents-idle gate, so this is a no-op for a workspace whose agents are
+        still busy and a real dispatch the moment they all go idle (SCU-1601).
+        """
+        with self._lock:
+            pending: list[tuple[CIBabysitterState, Transition, PrStatusInfo]] = []
+            for state in self._state.values():
+                transition = state.pending_dispatch_transition
+                status = state.pending_dispatch_status
+                if transition is not None and status is not None:
+                    pending.append((state, transition, status))
+        for state, transition, status in pending:
+            try:
+                self._dispatch_prompt(state, transition, status)
+            except Exception:
+                logger.opt(exception=True).error(
+                    "CIBabysitterCoordinator: error re-dispatching deferred prompt for {}", state.workspace_id
+                )
+
+    def _are_all_workspace_agents_idle(self, state: CIBabysitterState) -> bool:
+        """True when no non-babysitter agent in the workspace is busy or waiting.
+
+        Reads each agent's *live* messages so the status matches what the UI
+        shows (the babysitter's own task is excluded by
+        ``_workspace_agent_tasks_most_recent_first``). Any agent in a
+        busy/waiting state (see ``_BUSY_OR_WAITING_STATUSES``) makes the
+        workspace not-idle and the babysitter holds off (SCU-1601). A workspace
+        with no prior agent is trivially idle.
+        """
+        with self._data_model_service.open_transaction(RequestID()) as transaction:
+            tasks = self._workspace_agent_tasks_most_recent_first(state.workspace_id, state.project_id, transaction)
+        for task in tasks:
+            messages = self._task_service.get_live_messages_for_task(task.object_id)
+            if derive_agent_task_status(task, messages) in _BUSY_OR_WAITING_STATUSES:
+                return False
+        return True
 
     def _dispatch_prompt(self, state: CIBabysitterState, transition: Transition, new: PrStatusInfo) -> None:
         config = get_user_config_instance()
@@ -341,6 +410,28 @@ class CIBabysitterCoordinator(Service):
                         state.workspace_id,
                     )
                     return
+
+        # All-agents-idle gate (SCU-1601). Never inject a fix prompt while another
+        # agent in the workspace is busy or waiting for input — the babysitter
+        # runs as its own agent, so two agents would then edit the same workspace
+        # at once. Computing agent status does DB I/O, so it runs outside the
+        # lock. When an agent is busy, record this transition as pending and bail;
+        # the consumer loop's _process_deferred_dispatches re-checks each tick and
+        # dispatches once every agent is idle. The deferral counts no retry and
+        # sets no dedup, so re-checking re-enters this method cleanly.
+        if not self._are_all_workspace_agents_idle(state):
+            with self._lock:
+                state.pending_dispatch_transition = transition
+                state.pending_dispatch_status = new
+            logger.info(
+                "CIBabysitterCoordinator: deferring {} for workspace={} — another agent is busy/waiting",
+                transition,
+                state.workspace_id,
+            )
+            return
+        # Every agent is idle: this dispatch supersedes any earlier deferral.
+        with self._lock:
+            self._clear_pending_dispatch(state)
 
         if transition is Transition.PIPELINE_FAILED:
             prompt_text = config.ci_babysitter.pipeline_failed_prompt

--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
@@ -833,12 +833,13 @@ def _add_existing_agent(env: _FakeEnv, *, agent_config: Any = None) -> Task:
     return task
 
 
-def test_busy_agent_defers_dispatch_until_idle(
+def test_busy_agent_skips_dispatch_without_pouncing_on_idle(
     env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
 ) -> None:
-    """SCU-1601: with another agent busy, a PIPELINE_FAILED transition is
-    recorded as pending and NOT dispatched. Once that agent goes idle, the next
-    re-check delivers the deferred prompt."""
+    """SCU-1601: with another agent busy, a PIPELINE_FAILED transition is dropped,
+    not queued — nothing is dispatched and no retry is burned. The babysitter must
+    NOT pounce when that agent later goes idle (the same failure never re-arrives);
+    only a *fresh* CI failure observed while idle drives a prompt."""
     coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
     busy_agent = _add_existing_agent(env)
     task_service.set_live_messages(busy_agent.object_id, _busy_chat_messages())
@@ -846,27 +847,26 @@ def test_busy_agent_defers_dispatch_until_idle(
 
     coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
 
-    # Deferred: nothing dispatched, but the transition is pending and no retry burned.
+    # Dropped while busy: nothing dispatched, no retry burned, no dedup recorded.
     assert task_service.create_task_calls == []
     assert task_service.create_message_calls == []
     state = coordinator._state[env.workspace_id]
-    assert state.pending_dispatch_transition == Transition.PIPELINE_FAILED
     assert state.retry_count == 0
+    assert state.last_dispatched_pipeline_failed_id is None
 
-    # Re-checking while still busy is a no-op.
-    coordinator._process_deferred_dispatches()
+    # The agent goes idle, but the still-failing pipeline_id=1 never re-arrives
+    # (the classifier only fires on a change), so the babysitter stays silent —
+    # no pounce the instant the user's agent finishes a turn.
+    task_service.set_live_messages(busy_agent.object_id, _idle_agent_messages())
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
     assert task_service.create_message_calls == []
 
-    # The agent goes idle → the next re-check dispatches the deferred prompt.
-    task_service.set_live_messages(busy_agent.object_id, _idle_agent_messages())
-    coordinator._process_deferred_dispatches()
-
-    assert len(task_service.create_task_calls) == 1
+    # A *fresh* failure (new pipeline_id) observed while idle DOES drive a prompt —
+    # proving the silence above was the busy gate, not a dead path.
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=2))
     assert len(task_service.create_message_calls) == 1
     sent_message, _ = task_service.create_message_calls[0]
     assert sent_message.text == "FAILED_PROMPT"
-    assert state.pending_dispatch_transition is None
-    assert state.pending_dispatch_status is None
     assert state.retry_count == 1
 
 
@@ -874,7 +874,7 @@ def test_idle_agent_dispatches_immediately(
     env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
 ) -> None:
     """An idle prior agent does not block the babysitter — it dispatches on the
-    failed transition with no deferral."""
+    failed transition."""
     coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
     idle_agent = _add_existing_agent(env)
     task_service.set_live_messages(idle_agent.object_id, _idle_agent_messages())
@@ -884,32 +884,7 @@ def test_idle_agent_dispatches_immediately(
 
     assert len(task_service.create_message_calls) == 1
     state = coordinator._state[env.workspace_id]
-    assert state.pending_dispatch_transition is None
     assert state.retry_count == 1
-
-
-def test_pipeline_passed_clears_pending_deferral(
-    env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
-) -> None:
-    """A deferred prompt is cancelled when the pipeline passes before the busy
-    agent goes idle — the failure it was queued for is resolved."""
-    coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
-    busy_agent = _add_existing_agent(env)
-    task_service.set_live_messages(busy_agent.object_id, _busy_chat_messages())
-    _seed_baseline(coordinator, env.workspace_id)
-
-    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
-    state = coordinator._state[env.workspace_id]
-    assert state.pending_dispatch_transition == Transition.PIPELINE_FAILED
-
-    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="passed", pipeline_id=1))
-    assert state.pending_dispatch_transition is None
-    assert state.pending_dispatch_status is None
-
-    # Even after the agent goes idle, nothing is dispatched — the deferral is gone.
-    task_service.set_live_messages(busy_agent.object_id, _idle_agent_messages())
-    coordinator._process_deferred_dispatches()
-    assert task_service.create_message_calls == []
 
 
 def test_transient_pr_state_none_does_not_clobber_prev_status(

--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
@@ -44,6 +44,7 @@ from sculptor.interfaces.agents.agent import RegisteredTerminalAgentConfig
 from sculptor.interfaces.agents.agent import TerminalAgentConfig
 from sculptor.interfaces.agents.agent import TerminalAgentSignalRunnerMessage
 from sculptor.interfaces.agents.agent import TerminalStatusSignal
+from sculptor.interfaces.agents.tasks import TaskState
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import OrganizationReference
 from sculptor.primitives.ids import ProjectID
@@ -357,6 +358,24 @@ def _ready_terminal_messages() -> list[Message]:
     ]
 
 
+def _idle_agent_messages() -> list[Message]:
+    """Live messages for which derive_agent_task_status reports READY (idle).
+
+    Just the run-start anchor, no in-flight request and no busy/waiting signal —
+    yields READY for both chat and terminal agents.
+    """
+    return [EnvironmentAcquiredRunnerMessage.model_construct(message_id=AgentMessageID(), environment=None)]
+
+
+def _busy_chat_messages() -> list[Message]:
+    """Live messages for a chat agent mid-turn (a sent prompt with no matching
+    request-complete) → derive_agent_task_status reports RUNNING (busy)."""
+    return [
+        EnvironmentAcquiredRunnerMessage.model_construct(message_id=AgentMessageID(), environment=None),
+        ChatInputUserMessage(text="busy work", message_id=AgentMessageID(), model_name=LLMModel.FAKE_CLAUDE),
+    ]
+
+
 class _FakeTaskService(_StubTaskService):
     _env: _FakeEnv = PrivateAttr()
     _create_task_calls: list[Task] = PrivateAttr(default_factory=list)
@@ -368,11 +387,22 @@ class _FakeTaskService(_StubTaskService):
     # messages after the worker subscribes.
     _seeded_terminal_messages: list[Message] = PrivateAttr(default_factory=list)
     _live_terminal_queue: "Queue[Message] | None" = PrivateAttr(default=None)
+    # Per-task live messages backing get_live_messages_for_task (used by the
+    # all-agents-idle gate). Tasks without an explicit entry default to idle.
+    _live_messages_by_task_id: dict[TaskID, list[Message]] = PrivateAttr(default_factory=dict)
 
     def __init__(self, env: _FakeEnv, concurrency_group: ConcurrencyGroup) -> None:
         super().__init__(concurrency_group=concurrency_group, task_sync_dir=Path("/tmp"))
         self._env = env
         self._seeded_terminal_messages = _ready_terminal_messages()
+
+    def set_live_messages(self, task_id: TaskID, messages: list[Message]) -> None:
+        self._live_messages_by_task_id[task_id] = messages
+
+    def get_live_messages_for_task(self, task_id: TaskID) -> tuple[Message, ...]:
+        # Default to an at-rest (idle) agent; tests that exercise the all-idle
+        # gate set explicit busy/waiting messages via set_live_messages.
+        return tuple(self._live_messages_by_task_id.get(task_id, _idle_agent_messages()))
 
     @property
     def create_task_calls(self) -> list[Task]:
@@ -786,6 +816,99 @@ def test_scenario_8_feature_disabled(
     coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
 
     assert task_service.create_task_calls == []
+    assert task_service.create_message_calls == []
+
+
+def _add_existing_agent(env: _FakeEnv, *, agent_config: Any = None) -> Task:
+    """Register a non-babysitter agent task in the workspace and return it.
+
+    Its outcome is RUNNING so derive_agent_task_status reads its live messages
+    (a QUEUED task would short-circuit to BUILDING regardless of messages).
+    """
+    task = _make_agent_task(env, agent_config or ClaudeCodeSDKAgentConfig(), "2026-01-01T00:00:00").model_copy(
+        update={"outcome": TaskState.RUNNING}
+    )
+    env.tasks.append(task)
+    env.tasks_by_id[task.object_id] = task
+    return task
+
+
+def test_busy_agent_defers_dispatch_until_idle(
+    env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    """SCU-1601: with another agent busy, a PIPELINE_FAILED transition is
+    recorded as pending and NOT dispatched. Once that agent goes idle, the next
+    re-check delivers the deferred prompt."""
+    coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
+    busy_agent = _add_existing_agent(env)
+    task_service.set_live_messages(busy_agent.object_id, _busy_chat_messages())
+    _seed_baseline(coordinator, env.workspace_id)
+
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
+
+    # Deferred: nothing dispatched, but the transition is pending and no retry burned.
+    assert task_service.create_task_calls == []
+    assert task_service.create_message_calls == []
+    state = coordinator._state[env.workspace_id]
+    assert state.pending_dispatch_transition == Transition.PIPELINE_FAILED
+    assert state.retry_count == 0
+
+    # Re-checking while still busy is a no-op.
+    coordinator._process_deferred_dispatches()
+    assert task_service.create_message_calls == []
+
+    # The agent goes idle → the next re-check dispatches the deferred prompt.
+    task_service.set_live_messages(busy_agent.object_id, _idle_agent_messages())
+    coordinator._process_deferred_dispatches()
+
+    assert len(task_service.create_task_calls) == 1
+    assert len(task_service.create_message_calls) == 1
+    sent_message, _ = task_service.create_message_calls[0]
+    assert sent_message.text == "FAILED_PROMPT"
+    assert state.pending_dispatch_transition is None
+    assert state.pending_dispatch_status is None
+    assert state.retry_count == 1
+
+
+def test_idle_agent_dispatches_immediately(
+    env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    """An idle prior agent does not block the babysitter — it dispatches on the
+    failed transition with no deferral."""
+    coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
+    idle_agent = _add_existing_agent(env)
+    task_service.set_live_messages(idle_agent.object_id, _idle_agent_messages())
+    _seed_baseline(coordinator, env.workspace_id)
+
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
+
+    assert len(task_service.create_message_calls) == 1
+    state = coordinator._state[env.workspace_id]
+    assert state.pending_dispatch_transition is None
+    assert state.retry_count == 1
+
+
+def test_pipeline_passed_clears_pending_deferral(
+    env: _FakeEnv, patch_user_config: _ConfigSlot, test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    """A deferred prompt is cancelled when the pipeline passes before the busy
+    agent goes idle — the failure it was queued for is resolved."""
+    coordinator, task_service = _build_coordinator(env, test_root_concurrency_group)
+    busy_agent = _add_existing_agent(env)
+    task_service.set_live_messages(busy_agent.object_id, _busy_chat_messages())
+    _seed_baseline(coordinator, env.workspace_id)
+
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="failed", pipeline_id=1))
+    state = coordinator._state[env.workspace_id]
+    assert state.pending_dispatch_transition == Transition.PIPELINE_FAILED
+
+    coordinator._handle_status(_make_status(env.workspace_id, pipeline_status="passed", pipeline_id=1))
+    assert state.pending_dispatch_transition is None
+    assert state.pending_dispatch_status is None
+
+    # Even after the agent goes idle, nothing is dispatched — the deferral is gone.
+    task_service.set_live_messages(busy_agent.object_id, _idle_agent_messages())
+    coordinator._process_deferred_dispatches()
     assert task_service.create_message_calls == []
 
 

--- a/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/coordinator_test.py
@@ -359,17 +359,17 @@ def _ready_terminal_messages() -> list[Message]:
 
 
 def _idle_agent_messages() -> list[Message]:
-    """Live messages for which derive_agent_task_status reports READY (idle).
+    """Live messages for which is_agent_busy_or_waiting is False (idle).
 
     Just the run-start anchor, no in-flight request and no busy/waiting signal —
-    yields READY for both chat and terminal agents.
+    an IDLE agent status for both chat and terminal agents.
     """
     return [EnvironmentAcquiredRunnerMessage.model_construct(message_id=AgentMessageID(), environment=None)]
 
 
 def _busy_chat_messages() -> list[Message]:
     """Live messages for a chat agent mid-turn (a sent prompt with no matching
-    request-complete) → derive_agent_task_status reports RUNNING (busy)."""
+    request-complete) → is_agent_busy_or_waiting is True (WORKING)."""
     return [
         EnvironmentAcquiredRunnerMessage.model_construct(message_id=AgentMessageID(), environment=None),
         ChatInputUserMessage(text="busy work", message_id=AgentMessageID(), model_name=LLMModel.FAKE_CLAUDE),
@@ -822,7 +822,7 @@ def test_scenario_8_feature_disabled(
 def _add_existing_agent(env: _FakeEnv, *, agent_config: Any = None) -> Task:
     """Register a non-babysitter agent task in the workspace and return it.
 
-    Its outcome is RUNNING so derive_agent_task_status reads its live messages
+    Its outcome is RUNNING so is_agent_busy_or_waiting reads its live messages
     (a QUEUED task would short-circuit to BUILDING regardless of messages).
     """
     task = _make_agent_task(env, agent_config or ClaudeCodeSDKAgentConfig(), "2026-01-01T00:00:00").model_copy(

--- a/sculptor/sculptor/services/ci_babysitter_service/state.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/state.py
@@ -2,6 +2,7 @@ from sculptor.database.models import TaskID
 from sculptor.foundation.pydantic_serialization import MutableModel
 from sculptor.primitives.ids import ProjectID
 from sculptor.primitives.ids import WorkspaceID
+from sculptor.services.ci_babysitter_service.transitions import Transition
 from sculptor.web.data_types import PrStatusInfo
 
 
@@ -29,3 +30,11 @@ class CIBabysitterState(MutableModel):
     # this workspace's PTY, so a second near-simultaneous failure coalesces
     # instead of starting a racing worker.
     is_terminal_drive_in_progress: bool = False
+    # All-agents-idle gate (SCU-1601): an actionable transition whose dispatch
+    # was deferred because another agent in the workspace was busy/waiting.
+    # The consumer loop re-checks each tick and dispatches once every agent is
+    # idle; the deferral is cleared when the CI cycle resolves (pipeline passes,
+    # PR merged/closed) or superseded by a newer actionable transition. Both
+    # fields move together — set on defer, cleared on dispatch/resolve.
+    pending_dispatch_transition: Transition | None = None
+    pending_dispatch_status: PrStatusInfo | None = None

--- a/sculptor/sculptor/services/ci_babysitter_service/state.py
+++ b/sculptor/sculptor/services/ci_babysitter_service/state.py
@@ -2,7 +2,6 @@ from sculptor.database.models import TaskID
 from sculptor.foundation.pydantic_serialization import MutableModel
 from sculptor.primitives.ids import ProjectID
 from sculptor.primitives.ids import WorkspaceID
-from sculptor.services.ci_babysitter_service.transitions import Transition
 from sculptor.web.data_types import PrStatusInfo
 
 
@@ -30,11 +29,3 @@ class CIBabysitterState(MutableModel):
     # this workspace's PTY, so a second near-simultaneous failure coalesces
     # instead of starting a racing worker.
     is_terminal_drive_in_progress: bool = False
-    # All-agents-idle gate (SCU-1601): an actionable transition whose dispatch
-    # was deferred because another agent in the workspace was busy/waiting.
-    # The consumer loop re-checks each tick and dispatches once every agent is
-    # idle; the deferral is cleared when the CI cycle resolves (pipeline passes,
-    # PR merged/closed) or superseded by a newer actionable transition. Both
-    # fields move together — set on defer, cleared on dispatch/resolve.
-    pending_dispatch_transition: Transition | None = None
-    pending_dispatch_status: PrStatusInfo | None = None

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -842,3 +842,23 @@ def create_initial_task_view(
     instance._task_container.append(task)
     instance._settings_container.append(settings)
     return instance
+
+
+def derive_agent_task_status(task: Task, messages: Sequence[Message]) -> TaskStatus:
+    """The live ``TaskStatus`` of a coding-agent task from its messages.
+
+    A lightweight wrapper around ``CodingAgentTaskView.status`` for callers that
+    need an agent's status outside the streaming view (and without a
+    ``SculptorSettings`` — ``status`` does not read settings). The CI babysitter's
+    all-agents-idle gate uses it so it reads the exact status the UI shows.
+
+    ``messages`` MUST be the task's *live* messages (e.g. from
+    ``TaskService.get_live_messages_for_task``): the derivation depends on
+    ephemeral run-scoped messages (environment-acquired anchors, terminal-agent
+    signals) that the persisted message log never contains.
+    """
+    view = CodingAgentTaskView()
+    view._task_container.append(task)
+    for message in messages:
+        view.add_message(message)
+    return view.status

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -844,21 +844,28 @@ def create_initial_task_view(
     return instance
 
 
-def derive_agent_task_status(task: Task, messages: Sequence[Message]) -> TaskStatus:
-    """The live ``TaskStatus`` of a coding-agent task from its messages.
+def is_agent_busy_or_waiting(task: Task, messages: Sequence[Message]) -> bool:
+    """True when a coding agent is actively working (blue/busy) or waiting on the
+    user (yellow/waiting) — i.e. its agent status is ``WORKING`` or ``WAITING``.
+    False when it is idle, errored, or completed.
 
-    A lightweight wrapper around ``CodingAgentTaskView.status`` for callers that
-    need an agent's status outside the streaming view (and without a
-    ``SculptorSettings`` — ``status`` does not read settings). The CI babysitter's
-    all-agents-idle gate uses it so it reads the exact status the UI shows.
+    This is the "is another agent occupying the workspace right now?" predicate.
+    It is deliberately phrased in terms of the *agent status*
+    (``WorkspacePeekAgentStatus``) the UI surfaces — the status dot and workspace
+    peek — rather than a raw ``TaskStatus``, so callers can't drift from what the
+    user sees. ``WORKING`` covers ``BUILDING``/``RUNNING``; ``WAITING`` is a
+    pending question or plan approval; ``ERROR``/``COMPLETED``/``IDLE`` do not
+    occupy the workspace. The CI babysitter's all-agents-idle gate uses it so it
+    never injects a prompt while a second agent could be editing the tree.
 
     ``messages`` MUST be the task's *live* messages (e.g. from
     ``TaskService.get_live_messages_for_task``): the derivation depends on
     ephemeral run-scoped messages (environment-acquired anchors, terminal-agent
-    signals) that the persisted message log never contains.
+    signals) that the persisted message log never contains. No
+    ``SculptorSettings`` is needed — the status derivation does not read settings.
     """
     view = CodingAgentTaskView()
     view._task_container.append(task)
     for message in messages:
         view.add_message(message)
-    return view.status
+    return view.workspace_peek_status in (WorkspacePeekAgentStatus.WORKING, WorkspacePeekAgentStatus.WAITING)

--- a/sculptor/sculptor/web/derived_task_status_test.py
+++ b/sculptor/sculptor/web/derived_task_status_test.py
@@ -34,6 +34,7 @@ from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.web.derived import CodingAgentTaskView
 from sculptor.web.derived import TaskStatus
 from sculptor.web.derived import create_initial_task_view
+from sculptor.web.derived import derive_agent_task_status
 
 
 def _make_task(*, outcome: TaskState = TaskState.RUNNING) -> Task:
@@ -579,3 +580,22 @@ def test_terminal_status_outcome_short_circuit_beats_signals() -> None:
     view.add_message(_env_acquired())
     view.add_message(_signal(TerminalStatusSignal.BUSY))
     assert view.status == TaskStatus.ERROR
+
+
+def test_derive_agent_task_status_matches_view_for_running_agent() -> None:
+    """The CI babysitter's all-idle gate reads status via derive_agent_task_status;
+    it must report the same status as the CodingAgentTaskView it wraps. A sent
+    prompt with no matching request-complete is a mid-turn (RUNNING) agent."""
+    task = _make_task(outcome=TaskState.RUNNING)
+    messages = [_env_acquired(), ChatInputUserMessage(message_id=AgentMessageID(), text="work")]
+    view = _make_task_view(task)
+    for message in messages:
+        view.add_message(message)
+    assert view.status == TaskStatus.RUNNING
+    assert derive_agent_task_status(task, messages) == view.status
+
+
+def test_derive_agent_task_status_reports_ready_for_idle_agent() -> None:
+    """Just the run-start anchor → READY (idle), with no settings or streaming view."""
+    task = _make_task(outcome=TaskState.RUNNING)
+    assert derive_agent_task_status(task, [_env_acquired()]) == TaskStatus.READY

--- a/sculptor/sculptor/web/derived_task_status_test.py
+++ b/sculptor/sculptor/web/derived_task_status_test.py
@@ -34,7 +34,7 @@ from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.web.derived import CodingAgentTaskView
 from sculptor.web.derived import TaskStatus
 from sculptor.web.derived import create_initial_task_view
-from sculptor.web.derived import derive_agent_task_status
+from sculptor.web.derived import is_agent_busy_or_waiting
 
 
 def _make_task(*, outcome: TaskState = TaskState.RUNNING) -> Task:
@@ -582,20 +582,33 @@ def test_terminal_status_outcome_short_circuit_beats_signals() -> None:
     assert view.status == TaskStatus.ERROR
 
 
-def test_derive_agent_task_status_matches_view_for_running_agent() -> None:
-    """The CI babysitter's all-idle gate reads status via derive_agent_task_status;
-    it must report the same status as the CodingAgentTaskView it wraps. A sent
-    prompt with no matching request-complete is a mid-turn (RUNNING) agent."""
+def test_is_agent_busy_or_waiting_true_for_running_agent() -> None:
+    """The CI babysitter's all-idle gate blocks on the agent status the UI shows:
+    a sent prompt with no matching request-complete is a mid-turn (WORKING) agent,
+    so the predicate is True (busy)."""
     task = _make_task(outcome=TaskState.RUNNING)
     messages = [_env_acquired(), ChatInputUserMessage(message_id=AgentMessageID(), text="work")]
     view = _make_task_view(task)
     for message in messages:
         view.add_message(message)
     assert view.status == TaskStatus.RUNNING
-    assert derive_agent_task_status(task, messages) == view.status
+    assert is_agent_busy_or_waiting(task, messages) is True
 
 
-def test_derive_agent_task_status_reports_ready_for_idle_agent() -> None:
-    """Just the run-start anchor → READY (idle), with no settings or streaming view."""
+def test_is_agent_busy_or_waiting_true_for_waiting_agent() -> None:
+    """Yellow/waiting (an agent blocked on the user) counts as occupied — the
+    babysitter must not inject while a question or plan approval is pending."""
+    task = _make_terminal_task()
+    messages = [_env_acquired(), _signal(TerminalStatusSignal.WAITING)]
+    view = _make_task_view(task)
+    for message in messages:
+        view.add_message(message)
+    assert view.status == TaskStatus.WAITING
+    assert is_agent_busy_or_waiting(task, messages) is True
+
+
+def test_is_agent_busy_or_waiting_false_for_idle_agent() -> None:
+    """Just the run-start anchor → READY/IDLE, with no settings or streaming view,
+    so the predicate is False and the babysitter may act."""
     task = _make_task(outcome=TaskState.RUNNING)
-    assert derive_agent_task_status(task, [_env_acquired()]) == TaskStatus.READY
+    assert is_agent_busy_or_waiting(task, [_env_acquired()]) is False

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -65,6 +65,11 @@ _MERGED_MODE_STABLE_WAIT_MS = 25_000
 # poll. The polling service uses a 10s minimum interval in tests; 12s is a
 # safe lower bound that still keeps the test snappy.
 _BASELINE_POLL_SETTLE_MS = 12_000
+# Buffer, measured from the moment the pipeline badge confirms the failed poll
+# was observed, in which a babysitter that ignored the busy gate would have
+# spawned its tab. The coordinator consumes that same poll result (≤1s behind
+# the badge), so 15s is generous headroom against a contended runner.
+_BUSY_DEFER_STABLE_WAIT_MS = 15_000
 
 _FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
 
@@ -552,3 +557,69 @@ def test_github_pr_merge_conflict_creates_babysitter(sculptor_instance_: Sculpto
     alpha_chat = get_alpha_chat_view(sculptor_instance_.page)
     conflict_prompt_messages = alpha_chat.get_messages().filter(has_text=_MERGE_CONFLICT_PROMPT_FRAGMENT)
     expect(conflict_prompt_messages.first).to_be_visible()
+
+
+@user_story("to have the CI Babysitter wait until my other agent is idle before it starts fixing CI")
+def test_babysitter_defers_while_agent_busy_then_dispatches_when_idle(
+    sculptor_instance_: SculptorInstance, tmp_path: Path
+) -> None:
+    """The CI Babysitter must not inject a fix prompt while another agent in the
+    workspace is actively working — two agents editing the same workspace at
+    once corrupts the tree (SCU-1601). It holds off until every agent is idle,
+    then delivers the deferred prompt.
+
+    The workspace agent is held busy with ``fake_claude:wait_for_file`` so it
+    stays RUNNING until the test releases it. With a failed pipeline armed while
+    it is busy, no 'CI Babysitter' tab may appear. Releasing the agent (it goes
+    idle) lets the deferred prompt dispatch on the coordinator's next re-check.
+    """
+    page = sculptor_instance_.page
+    state_file = tmp_path / "gh_state"
+    state_file.write_text("running")
+    # Sentinel the busy agent blocks on; absent → the agent stays RUNNING.
+    release_file = tmp_path / "agent_release"
+
+    _enable_babysitter(sculptor_instance_)
+    _install_state_driven_gh(sculptor_instance_, state_file)
+    _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
+
+    # Start an agent that stays busy until the test creates the sentinel file.
+    busy_prompt = f'fake_claude:wait_for_file `{{"path": "{release_file}", "timeout_seconds": 300}}`'
+    task_page = start_task_and_wait_for_ready(page, busy_prompt, wait_for_agent_to_finish=False)
+    chat_panel = task_page.get_chat_panel()
+    # Confirm the agent is actually busy before arming CI.
+    expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=30_000)
+
+    # Arm the running → failed pipeline transition with the PR popover kept open
+    # the whole time, so the badge flip is read live without a re-open race. Once
+    # the badge shows "Failed", the coordinator has consumed that same poll result
+    # (observer fan-out is simultaneous with the cache update the badge renders
+    # from), so a babysitter ignoring the busy gate has already dispatched.
+    # Anchoring here — rather than on a fixed wall-clock window after arming —
+    # makes the negative assertion a reliable discriminator at any poll interval.
+    pr_popover = PlaywrightPrPopoverElement(page)
+    expect(pr_popover.get_chevron()).to_be_visible(timeout=60_000)
+    pr_popover.get_chevron().click()
+    badge = pr_popover.get_pipeline_status_badge()
+    expect(badge).to_have_text("Running", timeout=60_000)
+    state_file.write_text("failed")
+    expect(badge).to_have_text("Failed", timeout=60_000)
+    page.keyboard.press("Escape")
+
+    agent_tabs = PlaywrightAgentTabBarElement(page)
+    babysitter_tab = agent_tabs.get_agent_tab_by_name("CI Babysitter")
+    # The coordinator has now seen the failure. Give it a beat to act: with the
+    # bug it spawns the babysitter tab here; with the fix it defers while the
+    # workspace agent is busy, so no tab appears.
+    page.wait_for_timeout(_BUSY_DEFER_STABLE_WAIT_MS)
+    expect(babysitter_tab).to_have_count(0)
+
+    # Release the agent → it finishes its turn and goes idle → the deferred
+    # babysitter prompt is delivered on the coordinator's next re-check tick.
+    release_file.write_text("go")
+
+    expect(babysitter_tab.first).to_be_visible(timeout=60_000)
+    babysitter_tab.first.click()
+    alpha_chat = get_alpha_chat_view(page)
+    pipeline_prompt_messages = alpha_chat.get_messages().filter(has_text=_PIPELINE_PROMPT_FRAGMENT)
+    expect(pipeline_prompt_messages.first).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -66,11 +66,13 @@ _MERGED_MODE_STABLE_WAIT_MS = 25_000
 # poll. The polling service uses a 10s minimum interval in tests; 12s is a
 # safe lower bound that still keeps the test snappy.
 _BASELINE_POLL_SETTLE_MS = 12_000
-# Buffer, measured from the moment the pipeline badge confirms the failed poll
-# was observed, in which a babysitter that ignored the busy gate would have
-# spawned its tab. The coordinator consumes that same poll result (≤1s behind
-# the badge), so 15s is generous headroom against a contended runner.
-_BUSY_DEFER_STABLE_WAIT_MS = 15_000
+# Buffer in which a babysitter that ignored the busy gate (or one that queued the
+# failure to pounce when the agent goes idle) would have spawned its tab. Measured
+# from the moment the pipeline badge confirms the failed poll was observed, or from
+# the moment the busy agent goes idle. The coordinator consumes that same poll
+# result and re-checks idleness within ~1s, so 15s is generous headroom against a
+# contended runner.
+_BUSY_SKIP_STABLE_WAIT_MS = 15_000
 
 _FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
 
@@ -560,19 +562,18 @@ def test_github_pr_merge_conflict_creates_babysitter(sculptor_instance_: Sculpto
     expect(conflict_prompt_messages.first).to_be_visible()
 
 
-@user_story("to have the CI Babysitter wait until my other agent is idle before it starts fixing CI")
-def test_babysitter_defers_while_agent_busy_then_dispatches_when_idle(
-    sculptor_instance_: SculptorInstance, tmp_path: Path
-) -> None:
+@user_story("to keep the CI Babysitter from interrupting my other agent while it's working")
+def test_babysitter_ignores_ci_failure_while_agent_busy(sculptor_instance_: SculptorInstance, tmp_path: Path) -> None:
     """The CI Babysitter must not inject a fix prompt while another agent in the
-    workspace is actively working — two agents editing the same workspace at
-    once corrupts the tree (SCU-1601). It holds off until every agent is idle,
-    then delivers the deferred prompt.
+    workspace is actively working — two agents editing the same workspace at once
+    corrupts the tree (SCU-1601). It does not queue the failure to pounce when the
+    agent finishes; it simply skips it. A *fresh* CI failure observed once the
+    workspace is idle still drives a prompt.
 
-    The workspace agent is held busy with ``fake_claude:wait_for_file`` so it
-    stays RUNNING until the test releases it. With a failed pipeline armed while
-    it is busy, no 'CI Babysitter' tab may appear. Releasing the agent (it goes
-    idle) lets the deferred prompt dispatch on the coordinator's next re-check.
+    The workspace agent is held busy with FakeClaudePause so it stays RUNNING
+    until the test releases it. A failed pipeline armed while it is busy spawns no
+    'CI Babysitter' tab; releasing the agent (it goes idle) does NOT retroactively
+    spawn one; a fresh running → failed edge observed while idle does.
     """
     page = sculptor_instance_.page
     state_file = tmp_path / "gh_state"
@@ -594,7 +595,7 @@ def test_babysitter_defers_while_agent_busy_then_dispatches_when_idle(
     # the whole time, so the badge flip is read live without a re-open race. Once
     # the badge shows "Failed", the coordinator has consumed that same poll result
     # (observer fan-out is simultaneous with the cache update the badge renders
-    # from), so a babysitter ignoring the busy gate has already dispatched.
+    # from), so a babysitter ignoring the busy gate would already have dispatched.
     # Anchoring here — rather than on a fixed wall-clock window after arming —
     # makes the negative assertion a reliable discriminator at any poll interval.
     pr_popover = PlaywrightPrPopoverElement(page)
@@ -608,16 +609,21 @@ def test_babysitter_defers_while_agent_busy_then_dispatches_when_idle(
 
     agent_tabs = PlaywrightAgentTabBarElement(page)
     babysitter_tab = agent_tabs.get_agent_tab_by_name("CI Babysitter")
-    # The coordinator has now seen the failure. Give it a beat to act: with the
-    # bug it spawns the babysitter tab here; with the fix it defers while the
-    # workspace agent is busy, so no tab appears.
-    page.wait_for_timeout(_BUSY_DEFER_STABLE_WAIT_MS)
+    # Busy: the failure is skipped, so no babysitter tab appears.
+    page.wait_for_timeout(_BUSY_SKIP_STABLE_WAIT_MS)
     expect(babysitter_tab).to_have_count(0)
 
-    # Release the agent → it finishes its turn and goes idle → the deferred
-    # babysitter prompt is delivered on the coordinator's next re-check tick.
+    # Release the agent → it finishes its turn and goes idle. The skipped failure
+    # must NOT come back to pounce the instant the agent stops working: the
+    # babysitter stays absent even after the workspace is idle.
     pause.release()
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=30_000)
+    page.wait_for_timeout(_BUSY_SKIP_STABLE_WAIT_MS)
+    expect(babysitter_tab).to_have_count(0)
 
+    # A fresh running → failed edge observed while idle DOES drive a prompt —
+    # proving the babysitter still works and the silence above was the busy gate.
+    _arm_failed_transition(sculptor_instance_, state_file)
     expect(babysitter_tab.first).to_be_visible(timeout=60_000)
     babysitter_tab.first.click()
     alpha_chat = get_alpha_chat_view(page)

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -83,6 +83,13 @@ _FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
 #   mode = failed   → PR is open with a failed check rollup.
 #   mode = merged   → PR is merged.
 #   mode = closed   → PR is closed without merging.
+#   mode = conflict → PR is open and GitHub reports it CONFLICTING
+#                     (mergeable=CONFLICTING). The backend maps that to
+#                     has_conflicts=True, driving a MERGE_CONFLICT transition; a
+#                     backend that ignores the mergeable field (the SCU-1529 bug)
+#                     leaves has_conflicts=None and never fires. Every other mode
+#                     omits mergeable, so it reads as non-conflicting -- which
+#                     makes "running" the clean baseline a conflict is armed off.
 # The mode-file path is injected via ``.replace("{state_file}", ...)`` (not
 # ``.format``) so the JSON braces below don't need escaping.
 _FAKE_GH_STATE_SCRIPT = """\
@@ -98,6 +105,9 @@ case "$MODE" in
     merged)
         echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":7,"title":"Test PR","url":"https://github.com/test/repo/pull/7","state":"MERGED","baseRefName":"main","commits":{"nodes":[]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
         ;;
+    conflict)
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":7,"title":"Test PR","url":"https://github.com/test/repo/pull/7","state":"OPEN","baseRefName":"main","mergeable":"CONFLICTING","commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"PENDING"}}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
+        ;;
     *)
         echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
         ;;
@@ -109,21 +119,6 @@ def _install_fake_gh(fake_bin_dir: Path, script: str) -> None:
     script_path = fake_bin_dir / "gh"
     script_path.write_text(textwrap.dedent(script))
     script_path.chmod(script_path.stat().st_mode | stat.S_IEXEC)
-
-
-# Fake `gh` returning one OPEN PR that GitHub reports as CONFLICTING. The
-# backend issues a single `gh api graphql` query; this node carries
-# "mergeable":"CONFLICTING", so a backend that surfaces PR merge conflicts maps
-# it to has_conflicts=True and the babysitter fires on the very first poll (a
-# merge conflict needs no baseline change, unlike a pipeline failure -- see
-# transitions.classify_transitions). A backend that ignores the mergeable field
-# (the SCU-1529 bug) leaves has_conflicts=None and no babysitter tab appears.
-_FAKE_GH_CONFLICTING_PR_SCRIPT = """\
-#!/bin/bash
-if [[ "$*" == *"graphql"* ]]; then
-    echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","mergeable":"CONFLICTING","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
-fi
-"""
 
 
 def _install_state_driven_gh(instance: SculptorInstance, state_file: Path) -> None:
@@ -200,6 +195,31 @@ def _arm_failed_transition(instance: SculptorInstance, state_file: Path) -> None
     expect(pr_popover.get_pipeline_status_badge()).to_have_text("Running", timeout=60_000)
     instance.page.keyboard.press("Escape")
     state_file.write_text("failed")
+
+
+def _arm_merge_conflict_transition(instance: SculptorInstance, state_file: Path) -> None:
+    """Flip a PR mergeable → conflicting, confirming the poller observed the
+    non-conflicting baseline (via the PR popover "Running" badge) first.
+
+    Unlike PIPELINE_FAILED, MERGE_CONFLICT fires even on the first poll
+    (transitions.classify_transitions): a conflict present from the start would
+    dispatch immediately — but on the very first poll the just-started workspace
+    agent is typically still building/running, so the SCU-1601 all-agents-idle
+    gate DROPS that failure, and a persistent conflict never re-arms (no babysitter
+    ever appears). Arming the conflict as a fresh has_conflicts → True edge only
+    after the workspace agent is idle makes the dispatch deterministic, the same
+    way _arm_failed_transition does for pipeline failures. Waiting on the badge —
+    driven by the same poll result the coordinator consumes — guarantees a
+    non-conflicting poll landed before we write "conflict".
+    """
+    state_file.write_text("running")
+    pr_popover = PlaywrightPrPopoverElement(instance.page)
+    chevron = pr_popover.get_chevron()
+    expect(chevron).to_be_visible(timeout=60_000)
+    chevron.click()
+    expect(pr_popover.get_pipeline_status_badge()).to_have_text("Running", timeout=60_000)
+    instance.page.keyboard.press("Escape")
+    state_file.write_text("conflict")
 
 
 @user_story("to have Sculptor's CI Babysitter automatically investigate a failed pipeline")
@@ -534,23 +554,33 @@ def test_restart_reuses_existing_babysitter_tab(
 
 
 @user_story("to have the CI Babysitter automatically resolve a merge conflict on a GitHub PR")
-def test_github_pr_merge_conflict_creates_babysitter(sculptor_instance_: SculptorInstance) -> None:
-    """When a GitHub PR opened from a workspace has a merge conflict, the
+def test_github_pr_merge_conflict_creates_babysitter(sculptor_instance_: SculptorInstance, tmp_path: Path) -> None:
+    """When a GitHub PR opened from a workspace develops a merge conflict, the
     coordinator spawns a 'CI Babysitter' agent tab and delivers the configured
     merge-conflict prompt.
 
     Regression for SCU-1529: the GitHub PR status path never surfaced
     has_conflicts (the `gh api graphql` query didn't request `mergeable`, and
     the parser didn't map it), so the coordinator's MERGE_CONFLICT transition
-    never fired for PRs and no babysitter tab ever appeared. A merge conflict
-    surfaces on the first poll, so -- unlike the pipeline-failure scenarios --
-    no baseline bump is needed.
+    never fired for PRs and no babysitter tab ever appeared.
+
+    The conflict is armed as a fresh non-conflicting → conflicting edge only
+    after the workspace agent goes idle. MERGE_CONFLICT fires even on the first
+    poll, so a conflict present from the start would dispatch while the
+    just-started agent is still building -- which the SCU-1601 all-agents-idle
+    gate then drops (and a persistent conflict never re-arms). Arming it once the
+    workspace is idle, the way the pipeline-failure tests do, keeps the dispatch
+    deterministic.
     """
+    state_file = tmp_path / "gh_state"
+    state_file.write_text("running")
+
     _enable_babysitter(sculptor_instance_)
-    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_CONFLICTING_PR_SCRIPT)
+    _install_state_driven_gh(sculptor_instance_, state_file)
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
     start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
+    _arm_merge_conflict_transition(sculptor_instance_, state_file)
 
     agent_tabs = PlaywrightAgentTabBarElement(sculptor_instance_.page)
     babysitter_tab = agent_tabs.get_agent_tab_by_name("CI Babysitter")

--- a/sculptor/tests/integration/frontend/test_ci_babysitter.py
+++ b/sculptor/tests/integration/frontend/test_ci_babysitter.py
@@ -26,6 +26,7 @@ from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.pr_popover import PlaywrightPrPopoverElement
 from sculptor.testing.elements.terminal import get_agent_terminal_panel
 from sculptor.testing.elements.terminal import wait_for_xterm_substring
+from sculptor.testing.fake_claude_pause import FakeClaudePause
 from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 from sculptor.testing.playwright_utils import full_spa_reload
 from sculptor.testing.playwright_utils import navigate_to_settings_page
@@ -576,16 +577,15 @@ def test_babysitter_defers_while_agent_busy_then_dispatches_when_idle(
     page = sculptor_instance_.page
     state_file = tmp_path / "gh_state"
     state_file.write_text("running")
-    # Sentinel the busy agent blocks on; absent → the agent stays RUNNING.
-    release_file = tmp_path / "agent_release"
+    # Keep the workspace agent busy (RUNNING) until the test releases it — a
+    # signaled pause, not a wall-clock, so CI overhead can't race the window.
+    pause = FakeClaudePause()
 
     _enable_babysitter(sculptor_instance_)
     _install_state_driven_gh(sculptor_instance_, state_file)
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
-    # Start an agent that stays busy until the test creates the sentinel file.
-    busy_prompt = f'fake_claude:wait_for_file `{{"path": "{release_file}", "timeout_seconds": 300}}`'
-    task_page = start_task_and_wait_for_ready(page, busy_prompt, wait_for_agent_to_finish=False)
+    task_page = start_task_and_wait_for_ready(page, pause.prompt, wait_for_agent_to_finish=False)
     chat_panel = task_page.get_chat_panel()
     # Confirm the agent is actually busy before arming CI.
     expect(chat_panel.get_thinking_indicator()).to_be_visible(timeout=30_000)
@@ -616,7 +616,7 @@ def test_babysitter_defers_while_agent_busy_then_dispatches_when_idle(
 
     # Release the agent → it finishes its turn and goes idle → the deferred
     # babysitter prompt is delivered on the coordinator's next re-check tick.
-    release_file.write_text("go")
+    pause.release()
 
     expect(babysitter_tab.first).to_be_visible(timeout=60_000)
     babysitter_tab.first.click()


### PR DESCRIPTION
## Original bug

[SCU-1601](https://linear.app/imbue/issue/SCU-1601) — *CI Babysitter must not trigger while any agent in the workspace is working*

> When the CI Babysitter detects a CI / merge-conflict error, it should **not** inject a fix prompt if any agent in the workspace is actively working (blue/busy or yellow/waiting). It should only inject work when **all** agents are idle — otherwise two agents can modify the workspace at the same time.

## Behavior decision: ignore, don't defer

The ticket said "hold off and re-check later," but on review we chose to **drop** the failure when the workspace is busy rather than queue it to fire when agents go idle. Deferring means the babysitter pounces the instant your other agent finishes a turn — interrupting your work and possibly acting on a CI result your own changes already made moot. Ignoring respects the active work: a still-relevant **pipeline failure** re-arms naturally on the next push (a new `pipeline_id` is a fresh `PIPELINE_FAILED` edge), and a **merge conflict** re-arms when it next clears and recurs. The tradeoff — a one-shot failure you never re-trigger (and a persistent conflict that never recurs) won't get auto-handled — is acceptable; you can always trigger the babysitter manually. This also removes the deferral state machine entirely, shrinking the change.

## Hypotheses considered

1. **The babysitter dispatches a fix prompt regardless of whether another agent in the workspace is mid-flight, so a CI failure during active work spawns a second agent that edits the same tree concurrently.** — **REPRODUCED** (failing e2e test below).

## For each reproduced bug

### CI Babysitter injects a fix prompt while another agent in the workspace is busy

**Repro steps**

1. Enable the CI Babysitter and point the workspace at a GitHub remote whose PR status is driven by a fake `gh` CLI.
2. Start an agent and keep it **busy** (the test holds it RUNNING via the `FakeClaudePause` helper).
3. With the agent still busy, flip the pipeline running → **failed** (confirmed via the PR popover's pipeline badge reading "Failed", i.e. the coordinator has observed the failed poll).
4. Observe the agent tab bar.

**Expected vs actual**

- **Expected:** No "CI Babysitter" tab appears while the agent is busy; the failure is skipped, not queued. When the agent later goes idle, the babysitter does **not** retroactively pounce. A *fresh* CI failure observed while idle still drives a prompt.
- **Actual (before the fix):** A "CI Babysitter" tab appears and the fix prompt is delivered *while the original agent is still working* — two agents now act on the same workspace at once.

**Before**

The e2e test asserts no babysitter tab while the agent is busy; before the fix it fails because the tab appears:

```
        page.wait_for_timeout(_BUSY_SKIP_STABLE_WAIT_MS)
>       expect(babysitter_tab).to_have_count(0)
E       AssertionError: Locator expected to have count '0'
E       Actual value: 1
E         - waiting for get_by_test_id("AGENT_TAB").filter(has_text="CI Babysitter")
sculptor/tests/integration/frontend/test_ci_babysitter.py: AssertionError
========================= 1 failed =========================
```

The rendered-UI accessibility snapshot at that moment shows the offending tab next to the still-thinking agent:

```
- text: Thinking... 61.5s            ← the original agent is still busy
- tablist:
  - tab "Claude 1 …" [selected]
  - tab "CI Babysitter"              ← babysitter dispatched anyway (the bug)
```

(This background-coordinator behavior — triggered by PR polling plus a concurrently-busy agent — is reproduced faithfully and deterministically by the Playwright e2e test, which drives the real rendered app; the failing→passing test plus this rendered snapshot are the before/after evidence in lieu of hand-staged screenshots of a scenario that requires both a fake failed-CI provider and a busy agent.)

**Root cause**

`CIBabysitterCoordinator._dispatch_prompt` (`sculptor/sculptor/services/ci_babysitter_service/coordinator.py`) gated dispatch only on `enabled` / `retired` / `paused` / `retry_cap` / per-commit dedup. None of these consult the state of the *other* agents in the workspace, so a `PIPELINE_FAILED` / `MERGE_CONFLICT` transition delivered the configured prompt immediately — spawning the babysitter as a second agent even while the user's agent was actively editing.

**Fix**

Add an all-agents-idle gate as the last check in `_dispatch_prompt`. `_are_all_workspace_agents_idle` enumerates the workspace's non-babysitter agent tasks (the babysitter's own is excluded by `_workspace_agent_tasks_most_recent_first`) and asks `is_agent_busy_or_waiting` for each. If any agent's status is `WORKING` (blue/busy) or `WAITING` (yellow/needs-input), `_dispatch_prompt` returns immediately — **the failure is dropped**, counting no retry and setting no dedup, so a later fresh transition re-enters cleanly.

The gate keys off the **agent status** the UI surfaces, not a raw task status: `is_agent_busy_or_waiting` (new, in `derived.py`) reads the agent's `WorkspacePeekAgentStatus` — the same `WORKING`/`WAITING` the status dot and workspace peek show — and treats only those two as "occupying the workspace" (`IDLE`/`ERROR`/`COMPLETED` don't block, so a wedged or errored agent never blocks). Status is computed from `TaskService.get_live_messages_for_task` (in-memory; includes the ephemeral runner/terminal-signal messages the persisted log omits), so the gate and the UI can never disagree. `transitions.py` did not need changes — the gate lives in the coordinator, not the pure classifier.

**Test**

- Path: `sculptor/tests/integration/frontend/test_ci_babysitter.py::test_babysitter_ignores_ci_failure_while_agent_busy`
- Kind: e2e (Playwright). The test holds an agent busy, arms a failure, asserts no babysitter tab; releases the agent to idle and asserts the tab *still* doesn't appear (the no-pounce guarantee — this is the assertion that fails against a deferring implementation); then arms a fresh failure while idle and asserts the tab *does* appear.
- Also added backend unit tests: `coordinator_test.py` (`test_busy_agent_skips_dispatch_without_pouncing_on_idle`, `test_idle_agent_dispatches_immediately`) and `derived_task_status_test.py` (the new `is_agent_busy_or_waiting` helper — busy, waiting, and idle cases).
- Failing-test commit: `f2a6696940`
- Fix commit: `04e374f867` (gate) + this branch's later commits (agent-status framing, ignore-not-defer rework)

**After**

With the fix, the same test passes — no babysitter tab while busy, no pounce on idle, and a fresh failure while idle still drives a prompt:

```
[gw0] [100%] PASSED …::test_babysitter_ignores_ci_failure_while_agent_busy
========================= 1 passed in 143.95s =========================
```

I verified the e2e is a real discriminator by running it against the deferring implementation: it fails at the post-release assertion (`to_have_count(0)` → `Actual value: 1`), i.e. the deferring babysitter pounces the moment the agent goes idle.

## Review notes

A self-review pass (`/code-review-checklist`) ran over `main...HEAD`. Findings:

- **Acted on:** the busy-agent test uses the canonical `FakeClaudePause` helper (a signaled pause, not a wall-clock) per `docs/development/review/integration_tests.md`. The negative `wait_for_timeout → to_have_count(0)` assertions are the established absence-after-settle pattern in this file, anchored on the confirmed "Failed" badge / on the agent's thinking-indicator clearing so they stay reliable at any poll interval.
- **Noted (no change):** the fix does not touch `transitions.py` (named in the ticket as a likely-affected file) — the gate is a coordinator-level dispatch concern.
- **Noted (no change):** "ignore" gives merge conflicts weaker handling than pipeline failures, because a conflict that stays `CONFLICTING` produces no fresh edge to re-arm on (unlike a new pipeline_id). A persistent conflict the user never resolves-and-recurs won't get auto-handled. This is the accepted tradeoff of the ignore-don't-defer decision above.

(Sent by Claude)
