### PR TITLE
[SCU-1612] Fix background Bash tool call vanishing after turn ends

### DIFF
--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -758,14 +758,23 @@ def convert_agent_messages_to_task_update(
             #
             # Skip the synthesis when the parent tool is identifiable and is
             # NOT Agent/Task — the same notification subtype also fires for
-            # foreground Bash calls auto-promoted to ``local_bash`` background
-            # tasks, and a child ChatMessage attached to a Bash tool_use_id
+            # ``run_in_background`` (and auto-promoted ``local_bash``) Bash
+            # calls, and a child ChatMessage attached to a Bash tool_use_id
             # causes AlphaToolGroup to misclassify the Bash as a subagent
             # (children.length > 0) and render a subagent pill instead of the
-            # bash block.  When the parent isn't in scope we conservatively
-            # synthesize anyway: real Agent-tool notifications often arrive
-            # in a batch where the parent ToolUseBlock was emitted earlier
-            # and isn't visible in this call's local message list.
+            # bash block — the bash command appears to vanish.
+            #
+            # The lookup MUST span the whole conversation history, not just the
+            # messages completed in this batch: a background task's notification
+            # routinely arrives in a SEPARATE conversion batch from the one that
+            # finalized the launching turn (e.g. the user Stops the turn, the
+            # detached command keeps running, and its completion is delivered on
+            # the next invocation). By then the parent Bash ToolUseBlock lives
+            # only in ``completed_message_by_id``. Searching only the per-batch
+            # list there would miss it, fall through, and synthesize the
+            # subagent-misrendering child. We only synthesize when the parent is
+            # genuinely unknown (a notification for a tool we never saw) or is
+            # Agent/Task (where the child IS the completion signal — see SCU-1151).
             #
             # When the CLI's `usage.duration_ms` is available we backdate the
             # synthetic message's timestamp to (parent + duration_seconds) so
@@ -775,7 +784,7 @@ def convert_agent_messages_to_task_update(
             parent_tool_use = _find_tool_use_by_id(
                 msg.tool_use_id,
                 in_progress_chat_message,
-                completed_chat_messages,
+                completed_message_by_id,
             )
             if parent_tool_use is not None and parent_tool_use[0].name not in ("Agent", "Task"):
                 continue
@@ -855,22 +864,31 @@ def convert_agent_messages_to_task_update(
 def _find_tool_use_by_id(
     tool_use_id: str,
     in_progress: ChatMessage | None,
-    completed: list[ChatMessage],
+    completed_message_by_id: dict[AgentMessageID, ChatMessage],
 ) -> tuple[ToolUseBlock, datetime.datetime] | None:
     """Locate a ToolUseBlock by id and return it alongside the
     approximate_creation_time of the ChatMessage that contains it.
 
-    Returns ``None`` when no matching block is in the local message list. Used
-    by BackgroundTaskNotificationAgentMessage handling to (a) decide whether to
+    Returns ``None`` when no matching block is known. Used by
+    BackgroundTaskNotificationAgentMessage handling to (a) decide whether to
     synthesize a completion child (only for Agent/Task tools — see SCU-1151)
     and (b) timestamp that child as (parent + duration_seconds) so the
     subagent pill shows the exact wallclock duration rather than the
     notification's arrival delay.
+
+    Searches ``completed_message_by_id`` — the full conversation history that
+    persists across conversion batches — NOT just the messages completed in the
+    current batch. A background task's ``task_notification`` routinely lands in a
+    later batch, after its launching turn was already finalized and flushed to
+    history, so the parent ToolUseBlock is no longer in the current batch. Missing
+    it there would let the caller synthesize a child on a background Bash's
+    tool_use_id, which makes the frontend misrender the Bash as a subagent pill so
+    the bash block vanishes once the turn is done.
     """
     candidates: list[ChatMessage] = []
     if in_progress is not None:
         candidates.append(in_progress)
-    candidates.extend(completed)
+    candidates.extend(completed_message_by_id.values())
     for chat_message in candidates:
         for block in chat_message.content:
             if isinstance(block, ToolUseBlock) and block.id == tool_use_id:

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -3716,6 +3716,104 @@ def test_background_task_notification_for_bash_does_not_synthesize_child() -> No
     assert [m for m in state.chat_messages if m.parent_tool_use_id == bash_tool_use_id] == []
 
 
+def test_background_bash_notification_in_later_batch_does_not_synthesize_child() -> None:
+    """A background Bash whose completion arrives in a LATER batch (after the
+    launching turn was finalized) must still be recognised as a Bash and skip
+    child synthesis — otherwise the bash block silently turns into a subagent
+    pill and vanishes once the turn is done.
+
+    Real Claude keeps its process alive while a ``run_in_background`` Bash is
+    pending, so the completion normally arrives in the same request. But if the
+    user STOPS the turn while the command runs, ``RequestStopped`` finalizes the
+    turn (flushing the Bash ToolUseBlock to history) and the detached command's
+    completion is delivered on a later invocation — a SEPARATE conversion batch
+    in which the parent Bash is no longer in ``in_progress`` nor in the
+    per-batch completed list, only in the cross-batch history. The notification
+    handler must find it there and NOT synthesize a child (which AlphaToolGroup
+    would treat as ``children.length > 0`` and render as a subagent pill).
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+
+    user_message = ChatInputUserMessage(
+        text="Profile the backend",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    bash_tool_use_id = "toolu-bg-bash-pyspy"
+
+    request_started = RequestStartedAgentMessage(request_id=user_message.message_id)
+    response_block = ResponseBlockAgentMessage(
+        role="assistant",
+        assistant_message_id=AssistantMessageID("assistant-bg-bash"),
+        message_id=AgentMessageID(),
+        content=(
+            ToolUseBlock(
+                id=ToolUseID(bash_tool_use_id),
+                name="Bash",
+                input={"command": "sudo py-spy record --pid 123", "description": "Profile", "run_in_background": True},
+            ),
+        ),
+    )
+    task_started = BackgroundTaskStartedAgentMessage(
+        background_task_id="bg-task-pyspy",
+        tool_use_id=bash_tool_use_id,
+        description="Profile",
+    )
+
+    # Batch 1: the turn launches the background Bash and the user Stops it. The
+    # RequestStopped finalizes the turn, flushing the Bash to history.
+    state = convert_agent_messages_to_task_update(
+        [
+            user_message,
+            request_started,
+            response_block,
+            task_started,
+            RequestStoppedAgentMessage(
+                request_id=user_message.message_id, error=_make_serialized_exception("stopped")
+            ),
+        ],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+    assert state.in_progress_chat_message is None
+
+    # Batch 2 (later invocation): the detached command finished and its
+    # notification is delivered. The parent Bash is only in cross-batch history.
+    notification = BackgroundTaskNotificationAgentMessage(
+        background_task_id="bg-task-pyspy",
+        tool_use_id=bash_tool_use_id,
+        status="completed",
+        summary="Profile",
+    )
+    state = convert_agent_messages_to_task_update(
+        [notification],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+
+    # Assert against the cross-batch history (``completed_by_id``), which is what
+    # the frontend merges — the batch-2 ``state.chat_messages`` is only the
+    # incremental update and would not carry batch-1's Bash either way.
+    #
+    # No synthetic child attached to the Bash tool_use_id: the parent was found
+    # in history and recognised as a Bash, so synthesis was skipped. Without the
+    # cross-batch lookup, a child would be appended here and the frontend would
+    # render the Bash as a subagent pill instead of a bash block.
+    assert [m for m in completed_by_id.values() if m.parent_tool_use_id == bash_tool_use_id] == []
+    # The Bash ToolUseBlock itself is still present in history (still rendered).
+    all_tool_use_ids = {
+        block.id
+        for message in completed_by_id.values()
+        for block in message.content
+        if isinstance(block, ToolUseBlock)
+    }
+    assert bash_tool_use_id in all_tool_use_ids
+
+
 def test_background_task_started_is_noop() -> None:
     """BackgroundTaskStartedAgentMessage should not affect message state."""
     task_id = TaskID()


### PR DESCRIPTION
## Original bug (SCU-1612)

> A background tool call disappeared after the turn was done. It was the one that started `py-spy`.

A background `Bash` command (launched with `run_in_background: true`) renders while the turn streams, but **vanishes once the turn is finalized** — e.g. after the user Stops the turn while the command is still running.

## Root cause

When a background command finishes, the harness emits a `BackgroundTaskNotification`. The handler in `message_conversion.py` decides whether to synthesize a "completion" child message: for genuine `Agent`/`Task` subagents it must (that child is the completion signal); for `Bash` it must **not**, because a child attached to a Bash's `tool_use_id` makes the frontend (`AlphaToolGroup`) treat it as a subagent (`children.length > 0`) and render a subagent pill **instead of** the bash block.

The guard that prevents Bash synthesis only fires when it can *find* the parent tool. `_find_tool_use_by_id` searched only the **per-batch** completed-message list (rebuilt empty each conversion call). The harness stays alive while a background task is pending, so the completion normally arrives in the same request — but if the turn is **finalized first** (the user Stops it; the detached command keeps running and its completion is delivered on a later/resumed invocation), the notification is processed in a **separate conversion batch**, by which point the parent Bash lives only in the cross-batch history. The lookup returned `None`, the guard couldn't fire, a child was synthesized, and the bash block turned into a subagent pill — the command appeared to vanish.

## Fix

`_find_tool_use_by_id` now searches the persistent cross-batch history (`completed_message_by_id`) rather than just the current batch. It's a strict superset of the previous search, so it can only find the *same or more* parents — no regression to the in-batch or `Agent`/`Task` paths. Child synthesis still happens for genuine subagents and for genuinely-unknown tool ids.

## Proof (non-UI bug → failing-then-passing test)

Added `test_background_bash_notification_in_later_batch_does_not_synthesize_child` — launches a background Bash, finalizes the turn with `RequestStopped`, then delivers the completion notification in a **separate** conversion batch, and asserts no synthetic child is attached to the Bash.

- **Without the fix** (lookup restricted to the per-batch list): `FAILED … assert [...] == []` — a synthetic child is attached to the Bash `tool_use_id`.
- **With the fix:** `2 passed` (new test + the existing in-batch sibling). Full `message_conversion_test.py`: `75 passed`. `just format` / `just check` / `just test-unit-backend`: all green.

## Why a backend unit test, not an integration test

This is a message-conversion **batching** defect: it only manifests when the completion notification lands in a *separate* conversion batch from the (already-finalized) Bash. The integration harness can't deterministically produce that — `fake_claude` is one-process-per-turn and can't deliver a notification *after* a Stop, and a fresh stream subscription re-converts all messages cumulatively (one batch), which heals the orphan. The unit test reproduces the exact convert-level invariant deterministically. Follow-up SCU-1614 tracks adding an incremental-vs-cumulative `convert` invariant test that would structurally guard this whole bug class.

## Deferred follow-ups

- **SCU-1614** — add an incremental-vs-cumulative `convert` invariant test (feed a message log batch-by-batch vs all-at-once; assert identical final state). Would structurally catch this bug class and the related streaming-partial bugs.

## Review notes

_(no outstanding review notes — self-review via `/code-review-checklist` was clean)_

(Sent by Claude)
