### PR TITLE
openhost: fix from-source build (build-essential) + correct the deploy skill

### DIFF
--- a/.claude/skills/openhost-sculptor/SKILL.md
+++ b/.claude/skills/openhost-sculptor/SKILL.md
@@ -49,16 +49,23 @@ echo "OPENHOST_HOST=sculptor.<your-zone>" >>.sculptor/.env   # gitignored
 To run ad-hoc `oh` commands in a shell, just use those values directly, e.g.:
 
 ```bash
-oh app status sculptor
+oh app status sculptor   # see "Gotchas": older instances need the app_id, not the name
 oh app deploy "https://github.com/imbue-ai/sculptor@$(git rev-parse --abbrev-ref HEAD)" \
-  --name sculptor --grant-permissions-v2 --wait
+  --name sculptor --wait
 ```
 
 ## Prereqs
 
-- **`oh` CLI** installed and authenticated on this machine. Sanity check:
-  `oh app list` should show your apps without an auth error. (Authenticate once
-  with `oh instance login`.)
+- **`oh` CLI** installed and authenticated on this machine.
+  - Install (it's not on PyPI — installs from the private openhost repo):
+    ```bash
+    uv tool install "oh @ git+https://github.com/imbue-ai/openhost.git#subdirectory=compute_space_cli"
+    ```
+    `uv` drops the binary at `~/.local/bin/oh`; add that to PATH if needed.
+  - Authenticate once with **`oh login`** (prompts for the compute-space URL and a
+    token). Sanity check: **`oh status`** should print `<url> — up (HTTP 200)`.
+    (Don't rely on `oh app list` for the check — it crashes against older
+    instances; see "Gotchas".)
 - **The branch must be pushed to GitHub first.** The deploy builds from
   `$REPO@$BRANCH` — OpenHost clones from GitHub, so unpushed local commits are
   invisible to it. Push (with the user's permission) before deploying.
@@ -85,14 +92,14 @@ Knowing how the container is wired explains the deploy and reset behavior below.
 ## Deploy / update
 
 Each script deploys the current git branch (`BRANCH`) and runs `oh` with `--wait`
-(the from-source build takes **~10 min** — uv sync, frontend `npm install` /
+(the from-source build takes **~10 min** — uv sync, frontend `pnpm install` /
 `generate-api` / `build`; don't assume it's instant).
 
 ### Fresh deploy — app name not yet in use
 
 ```bash
 .claude/skills/openhost-sculptor/scripts/deploy.sh
-# → oh app deploy "$REPO@$BRANCH" --name "$APP" --grant-permissions-v2 --wait
+# → oh app deploy "$REPO@$BRANCH" --name "$APP" --wait
 ```
 
 ### Update, or switch branches — keep data
@@ -105,7 +112,7 @@ remove` blocks until the app is gone, so the deploy reuses the name cleanly.
 ```bash
 .claude/skills/openhost-sculptor/scripts/redeploy.sh
 # → oh app remove "$APP" --keep-data
-# → oh app deploy "$REPO@$BRANCH" --name "$APP" --grant-permissions-v2 --wait
+# → oh app deploy "$REPO@$BRANCH" --name "$APP" --wait
 ```
 
 Note: `oh app reload "$APP" --update` only `git pull`s and rebuilds the *same*
@@ -125,8 +132,11 @@ missing):
 
 It checks:
 
-1. **Right code is live** — `oh app status "$APP"` prints `git: <branch> @ <sha>`.
-   Confirm the branch and SHA match what you deployed.
+1. **It's up** — `oh app status "$APP"` prints `<app>: <status>` (expect
+   `running`; `building` means the deploy is still in progress). To confirm
+   *which* code is live (branch/SHA), check the deploy's build logs — `oh app
+   status` reports only the status string. (On an instance older than the CLI
+   this call needs the app_id, not the name — see "Gotchas".)
 2. **It's serving** — `curl` the live URL.
    - **`302` = healthy.** That's the OpenHost SSO login redirect, not an error.
    - `502` / `503` = down (still building, crashed, or failed to bind).
@@ -146,7 +156,7 @@ It prompts for confirmation first, then rebuilds (~10 min).
 ```bash
 .claude/skills/openhost-sculptor/scripts/reset.sh
 # → oh app remove "$APP"            # no --keep-data: deletes persistent app_data
-# → oh app deploy "$REPO@$BRANCH" --name "$APP" --grant-permissions-v2 --wait
+# → oh app deploy "$REPO@$BRANCH" --name "$APP" --wait
 ```
 
 `oh app remove --keep-data` (what `redeploy.sh` uses) preserves `app_data`,
@@ -162,6 +172,32 @@ wipe only *part* of the data, or restart without a rebuild — require host acce
 for any flow above; reach for it only for one-off inspection or surgical fixes.
 
 ## Gotchas
+
+- **An instance older than the `oh` CLI breaks name-based `app` commands.** The
+  current CLI (and openhost repo HEAD) addresses apps by **name** and expects
+  `GET /api/apps` to return a name-keyed dict. Older compute-space servers instead
+  return a **list** of `{app_id, name, status}` and key `app_status`/`app_logs` on
+  an opaque **app_id**. Against such an instance:
+  - `oh app list` crashes with `AttributeError: 'list' object has no attribute
+    'items'` (it calls `.items()` on the list).
+  - `oh app status <name>` / `oh app logs <name>` fail with `Error (400): Invalid
+    app_id` — they need the app_id, which changes on every remove+redeploy.
+
+  Fetch the current app_id (and a working list) by calling the API directly with
+  the CLI's own saved auth, then pass the id to `status`/`logs`:
+  ```bash
+  ~/.local/share/uv/tools/oh/bin/python - <<'PY'
+  import json
+  from compute_space_cli import config
+  from compute_space_cli.main import make_api_request
+  mc = config.MultiConfig.load()
+  inst = mc.instances[mc.default_instance or "default"]
+  print(json.dumps(make_api_request(inst.url, inst.token, "GET", "/api/apps").json(), indent=2))
+  PY
+  # → oh app logs <app_id>
+  ```
+  The durable fix is to **update the compute-space instance** to current openhost;
+  then the name-based commands (and these scripts) work as written.
 
 - **A returning browser can skip onboarding/Add Workspace.** Post-onboarding
   landing is driven by the browser's `sculptor-tabs` localStorage, not the server:

--- a/.claude/skills/openhost-sculptor/scripts/deploy.sh
+++ b/.claude/skills/openhost-sculptor/scripts/deploy.sh
@@ -9,4 +9,4 @@ REPO=https://github.com/imbue-ai/sculptor
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "Deploying $REPO@$BRANCH as app '$APP' (~10 min build)..."
-exec oh app deploy "$REPO@$BRANCH" --name "$APP" --grant-permissions-v2 --wait
+exec oh app deploy "$REPO@$BRANCH" --name "$APP" --wait

--- a/.claude/skills/openhost-sculptor/scripts/redeploy.sh
+++ b/.claude/skills/openhost-sculptor/scripts/redeploy.sh
@@ -13,4 +13,4 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "Redeploying '$APP' at $REPO@$BRANCH (keeping data)..."
 oh app remove "$APP" --keep-data
-exec oh app deploy "$REPO@$BRANCH" --name "$APP" --grant-permissions-v2 --wait
+exec oh app deploy "$REPO@$BRANCH" --name "$APP" --wait

--- a/.claude/skills/openhost-sculptor/scripts/reset.sh
+++ b/.claude/skills/openhost-sculptor/scripts/reset.sh
@@ -22,4 +22,4 @@ esac
 echo "Removing '$APP' (full data wipe)..."
 oh app remove "$APP" # no --keep-data: deletes persistent app_data
 echo "Deploying fresh $REPO@$BRANCH as '$APP' (~10 min build)..."
-exec oh app deploy "$REPO@$BRANCH" --name "$APP" --grant-permissions-v2 --wait
+exec oh app deploy "$REPO@$BRANCH" --name "$APP" --wait

--- a/.claude/skills/openhost-sculptor/scripts/verify.sh
+++ b/.claude/skills/openhost-sculptor/scripts/verify.sh
@@ -9,8 +9,12 @@ set -eu
 APP=sculptor
 HOST=${1:?usage: verify.sh <host> (e.g. sculptor.<your-zone>); see SKILL.md "Config"}
 
-echo "== app status (confirm branch + sha match what you deployed) =="
-oh app status "$APP"
+echo "== app status (expect 'running') =="
+# `oh app status`/`logs` address the app by name. An instance older than the CLI
+# keys these endpoints on an opaque app_id instead and rejects the name with
+# "Invalid app_id" — see SKILL.md "Gotchas" for the version skew and how to fetch
+# the id. Don't let that abort the rest of the checks (set -eu).
+oh app status "$APP" || echo "  (status failed — if 'Invalid app_id', your instance predates name-based status; see SKILL.md Gotchas)"
 
 echo
 echo "== serving: https://$HOST/ =="
@@ -23,7 +27,7 @@ esac
 
 echo
 echo "== boot markers =="
-logs=$(oh app logs "$APP")
+logs=$(oh app logs "$APP" 2>/dev/null || true)
 printf '%s\n' "$logs" | grep -q "Uvicorn running on" &&
     echo "  ok  Uvicorn running" || echo "  --  'Uvicorn running' not found yet"
 printf '%s\n' "$logs" | grep -q "Application startup complete" &&

--- a/openhost.Dockerfile
+++ b/openhost.Dockerfile
@@ -16,9 +16,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # libnss-wrapper lets the entrypoint present a passwd/group entry for the
 # arbitrary runtime UID without making /etc/passwd writable (see entrypoint below).
+# build-essential supplies a C compiler/linker (cc): some Python deps (e.g.
+# typeid-python, which has a Rust extension) ship no wheel for this repo's pinned
+# Python (3.14), so `uv sync` compiles them from sdist. uv/maturin auto-installs
+# Rust on demand, but the link step still needs a system C toolchain.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        git curl ca-certificates xz-utils libnss-wrapper && \
+        git curl ca-certificates xz-utils libnss-wrapper build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Node.js 24 — for the frontend build and the API-client codegen. Matches the

--- a/openhost.Dockerfile
+++ b/openhost.Dockerfile
@@ -16,10 +16,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # libnss-wrapper lets the entrypoint present a passwd/group entry for the
 # arbitrary runtime UID without making /etc/passwd writable (see entrypoint below).
-# build-essential supplies a C compiler/linker (cc): some Python deps (e.g.
-# typeid-python, which has a Rust extension) ship no wheel for this repo's pinned
-# Python (3.14), so `uv sync` compiles them from sdist. uv/maturin auto-installs
-# Rust on demand, but the link step still needs a system C toolchain.
+# build-essential supplies a C compiler/linker (cc): Python deps with native
+# extensions (e.g. typeid-python's Rust module) compile from sdist whenever no
+# prebuilt wheel matches the interpreter, and uv/maturin's on-demand Rust install
+# still needs a system C toolchain to link.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git curl ca-certificates xz-utils libnss-wrapper build-essential && \


### PR DESCRIPTION
Two related OpenHost fixes.

## 1. Fix the from-source build (`openhost.Dockerfile`)

The image builds Sculptor from source against the repo's pinned Python (3.14). Some deps — notably `typeid-python`, which has a Rust extension — ship no wheel for 3.14 yet, so `uv sync` builds them from sdist. `uv`/`maturin` auto-install Rust, but the link step failed because the image had no system C toolchain:

```
error: linker `cc` not found
Error: building at STEP "RUN cd /app/sculptor && uv sync": ... exit status 1
```

Add `build-essential` to provide `cc`/`gcc` — the only missing piece.

**Verified:** deployed to an OpenHost instance — `uv sync` completes (`Built typeid-python==0.3.10`), backend boots clean (`Uvicorn running on http://0.0.0.0:5050`, `Application startup complete`), live URL returns `302` (expected SSO redirect).

Note: from-source builds are now slightly slower (they compile `typeid-python` + its Rust deps) until upstream ships cp314 wheels.

## 2. Correct the `openhost-sculptor` skill

The skill had drifted from the real `oh` CLI:

- Add the install command (`uv tool install` from the openhost repo); fix auth to `oh login` (was `oh instance login`) and the sanity check to `oh status` (was `oh app list`, which can crash).
- Drop the nonexistent `--grant-permissions-v2` flag from every deploy command and script (the CLI's `deploy` only takes `--name`/`--wait`/`--port`).
- Fix the Verify step: `oh app status` prints `<app>: <status>`, not a git branch/SHA.
- Make `verify.sh` resilient under `set -eu` when status/logs calls fail.
- Document the key gotcha: a compute-space instance **older than the CLI** returns a list-shaped `/api/apps` and keys `app_status`/`app_logs` on an opaque `app_id`, so name-based commands break — with the workaround to fetch the id, and noting that updating the instance is the durable fix.
- Note the frontend build uses pnpm, matching the Dockerfile.

(Sent by Claude)