### PR TITLE
Relaunch Electron in tests on transient esbuild dev-bundle crash

### DIFF
--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import time
 from collections import deque
+from collections.abc import Sequence
 from pathlib import Path
 
 from filelock import FileLock
@@ -34,6 +35,11 @@ _SLOW_LOCK_WAIT_LOG_THRESHOLD_SECONDS = 1.0
 _CDP_CONNECT_TIMEOUT_SECONDS = 120
 _CDP_CONNECT_RETRY_INTERVAL_SECONDS = 1
 _PROCESS_KILL_TIMEOUT_SECONDS = 5
+# Relaunch a few times so a transient esbuild crash doesn't fail the test's setup.
+_MAX_ELECTRON_LAUNCH_ATTEMPTS = 3
+# esbuild's Go crash dump spans many goroutines; keep enough of the tail that its
+# bundler frames survive both for the raised error and the relaunch decision.
+_RECENT_OUTPUT_LINES = 200
 
 
 def _is_known_harmless_electron_error(line: str) -> bool:
@@ -45,6 +51,27 @@ def _is_known_harmless_electron_error(line: str) -> bool:
         "X connection error received.",
     ]
     return any(substring in line for substring in harmless_substrings)
+
+
+def _is_transient_electron_start_crash(output: str) -> bool:
+    """Whether the captured Electron output shows esbuild's Go binary crashing at startup.
+
+    ``electron-forge start`` drives the renderer's background dependency
+    optimization and the main/preload bundle build over a single shared esbuild
+    service. Under that concurrent load — and the CI sandbox's limited CPU/memory —
+    the esbuild process intermittently dies with a Go runtime crash dump whose
+    goroutine traces name ``github.com/evanw/esbuild``, so the renderer never
+    reaches its ready message and forge exits non-zero. Such a launch recovers on a
+    fresh attempt.
+    """
+    return "github.com/evanw/esbuild" in output
+
+
+def _should_retry_electron_launch(attempt_index: int, max_attempts: int, recent_output: Sequence[str]) -> bool:
+    """Whether to relaunch after a failed start: a transient esbuild crash with attempts remaining."""
+    if attempt_index >= max_attempts - 1:
+        return False
+    return _is_transient_electron_start_crash("\n".join(recent_output))
 
 
 class ElectronFrontend:
@@ -118,55 +145,9 @@ class ElectronFrontend:
 
         frontend_dir = get_v1_frontend_path()
         lock_path = Path("/tmp/sculptor_electron_forge.lock")
-
-        is_launched = False
-        # Keep the most recent Electron output (stderr is merged into stdout
-        # below) so that if it never reaches its ready message we can surface
-        # the crash output in the raised error.
-        recent_output: deque[str] = deque(maxlen=50)
         file_lock = FileLock(str(lock_path), timeout=_FORGE_LOCK_TIMEOUT_SECONDS)
-        t_lock = time.monotonic()
-        file_lock.acquire()
-        lock_wait = time.monotonic() - t_lock
-        if lock_wait > _SLOW_LOCK_WAIT_LOG_THRESHOLD_SECONDS:
-            logger.info("[timing] Electron forge lock wait: {:.2f}s", lock_wait)
-        try:
-            t_proc = time.monotonic()
-            self._electron_proc = subprocess.Popen(
-                cmd,
-                cwd=frontend_dir,
-                env=full_env,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                preexec_fn=lambda: os.setpgid(0, 0),
-            )
-            assert self._electron_proc.stdout is not None
-            for line in self._electron_proc.stdout:
-                recent_output.append(line.rstrip())
-                logger.info("[Electron stdout] {}", line.rstrip())
-                if ELECTRON_READY_MESSAGE in line:
-                    is_launched = True
-                    self._forwarder = Forwarder(
-                        self._electron_proc,
-                        prefix="[Electron stdout] ",
-                        known_harmless_func=_is_known_harmless_electron_error,
-                    )
-                    self._forwarder.start()
-                    break
-        finally:
-            file_lock.release()
-        logger.info(
-            "[timing] Electron process launch (xvfb + Vite + Electron ready): {:.2f}s", time.monotonic() - t_proc
-        )
 
-        if not is_launched:
-            self._kill_electron()
-            exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
-            tail = "\n".join(recent_output) or "(no output captured)"
-            message = f"Electron frontend failed to start (exit code {exit_code}). Last Electron output:\n{tail}"
-            raise RuntimeError(message)
+        recent_output = self._launch_electron_with_retries(cmd, full_env, frontend_dir, file_lock)
 
         t_cdp = time.monotonic()
         try:
@@ -201,6 +182,90 @@ class ElectronFrontend:
         self._page = page
 
         return (context, page)
+
+    def _launch_electron_with_retries(
+        self,
+        cmd: tuple[str, ...],
+        full_env: dict[str, str],
+        frontend_dir: Path,
+        file_lock: FileLock,
+    ) -> deque[str]:
+        """Launch electron-forge, relaunching on a transient esbuild dev-bundle crash.
+
+        Returns the most recent Electron output of the successful launch; raises
+        ``RuntimeError`` if every attempt fails, or any attempt fails for a
+        non-transient reason.
+        """
+        recent_output: deque[str] = deque(maxlen=_RECENT_OUTPUT_LINES)
+        for attempt_index in range(_MAX_ELECTRON_LAUNCH_ATTEMPTS):
+            is_launched, recent_output = self._start_electron_process(cmd, full_env, frontend_dir, file_lock)
+            if is_launched:
+                return recent_output
+            self._kill_electron()
+            if _should_retry_electron_launch(attempt_index, _MAX_ELECTRON_LAUNCH_ATTEMPTS, recent_output):
+                logger.warning(
+                    "[Electron] dev bundler (esbuild) crashed on launch attempt {}/{}; relaunching",
+                    attempt_index + 1,
+                    _MAX_ELECTRON_LAUNCH_ATTEMPTS,
+                )
+                continue
+            exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
+            tail = "\n".join(recent_output) or "(no output captured)"
+            message = f"Electron frontend failed to start (exit code {exit_code}). Last Electron output:\n{tail}"
+            raise RuntimeError(message)
+        # Unreachable, but satisfies the return-type checker.
+        raise RuntimeError("Electron frontend failed to start after all launch attempts.")
+
+    def _start_electron_process(
+        self,
+        cmd: tuple[str, ...],
+        full_env: dict[str, str],
+        frontend_dir: Path,
+        file_lock: FileLock,
+    ) -> tuple[bool, deque[str]]:
+        """Launch electron-forge once and read stdout until its ready message or exit.
+
+        Returns whether the ready message was seen and the most recent output
+        captured. The forge lock serialises this across concurrent test workers.
+        """
+        recent_output: deque[str] = deque(maxlen=_RECENT_OUTPUT_LINES)
+        is_launched = False
+        t_lock = time.monotonic()
+        file_lock.acquire()
+        lock_wait = time.monotonic() - t_lock
+        if lock_wait > _SLOW_LOCK_WAIT_LOG_THRESHOLD_SECONDS:
+            logger.info("[timing] Electron forge lock wait: {:.2f}s", lock_wait)
+        t_proc = time.monotonic()
+        try:
+            self._electron_proc = subprocess.Popen(
+                cmd,
+                cwd=frontend_dir,
+                env=full_env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                preexec_fn=lambda: os.setpgid(0, 0),
+            )
+            assert self._electron_proc.stdout is not None
+            for line in self._electron_proc.stdout:
+                recent_output.append(line.rstrip())
+                logger.info("[Electron stdout] {}", line.rstrip())
+                if ELECTRON_READY_MESSAGE in line:
+                    is_launched = True
+                    self._forwarder = Forwarder(
+                        self._electron_proc,
+                        prefix="[Electron stdout] ",
+                        known_harmless_func=_is_known_harmless_electron_error,
+                    )
+                    self._forwarder.start()
+                    break
+        finally:
+            file_lock.release()
+        logger.info(
+            "[timing] Electron process launch (xvfb + Vite + Electron ready): {:.2f}s", time.monotonic() - t_proc
+        )
+        return is_launched, recent_output
 
     def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         self._kill_electron()

--- a/sculptor/sculptor/testing/electron_frontend_test.py
+++ b/sculptor/sculptor/testing/electron_frontend_test.py
@@ -1,0 +1,154 @@
+"""Unit tests for the Electron launch helpers in :mod:`sculptor.testing.electron_frontend`."""
+
+from collections import deque
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+from filelock import FileLock
+
+from sculptor.testing.electron_frontend import ElectronFrontend
+from sculptor.testing.electron_frontend import _is_transient_electron_start_crash
+from sculptor.testing.electron_frontend import _should_retry_electron_launch
+
+_READY_OUTPUT = ["Logging to temp file: /tmp/sculptor.log"]
+
+# Real "Last Electron output" tails captured from the offload electron lane when
+# esbuild's Go binary crashed during dev-bundle startup — one in a plugin onLoad
+# callback, one in the linker.
+_ESBUILD_ONLOAD_CRASH_TAIL = """\
+github.com/evanw/esbuild/pkg/api.(*pluginImpl).onLoad.func1({{0x0, 0x0}, {{0xc00012fdb0, 0x4f...
+	github.com/evanw/esbuild/internal/bundler/bundler.go:1193 +0xcf5
+github.com/evanw/esbuild/internal/bundler.parseFile(...)
+	github.com/evanw/esbuild/internal/bundler/bundler.go:163 +0x2b5
+created by github.com/evanw/esbuild/internal/bundler.(*scanner).maybeParseFile in goroutine 386
+main.(*serviceType).sendRequest(0xc000182390, {0x9973a0, 0xc0034a9020})
+	github.com/evanw/esbuild/cmd/esbuild/service.go:192 +0x12b"""
+
+_ESBUILD_LINKER_CRASH_TAIL = """\
+	runtime/malloc.go:1349 +0x54 fp=0xc0003c76d0 sp=0xc0003c76a8 pc=0x40d554
+runtime.mallocgc(0x20, 0x9e9800, 0x1)
+runtime.newobject(0x9e9800?)
+github.com/evanw/esbuild/internal/linker.(*linkerContext).createExportsForFile(0xc0005e2420, 0x1916b0?)
+	github.com/evanw/esbuild/internal/linker/linker.go:2311 +0x691
+created by github.com/evanw/esbuild/internal/linker.(*linkerContext).scanImportsAndExports in goroutine 159"""
+
+# A non-esbuild start failure (the renderer port was already taken), which must not
+# be mistaken for a transient bundler crash.
+_PORT_IN_USE_TAIL = """\
+Proxying frontend: target=http://127.0.0.1:5050 SCULPTOR_FRONTEND_PORT=5173
+error when starting dev server:
+Error: Port 5173 is already in use
+    at Server.onError (node_modules/vite/dist/node/chunks/dep.js:78010:28)"""
+
+
+def test_is_transient_electron_start_crash_detects_esbuild_onload_panic() -> None:
+    """The esbuild onLoad/bundler crash variant is recognised as transient."""
+    assert _is_transient_electron_start_crash(_ESBUILD_ONLOAD_CRASH_TAIL)
+
+
+def test_is_transient_electron_start_crash_detects_esbuild_linker_panic() -> None:
+    """The esbuild linker crash variant is recognised as transient."""
+    assert _is_transient_electron_start_crash(_ESBUILD_LINKER_CRASH_TAIL)
+
+
+def test_is_transient_electron_start_crash_ignores_unrelated_failure() -> None:
+    """A non-esbuild start failure is not mistaken for the transient bundler crash."""
+    assert not _is_transient_electron_start_crash(_PORT_IN_USE_TAIL)
+
+
+def test_is_transient_electron_start_crash_ignores_empty_output() -> None:
+    """No captured output is not a transient esbuild crash."""
+    assert not _is_transient_electron_start_crash("")
+
+
+def test_should_retry_electron_launch_relaunches_transient_crash_with_attempts_left() -> None:
+    """An esbuild crash on a non-final attempt triggers a relaunch."""
+    assert _should_retry_electron_launch(0, 3, _ESBUILD_ONLOAD_CRASH_TAIL.splitlines())
+
+
+def test_should_retry_electron_launch_does_not_relaunch_on_final_attempt() -> None:
+    """Even a transient crash on the final attempt stops retrying so the error surfaces."""
+    assert not _should_retry_electron_launch(2, 3, _ESBUILD_LINKER_CRASH_TAIL.splitlines())
+
+
+def test_should_retry_electron_launch_does_not_relaunch_unrelated_failure() -> None:
+    """A non-transient failure is never retried, even with attempts remaining."""
+    assert not _should_retry_electron_launch(0, 3, _PORT_IN_USE_TAIL.splitlines())
+
+
+class _FakeElectronProcess:
+    """Stand-in for a dead forge process; the retry loop only reads its exit code."""
+
+    def poll(self) -> int:
+        return 1
+
+
+class _ScriptedElectronFrontend(ElectronFrontend):
+    """Drives the retry loop with scripted per-attempt outcomes — no real Electron."""
+
+    def __init__(self, attempts: Sequence[tuple[bool, Sequence[str]]]) -> None:
+        self._scripted_attempts = list(attempts)
+        self.start_call_count = 0
+        self.kill_call_count = 0
+        self._electron_proc = _FakeElectronProcess()  # type: ignore[assignment]
+        self._forwarder = None
+
+    def _start_electron_process(
+        self,
+        cmd: tuple[str, ...],
+        full_env: dict[str, str],
+        frontend_dir: Path,
+        file_lock: FileLock,
+    ) -> tuple[bool, deque[str]]:
+        is_launched, lines = self._scripted_attempts[self.start_call_count]
+        self.start_call_count += 1
+        return is_launched, deque(lines)
+
+    def _kill_electron(self) -> None:
+        self.kill_call_count += 1
+
+
+def test_launch_retries_after_transient_esbuild_crash_then_succeeds(tmp_path: Path) -> None:
+    """A transient esbuild crash on the first attempt is relaunched, and the retry succeeds."""
+    frontend = _ScriptedElectronFrontend(
+        [
+            (False, _ESBUILD_ONLOAD_CRASH_TAIL.splitlines()),
+            (True, _READY_OUTPUT),
+        ]
+    )
+    file_lock = FileLock(str(tmp_path / "forge.lock"))
+
+    output = frontend._launch_electron_with_retries((), {}, tmp_path, file_lock)
+
+    assert frontend.start_call_count == 2
+    assert frontend.kill_call_count == 1
+    assert list(output) == _READY_OUTPUT
+
+
+def test_launch_raises_on_non_transient_failure_without_retrying(tmp_path: Path) -> None:
+    """A non-transient start failure raises immediately and is never relaunched."""
+    frontend = _ScriptedElectronFrontend(
+        [
+            (False, _PORT_IN_USE_TAIL.splitlines()),
+            (True, _READY_OUTPUT),
+        ]
+    )
+    file_lock = FileLock(str(tmp_path / "forge.lock"))
+
+    with pytest.raises(RuntimeError, match="Electron frontend failed to start"):
+        frontend._launch_electron_with_retries((), {}, tmp_path, file_lock)
+
+    assert frontend.start_call_count == 1
+
+
+def test_launch_gives_up_after_max_attempts_of_transient_crashes(tmp_path: Path) -> None:
+    """Persistent transient crashes are retried up to the cap, then surface the error."""
+    frontend = _ScriptedElectronFrontend([(False, _ESBUILD_LINKER_CRASH_TAIL.splitlines())] * 5)
+    file_lock = FileLock(str(tmp_path / "forge.lock"))
+
+    with pytest.raises(RuntimeError, match="Electron frontend failed to start"):
+        frontend._launch_electron_with_retries((), {}, tmp_path, file_lock)
+
+    assert frontend.start_call_count == 3
+    assert frontend.kill_call_count == 3


### PR DESCRIPTION
## Original bug
Tracked by SCU-1596. In the Electron launch lane, `@electron` integration tests intermittently failed on setup with `RuntimeError: Electron frontend failed to start (exit code 1)` and an esbuild Go-runtime crash dump. Example flakes on recent `main`/merge-queue commits: `test_image_upload_from_create_task_form` (`34bd5018`, `789d420a` — esbuild plugin `onLoad` panic) and `test_disabled_env_version_popover_shows_dash` (`4357bf3f` — esbuild linker `mallocgc` crash).

## Root cause
`electron-forge start` brings up the renderer's Vite dev server — whose dependency optimization (esbuild scan + optimize) runs in the background after `listen()` returns — and then builds the main + preload bundles (`vite.build()`, esbuild transform). These esbuild workloads run concurrently in one Node process, multiplexed over esbuild's single shared service (the Go binary). Under that concurrent startup load, plus the constrained CPU/memory of the offload sandbox, the esbuild process intermittently crashes. The crash site varies run to run (the bundler's plugin `onLoad` path vs. the linker's allocator) — the signature of a nondeterministic startup crash, not a fixed bug. The renderer then never prints its ready line, forge exits non-zero, and `ElectronFrontend.__enter__` (which had no retry) raised — failing on setup whichever `@electron` test first built the per-worker shared instance (hence the varying test name). The browser lane is immune: it serves a prebuilt static dist with no dev-server esbuild at launch.

I instrumented a real renderer dev-server startup and confirmed Vite 6 sequences our own `bundledPlugins` `configureServer` build *before* the renderer's `optimizeDeps`, and electron-forge runs the renderer before main/preload — so our nested plugin build is **not** the trigger. The crash-inducing concurrency lives in electron-forge + esbuild, which we don't control.

## Fix
Make `ElectronFrontend.__enter__` relaunch electron-forge up to 3 times when a launch fails with the esbuild Go-crash signature (`github.com/evanw/esbuild` in the captured output). This is a deterministic, signature-gated relaunch — not a sleep or timeout bump — and it mirrors the harness's existing `tenacity` retry around the CDP connect. Non-transient failures still raise immediately, so real breakage is never masked.

## Test
- Path: `sculptor/sculptor/testing/electron_frontend_test.py`
- Kind: **unit**. Per `.sculptor/testing.md`, an integration test is required unless impossible; this qualifies — the bug is in the harness's Electron-launch code, which runs before any UI exists, and the rare external esbuild crash cannot be reproduced through the UI.
- 10 deterministic tests: crash-signature detection against the two real captured tails plus negatives (port-in-use, empty); retry loop (relaunch-then-succeed, no retry on a non-transient failure, give-up after the attempt cap).

**Before** (test fails without the fix — the helpers don't exist):
```
ImportError: cannot import name '_is_transient_electron_start_crash' from 'sculptor.testing.electron_frontend'
```

**After** (with the fix):
```
10 passed in 0.11s
```

`just format`, `just check` (lint + pyrefly + tsc + ratchets + file-hygiene), and the full `testing/` unit suite (68 tests) are green. `vet` and `/code-review-checklist` found no outstanding issues.

## Review notes
_(no outstanding review notes)_

(Sent by Claude)
