### PR TITLE
Guard runtime trace arm/disarm with a session lock

### DIFF
--- a/sculptor/sculptor/utils/tracing.py
+++ b/sculptor/sculptor/utils/tracing.py
@@ -64,7 +64,7 @@ MAX_BUFFERED_EXTERNAL_EVENTS = 100_000
 DEFAULT_TRACER_ENTRIES = 50_000_000
 
 # Smaller default ring buffer for ad-hoc tracing armed at runtime (via the
-# trace-control HTTP endpoint / `sculpt trace start`) rather than at boot.
+# trace-control HTTP endpoint / `sculpt debug trace start`) rather than at boot.
 # Runtime arming targets steady-state interactive work, whose event rate is
 # far below the boot peak the 50M buffer is sized for, so a fifth of the
 # entries (~500 MB) still covers a generous capture window while keeping the
@@ -89,10 +89,26 @@ _MERGE_BATCH_SIZE = 4096
 _trace_to_path: Path | None = None
 _tracer: Any = None
 _internal_trace_path: Path | None = None
+# Serializes the arm/disarm session state (`_tracer`, `_trace_to_path`,
+# `_internal_trace_path`). The runtime trace-control endpoints run on FastAPI
+# worker threads, so concurrent `POST /api/v1/trace/start` (or
+# `/api/v1/trace/stop`) calls would otherwise race the check-and-set in
+# start_tracing / stop_and_write_trace —
+# two starts could each see `_tracer is None` and build a second VizTracer,
+# leaking the first; two stops could both try to stop/save the same tracer.
+# Distinct from `_external_events_lock`, which guards only the event buffer;
+# start/stop acquire this one first, then that one (never the reverse).
+_trace_session_lock = Lock()
 _external_events_lock = Lock()
 _external_events: list[dict[str, Any]] = []
 _dropped_event_count = 0
 _invalid_event_count = 0
+# Whether `add_external_events` should buffer incoming /api/v1/trace/batch
+# payloads. Guarded by `_external_events_lock`. start_tracing sets it True;
+# stop_and_write_trace sets it False at the same instant it snapshots and clears
+# the buffer, so a batch that arrives during the (lock-held) flush is dropped
+# rather than buffered into the just-finished session and leaked into the next.
+_external_events_accepting = False
 
 
 @dataclass(frozen=True)
@@ -135,28 +151,35 @@ def start_tracing(output_path: Path, tracer_entries: int | None = None) -> None:
     Idempotent — a second call while a trace is already running is a no-op (it
     does NOT change the path or buffer size). After ``stop_and_write_trace``
     has flushed and torn down a session, calling this again arms a fresh one,
-    which is what makes the runtime arm/disarm cycle (`sculpt trace start` then
-    `stop` then `start`) work.
-    """
-    global _trace_to_path, _tracer, _internal_trace_path
-    if _tracer is not None:
-        return
-    from viztracer import VizTracer
+    which is what makes the runtime arm/disarm cycle (`sculpt debug trace start`
+    then `stop` then `start`) work.
 
-    if tracer_entries is None:
-        tracer_entries = DEFAULT_TRACER_ENTRIES
-    _trace_to_path = output_path.resolve()
-    tmp_dir = Path(tempfile.mkdtemp(prefix="sculptor_viztrace_"))
-    _internal_trace_path = tmp_dir / "viztracer.json"
-    _tracer = VizTracer(
-        output_file=str(_internal_trace_path),
-        tracer_entries=tracer_entries,
-        log_func_args=False,
-        log_print=False,
-        minimize_memory=True,
-        process_name="sculptor_backend",
-    )
-    _tracer.start()
+    The check-and-arm runs under ``_trace_session_lock`` so concurrent callers
+    (the runtime trace-control endpoints run on worker threads) cannot both pass
+    the ``_tracer is None`` guard and build two VizTracer instances.
+    """
+    global _trace_to_path, _tracer, _internal_trace_path, _external_events_accepting
+    with _trace_session_lock:
+        if _tracer is not None:
+            return
+        from viztracer import VizTracer
+
+        if tracer_entries is None:
+            tracer_entries = DEFAULT_TRACER_ENTRIES
+        _trace_to_path = output_path.resolve()
+        tmp_dir = Path(tempfile.mkdtemp(prefix="sculptor_viztrace_"))
+        _internal_trace_path = tmp_dir / "viztracer.json"
+        _tracer = VizTracer(
+            output_file=str(_internal_trace_path),
+            tracer_entries=tracer_entries,
+            log_func_args=False,
+            log_print=False,
+            minimize_memory=True,
+            process_name="sculptor_backend",
+        )
+        _tracer.start()
+        with _external_events_lock:
+            _external_events_accepting = True
 
 
 def add_external_events(events: Sequence[dict[str, Any]], source_pid: int) -> None:
@@ -192,6 +215,12 @@ def add_external_events(events: Sequence[dict[str, Any]], source_pid: int) -> No
         return
 
     with _external_events_lock:
+        # Re-checked under the lock (not just the cheap `_trace_to_path is None`
+        # fast-path above): a stop in progress flips this False while holding the
+        # lock, so a batch racing the flush is dropped rather than buffered into
+        # the finished session.
+        if not _external_events_accepting:
+            return
         _invalid_event_count += invalid_count
         if valid_events:
             _external_events.extend(valid_events)
@@ -284,68 +313,88 @@ def stop_and_write_trace() -> TraceWriteResult | None:
     (or use the returned result), since the global is cleared here.
     """
     global _trace_to_path, _tracer, _internal_trace_path, _dropped_event_count, _invalid_event_count
-    trace_to_path = _trace_to_path
-    tracer = _tracer
-    internal_trace_path = _internal_trace_path
-    if trace_to_path is None or tracer is None or internal_trace_path is None:
-        return None
+    global _external_events_accepting
+    # Hold the session lock across the whole stop — including the flush — so a
+    # concurrent stop can't double-stop/save the same tracer, and a concurrent
+    # start can't build a new VizTracer while this one is still being saved
+    # (viztracer keeps a single process-global tracer; overlapping them would
+    # corrupt the in-progress save). The session stays "armed" (path still set)
+    # until the disarm in the finally, so a racing start is rejected at the
+    # endpoint's 409 gate rather than slipping in mid-flush.
+    with _trace_session_lock:
+        trace_to_path = _trace_to_path
+        tracer = _tracer
+        internal_trace_path = _internal_trace_path
+        if trace_to_path is None or tracer is None or internal_trace_path is None:
+            return None
 
-    try:
-        tracer.stop()
-        tracer.save()
-
-        with open(internal_trace_path) as f:
-            viztracer_data = json.load(f)
-        viztracer_events = viztracer_data.get("traceEvents", [])
-
-        with _external_events_lock:
-            buffered = list(_external_events)
-            _external_events.clear()
-            dropped_snapshot = _dropped_event_count
-            invalid_snapshot = _invalid_event_count
-
-        seen_synthetic_pids = {e["pid"] for e in buffered}
-        metadata_events: list[dict[str, Any]] = []
-        if RENDERER_PID in seen_synthetic_pids:
-            metadata_events.append(_process_name_metadata(RENDERER_PID, "renderer"))
-        if ELECTRON_MAIN_PID in seen_synthetic_pids:
-            metadata_events.append(_process_name_metadata(ELECTRON_MAIN_PID, "electron_main"))
-        if dropped_snapshot > 0 or invalid_snapshot > 0:
-            metadata_events.append(_dropped_marker_event(dropped_snapshot, invalid_snapshot))
-
-        trace_to_path.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic write: stream to a sibling `.tmp` file, then `os.replace` into
-        # place on success. A mid-write serialization failure must not leave a
-        # truncated file at the user-facing path, and any prior file there
-        # must remain untouched.
-        tmp_path = trace_to_path.parent / (trace_to_path.name + ".tmp")
         try:
-            with open(tmp_path, "w") as f:
-                f.write('{"traceEvents":[')
-                _stream_events_batched(itertools.chain(viztracer_events, metadata_events, buffered), f)
-                f.write("]}")
-            os.replace(tmp_path, trace_to_path)
+            tracer.stop()
+            tracer.save()
+
+            with open(internal_trace_path) as f:
+                viztracer_data = json.load(f)
+            viztracer_events = viztracer_data.get("traceEvents", [])
+
+            with _external_events_lock:
+                # Stop accepting batches at the same instant we snapshot+clear,
+                # so any /api/v1/trace/batch arriving during the rest of this
+                # (lock-held) flush is dropped instead of buffered into the
+                # finished session. Reset the counters here too — under the same
+                # lock add_external_events bumps them — so the disarm can't race
+                # a concurrent bump (the reset used to live in the finally,
+                # outside this lock).
+                _external_events_accepting = False
+                buffered = list(_external_events)
+                _external_events.clear()
+                dropped_snapshot = _dropped_event_count
+                invalid_snapshot = _invalid_event_count
+                _dropped_event_count = 0
+                _invalid_event_count = 0
+
+            seen_synthetic_pids = {e["pid"] for e in buffered}
+            metadata_events: list[dict[str, Any]] = []
+            if RENDERER_PID in seen_synthetic_pids:
+                metadata_events.append(_process_name_metadata(RENDERER_PID, "renderer"))
+            if ELECTRON_MAIN_PID in seen_synthetic_pids:
+                metadata_events.append(_process_name_metadata(ELECTRON_MAIN_PID, "electron_main"))
+            if dropped_snapshot > 0 or invalid_snapshot > 0:
+                metadata_events.append(_dropped_marker_event(dropped_snapshot, invalid_snapshot))
+
+            trace_to_path.parent.mkdir(parents=True, exist_ok=True)
+            # Atomic write: stream to a sibling `.tmp` file, then `os.replace` into
+            # place on success. A mid-write serialization failure must not leave a
+            # truncated file at the user-facing path, and any prior file there
+            # must remain untouched.
+            tmp_path = trace_to_path.parent / (trace_to_path.name + ".tmp")
+            try:
+                with open(tmp_path, "w") as f:
+                    f.write('{"traceEvents":[')
+                    _stream_events_batched(itertools.chain(viztracer_events, metadata_events, buffered), f)
+                    f.write("]}")
+                os.replace(tmp_path, trace_to_path)
+            finally:
+                # On success, the tmp file has been renamed away and this is a
+                # no-op. On failure, drop the partial `.tmp` so we don't leak it.
+                tmp_path.unlink(missing_ok=True)
+            return TraceWriteResult(
+                path=trace_to_path,
+                backend_event_count=len(viztracer_events),
+                external_event_count=len(buffered),
+            )
         finally:
-            # On success, the tmp file has been renamed away and this is a
-            # no-op. On failure, drop the partial `.tmp` so we don't leak it.
-            tmp_path.unlink(missing_ok=True)
-        return TraceWriteResult(
-            path=trace_to_path,
-            backend_event_count=len(viztracer_events),
-            external_event_count=len(buffered),
-        )
-    finally:
-        # Always clean up the viztracer temp dir, even on partial-write
-        # failure. The user-facing trace file at trace_to_path is intentionally
-        # NOT cleaned up — that's the artifact they came here for.
-        shutil.rmtree(internal_trace_path.parent, ignore_errors=True)
-        # Disarm: drop references to the stopped tracer and clear the path so
-        # the module is ready to arm a fresh session. Dropping the only
-        # reference to the VizTracer also lets it be garbage-collected; the
-        # next start_tracing builds a new instance (viztracer's global
-        # __viz_tracer__ pointer is simply overwritten).
-        _tracer = None
-        _trace_to_path = None
-        _internal_trace_path = None
-        _dropped_event_count = 0
-        _invalid_event_count = 0
+            # Always clean up the viztracer temp dir, even on partial-write
+            # failure. The user-facing trace file at trace_to_path is intentionally
+            # NOT cleaned up — that's the artifact they came here for.
+            shutil.rmtree(internal_trace_path.parent, ignore_errors=True)
+            # Disarm: drop references to the stopped tracer and clear the path so
+            # the module is ready to arm a fresh session. Dropping the only
+            # reference to the VizTracer also lets it be garbage-collected; the
+            # next start_tracing builds a new instance (viztracer's global
+            # __viz_tracer__ pointer is simply overwritten).
+            _tracer = None
+            _trace_to_path = None
+            _internal_trace_path = None
+            # _dropped_event_count / _invalid_event_count and
+            # _external_events_accepting were already reset under
+            # _external_events_lock in the snapshot block above.

--- a/sculptor/sculptor/utils/tracing.py
+++ b/sculptor/sculptor/utils/tracing.py
@@ -142,26 +142,29 @@ def get_buffered_external_event_count() -> int:
         return len(_external_events)
 
 
-def start_tracing(output_path: Path, tracer_entries: int | None = None) -> None:
+def start_tracing(output_path: Path, tracer_entries: int | None = None) -> bool:
     """Start viztracer, writing the combined trace to ``output_path`` when it is
     later stopped. ``tracer_entries`` sizes viztracer's in-memory ring buffer;
     ``None`` uses ``DEFAULT_TRACER_ENTRIES`` (resolved at call time so tests can
     monkeypatch the constant).
 
-    Idempotent — a second call while a trace is already running is a no-op (it
-    does NOT change the path or buffer size). After ``stop_and_write_trace``
-    has flushed and torn down a session, calling this again arms a fresh one,
-    which is what makes the runtime arm/disarm cycle (`sculpt debug trace start`
-    then `stop` then `start`) work.
+    Returns ``True`` if this call armed a fresh session, or ``False`` if a trace
+    was already running (in which case nothing changed — the existing path and
+    buffer size are kept). After ``stop_and_write_trace`` has flushed and torn
+    down a session, calling this again arms a fresh one, which is what makes the
+    runtime arm/disarm cycle (`sculpt debug trace start` then `stop` then
+    `start`) work.
 
     The check-and-arm runs under ``_trace_session_lock`` so concurrent callers
     (the runtime trace-control endpoints run on worker threads) cannot both pass
-    the ``_tracer is None`` guard and build two VizTracer instances.
+    the ``_tracer is None`` guard and build two VizTracer instances. The boolean
+    return lets the caller distinguish "armed" from "already running" without a
+    separate, racy ``is_tracing_enabled()`` check.
     """
     global _trace_to_path, _tracer, _internal_trace_path, _external_events_accepting
     with _trace_session_lock:
         if _tracer is not None:
-            return
+            return False
         from viztracer import VizTracer
 
         if tracer_entries is None:
@@ -180,6 +183,7 @@ def start_tracing(output_path: Path, tracer_entries: int | None = None) -> None:
         _tracer.start()
         with _external_events_lock:
             _external_events_accepting = True
+        return True
 
 
 def add_external_events(events: Sequence[dict[str, Any]], source_pid: int) -> None:

--- a/sculptor/sculptor/utils/tracing_test.py
+++ b/sculptor/sculptor/utils/tracing_test.py
@@ -82,9 +82,9 @@ def test_start_stop_writes_combined_trace(tmp_path: Path) -> None:
 
 def test_start_tracing_is_idempotent(tmp_path: Path) -> None:
     out = tmp_path / "trace.json"
-    tracing.start_tracing(out)
+    assert tracing.start_tracing(out) is True  # armed a fresh session
     first_tracer = tracing._tracer
-    tracing.start_tracing(out)
+    assert tracing.start_tracing(out) is False  # already running → no-op, reports it didn't arm
     assert tracing._tracer is first_tracer
     # Tear down so the autouse fixture's reset is clean.
     tracing.stop_and_write_trace()

--- a/sculptor/sculptor/utils/tracing_test.py
+++ b/sculptor/sculptor/utils/tracing_test.py
@@ -7,6 +7,7 @@ and merge.
 """
 
 import json
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
@@ -25,6 +26,7 @@ def _reset_tracing_state() -> None:
     tracing._internal_trace_path = None
     tracing._dropped_event_count = 0
     tracing._invalid_event_count = 0
+    tracing._external_events_accepting = False
     with tracing._external_events_lock:
         tracing._external_events.clear()
 
@@ -350,4 +352,79 @@ def test_concurrent_overflow_counts_accurately(tmp_path: Path, monkeypatch: pyte
     # One invalid event per batch, no losses.
     assert invalid_now == n_threads
 
+    tracing.stop_and_write_trace()
+
+
+def test_concurrent_start_creates_one_tracer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pins the session-lock fix in ``start_tracing``.
+
+    The runtime trace-control endpoints run on FastAPI worker threads, so two
+    ``POST /api/v1/trace/start`` calls can race the ``_tracer is None`` check. Without
+    ``_trace_session_lock`` both threads pass the guard and each builds a
+    ``VizTracer``, leaking the first. A counting fake (which sleeps before the
+    module assigns ``_tracer``, widening the race window) asserts exactly one
+    instance is ever constructed under concurrent starts.
+    """
+    instances: list[Any] = []
+
+    class _CountingTracer:
+        def __init__(self, *, output_file: str, **_kwargs: Any) -> None:
+            # Delay before returning so that, absent the lock, every concurrent
+            # caller would observe `_tracer is None` and construct. With the
+            # lock, only the first caller reaches here.
+            time.sleep(0.02)
+            instances.append(self)
+            self._output_file = output_file
+
+        def start(self) -> None: ...
+
+        def stop(self) -> None: ...
+
+        def save(self) -> None:
+            Path(self._output_file).write_text('{"traceEvents": []}')
+
+    monkeypatch.setattr("viztracer.VizTracer", _CountingTracer)
+
+    out = tmp_path / "trace.json"
+    n_threads = 8
+    with ThreadPoolExecutor(max_workers=n_threads) as pool:
+        futures = [pool.submit(tracing.start_tracing, out) for _ in range(n_threads)]
+        for f in futures:
+            f.result()
+
+    assert len(instances) == 1, f"expected exactly one VizTracer under concurrent start, got {len(instances)}"
+    assert tracing._tracer is instances[0]
+
+    tracing.stop_and_write_trace()
+
+
+def test_external_batch_during_flush_is_not_buffered(tmp_path: Path) -> None:
+    """A /api/v1/trace/batch arriving mid-flush must be dropped, not buffered.
+
+    stop_and_write_trace holds the session lock across the flush, so the trace
+    stays "armed" (path set, `is_tracing_enabled()` true) until the very end —
+    which is what keeps a racing start at the 409 gate. But that also means
+    add_external_events' cheap `_trace_to_path is None` fast-path does NOT
+    short-circuit during the flush. The `_external_events_accepting` flag (flipped
+    False under `_external_events_lock` at snapshot time) is what stops a late
+    batch from buffering into the just-finished session and leaking into the
+    next. This reproduces that mid-disarm window directly: path still set, but no
+    longer accepting.
+    """
+    tracing._trace_to_path = tmp_path / "x.json"  # so the fast-path does not fire
+    tracing._external_events_accepting = False  # snapshot already taken; disarming
+
+    tracing.add_external_events([{"ph": "X", "name": "late", "ts": 0}], tracing.RENDERER_PID)
+
+    with tracing._external_events_lock:
+        assert tracing._external_events == [], "late batch must be dropped, not buffered into a dead session"
+
+
+def test_external_batch_buffered_while_accepting(tmp_path: Path) -> None:
+    """Sanity counterpart: while a session is armed and accepting, batches buffer
+    as before (the new flag gate doesn't reject the happy path)."""
+    tracing.start_tracing(tmp_path / "out.json")
+    tracing.add_external_events([{"ph": "X", "name": "live", "ts": 0}], tracing.RENDERER_PID)
+    with tracing._external_events_lock:
+        assert len(tracing._external_events) == 1
     tracing.stop_and_write_trace()

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -4424,7 +4424,8 @@ def post_trace_start(
     settings: SculptorSettings = Depends(get_settings),
 ) -> TraceStatusResponse:
     """Arm viztracer on the running backend, writing to a fresh timestamped
-    file under ``{LOG_PATH}/traces``. 409 if a trace is already running.
+    file under ``{LOG_PATH}/traces``. 409 if a trace is already running (the
+    response reports where that trace is writing).
 
     Renderer / Electron-main events are only captured if the renderer learned
     tracing was on at boot (it reads ``window.__SCULPTOR_TRACING__`` once);
@@ -4432,12 +4433,6 @@ def post_trace_start(
     the point of this endpoint — profiling a live (e.g. production) backend
     without a restart. Requires the session token (not exempt like
     ``/trace/batch``)."""
-    if is_tracing_enabled():
-        raise HTTPException(
-            status_code=409,
-            detail="A trace is already running. Stop it first with POST /api/v1/trace/stop.",
-        )
-
     tracer_entries = payload.tracer_entries if payload.tracer_entries is not None else DEFAULT_ADHOC_TRACER_ENTRIES
     if tracer_entries <= 0 or tracer_entries > DEFAULT_TRACER_ENTRIES:
         raise HTTPException(
@@ -4450,7 +4445,17 @@ def post_trace_start(
     # os.replace would silently overwrite the previous session's trace.
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     output_path = _adhoc_trace_dir(settings) / f"trace-{timestamp}.json"
-    start_tracing(output_path, tracer_entries=tracer_entries)
+    # Atomic check-and-arm: start_tracing returns False if a trace was already
+    # running. Gating the 409 on its return (rather than a separate, racy
+    # is_tracing_enabled() pre-check) means concurrent/duplicate starts get a
+    # truthful 409 pointing at the active trace, instead of all reporting
+    # "armed" for the one session that actually won.
+    if not start_tracing(output_path, tracer_entries=tracer_entries):
+        active = get_trace_to_path()
+        raise HTTPException(
+            status_code=409,
+            detail=f"A trace is already running, writing to {active}. Stop it first with `sculpt debug trace stop`.",
+        )
     # Report the resolved path that start_tracing stored, so it matches what
     # /trace/status and /trace/stop later report (start_tracing resolves it,
     # e.g. /tmp -> /private/tmp on macOS).

--- a/sculptor/sculptor/web/trace_endpoint_test.py
+++ b/sculptor/sculptor/web/trace_endpoint_test.py
@@ -161,10 +161,14 @@ def test_trace_start_status_stop_roundtrip(client: TestClient) -> None:
 
 
 def test_trace_start_conflicts_when_already_running(client: TestClient) -> None:
-    assert client.post("/api/v1/trace/start", json={}).status_code == 200
+    first = client.post("/api/v1/trace/start", json={})
+    assert first.status_code == 200
+    active_path = first.json()["outputPath"]
     try:
         second = client.post("/api/v1/trace/start", json={})
         assert second.status_code == 409
+        # The conflict names where the already-running trace is writing.
+        assert active_path in second.json()["detail"]
     finally:
         client.post("/api/v1/trace/stop")
 

--- a/tools/sculpt/sculpt/commands/trace.py
+++ b/tools/sculpt/sculpt/commands/trace.py
@@ -32,19 +32,25 @@ _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON")
 
 def _request(method: str, path: str, json_output: bool, body: dict | None = None) -> dict:
     """Make an authenticated request to a trace-control endpoint and return the
-    decoded JSON body. Exits with a friendly message on connection failure or a
-    non-2xx response (the backend sends a useful ``detail`` on 409/422)."""
+    decoded JSON body. Exits (code 1) with a friendly message on connection
+    failure or a non-2xx response.
+
+    A 409 from these endpoints is a trace-state conflict (already-running /
+    not-running) whose ``detail`` is already a complete, user-facing sentence —
+    including the active trace's path — so it's surfaced as-is rather than under
+    the generic 'Request failed with status N' framing."""
     client = get_authenticated_client(get_default_base_url())
     try:
         response = client.get_httpx_client().request(method, path, json=body)
     except (httpx.ConnectError, httpx.ConnectTimeout):
         handle_connection_error(json_output)
     if response.status_code >= 400:
-        detail = ""
         try:
             detail = response.json().get("detail", "")
         except (json.JSONDecodeError, ValueError):
             detail = response.text
+        if response.status_code == 409 and detail:
+            cli_error(detail, json_output=json_output)
         cli_error(f"Request failed with status {response.status_code}", detail=detail, json_output=json_output)
     return response.json()
 

--- a/tools/sculpt/tests/unit/test_trace.py
+++ b/tools/sculpt/tests/unit/test_trace.py
@@ -77,9 +77,26 @@ def test_trace_stop_surfaces_409_detail(runner: CliRunner) -> None:
 
     result = runner.invoke(app, ["debug", "trace", "stop"])
 
+    # A 409 is a conflict (operation didn't happen) so it still exits non-zero,
+    # but the backend's detail is a complete user-facing sentence and is shown
+    # as-is, without the generic "Request failed with status 409" framing.
     assert result.exit_code == 1
-    assert "409" in result.stderr
     assert "No trace is running." in result.stderr
+
+
+@respx.mock
+def test_trace_start_409_reports_active_path(runner: CliRunner) -> None:
+    """A duplicate/racing start gets a 409 whose message names where the
+    already-running trace is writing — not a bare 'armed' or generic failure."""
+    _mock_session()
+    detail = "A trace is already running, writing to /logs/traces/trace-X.json. Stop it first with `sculpt debug trace stop`."
+    respx.post(f"{_BASE_URL}/api/v1/trace/start").mock(return_value=Response(409, json={"detail": detail}))
+
+    result = runner.invoke(app, ["debug", "trace", "start"])
+
+    assert result.exit_code == 1
+    assert "already running" in result.stderr
+    assert "/logs/traces/trace-X.json" in result.stderr
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

Fixes a data race in the runtime trace-control path (from #163), flagged by GitHub Copilot's review.

`POST /api/v1/trace/start|stop` run on FastAPI worker threads, so concurrent calls raced the unsynchronized check-and-set in `start_tracing` / `stop_and_write_trace`:
- two `start`s could each observe `_tracer is None` and build a second `VizTracer`, **leaking the first**;
- two `stop`s could both try to stop/save the same tracer.

### Fix
- Adds a dedicated `_trace_session_lock` (separate from `_external_events_lock`, which guards only the event buffer) and makes arm/disarm atomic under it.
- `stop_and_write_trace` holds the lock **across the whole flush** so a concurrent `start` can't build a new `VizTracer` while the old one is still being saved — viztracer keeps a single process-global tracer, and overlapping them would corrupt the in-progress save. The session stays "armed" until the disarm in `finally`, so a racing `start` hits the endpoint's 409 gate instead of slipping in mid-flush.
- Regression test fans out concurrent `start_tracing` calls and asserts exactly one tracer is constructed.

### Also
Fixes two stale `sculpt trace start` → `sculpt debug trace start` references in the same file (also Copilot-flagged).

Lock ordering: start/stop take `_trace_session_lock` first, then `_external_events_lock`; nothing takes them in the reverse order, so no deadlock. The other three Copilot comments were already resolved in `main` (the optional-type-hint commit).

`just check` + `tracing_test.py` (17 passed) green locally.

Follow-up to #163.

(Sent by Claude)