### PR TITLE
Use tenacity @retry for the Electron launch relaunch (SCU-1596)

### DIFF
--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -6,7 +6,6 @@ import sys
 import tempfile
 import time
 from collections import deque
-from collections.abc import Sequence
 from pathlib import Path
 
 from filelock import FileLock
@@ -15,8 +14,10 @@ from playwright.sync_api import BrowserContext
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import Playwright
+from tenacity import RetryCallState
 from tenacity import retry
 from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
 from tenacity import stop_after_delay
 from tenacity import wait_fixed
 
@@ -40,6 +41,14 @@ _MAX_ELECTRON_LAUNCH_ATTEMPTS = 3
 # esbuild's Go crash dump spans many goroutines; keep enough of the tail that its
 # bundler frames survive both for the raised error and the relaunch decision.
 _RECENT_OUTPUT_LINES = 200
+
+
+class _TransientElectronStartError(RuntimeError):
+    """Electron exited before its ready message with a transient esbuild dev-bundle crash.
+
+    Tenacity retries on this so a fresh launch can win the startup race; other
+    startup failures raise a plain ``RuntimeError`` and are not retried.
+    """
 
 
 def _is_known_harmless_electron_error(line: str) -> bool:
@@ -67,11 +76,13 @@ def _is_transient_electron_start_crash(output: str) -> bool:
     return "github.com/evanw/esbuild" in output
 
 
-def _should_retry_electron_launch(attempt_index: int, max_attempts: int, recent_output: Sequence[str]) -> bool:
-    """Whether to relaunch after a failed start: a transient esbuild crash with attempts remaining."""
-    if attempt_index >= max_attempts - 1:
-        return False
-    return _is_transient_electron_start_crash("\n".join(recent_output))
+def _log_electron_relaunch(retry_state: RetryCallState) -> None:
+    """Warn before each relaunch (tenacity ``before_sleep`` hook)."""
+    logger.warning(
+        "[Electron] dev bundler (esbuild) crashed on launch attempt {}/{}; relaunching",
+        retry_state.attempt_number,
+        _MAX_ELECTRON_LAUNCH_ATTEMPTS,
+    )
 
 
 class ElectronFrontend:
@@ -183,6 +194,12 @@ class ElectronFrontend:
 
         return (context, page)
 
+    @retry(
+        stop=stop_after_attempt(_MAX_ELECTRON_LAUNCH_ATTEMPTS),
+        retry=retry_if_exception_type(_TransientElectronStartError),
+        before_sleep=_log_electron_relaunch,
+        reraise=True,
+    )
     def _launch_electron_with_retries(
         self,
         cmd: tuple[str, ...],
@@ -190,31 +207,23 @@ class ElectronFrontend:
         frontend_dir: Path,
         file_lock: FileLock,
     ) -> deque[str]:
-        """Launch electron-forge, relaunching on a transient esbuild dev-bundle crash.
+        """Launch electron-forge once, returning its recent output once it is ready.
 
-        Returns the most recent Electron output of the successful launch; raises
-        ``RuntimeError`` if every attempt fails, or any attempt fails for a
-        non-transient reason.
+        A transient esbuild dev-bundle crash raises ``_TransientElectronStartError``,
+        which the ``@retry`` above relaunches on (up to ``_MAX_ELECTRON_LAUNCH_ATTEMPTS``
+        times); any other startup failure raises a plain ``RuntimeError`` and is not
+        retried.
         """
-        recent_output: deque[str] = deque(maxlen=_RECENT_OUTPUT_LINES)
-        for attempt_index in range(_MAX_ELECTRON_LAUNCH_ATTEMPTS):
-            is_launched, recent_output = self._start_electron_process(cmd, full_env, frontend_dir, file_lock)
-            if is_launched:
-                return recent_output
-            self._kill_electron()
-            if _should_retry_electron_launch(attempt_index, _MAX_ELECTRON_LAUNCH_ATTEMPTS, recent_output):
-                logger.warning(
-                    "[Electron] dev bundler (esbuild) crashed on launch attempt {}/{}; relaunching",
-                    attempt_index + 1,
-                    _MAX_ELECTRON_LAUNCH_ATTEMPTS,
-                )
-                continue
-            exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
-            tail = "\n".join(recent_output) or "(no output captured)"
-            message = f"Electron frontend failed to start (exit code {exit_code}). Last Electron output:\n{tail}"
-            raise RuntimeError(message)
-        # Unreachable, but satisfies the return-type checker.
-        raise RuntimeError("Electron frontend failed to start after all launch attempts.")
+        is_launched, recent_output = self._start_electron_process(cmd, full_env, frontend_dir, file_lock)
+        if is_launched:
+            return recent_output
+        self._kill_electron()
+        exit_code = self._electron_proc.poll() if self._electron_proc is not None else None
+        tail = "\n".join(recent_output) or "(no output captured)"
+        message = f"Electron frontend failed to start (exit code {exit_code}). Last Electron output:\n{tail}"
+        if _is_transient_electron_start_crash(tail):
+            raise _TransientElectronStartError(message)
+        raise RuntimeError(message)
 
     def _start_electron_process(
         self,

--- a/sculptor/sculptor/testing/electron_frontend.py
+++ b/sculptor/sculptor/testing/electron_frontend.py
@@ -44,11 +44,7 @@ _RECENT_OUTPUT_LINES = 200
 
 
 class _TransientElectronStartError(RuntimeError):
-    """Electron exited before its ready message with a transient esbuild dev-bundle crash.
-
-    Tenacity retries on this so a fresh launch can win the startup race; other
-    startup failures raise a plain ``RuntimeError`` and are not retried.
-    """
+    """Electron exited before its ready message with a transient esbuild dev-bundle crash."""
 
 
 def _is_known_harmless_electron_error(line: str) -> bool:
@@ -207,12 +203,11 @@ class ElectronFrontend:
         frontend_dir: Path,
         file_lock: FileLock,
     ) -> deque[str]:
-        """Launch electron-forge once, returning its recent output once it is ready.
+        """Launch electron-forge once, returning its recent output when it is ready.
 
-        A transient esbuild dev-bundle crash raises ``_TransientElectronStartError``,
-        which the ``@retry`` above relaunches on (up to ``_MAX_ELECTRON_LAUNCH_ATTEMPTS``
-        times); any other startup failure raises a plain ``RuntimeError`` and is not
-        retried.
+        A transient esbuild dev-bundle crash raises ``_TransientElectronStartError``, which
+        the ``@retry`` decorator relaunches on; other startup failures raise a plain
+        ``RuntimeError`` and surface immediately.
         """
         is_launched, recent_output = self._start_electron_process(cmd, full_env, frontend_dir, file_lock)
         if is_launched:

--- a/sculptor/sculptor/testing/electron_frontend_test.py
+++ b/sculptor/sculptor/testing/electron_frontend_test.py
@@ -8,8 +8,9 @@ import pytest
 from filelock import FileLock
 
 from sculptor.testing.electron_frontend import ElectronFrontend
+from sculptor.testing.electron_frontend import _MAX_ELECTRON_LAUNCH_ATTEMPTS
+from sculptor.testing.electron_frontend import _TransientElectronStartError
 from sculptor.testing.electron_frontend import _is_transient_electron_start_crash
-from sculptor.testing.electron_frontend import _should_retry_electron_launch
 
 _READY_OUTPUT = ["Logging to temp file: /tmp/sculptor.log"]
 
@@ -62,30 +63,15 @@ def test_is_transient_electron_start_crash_ignores_empty_output() -> None:
     assert not _is_transient_electron_start_crash("")
 
 
-def test_should_retry_electron_launch_relaunches_transient_crash_with_attempts_left() -> None:
-    """An esbuild crash on a non-final attempt triggers a relaunch."""
-    assert _should_retry_electron_launch(0, 3, _ESBUILD_ONLOAD_CRASH_TAIL.splitlines())
-
-
-def test_should_retry_electron_launch_does_not_relaunch_on_final_attempt() -> None:
-    """Even a transient crash on the final attempt stops retrying so the error surfaces."""
-    assert not _should_retry_electron_launch(2, 3, _ESBUILD_LINKER_CRASH_TAIL.splitlines())
-
-
-def test_should_retry_electron_launch_does_not_relaunch_unrelated_failure() -> None:
-    """A non-transient failure is never retried, even with attempts remaining."""
-    assert not _should_retry_electron_launch(0, 3, _PORT_IN_USE_TAIL.splitlines())
-
-
 class _FakeElectronProcess:
-    """Stand-in for a dead forge process; the retry loop only reads its exit code."""
+    """Stand-in for a dead forge process; the launch path only reads its exit code."""
 
     def poll(self) -> int:
         return 1
 
 
 class _ScriptedElectronFrontend(ElectronFrontend):
-    """Drives the retry loop with scripted per-attempt outcomes — no real Electron."""
+    """Drives ``_launch_electron_with_retries`` with scripted per-attempt outcomes — no real Electron."""
 
     def __init__(self, attempts: Sequence[tuple[bool, Sequence[str]]]) -> None:
         self._scripted_attempts = list(attempts)
@@ -136,9 +122,10 @@ def test_launch_raises_on_non_transient_failure_without_retrying(tmp_path: Path)
     )
     file_lock = FileLock(str(tmp_path / "forge.lock"))
 
-    with pytest.raises(RuntimeError, match="Electron frontend failed to start"):
+    with pytest.raises(RuntimeError) as exc_info:
         frontend._launch_electron_with_retries((), {}, tmp_path, file_lock)
 
+    assert not isinstance(exc_info.value, _TransientElectronStartError)
     assert frontend.start_call_count == 1
 
 
@@ -147,8 +134,8 @@ def test_launch_gives_up_after_max_attempts_of_transient_crashes(tmp_path: Path)
     frontend = _ScriptedElectronFrontend([(False, _ESBUILD_LINKER_CRASH_TAIL.splitlines())] * 5)
     file_lock = FileLock(str(tmp_path / "forge.lock"))
 
-    with pytest.raises(RuntimeError, match="Electron frontend failed to start"):
+    with pytest.raises(_TransientElectronStartError, match="Electron frontend failed to start"):
         frontend._launch_electron_with_retries((), {}, tmp_path, file_lock)
 
-    assert frontend.start_call_count == 3
-    assert frontend.kill_call_count == 3
+    assert frontend.start_call_count == _MAX_ELECTRON_LAUNCH_ATTEMPTS
+    assert frontend.kill_call_count == _MAX_ELECTRON_LAUNCH_ATTEMPTS


### PR DESCRIPTION
## What & why
Follow-up to #166, which fixed the SCU-1596 `@electron` setup flake by relaunching `electron-forge` when startup fails with a transient esbuild dev-bundle crash. That PR used a hand-rolled attempt loop; this replaces it with tenacity's `@retry` — the same mechanism `ElectronFrontend` already uses for the CDP connect — so the retry policy is declarative and consistent with the rest of the file.

## Change
- A transient esbuild crash now raises a typed `_TransientElectronStartError`. `@retry(stop=stop_after_attempt(_MAX_ELECTRON_LAUNCH_ATTEMPTS), retry=retry_if_exception_type(_TransientElectronStartError), before_sleep=_log_electron_relaunch, reraise=True)` relaunches **only** on that type.
- Any other startup failure raises a plain `RuntimeError` and is not retried.
- `_launch_electron_with_retries` collapses to a single launch attempt under the decorator; the manual `for` loop, the unreachable trailing `raise`, and the `_should_retry_electron_launch` helper are removed.
- **No behavior change**: same attempt cap, same "retry only on the esbuild Go-crash signature," same error surfaced once the cap is hit.

## Tests
The unit tests are updated to assert the typed exception and the attempt cap (via the `_MAX_ELECTRON_LAUNCH_ATTEMPTS` constant). The scripted-fake retry tests (relaunch-then-succeed, no-retry-on-non-transient, give-up-after-cap) and the crash-signature predicate tests still hold:

```
sculptor/sculptor/testing/electron_frontend_test.py ....... 7 passed
```

`just format` and `just check` (lint + pyrefly + tsc + ratchets + file-hygiene) are green.

## Review notes
_(no outstanding review notes)_

(Sent by Claude)
