### PR TITLE
[SCU-1608] Bump pydantic-settings to 2.14.2

### DIFF
--- a/sculptor/pyproject.toml
+++ b/sculptor/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "loguru",
     "psutil>=5.9.0",
     "pydantic>=2.11.4",
-    "pydantic-settings",
+    "pydantic-settings>=2.14.2",
     "pygit2>=1.18.0",
     "pyjwt[crypto]",
     "python-multipart",

--- a/uv.lock
+++ b/uv.lock
@@ -905,16 +905,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1434,7 +1434,7 @@ requires-dist = [
     { name = "loguru" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.11.4" },
-    { name = "pydantic-settings" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygit2", specifier = ">=1.18.0" },
     { name = "pyinstaller", marker = "extra == 'packaging'", specifier = ">=6.15.0" },
     { name = "pyjwt", extras = ["crypto"] },


### PR DESCRIPTION
## Summary

Routine non-major dependency upkeep: raise the `pydantic-settings` floor from unpinned to `>=2.14.2`, and update `uv.lock` from `2.14.1` to `2.14.2`.

## Changes

- `sculptor/pyproject.toml`: `pydantic-settings` → `pydantic-settings>=2.14.2`
- `uv.lock`: regenerated `pydantic-settings` entry (2.14.1 → 2.14.2) plus the matching `requires-dist` specifier

## Why

Pinning the floor to the latest patch release keeps the resolved environment current and reproducible. This continues the broader dependency-modernization effort.

## Risk / compatibility

`pydantic-settings` 2.14.1 → 2.14.2 is a patch release within the same minor line. The only consumer in the codebase (`sculptor/config/settings.py`) relies on the stable `BaseSettings` / `SettingsConfigDict` API, which is unaffected.

## Verification

- `uv lock --check` — lockfile is in sync with the manifest
- `just format` — clean, no changes
- `just check` — green (includes `check-uv-lock`, `typecheck`, `lint`, `ratchets`)
- `just test-unit` — green (backend, frontend, foundation, sculpt CLI)

Linear: SCU-1608

(Sent by Claude)