### PR TITLE
Fix add-agent race in multi-agent integration tests (SCU-1595)

### DIFF
--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -388,6 +388,44 @@ def start_task_and_wait_for_ready(
     return task_page
 
 
+def add_agent_and_wait_for_ready(page: Page) -> PlaywrightTaskPage:
+    """Click the agent tab "+" to add an agent and wait until the new agent is
+    the active one, with a chat input ready to receive a message.
+
+    Returns a ``PlaywrightTaskPage`` bound to the new (now-active) agent.
+
+    Adding an agent navigates to it only after an async create request
+    resolves, but the agent-tab count flips to N+1 as soon as the agent-list
+    query refreshes — which can happen before that navigation lands.  Callers
+    must not type into the chat input until the switch completes, or the text
+    lands in the outgoing agent's editor (or no editor, mid-remount).  Waiting
+    for the URL to point at a different agent id is the settle signal.
+    """
+    task_page = PlaywrightTaskPage(page=page)
+    previous_agent_id = task_page.get_task_id()
+    agent_tab_bar = task_page.get_agent_tab_bar()
+    existing_tab_count = agent_tab_bar.get_agent_tabs().count()
+
+    agent_tab_bar.get_add_agent_button().click()
+    expect(agent_tab_bar.get_agent_tabs()).to_have_count(existing_tab_count + 1)
+
+    # The create-agent POST and clone/setup can be slow on contended runners.
+    page.wait_for_function(
+        r"""(previousAgentId) => {
+            const match = window.location.href.match(/\/agent\/([A-Za-z0-9_-]+)/);
+            return match !== null && match[1] !== previousAgentId;
+        }""",
+        arg=previous_agent_id,
+        timeout=60_000,
+    )
+
+    new_task_page = PlaywrightTaskPage(page=page)
+    # The chat input is keyed by agent id, so it remounts for the new agent;
+    # wait for it to attach before callers type into it.
+    expect(new_task_page.get_chat_panel().get_chat_input()).to_be_visible()
+    return new_task_page
+
+
 def navigate_to_frontend(page: Page, url: str, retry_seconds: float = 60) -> Page:
     """Navigate the browser to the Sculptor frontend URL with retries.
 

--- a/sculptor/tests/integration/frontend/test_multi_agent_workspace.py
+++ b/sculptor/tests/integration/frontend/test_multi_agent_workspace.py
@@ -14,6 +14,7 @@ from playwright.sync_api import expect
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
+from sculptor.testing.playwright_utils import add_agent_and_wait_for_ready
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -50,6 +51,39 @@ def test_create_second_agent_in_existing_workspace(
     # Verify the chat panel is visible for the new agent
     chat_panel = task_page.get_chat_panel()
     expect(chat_panel).to_be_visible()
+
+
+@user_story("to immediately chat with a newly added agent")
+def test_message_to_newly_added_agent_lands_on_that_agent(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """A message sent immediately after adding a second agent must reach the new
+    agent's chat, not the outgoing one.
+
+    Adding an agent switches to it asynchronously; typing before the switch
+    settles can leave the new agent's send button disabled or its editor
+    unmounted.  ``add_agent_and_wait_for_ready`` settles the switch, and this
+    test pins that the new agent receives the message and no copy leaks onto
+    the first.
+    """
+    page = sculptor_instance_.page
+    second_agent_message = "Hello from the second agent"
+
+    task_page = start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="New Agent Chat WS")
+    wait_for_completed_message_count(task_page.get_chat_panel(), expected_message_count=2)
+
+    task_page_2 = add_agent_and_wait_for_ready(page)
+    chat_panel_2 = task_page_2.get_chat_panel()
+    send_chat_message(chat_panel_2, second_agent_message)
+    wait_for_completed_message_count(chat_panel_2, expected_message_count=2)
+    expect(chat_panel_2.get_messages().filter(has_text=second_agent_message)).to_have_count(1)
+
+    # The message landed only on the new agent: switching back shows the first
+    # agent still has just its own single exchange and no copy of the message.
+    task_page.get_agent_tab_bar().get_agent_tabs().first.click()
+    first_agent_chat = task_page.get_chat_panel()
+    expect(first_agent_chat.get_messages()).to_have_count(2)
+    expect(first_agent_chat.get_messages().filter(has_text=second_agent_message)).to_have_count(0)
 
 
 @user_story("to see which agents share a workspace")

--- a/sculptor/tests/integration/frontend/test_workspace_scoped_changes.py
+++ b/sculptor/tests/integration/frontend/test_workspace_scoped_changes.py
@@ -18,7 +18,7 @@ from playwright.sync_api import expect
 
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
-from sculptor.testing.pages.task_page import PlaywrightTaskPage
+from sculptor.testing.playwright_utils import add_agent_and_wait_for_ready
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
@@ -60,13 +60,7 @@ fake_claude:write_file `{
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    agent_tab_bar = task_page.get_agent_tab_bar()
-    agent_tab_bar.get_add_agent_button().click()
-
-    agent_tabs = agent_tab_bar.get_agent_tabs()
-    expect(agent_tabs).to_have_count(2)
-
-    task_page_2 = PlaywrightTaskPage(page=page)
+    task_page_2 = add_agent_and_wait_for_ready(page)
     chat_panel_2 = task_page_2.get_chat_panel()
     send_chat_message(
         chat_panel=chat_panel_2,
@@ -83,7 +77,7 @@ fake_claude:write_file `{
     expect(changes_tree).to_be_visible()
     expect(changes_tree.get_tree_rows()).to_have_count(2)
 
-    agent_tabs.first.click()
+    task_page.get_agent_tab_bar().get_agent_tabs().first.click()
 
     task_page.activate_changes_panel(scope="uncommitted")
     changes_tree_1 = task_page.get_changes_panel().get_changes_tree()
@@ -120,13 +114,7 @@ fake_claude:write_file `{
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    agent_tab_bar = task_page.get_agent_tab_bar()
-    agent_tab_bar.get_add_agent_button().click()
-
-    agent_tabs = agent_tab_bar.get_agent_tabs()
-    expect(agent_tabs).to_have_count(2)
-
-    task_page_2 = PlaywrightTaskPage(page=page)
+    task_page_2 = add_agent_and_wait_for_ready(page)
     chat_panel_2 = task_page_2.get_chat_panel()
     send_chat_message(
         chat_panel=chat_panel_2,
@@ -184,13 +172,7 @@ fake_claude:write_file `{
     expect(changes_tree).to_be_visible()
     expect(changes_tree.get_tree_rows()).to_have_count(1)
 
-    agent_tab_bar = task_page.get_agent_tab_bar()
-    agent_tab_bar.get_add_agent_button().click()
-
-    agent_tabs = agent_tab_bar.get_agent_tabs()
-    expect(agent_tabs).to_have_count(2)
-
-    task_page_2 = PlaywrightTaskPage(page=page)
+    task_page_2 = add_agent_and_wait_for_ready(page)
     chat_panel_2 = task_page_2.get_chat_panel()
     send_chat_message(
         chat_panel=chat_panel_2,
@@ -202,7 +184,7 @@ fake_claude:write_file `{
     )
     wait_for_completed_message_count(chat_panel=chat_panel_2, expected_message_count=2)
 
-    agent_tabs.first.click()
+    task_page.get_agent_tab_bar().get_agent_tabs().first.click()
 
     task_page.activate_changes_panel(scope="uncommitted")
     changes_tree_1 = task_page.get_changes_panel().get_changes_tree()


### PR DESCRIPTION
## Original bug

Flaky integration tests tracked by [SCU-1595](https://linear.app/imbue/issue/SCU-1595).
On recent `main` / merge-queue commits, the multi-agent tests in
`test_workspace_scoped_changes.py` flaked in `send_chat_message` for the
**second** agent — the `SEND_BUTTON` stayed `disabled`, or the Tiptap editor
could not be found. Affected (same root cause):

- `test_uncommitted_tab_updates_when_other_agent_modifies_files`
- `test_uncommitted_tab_shows_changes_from_all_agents`
- `test_review_modal_shows_changes_from_all_agents`

## Hypotheses considered

1. **Cross-agent propagation race in the uncommitted-changes tab** (the ticket's
   starting hypothesis) — **DISCARDED.** Every CI failure lands in
   `send_chat_message` for agent 2, *before* the changes-tab assertion is ever
   reached; once agent 2 actually writes its file, propagation to agent 1 works.
2. **Add-agent switch race: tests interact with the new agent's chat input
   before the async navigation to it lands** — **REPRODUCED** (root cause).

## Reproduced bug

### Second agent's chat input is raced after "+"

**Repro steps**
1. Create a workspace with a Fake Claude agent (agent 1) and have it write a file.
2. Click the agent-tab "+" to add agent 2.
3. Wait only for the agent-tab count to reach 2 (what the tests did).
4. Immediately type into "the chat input" and click send for agent 2.

Under load (the offload runner, or a contended local machine) this flakes ~1 in 4.

**Expected vs actual**
- Expected: the message is typed into and sent from the new agent's chat input.
- Actual (intermittent): the new agent's `SEND_BUTTON` stays `disabled`, or
  `type_into_tiptap` raises "Could not find Tiptap editor instance".

**Before** (offload check-run tracebacks)

```
# SHA 92b30517 — SEND_BUTTON never enables
test_workspace_scoped_changes.py:195: in test_uncommitted_tab_updates_when_other_agent_modifies_files
    send_chat_message(...)
chat_panel.py:309: in send_chat_message
    expect(send_button).to_be_enabled()
E   AssertionError: Locator expected to be enabled
E   Actual value: disabled
E     - Expect "to_be_enabled" with timeout 30000ms
E       64 × locator resolved to <button disabled ... data-testid="SEND_BUTTON" ...>

# SHA d457af55 / e80488ef — editor not mounted
chat_panel.py:307: in send_chat_message
    type_into_tiptap(chat_panel._page, chat_input, message)
E   playwright._impl._errors.Error: Locator.evaluate: Error: Could not find Tiptap editor instance
```

**Root cause**
`AgentTabs.handleCreateAgent` (`AgentTabs.tsx:309`) creates the agent with an
async POST and navigates to it **only after that POST resolves**. The agent-tab
count, however, flips to N+1 as soon as the agent-list query refreshes — which
can happen before the navigation lands. The tests waited only for
`expect(agent_tabs).to_have_count(2)`, then typed immediately. In the gap before
navigation, the resolved `CHAT_INPUT` is still the *outgoing* agent's editor, so
the text lands in agent 1's draft and agent 2's own draft stays empty (its send
button is gated on `!promptDraft?.trim()`, `ChatInput.tsx:721`); or the old input
has unmounted and the new one (keyed `chat-input-${taskID}`) has not yet mounted.
It's load-dependent because the navigation usually wins the race on a fast runner.
The product is correct — the test was missing a settle signal.

**Fix**
Add `add_agent_and_wait_for_ready()` to `playwright_utils.py`: it clicks "+" and
then waits for `window.location.href` to point at a *different* `/agent/<id>` (the
navigation landing) before returning a `PlaywrightTaskPage` bound to the new
agent. This is a deterministic settle — no sleeps. Once the new agent is active,
the only chat input in the DOM is its own, so typing cannot leak onto the
outgoing agent. The three tests route through it.

**Test**
- Helper + call-site changes: `sculptor/sculptor/testing/playwright_utils.py`,
  `sculptor/tests/integration/frontend/test_workspace_scoped_changes.py`.
- New focused regression test (kind: integration / Playwright):
  `test_message_to_newly_added_agent_lands_on_that_agent` in
  `sculptor/tests/integration/frontend/test_multi_agent_workspace.py` — sends a
  message immediately after adding an agent and asserts it lands on the new
  agent and does not leak onto the first.
- Single atomic commit (`fbbad268`): this is a test-infra fix, so the settle
  helper and the tests that depend on it belong in one logical change.

**After** (local serial run, `XDIST_WORKERS=1`, on the same contended machine
whose load caused the original flake)

```
…multi_agent_workspace.py::test_message_to_newly_added_agent_lands_on_that_agent  PASSED
…workspace_scoped_changes.py::test_review_modal_shows_changes_from_all_agents     PASSED
…workspace_scoped_changes.py::test_uncommitted_tab_shows_changes_from_all_agents  PASSED
…scoped_changes.py::test_uncommitted_tab_updates_when_other_agent_modifies_files  PASSED
======================== 4 passed in 144.23s (0:02:24) =========================
```

`just format` and `just check` (lint + typecheck + ratchets + hygiene) both pass.

## Review notes

- The regression test is **not** a deterministic fail-without-the-fix — the race
  is probabilistic, so a single run could pass even on the old code. This is
  intrinsic to timing-flake fixes; the test still pins the add-agent→send flow
  and guards the settle helper against being removed.
- An earlier *parallel* run on a load-32 machine showed 2 of these tests
  ERROR in fixture setup (`expect_app_not_onboarding` — the backend-ack-under-load
  flake; test bodies never executed). That is a separate, environmental setup
  flake unrelated to this change; `test_review_modal` passed through the new
  helper even in that run.

(Sent by Claude)
