### PR TITLE
Fix two recurring SCU-1575 flakes: delete dialog and chat focus

### DIFF
--- a/sculptor/frontend/src/layouts/hooks/usePageLayoutKeyboardShortcuts.ts
+++ b/sculptor/frontend/src/layouts/hooks/usePageLayoutKeyboardShortcuts.ts
@@ -66,9 +66,12 @@ export const usePageLayoutKeyboardShortcuts = (): void => {
         return;
       }
 
-      // Cmd+W / Ctrl+W: when an overlay is open, close it instead of
-      // letting Electron close the window.
-      if ((e.metaKey || e.ctrlKey) && e.key === "w" && isDismissibleOverlayOpen()) {
+      // Cmd+W / Ctrl+W: when an overlay is open, close it instead of letting
+      // Electron close the window. Scoped to the bare close_workspace chord
+      // (no Shift/Alt): Cmd+Shift+W is delete_workspace and opens the
+      // confirmation dialog, so treating it as a close-overlay gesture would
+      // dismiss the dialog it just opened.
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "w" && isDismissibleOverlayOpen()) {
         e.preventDefault();
         document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
         return;

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -347,6 +347,11 @@ def start_task_and_wait_for_ready(
     # that assert post-creation focus rely on this.
     if model_name is not None:
         select_model_by_name(chat_panel=chat_panel, model_name=model_name)
+        # The model selector is a Radix Select; closing it restores focus to its
+        # trigger asynchronously (FocusScope onUnmountAutoFocus -> trigger.focus()).
+        # Wait for that restore to land before focusing the chat input below, so the
+        # late refocus can't steal focus back from it.
+        expect(chat_panel.get_model_selector()).to_be_focused()
     chat_input = chat_panel.get_chat_input()
     chat_input.focus()
 

--- a/sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py
+++ b/sculptor/tests/integration/frontend/test_workspace_close_vs_delete.py
@@ -132,6 +132,57 @@ def test_cmd_shift_w_deletes_active_workspace(
     expect(home_page.get_workspace_rows().filter(has_text="Delete WS")).to_have_count(0)
 
 
+@user_story("to delete a workspace with Cmd+Shift+W without the dialog flickering shut")
+def test_cmd_shift_w_does_not_dismiss_open_delete_dialog(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Cmd+Shift+W must not dismiss an already-open dismissible overlay.
+
+    Regression test for SCU-1575. The page-layout shortcut handler closes an
+    open overlay on Cmd+W (so the tab-close chord dismisses a dialog rather
+    than closing the Electron window). Cmd+Shift+W is a different chord
+    (delete_workspace) that *opens* the delete-confirmation dialog, so it must
+    not be treated as a close-overlay gesture.
+
+    Opening the dialog via the context menu (not the racy Cmd+Shift+W path)
+    makes the overlay reliably present, so pressing Cmd+Shift+W here
+    deterministically checks that the chord leaves the dialog open and
+    confirmable.
+
+    Steps:
+    1. Create a workspace
+    2. Open the delete-confirmation dialog via the right-click context menu
+    3. Press Cmd+Shift+W
+    4. Verify the dialog is still open (not dismissed) and still deletes
+    """
+    page = sculptor_instance_.page
+    layout = PlaywrightProjectLayoutPage(page=page)
+
+    start_task_and_wait_for_ready(page, prompt="Task", workspace_name="Dialog WS")
+
+    workspace_tabs = layout.get_workspace_tabs()
+    expect(workspace_tabs).to_have_count(1)
+
+    # Open the delete-confirmation dialog deterministically (not via the racy
+    # Cmd+Shift+W path) so the overlay is reliably present for step 3.
+    layout.open_workspace_tab_context_menu(0)
+    delete_item = layout.get_tab_context_menu_delete()
+    expect(delete_item).to_be_visible()
+    delete_item.click()
+
+    confirm_dialog = layout.get_delete_confirmation_dialog()
+    expect(confirm_dialog).to_be_visible()
+
+    # Press the delete chord while the dialog is open. It must NOT be treated
+    # as a "close the open overlay" gesture (only bare Cmd+W is).
+    mod_key = get_playwright_modifier_key()
+    page.keyboard.press(f"{mod_key}+Shift+w")
+
+    expect(confirm_dialog).to_be_visible()
+    layout.confirm_delete()
+    expect(workspace_tabs).to_have_count(0)
+
+
 @user_story("to reopen a previously closed workspace from the workspace list")
 def test_reopen_closed_workspace_from_list(
     sculptor_instance_: SculptorInstance,


### PR DESCRIPTION
## Original bug

Two of the highest-recurrence flaky integration tests in the SCU-1575
"long tail" cluster (offload `push:main` + `merge_group`, last 2 days):

- `test_cmd_shift_w_deletes_active_workspace` — ~20 commit-SHAs
- `test_chat_input_focused_after_workspace_creation` — ~15 commit-SHAs

Both are fixed here. Each root cause was confirmed with an instrumented
local reproduction before fixing.

## Bug 1 — Cmd+Shift+W self-dismisses its own delete dialog (product bug)

**Root cause.** `usePageLayoutKeyboardShortcuts` closes an open dismissible
overlay when `Cmd/Ctrl+W` is pressed (it dispatches a synthetic `Escape`, so
the tab-close chord dismisses a dialog instead of letting Electron close the
window). The branch matched on `(metaKey||ctrlKey) && key === "w"` only, so
it **also matched `Cmd+Shift+W`** — the *delete* chord. When `Cmd+Shift+W`
opened the delete-confirmation dialog, the same keystroke synthesized an
`Escape` the instant the dialog mounted and dismissed it, detaching the
confirm button mid-click (the 30s `Locator.click` timeout in the failures).

An instrumented run confirmed the chain, with **no real key/pointer event**:
`deleteTarget set → onEscapeKeyDown → onOpenChange(false) → dialog removed`.

**Fix.** Scope the overlay-close branch to the bare `close_workspace` chord
(`!e.shiftKey && !e.altKey`). Plain `Cmd+W` overlay-close is unchanged
(verified against `test_file_browser.py`'s Cmd+W diff-tab-close coverage).

**Test.** New deterministic regression
`test_cmd_shift_w_does_not_dismiss_open_delete_dialog`: it opens the delete
dialog via the context menu (so the overlay is reliably present), presses
`Cmd+Shift+W`, and asserts the dialog stays open and still deletes.

- Fails on the old code, passes after the fix (confirmed by reverting the
  one-line fix and re-running: `1 failed` → re-apply → `passed`).
- Stress repro loop (8 create-and-delete cycles): dialog auto-dismissed
  **2/8 before → 0/8 after**.

## Bug 2 — chat input focus stolen after workspace creation (test-infra race)

**Root cause.** The shared `start_task_and_wait_for_ready` helper selects the
agent model through the chat panel's Radix `Select`, then focuses the chat
input so tests can assert post-creation focus. Radix `Select` restores focus
to its trigger **asynchronously** when it closes (`FocusScope`
`onUnmountAutoFocus → trigger.focus()`, ~100ms after the option click). The
helper's `focus()` ran before that restore landed, so the late refocus stole
focus back to the model selector. The test flaked because Playwright's first
`to_be_focused()` poll only sometimes won the ~100ms race.

**Fix.** After selecting the model, wait for the Select's focus restore to
land (`expect(model_selector).to_be_focused()`) before focusing the chat
input, so the helper's `focus()` is the final word.

- Stress repro loop (10 workspace creations): focus stolen **10/10 before →
  0/10 after**.

## Verification

`just format` clean · `just check` green (`shellcheck / yaml / ratchets /
typecheck / lint / file-hygiene` all OK) · `just test-unit` green · the new
regression test + both real flaky tests pass.

## Deferred follow-ups (same SCU-1575 cluster, tracked there — not in this PR)

- `test_workspace_tab_navigation_works_in_zen_mode` (~15 SHAs): back-to-back
  `Cmd+]`/`Cmd+[` chord misfire. The offload (Linux) flake cannot be
  faithfully reproduced or a fix *proven* on local macOS, where a different,
  near-deterministic Chromium modifier-`keyup`-drop quirk dominates. Needs
  offload-based reproduction. Likely direction: route the chords through the
  `press_keyboard_shortcut` helper (which releases held modifiers) and have
  the tab-cycle handler read the active workspace from the URL rather than the
  render-lagging router params.
- `test_review_modal_shows_changes_from_all_agents` (~9 SHAs): the Tiptap
  editor is not ready within `type_into_tiptap`'s budget when sending into a
  second agent's chat input after add-agent.

(Sent by Claude)
