### PR TITLE
Fix terminal agents showing unread (green) status after restart

### DIFF
--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -342,9 +342,19 @@ class TaskView(LimitedBaseTaskView[TaskInputType, TaskStateType], Generic[TaskIn
         for msg in reversed(self._messages):
             if _is_content_message(msg):
                 return msg.approximate_creation_time
-        # No content messages yet (e.g. freshly created task with only a user input)
-        # — use the earliest message.
-        return self._messages[0].approximate_creation_time
+        # No content messages: fall back to the earliest NON-ephemeral message
+        # (e.g. a freshly created chat task whose only message is the user's
+        # first input). Ephemeral messages (environment lifecycle, runner
+        # signals) are re-created on restart with a fresh timestamp, so they
+        # must not drive updated_at — otherwise a restored terminal agent, whose
+        # only messages are the ephemeral EnvironmentAcquiredRunnerMessage,
+        # advances updated_at past last_read_at and lights up "unread" (green)
+        # instead of staying "read" (grey) after a restart (SCU-1611). Terminal
+        # agents have no persistent messages, so they fall through to created_at.
+        for msg in self._messages:
+            if not msg.is_ephemeral:
+                return msg.approximate_creation_time
+        return self.created_at
 
     def add_message(self, message: Message) -> None:
         """During each update, we add the new messages"""

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -345,12 +345,11 @@ class TaskView(LimitedBaseTaskView[TaskInputType, TaskStateType], Generic[TaskIn
         # No content messages: fall back to the earliest NON-ephemeral message
         # (e.g. a freshly created chat task whose only message is the user's
         # first input). Ephemeral messages (environment lifecycle, runner
-        # signals) are re-created on restart with a fresh timestamp, so they
-        # must not drive updated_at — otherwise a restored terminal agent, whose
-        # only messages are the ephemeral EnvironmentAcquiredRunnerMessage,
-        # advances updated_at past last_read_at and lights up "unread" (green)
-        # instead of staying "read" (grey) after a restart (SCU-1611). Terminal
-        # agents have no persistent messages, so they fall through to created_at.
+        # signals) are re-created with fresh timestamps on every restart, so
+        # using one here would push updated_at past last_read_at and make an
+        # idle, already-read terminal agent — whose only message is the
+        # ephemeral EnvironmentAcquiredRunnerMessage — look unread. With no
+        # non-ephemeral message, fall back to created_at.
         for msg in self._messages:
             if not msg.is_ephemeral:
                 return msg.approximate_creation_time

--- a/sculptor/tests/integration/frontend/test_read_unread_status.py
+++ b/sculptor/tests/integration/frontend/test_read_unread_status.py
@@ -330,7 +330,7 @@ def test_terminal_agent_read_status_persists_after_restart(
         # restored terminal shows "running" (BUILDING) until the run-start
         # EnvironmentAcquiredRunnerMessage is re-emitted, after which an idle
         # terminal is neutral (read/unread).
-        expect(terminal_tab).to_have_attribute("data-dot-status", re.compile(r"^(read|unread)$"), timeout=30_000)
+        expect(terminal_tab).to_have_attribute("data-dot-status", re.compile(r"^(read|unread)$"))
 
         # The fix: the re-emitted ephemeral EnvironmentAcquired must NOT advance
         # updated_at past last_read_at, so the restored idle terminal stays read

--- a/sculptor/tests/integration/frontend/test_read_unread_status.py
+++ b/sculptor/tests/integration/frontend/test_read_unread_status.py
@@ -8,8 +8,11 @@ These tests verify:
 - Read/unread status persists across server restarts
 """
 
+import re
+
 from playwright.sync_api import expect
 
+from sculptor.testing.elements.agent_tab import PlaywrightAgentTabBarElement
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
@@ -242,3 +245,94 @@ def test_read_status_persists_after_restart(
         # and trigger useMarkRead — which would re-mark the agent as read,
         # masking the persistence bug.
         expect(workspace_tabs.first).to_have_attribute("data-has-unread", "false")
+
+
+@user_story("to see my idle terminal agent stay read (idle) after restarting Sculptor")
+def test_terminal_agent_read_status_persists_after_restart(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+) -> None:
+    """A restored, idle terminal agent must show read (grey), not unread (green).
+
+    Regression test for SCU-1611. Terminal agents have no chat content
+    messages, so CodingAgentTaskView.updated_at fell back to the *earliest*
+    message's timestamp. On restart the only message present is the ephemeral
+    EnvironmentAcquiredRunnerMessage, re-emitted with a fresh timestamp — so
+    updated_at advanced past last_read_at and the idle terminal lit up green
+    (unread) instead of staying grey (read). This is the terminal-agent
+    counterpart of test_read_status_persists_after_restart above.
+
+    Steps:
+    1. Start Sculptor, create a chat agent and a terminal agent, view both
+       (so both are read), and let the debounced mark_read persist.
+    2. Restart Sculptor against the same database.
+    3. Without viewing the terminal (viewing re-marks it read and masks the
+       bug), wait for it to re-acquire its environment, then assert its tab
+       dot is "read".
+    """
+    # === First instance: create a terminal agent and mark it read ===
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        page = instance.page
+
+        task_page = start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Terminal Restart WS")
+        chat_panel = task_page.get_chat_panel()
+        wait_for_completed_message_count(chat_panel, expected_message_count=2)
+
+        agent_tab_bar = PlaywrightAgentTabBarElement(page)
+        agent_tabs = agent_tab_bar.get_agent_tabs()
+        expect(agent_tabs).to_have_count(1)
+
+        # Add a terminal agent (creating it navigates to it, so it is viewed).
+        agent_tab_bar.open_agent_type_menu()
+        agent_tab_bar.get_agent_type_menu_item_terminal().click()
+        expect(agent_tabs).to_have_count(2)
+        terminal_tab = agent_tab_bar.get_agent_tab_by_name("Terminal 1").first
+        expect(terminal_tab).to_be_visible()
+
+        # The idle terminal settles to read (grey) once its environment is
+        # acquired and the debounced mark_read has run.
+        expect(terminal_tab).to_have_attribute("data-dot-status", "read")
+
+        # Return to the chat agent and leave it focused: it (not the terminal)
+        # is then the restored active agent after restart, so the terminal is
+        # never viewed in the second instance (viewing it would re-mark it read
+        # and mask the bug). Re-focusing also re-marks the chat read after the
+        # switch away.
+        agent_tabs.first.click()
+        expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+
+        # With both agents read, the whole workspace shows read before the restart.
+        workspace_tabs = task_page.get_workspace_tabs()
+        expect(workspace_tabs.first).to_have_attribute("data-has-unread", "false")
+
+        # Give the debounced mark_read POSTs time to persist to the database.
+        page.wait_for_timeout(2000)
+
+    # === Second instance: the restored idle terminal must still be read ===
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        page = instance.page
+
+        task_page = PlaywrightTaskPage(page=page)
+        workspace_tabs = task_page.get_workspace_tabs()
+        expect(workspace_tabs.first).to_be_visible()
+        workspace_tabs.first.click()
+
+        agent_tab_bar = PlaywrightAgentTabBarElement(page)
+        agent_tabs = agent_tab_bar.get_agent_tabs()
+        expect(agent_tabs).to_have_count(2)
+        # Keep the chat agent focused; never view the terminal (viewing it would
+        # re-mark it read and mask the bug).
+        agent_tabs.first.click()
+
+        terminal_tab = agent_tab_bar.get_agent_tab_by_name("Terminal 1").first
+        expect(terminal_tab).to_be_visible()
+
+        # Gate on the terminal re-acquiring its environment after restart: a
+        # restored terminal shows "running" (BUILDING) until the run-start
+        # EnvironmentAcquiredRunnerMessage is re-emitted, after which an idle
+        # terminal is neutral (read/unread).
+        expect(terminal_tab).to_have_attribute("data-dot-status", re.compile(r"^(read|unread)$"), timeout=30_000)
+
+        # The fix: the re-emitted ephemeral EnvironmentAcquired must NOT advance
+        # updated_at past last_read_at, so the restored idle terminal stays read
+        # (grey) rather than lighting up unread (green).
+        expect(terminal_tab).to_have_attribute("data-dot-status", "read")


### PR DESCRIPTION
## Original bug

> After restarting Sculptor, all terminal agents come up in a green/new-activity state when they should be gray/idle. The restart restore path is marking restored terminal agents as having new (unread) activity rather than idle. Fix the status/activity derivation so a restored, not-actually-working terminal agent shows idle.
>
> Lives in the status-dot / activity code (`components/statusDot/statusUtils.ts`, `StatusDot.tsx`, the unread/activity state and `useMarkRead.ts`) plus the terminal-agent restart restore.

Linear: [SCU-1611](https://linear.app/imbue/issue/SCU-1611/terminal-agents-show-greennew-activity-after-restart-instead-of)

## Hypotheses considered

1. **`updated_at` falls back to an ephemeral message's timestamp on restart** — **REPRODUCED**. `CodingAgentTaskView.updated_at` returned the *earliest* message's timestamp when a task had no content messages. For a restored terminal agent the only message is the ephemeral `EnvironmentAcquiredRunnerMessage`, re-emitted with a fresh restart-time timestamp, so `updated_at` jumped past `last_read_at`.
2. **`last_read_at` is lost / reset to null on restart** — **DISCARDED**. `last_read_at` is a persisted DB column (`task.last_read_at`, added in migration `2755d9e9f872`), restored on startup and serialized to the frontend (`TaskView.last_read_at`). It survives a restart intact, so it is not the cause.

## For each reproduced bug

### Restored idle terminal agent shows unread (green) instead of read (grey)

**Repro steps**
1. Start Sculptor and open a workspace with a chat agent.
2. Add a terminal agent (the agent-type menu → Terminal). Viewing it marks it read; confirm its tab status dot is grey (read).
3. Fully restart Sculptor against the same database.
4. Without re-opening the terminal agent (re-viewing it would re-mark it read and hide the bug), observe its tab status dot once it has re-acquired its environment.

**Expected vs actual**
- Expected: the idle terminal agent stays grey (read / idle).
- Actual: the terminal agent — and the workspace tab that aggregates it — light up green (unread / new-activity), as if it had unseen activity.

**Before**

![terminal tab — green/unread dot after restart](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1611-proof/scu1611-terminal-tab-before.png)

**Root cause**
A terminal agent has no chat *content* messages. `CodingAgentTaskView.updated_at` (`sculptor/sculptor/web/derived.py`) walks the messages newest-first looking for a content message (`_is_content_message`, which excludes ephemeral / bookkeeping / user messages) and, finding none, fell back to `self._messages[0].approximate_creation_time` — the *earliest* message. On restart the terminal handler (`run_terminal_agent_task_v1`) re-acquires the workspace environment and re-emits the **ephemeral** `EnvironmentAcquiredRunnerMessage` with a fresh timestamp. That ephemeral message is the terminal agent's only message, so it became `_messages[0]` and `updated_at` advanced to the restart time — newer than the persisted `last_read_at`. The frontend's `getAgentDotStatus` (`statusUtils.ts`) then derives `"unread"` (green) for the idle (READY) terminal agent because `updatedAt > lastReadAt`. This is the terminal-agent counterpart of the chat-agent bug already guarded by `test_read_status_persists_after_restart`.

**Fix**
Make the `updated_at` fallback skip ephemeral messages: when there are no content messages, return the earliest **non-ephemeral** message's timestamp, or `self.created_at` if there are none. Ephemeral messages (environment lifecycle, runner signals) are re-created on restart with fresh timestamps, so they must never drive `updated_at`. Terminal agents have no persistent messages, so they now fall through to `created_at` (stable, and older than `last_read_at`) and correctly read as idle. Chat agents are unaffected: a freshly created chat task's first message is the user's (non-ephemeral) input, which the fallback still returns, matching the previous behaviour.

**Test**
- Path: `sculptor/tests/integration/frontend/test_read_unread_status.py`
- Test: `test_terminal_agent_read_status_persists_after_restart`
- Kind: e2e (Playwright). The terminal-agent restart path is fully reachable from the UI, so no unit-test fallback was needed. The test creates a terminal agent, marks it read, restarts the server, and — without re-viewing the terminal — waits for it to re-acquire its environment (status leaves `BUILDING`) and asserts its tab dot is `read`. It failed before the fix (`data-dot-status="unread"`, `data-status="READY"`, tab unfocused) and passes after.
- Failing-test commit: `0786df1d77`
- Fix commit: `328cf1b136`
- Self-review follow-up commit: `c695186da4`

**After**

![terminal tab — grey/read dot after restart](https://raw.githubusercontent.com/imbue-ai/sculptor/assets/scu-1611-proof/scu1611-terminal-tab-after.png)

## Deferred follow-ups
_(none)_

## Review notes

The self-review pass (`/code-review-checklist`) ran on the full diff. Findings acted on (follow-up commit `c695186da4`):
- Tightened the new `updated_at` fallback comment to state the invariant (ephemeral message timestamps reset on every restart) rather than narrate the fix.
- Removed the redundant explicit `timeout=30_000` on the test's re-acquisition gate so it uses the harness default, avoiding a lower-than-default ceiling under load.

Findings noted but not acted on:
- `derived.py` `updated_at`: the `if len(self._messages) == 0: return self.created_at` early-return is now technically redundant with the new `return self.created_at` fallback. Retained as a cheap, explicit fast-path for the common empty-message case; it predates this change.

(Sent by Claude)
