### PR TITLE
Fix Browser panel webview flakes: dom-ready gate + screenshot retry

### DIFF
--- a/sculptor/frontend/src/electron/captureNonEmptyPage.test.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { captureNonEmptyPage } from "./captureNonEmptyPage";
+
+const emptyImage = { isEmpty: (): boolean => true };
+const paintedImage = { isEmpty: (): boolean => false };
+
+describe("captureNonEmptyPage", () => {
+  it("retries capturePage until the guest has painted a non-empty frame", async () => {
+    // Under xvfb + software rendering the guest can return an empty image for
+    // the first few frames after a navigation; writing that empty image to the
+    // clipboard leaves no PNG and the screenshot test fails.
+    const capturePage = vi
+      .fn()
+      .mockResolvedValueOnce(emptyImage)
+      .mockResolvedValueOnce(emptyImage)
+      .mockResolvedValueOnce(paintedImage);
+    const sleep = vi.fn(() => Promise.resolve());
+
+    const result = await captureNonEmptyPage({ capturePage }, { delayMs: 0, sleep });
+
+    expect(result).toBe(paintedImage);
+    expect(capturePage).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns immediately when the first capture is already painted", async () => {
+    const capturePage = vi.fn(() => Promise.resolve(paintedImage));
+
+    const result = await captureNonEmptyPage({ capturePage });
+
+    expect(result).toBe(paintedImage);
+    expect(capturePage).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the attempt budget and returns the last image", async () => {
+    const capturePage = vi.fn(() => Promise.resolve(emptyImage));
+    const sleep = vi.fn(() => Promise.resolve());
+
+    const result = await captureNonEmptyPage({ capturePage }, { attempts: 4, delayMs: 0, sleep });
+
+    expect(result).toBe(emptyImage);
+    expect(capturePage).toHaveBeenCalledTimes(4);
+  });
+});

--- a/sculptor/frontend/src/electron/captureNonEmptyPage.test.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.test.ts
@@ -32,11 +32,20 @@ describe("captureNonEmptyPage", () => {
     expect(capturePage).toHaveBeenCalledTimes(1);
   });
 
-  it("gives up after the attempt budget and returns the last image", async () => {
+  it("captures exactly once when retries is 0", async () => {
+    const capturePage = vi.fn(() => Promise.resolve(emptyImage));
+
+    const result = await captureNonEmptyPage({ capturePage }, { retries: 0 });
+
+    expect(result).toBe(emptyImage);
+    expect(capturePage).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the retry budget and returns the last image", async () => {
     const capturePage = vi.fn(() => Promise.resolve(emptyImage));
     const sleep = vi.fn(() => Promise.resolve());
 
-    const result = await captureNonEmptyPage({ capturePage }, { attempts: 4, delayMs: 0, sleep });
+    const result = await captureNonEmptyPage({ capturePage }, { retries: 3, delayMs: 0, sleep });
 
     expect(result).toBe(emptyImage);
     expect(capturePage).toHaveBeenCalledTimes(4);

--- a/sculptor/frontend/src/electron/captureNonEmptyPage.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.ts
@@ -1,0 +1,27 @@
+// Capturing a Browser panel webview's guest page for the screenshot ->
+// clipboard feature. Lives apart from main.ts (no electron imports) so the
+// retry policy can be unit-tested against a structurally-typed stand-in.
+
+export type CapturedImage = {
+  isEmpty(): boolean;
+};
+
+export type CapturablePage<T extends CapturedImage> = {
+  capturePage(): Promise<T>;
+};
+
+export type CaptureNonEmptyPageOptions = {
+  /** Maximum number of capturePage() calls before giving up. */
+  attempts?: number;
+  /** Delay between capture attempts, in milliseconds. */
+  delayMs?: number;
+  /** Injectable sleep so tests don't wait in real time. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export const captureNonEmptyPage = async <T extends CapturedImage>(
+  contents: CapturablePage<T>,
+  _options: CaptureNonEmptyPageOptions = {},
+): Promise<T> => {
+  return contents.capturePage();
+};

--- a/sculptor/frontend/src/electron/captureNonEmptyPage.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.ts
@@ -11,34 +11,40 @@ export type CapturablePage<T extends CapturedImage> = {
 };
 
 export type CaptureNonEmptyPageOptions = {
-  /** Maximum number of capturePage() calls before giving up. */
-  attempts?: number;
+  /**
+   * How many extra capture attempts to make after the mandatory first one if
+   * the guest is still blank. Zero (or less) means a single capture with no
+   * retries — there is no way to ask for fewer than one capture.
+   */
+  retries?: number;
   /** Delay between capture attempts, in milliseconds. */
   delayMs?: number;
   /** Injectable sleep so tests don't wait in real time. */
   sleep?: (ms: number) => Promise<void>;
 };
 
-// 60 * 250ms = 15s of retries, comfortably inside the integration test's 30s
-// clipboard-poll budget while leaving room for the OS clipboard round-trip.
-const DEFAULT_ATTEMPTS = 60;
+// 60 retries * 250ms = 15s of retrying, comfortably inside the integration
+// test's 30s clipboard-poll budget while leaving room for the OS clipboard
+// round-trip.
+const DEFAULT_RETRIES = 60;
 const DEFAULT_DELAY_MS = 250;
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 // capturePage() resolves with an empty NativeImage until the guest has
-// composited a frame. Retry until it yields a painted image (or the budget is
-// spent) so the screenshot -> clipboard path doesn't write an empty image.
+// composited a frame. Capture once, then keep retrying while the image is
+// blank (up to the retry budget) so the screenshot -> clipboard path doesn't
+// write an empty image.
 export const captureNonEmptyPage = async <T extends CapturedImage>(
   contents: CapturablePage<T>,
   options: CaptureNonEmptyPageOptions = {},
 ): Promise<T> => {
-  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const retries = options.retries ?? DEFAULT_RETRIES;
   const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
   const sleep = options.sleep ?? defaultSleep;
 
   let image = await contents.capturePage();
-  for (let attempt = 1; attempt < attempts && image.isEmpty(); attempt++) {
+  for (let retry = 0; retry < retries && image.isEmpty(); retry++) {
     await sleep(delayMs);
     image = await contents.capturePage();
   }

--- a/sculptor/frontend/src/electron/captureNonEmptyPage.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.ts
@@ -19,9 +19,28 @@ export type CaptureNonEmptyPageOptions = {
   sleep?: (ms: number) => Promise<void>;
 };
 
+// 60 * 250ms = 15s of retries, comfortably inside the integration test's 30s
+// clipboard-poll budget while leaving room for the OS clipboard round-trip.
+const DEFAULT_ATTEMPTS = 60;
+const DEFAULT_DELAY_MS = 250;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// capturePage() resolves with an empty NativeImage until the guest has
+// composited a frame. Retry until it yields a painted image (or the budget is
+// spent) so the screenshot -> clipboard path doesn't write an empty image.
 export const captureNonEmptyPage = async <T extends CapturedImage>(
   contents: CapturablePage<T>,
-  _options: CaptureNonEmptyPageOptions = {},
+  options: CaptureNonEmptyPageOptions = {},
 ): Promise<T> => {
-  return contents.capturePage();
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let image = await contents.capturePage();
+  for (let attempt = 1; attempt < attempts && image.isEmpty(); attempt++) {
+    await sleep(delayMs);
+    image = await contents.capturePage();
+  }
+  return image;
 };

--- a/sculptor/frontend/src/electron/main.ts
+++ b/sculptor/frontend/src/electron/main.ts
@@ -24,6 +24,7 @@ import Store from "electron-store";
 import type { AnyBackendStatus, SculptorDevInfo } from "../shared/types";
 import { APP_SCHEME, getAppRendererUrl, resolveRequestToFilePath, shouldFallbackToIndex } from "./appProtocol";
 import { initAutoUpdater } from "./autoUpdater";
+import { captureNonEmptyPage } from "./captureNonEmptyPage";
 import type { ZoomCommand } from "./constants";
 import {
   BACKEND_PORT_CHANNEL_NAME,
@@ -1090,7 +1091,10 @@ app.whenReady().then(async () => {
     if (!contents) {
       throw new Error(`No webContents with id ${webContentsId}`);
     }
-    const image = await contents.capturePage();
+    // Retry until the guest has painted: capturePage() resolves with an empty
+    // image until the first frame is composited, and writing that empty image
+    // would leave no PNG on the clipboard.
+    const image = await captureNonEmptyPage(contents);
     clipboard.writeImage(image);
   });
 

--- a/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.test.tsx
@@ -89,4 +89,34 @@ describe("useBrowserWebview navigation readiness", () => {
     expect(webview.loadURL).toHaveBeenCalledTimes(1);
     expect(webview.loadURL).toHaveBeenCalledWith("http://example.test/page.html");
   });
+
+  it("re-waits for dom-ready after the guest is re-attached", () => {
+    const webview = mountWebview();
+    // First guest reaches readiness and navigates fine.
+    act(() => {
+      webview.dispatchEvent(new Event("did-attach"));
+      webview.dispatchEvent(new Event("dom-ready"));
+    });
+    act(() => {
+      captured?.navigate("http://example.test/first.html");
+    });
+    expect(webview.loadURL).toHaveBeenCalledTimes(1);
+
+    // The guest is recreated: did-attach fires again, but the new guest's
+    // document is not ready yet. A navigation now must be held until the new
+    // guest fires dom-ready — not issued against the previous guest's readiness.
+    act(() => {
+      webview.dispatchEvent(new Event("did-attach"));
+    });
+    act(() => {
+      captured?.navigate("http://example.test/second.html");
+    });
+    expect(webview.loadURL).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      webview.dispatchEvent(new Event("dom-ready"));
+    });
+    expect(webview.loadURL).toHaveBeenCalledTimes(2);
+    expect(webview.loadURL).toHaveBeenLastCalledWith("http://example.test/second.html");
+  });
 });

--- a/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.test.tsx
@@ -1,0 +1,92 @@
+import { act, cleanup, render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type BrowserWebviewController, useBrowserWebview } from "./useBrowserWebview";
+
+// A stand-in for the Electron <webview> guest element. jsdom renders <webview>
+// as a real EventTarget (so the hook's addEventListener/dispatchEvent wiring
+// works), which we augment with the guest methods the hook calls. The methods
+// are attached after render because the hook's effect only references the
+// element to register listeners — it invokes loadURL/getWebContentsId later,
+// from inside the event handlers the tests drive below.
+type FakeWebview = HTMLElement & {
+  loadURL: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+  getWebContentsId: () => number;
+  canGoBack: () => boolean;
+  canGoForward: () => boolean;
+};
+
+let captured: BrowserWebviewController | null = null;
+
+const Harness = (): ReactElement => {
+  const controller = useBrowserWebview("", vi.fn(), vi.fn());
+  const { webviewRef } = controller;
+  // Capture the controller from an effect (not during render) so the test can
+  // drive navigate() and reach the bound element.
+  useEffect(() => {
+    captured = controller;
+  });
+  return <webview ref={webviewRef} />;
+};
+
+const mountWebview = (): FakeWebview => {
+  render(<Harness />);
+  const webview = captured?.webviewRef.current as unknown as FakeWebview;
+  webview.loadURL = vi.fn(() => Promise.resolve());
+  webview.reload = vi.fn();
+  webview.getWebContentsId = (): number => 42;
+  webview.canGoBack = (): boolean => false;
+  webview.canGoForward = (): boolean => false;
+  return webview;
+};
+
+afterEach(() => {
+  cleanup();
+  captured = null;
+});
+
+describe("useBrowserWebview navigation readiness", () => {
+  it("defers loadURL until the guest fires dom-ready, then replays the pending URL", () => {
+    const webview = mountWebview();
+
+    // The guest attaches: getWebContentsId() now works and the test bridge can
+    // see the webContentsId. But the guest document is NOT ready yet — Electron's
+    // <webview>.loadURL throws "WebView must be attached to the DOM and the
+    // dom-ready event emitted" until dom-ready fires.
+    act(() => {
+      webview.dispatchEvent(new Event("did-attach"));
+    });
+
+    // A navigation requested in the did-attach -> dom-ready window must be held,
+    // not issued: calling loadURL here rejects and the navigation is lost,
+    // stranding the guest at about:blank.
+    act(() => {
+      captured?.navigate("http://example.test/index.html");
+    });
+    expect(webview.loadURL).not.toHaveBeenCalled();
+
+    // Once the document is ready, the held navigation replays exactly once.
+    act(() => {
+      webview.dispatchEvent(new Event("dom-ready"));
+    });
+    expect(webview.loadURL).toHaveBeenCalledTimes(1);
+    expect(webview.loadURL).toHaveBeenCalledWith("http://example.test/index.html");
+  });
+
+  it("navigates immediately once the guest is dom-ready", () => {
+    const webview = mountWebview();
+    act(() => {
+      webview.dispatchEvent(new Event("did-attach"));
+      webview.dispatchEvent(new Event("dom-ready"));
+    });
+
+    act(() => {
+      captured?.navigate("http://example.test/page.html");
+    });
+    expect(webview.loadURL).toHaveBeenCalledTimes(1);
+    expect(webview.loadURL).toHaveBeenCalledWith("http://example.test/page.html");
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
@@ -103,6 +103,11 @@ export const useBrowserWebview = (
       const id = webview.getWebContentsId();
       setWebContentsId(id);
       publishStatus({ webContentsId: id });
+      // A freshly-attached guest has not fired dom-ready yet, so loadURL is not
+      // usable until it does. Clearing the flag keeps "isReadyRef true" meaning
+      // "the currently-attached guest has reached dom-ready" even when a guest
+      // is recreated and re-attaches.
+      isReadyRef.current = false;
     };
 
     const handleDomReady = (): void => {

--- a/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
@@ -33,11 +33,18 @@ export const useBrowserWebview = (
   // slot. The ref holds the running value so partial updates can merge.
   const statusRef = useRef<BrowserViewStatus>({ ...INITIAL_STATUS, currentUrl: initialUrl });
 
-  // A navigation requested before the guest <webview> has fired did-attach.
-  // loadURL throws "WebView must be attached to the DOM and the dom-ready
-  // event emitted" until then, so navigate() stashes the URL here instead of
-  // losing it, and handleDidAttach replays it once the guest attaches.
+  // A navigation requested before the guest <webview> is ready to accept
+  // loadURL. navigate() stashes the URL here instead of losing it, and
+  // handleDomReady replays it once the guest fires dom-ready.
   const pendingNavigationUrlRef = useRef<string | null>(null);
+
+  // Whether the guest has fired dom-ready. <webview>.loadURL throws "WebView
+  // must be attached to the DOM and the dom-ready event emitted" until then, so
+  // did-attach (which yields the webContentsId) is necessary but not
+  // sufficient. navigate() gates on this so a URL requested in the brief
+  // did-attach -> dom-ready window is held and replayed rather than sent to
+  // loadURL, where it would reject and be silently swallowed.
+  const isReadyRef = useRef(false);
 
   // Latest-ref pattern: the event-listener effect runs once with [], so it
   // captures the originally-passed callbacks. Reading via ref keeps it
@@ -96,9 +103,16 @@ export const useBrowserWebview = (
       const id = webview.getWebContentsId();
       setWebContentsId(id);
       publishStatus({ webContentsId: id });
-      // Replay a navigation requested before the guest attached (loadURL
-      // would have thrown then). This also overrides the initial
-      // src="about:blank" load so the user's first typed URL wins.
+    };
+
+    const handleDomReady = (): void => {
+      // dom-ready is the first point at which <webview>.loadURL is usable
+      // (did-attach yields the webContentsId but the guest document is not yet
+      // ready). Mark the guest ready and replay a navigation requested in the
+      // did-attach -> dom-ready window, which would otherwise have been lost.
+      // Replaying here also overrides the initial src="about:blank" load so the
+      // user's first typed URL wins.
+      isReadyRef.current = true;
       const pendingUrl = pendingNavigationUrlRef.current;
       if (pendingUrl !== null) {
         pendingNavigationUrlRef.current = null;
@@ -112,6 +126,7 @@ export const useBrowserWebview = (
     webview.addEventListener("did-stop-loading", handleStopLoading);
     webview.addEventListener("did-fail-load", handleDidFailLoad);
     webview.addEventListener("did-attach", handleDidAttach);
+    webview.addEventListener("dom-ready", handleDomReady);
 
     return (): void => {
       webview.removeEventListener("did-navigate", handleDidNavigate);
@@ -120,6 +135,7 @@ export const useBrowserWebview = (
       webview.removeEventListener("did-stop-loading", handleStopLoading);
       webview.removeEventListener("did-fail-load", handleDidFailLoad);
       webview.removeEventListener("did-attach", handleDidAttach);
+      webview.removeEventListener("dom-ready", handleDomReady);
     };
   }, []);
 
@@ -155,12 +171,12 @@ export const useBrowserWebview = (
 
   const navigate = useCallback((url: string): void => {
     const webview = webviewRef.current;
-    // Until the guest has fired did-attach (webContentsId still null),
-    // loadURL throws and the navigation is silently lost. Stash the URL so
-    // handleDidAttach can replay it once the guest attaches — mirroring the
-    // agent-command gate in BrowserViewSlot. Last write wins, so the user's
-    // most recent typed URL is the one that loads.
-    if (!webview || statusRef.current.webContentsId === null) {
+    // Until the guest has fired dom-ready, loadURL throws ("WebView must be
+    // attached to the DOM and the dom-ready event emitted") and the navigation
+    // is silently lost. Stash the URL so handleDomReady can replay it once the
+    // guest is ready. Last write wins, so the user's most recent typed URL is
+    // the one that loads.
+    if (!webview || !isReadyRef.current) {
       pendingNavigationUrlRef.current = url;
       return;
     }


### PR DESCRIPTION
## Original bug

[SCU-1607](https://linear.app/imbue/issue/SCU-1607/flake-cluster-browser-panel-webview-root-cause-fix-readiness) — root-cause follow-up to SCU-1565 / PR #125, which only hardened the *test helper*. The Browser-panel webview tests (chromium-in-chromium under CI) still flake on commits that already contain PR #125, in three signatures:

1. `Webview location did not reach <url>; last value was 'about:blank'` — the guest never finishes navigating.
2. `No PNG on clipboard after 30.0s` — the screenshot→clipboard path is unreliable.
3. `__test_browser_webview_execute: Script failed to execute` — the in-guest execute bridge intermittently throws.

This change fixes the nondeterminism **at the source** (the webview/Electron integration), not with another test-side mitigation.

## Hypotheses considered

1. **Navigation issued before the guest is ready is silently lost (signatures 1 & 3)** — REPRODUCED.
2. **Screenshot capture writes an empty frame to the clipboard (signature 2)** — REPRODUCED.
3. **The execute bridge needs independent hardening (signature 3)** — DISCARDED. The `Script failed to execute` failures are *downstream* of hypothesis 1: the test evaluates `document.getElementById('increment').click()` into a guest that never navigated off `about:blank`, so the element is null and the injected script throws. Fixing the navigation race removes the cause; adding speculative retry logic to the bridge without an independent proven cause would be a test-side band-aid, exactly what this ticket asks to avoid. (The existing helper already retries this error for 15s — it only fails when the nav was permanently lost.)

## Root-cause analysis

The Browser panel renders one Electron `<webview>` guest per workspace. `useBrowserWebview` wires the guest's lifecycle events and exposes `navigate()`, which the toolbar and agent commands call.

Electron's `<webview>.loadURL` is only usable **after the guest fires `dom-ready`** — `did-attach` makes `getWebContentsId()` valid but the guest document does not exist yet, and `loadURL` throws *"WebView must be attached to the DOM and the dom-ready event emitted"* until `dom-ready`. The hook gated `navigate()` on the `webContentsId` (set at `did-attach`) and replayed pending navigations from the `did-attach` handler. So a URL requested in the **`did-attach` → `dom-ready` window** was sent to `loadURL` too early; `loadURL` rejected, the rejection was swallowed by `.catch(() => {})`, and nothing retried — the guest stayed at `about:blank` forever. Under heavy CI parallelism (xvfb + software rendering) that window widens, which is exactly when the flake appears. The address bar still showed the typed URL (it mirrors input optimistically), so only the *webview's* `document.location` was stuck — matching the `last value was 'about:blank'` symptom and the downstream `Script failed to execute`.

Separately, `webContents.capturePage()` resolves with an **empty `NativeImage` until the guest has composited a frame**. The screenshot→clipboard handler captured once and wrote the result unconditionally, so under software rendering an empty first frame was written to the clipboard and the test polled 30s for a PNG that never arrived.

Real offload traceback (`offload electron integration tests`, SHA `35ef0343`, post-PR-#125):
```
test_browser_panel_screenshot — AssertionError: No PNG on clipboard after 30.0s (last=None)
test_browser_panel_in_page_state_preserved_across_workspace_switch —
  AssertionError: Webview location did not reach 'http://127.0.0.1:54850/counter.html'; last value was '' ...
```

## For each reproduced bug

### Browser panel navigation lost in the did-attach → dom-ready window (signatures 1 & 3)

**Repro steps**
1. Open a workspace's Browser panel (Electron mode).
2. Type a URL and press Enter while the guest is in the `did-attach`→`dom-ready` window (reliably hit under CI load by `test_browser_panel_*` navigating right after the panel mounts).
3. The address bar shows the typed URL, but the webview's `document.location` never leaves `about:blank`; any `webview_evaluate` into the page then throws `Script failed to execute`.

**Expected vs actual**
- Expected: the guest navigates to the typed URL once it is able to.
- Actual: `loadURL` is called before `dom-ready`, rejects, is swallowed, and the navigation is permanently lost.

**Before**
```
NAV TEST — BEFORE FIX (pre-dom-ready-gate hook)
  × defers loadURL until the guest fires dom-ready, then replays the pending URL
  AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
  Tests  1 failed | 1 passed (2)
```

**Root cause**
`useBrowserWebview` gated `navigate()` on `statusRef.current.webContentsId` (set at `did-attach`) and replayed `pendingNavigationUrlRef` from the `did-attach` handler. `<webview>.loadURL` requires `dom-ready`, which fires strictly later, so navigations in that gap were issued too early and rejected. The rejection was swallowed and nothing retried.

**Fix**
Track `dom-ready` in `isReadyRef`, gate `navigate()` on it instead of the `webContentsId`, and replay the pending navigation from a new `dom-ready` handler. `did-attach` still only records the `webContentsId` for the test bridge. `dom-ready` is the correct, deterministic "guest is ready to navigate" signal, so a typed URL is always either issued immediately (steady state) or held and replayed exactly once when the guest becomes ready — never dropped.

**Test**
- Path: `sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.test.tsx`
- Kind: frontend unit (Vitest). Fallback justification: the bug is a renderer event-ordering race between Electron's `did-attach` and `dom-ready` that only manifests intermittently under CI load. Playwright cannot deterministically produce that timing window against a real Electron webview ("the bug only manifests under conditions Playwright cannot produce"), so the deterministic regression test drives the hook's event handlers in the exact problematic order. The flaky integration tests remain the e2e coverage.
- Failing-test commit: `a9d0ba3e`
- Fix commit: `b26b17da`

**After**
```
NAV TEST — AFTER FIX (HEAD)
  ✓ defers loadURL until the guest fires dom-ready, then replays the pending URL
  ✓ navigates immediately once the guest is dom-ready
  Tests  2 passed (2)
```

### Browser panel screenshot writes an empty frame to the clipboard (signature 2)

**Repro steps**
1. Open a workspace's Browser panel (Electron mode).
2. Click the screenshot button before the guest has composited a frame (reliably hit under xvfb in `test_browser_panel_screenshot`).
3. `capturePage()` returns an empty image, which is written to the clipboard; the test polls 30s and finds no PNG.

**Expected vs actual**
- Expected: a non-empty PNG lands on the clipboard.
- Actual: an empty `NativeImage` is written, leaving the clipboard without a PNG.

**Before**
```
SCREENSHOT TEST — BEFORE FIX (baseline single-capture helper)
  × retries capturePage until the guest has painted a non-empty frame
  × gives up after the attempt budget and returns the last image
  AssertionError: expected "vi.fn()" to be called 4 times, but got 1 times
  Tests  2 failed | 1 passed (3)
```

**Root cause**
`BROWSER_PANEL_CAPTURE_TO_CLIPBOARD` in `main.ts` called `contents.capturePage()` once and wrote the result unconditionally. `capturePage()` resolves with an empty image until the guest composites its first frame, which under software rendering can lag the click.

**Fix**
Extract a `captureNonEmptyPage` helper (no electron imports, so it is unit-testable against a structurally-typed `capturePage` stand-in) that retries `capturePage()` until it returns a painted (non-empty) image or a bounded attempt budget is spent (60 × 250ms = 15s, inside the test's 30s clipboard poll). The handler writes the result of this helper. Empty-frame races are absorbed at the source.

**Test**
- Path: `sculptor/frontend/src/electron/captureNonEmptyPage.test.ts`
- Kind: frontend unit (Vitest). Fallback justification: the empty-frame race is an Electron/OS compositor timing condition Playwright cannot deterministically produce; the helper is unit-tested by injecting a `capturePage` that returns empty frames then a painted one.
- Failing-test commit: `f5d1a83a`
- Fix commit: `f1c317e2`

**After**
```
SCREENSHOT TEST — AFTER FIX (HEAD)
  ✓ retries capturePage until the guest has painted a non-empty frame
  ✓ returns immediately when the first capture is already painted
  ✓ gives up after the attempt budget and returns the last image
  Tests  3 passed (3)
```

## Verification

- `just format` — clean.
- `just check` — typecheck, lint, ratchets, file-hygiene all OK.
- `just test-unit-frontend` — full frontend Vitest suite green (the two new tests plus all siblings).
- The flaky `@pytest.mark.electron` integration tests run in the `offload electron` lane; they are the existing e2e coverage and could not be reproduced deterministically locally without a full Electron build, which is why the deterministic regressions live as unit tests.

## Follow-up (review feedback)

Two issues raised in review, both fixed by making the invalid state unrepresentable rather than guarding against it at runtime:

1. **Webview readiness was never reset on guest re-attach.** `isReadyRef` was only ever set true, so a recreated guest firing `did-attach` again left the flag stale-true and `navigate()` could call `loadURL` before the new guest reached `dom-ready` — the original race. Fixed by resetting `isReadyRef` to `false` in the `did-attach` handler, so the flag always means "the currently-attached guest has reached dom-ready." Regression test in `useBrowserWebview.test.tsx` (failing-test commit `952daa44`, fix `68c1718e`).

2. **Screenshot capture budget contradicted its own contract.** The option was `attempts` ("max capturePage() calls"), but one capture always runs before the loop, so `attempts: 0` still captured once. Reframed to `retries` (extra attempts after the mandatory first capture): `0`/negative now means a single capture with no retries, and no value can request fewer than one capture, so there is nothing to misconfigure. Behavior is otherwise unchanged (`retries: N` == old `attempts: N+1`). Commit `2c94d82b`; a unit test pins `retries: 0` → exactly one capture.

## Review notes

_(no outstanding review notes)_

(Sent by Claude)

