### PR TITLE
Fix flaky terminal xterm-wait races (SCU-1567)

### DIFF
--- a/sculptor/tests/integration/frontend/test_registered_terminal_agent.py
+++ b/sculptor/tests/integration/frontend/test_registered_terminal_agent.py
@@ -80,13 +80,16 @@ def test_registered_terminal_agent_launches_program(sculptor_instance_: Sculptor
         (registrations_dir / "fake-tui.toml").unlink(missing_ok=True)
 
 
-# The SESSION-REPORTED marker is assembled via printf so the echoed command
-# line never contains it: the xterm wait must trip on the program OUTPUT
-# (the session-id POST completed) — matching the command echo would let the
-# instance shut down before the signal persists, and the restart would
-# relaunch instead of resume.
+# The session id must be durably persisted before the first instance is torn
+# down, or the restart relaunches instead of resuming. `until sculpt signal ...`
+# retries until the report succeeds (CLI exit 0 == the backend committed the id);
+# a plain `; sculpt signal ... ;` would let SESSION-REPORTED print even when the
+# report fails transiently under load, tearing the instance down unpersisted.
+# SESSION-REPORTED is printf-assembled so it appears only in the program output,
+# never the echoed command line -- the xterm wait must trip on the output.
 _FAKE_RESUME_LAUNCH = (
-    "echo FIRST-RUN-BANNER; sculpt signal session-id fake-session-42; printf %sREPORTED SESSION-; echo; read -r _line"
+    "echo FIRST-RUN-BANNER; until sculpt signal session-id fake-session-42; do sleep 0.2; done; "
+    + "printf %sREPORTED SESSION-; echo; read -r _line"
 )
 _FAKE_RESUME_TEMPLATE = "echo RESUMED-WITH {session_id}; read -r _line"
 

--- a/sculptor/tests/integration/frontend/test_terminal.py
+++ b/sculptor/tests/integration/frontend/test_terminal.py
@@ -347,9 +347,15 @@ def test_terminal_does_not_expose_sculptor_api_port(sculptor_instance_: Sculptor
     # Print a deterministic marker. If SCULPTOR_API_PORT is unset (correct),
     # the shell expands ${SCULPTOR_API_PORT:-NOT_SET} to "NOT_SET" and we see
     # "LEAK_CHECK:NOT_SET".  If it is set (the bug), we see e.g. "LEAK_CHECK:5050".
-    type_with_delay(terminal_textarea, 'echo "LEAK_CHECK:${SCULPTOR_API_PORT:-NOT_SET}"', 30)
+    #
+    # LEAK_CHECK / LEAK_END are built from a shell variable so the contiguous
+    # tokens appear only in the OUTPUT, not the echoed command line
+    # ("${lk}_CHECK" / "${lk}_END"). Waiting on a bare "LEAK_CHECK:" would match
+    # the echo before the shell runs, racing the not-yet-printed value; LEAK_END
+    # prints after the value, so its presence means the value is in the buffer.
+    type_with_delay(terminal_textarea, 'lk=LEAK; echo "${lk}_CHECK:${SCULPTOR_API_PORT:-NOT_SET}:${lk}_END"', 30)
     terminal_textarea.press("Enter")
-    wait_for_xterm_substring(page, "LEAK_CHECK:")
+    wait_for_xterm_substring(page, "LEAK_END")
 
     buffer_text = get_xterm_buffer_text(page)
 


### PR DESCRIPTION
## Original bug
SCU-1567 cluster "Terminal xterm buffer timing / env" — two integration tests flake on the offload runner:
- `frontend/test_terminal.py::test_terminal_does_not_expose_sculptor_api_port`
- `frontend/test_registered_terminal_agent.py::test_registered_terminal_agent_resumes_after_restart`

https://linear.app/imbue/issue/SCU-1567

Both flakes share a root cause class: the test advances past a wait that fires **before** the state it asserts on actually exists.

## Hypotheses considered
1. **xterm buffer assertions race the shell output** (starting hypothesis) — **REPRODUCED** for both; the precise mechanism differs per test (below).
2. A real `SCULPTOR_API_PORT` env leak — **DISCARDED**: the var is genuinely unset; the failure buffer holds only the echoed command, not the output line.
3. Backend session-id persistence / cross-process loss after restart — **DISCARDED**: persistence is correct (unit-tested) and durable across the restart; the real loss is that the signal sometimes never commits in the first place.

## Reproduced bug 1 — test_terminal_does_not_expose_sculptor_api_port

**Repro steps**
1. Open the terminal panel.
2. Type `echo "LEAK_CHECK:${SCULPTOR_API_PORT:-NOT_SET}"` and press Enter.
3. `wait_for_xterm_substring(page, "LEAK_CHECK:")`, then read the buffer and assert `LEAK_CHECK:NOT_SET` is present.

**Expected vs actual**
- Expected: the wait fires on the command's *output* line (`LEAK_CHECK:NOT_SET`).
- Actual (under load): the wait fires on the *echoed command line*, which literally contains `LEAK_CHECK:`; the buffer is then read before the output renders, so the assert fails.

**Before** (failing-buffer excerpt — paths genericized)
```
tests/integration/frontend/test_terminal.py:356: in test_terminal_does_not_expose_sculptor_api_port
    assert "LEAK_CHECK:NOT_SET" in buffer_text
E   AssertionError: ... Terminal buffer:
E     root@host:/tmp/.../code# echo "LEAK_CHECK:${SCULPTOR_API_PORT:-NOT_SET}"
```
(buffer holds only the echoed command — the output line had not printed yet)

**Root cause**
`wait_for_xterm_substring` polls the whole xterm buffer, which includes the line the shell echoes as you type. The wait token `LEAK_CHECK:` is present verbatim in the typed command, so the wait returns the instant the command is echoed — before the shell runs it — and the subsequent buffer read races the not-yet-printed output.

**Fix**
Build the marker from a shell variable (`lk=LEAK; echo "${lk}_CHECK:${SCULPTOR_API_PORT:-NOT_SET}:${lk}_END"`) so the contiguous `LEAK_CHECK`/`LEAK_END` tokens exist only in the output (the echo shows `${lk}_CHECK`). Wait on the trailing `LEAK_END` sentinel, printed after the value, so the value is guaranteed present before the assert.

**Test**: `sculptor/tests/integration/frontend/test_terminal.py` (existing integration test, made deterministic). Fix commit `528dec26`.

**After**
```
============================== 1 passed in 24.18s ==============================
```

## Reproduced bug 2 — test_registered_terminal_agent_resumes_after_restart

**Repro steps**
1. Register a fake terminal agent whose launch command reports a session id via `sculpt signal session-id`, then prints `SESSION-REPORTED`.
2. Create the agent; wait for `SESSION-REPORTED`; tear down the first backend instance.
3. Start a second instance; open the agent tab; wait for `RESUMED-WITH fake-session-42`.

**Expected vs actual**
- Expected: the second instance relaunches via the rendered resume command (`RESUMED-WITH fake-session-42`).
- Actual (under load): the second instance runs the *launch* command instead (`terminal_session_id` is `None`), so `RESUMED-WITH` never appears and the wait times out.

**Before** (failing-buffer excerpt — paths genericized)
```
E   AssertionError: Expected xterm buffer to contain 'RESUMED-WITH fake-session-42', but timed out. Buffer:
E   root@host:/tmp/.../code# echo FIRST-RUN-BANNER; sculpt signal session-id fake-session-42; printf %sREPORTED SESSION-; echo; read -r _line
E   FIRST-RUN-BANNER
E   SESSION-REPORTED
```
(instance 2 ran the *launch* command → the session id was never persisted)

**Root cause**
The fake agent's launch command chained `sculpt signal session-id` with `;`, so `SESSION-REPORTED` — the gate the test uses to decide the signal "landed" before tearing down instance 1 — printed regardless of whether the signal succeeded. Under load `sculpt`'s POST can fail transiently (its HTTP client sets no timeout, so httpx's 5s default applies, and the backend can also return a transient non-2xx). The test then tore down instance 1 with the id unpersisted, and the restart relaunched instead of resuming.

**Fix**
Retry the report until it succeeds: `until sculpt signal session-id fake-session-42; do sleep 0.2; done`. The loop exits only on CLI exit 0 (HTTP 204 == the backend committed the id), so `SESSION-REPORTED` — and therefore the teardown — fires only after the id is durably persisted.

**Test**: `sculptor/tests/integration/frontend/test_registered_terminal_agent.py` (existing integration test, made deterministic). Fix commit `528dec26`.

**Proof (deterministic before/after)** — by injecting a transient 503 on the first `session-id` signal per backend process:
- old `;` chaining → `1 failed`, `Expected xterm buffer to contain 'RESUMED-WITH fake-session-42', but timed out` (the exact ticket symptom).
- new `until` retry → `1 passed` (the retry re-sends after the 503, commits, and instance 2 resumes).

**After** (both test files, run together)
```
======================== 13 passed in 120.05s ========================
```

## Deferred follow-ups
- `sculpt`'s HTTP client (`tools/sculpt/sculpt/auth.py`) sets no timeout (httpx 5s default) and `sculpt signal session-id` does not retry. A real registered agent reporting its session id under a momentarily-slow backend could silently fail to persist it and relaunch-instead-of-resume after a restart. Tracking ticket: https://linear.app/imbue/issue/SCU-1615

## Review notes
_(no outstanding review notes)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
