### PR TITLE
Retry sculpt signal session-id and pin an explicit client timeout (SCU-1615)

### DIFF
--- a/tools/sculpt/sculpt/auth.py
+++ b/tools/sculpt/sculpt/auth.py
@@ -12,11 +12,22 @@ from sculpt.session import get_session_token
 
 DEFAULT_PORT = 5050
 
+# httpx silently defaults to a 5s request timeout, which a momentarily slow local
+# backend can exceed (e.g. a large POST while the backend is busy), dropping the
+# request. Pin a longer, explicit ceiling so transient slowness isn't mistaken for
+# failure.
+_HTTP_TIMEOUT_SECONDS = 30.0
+
 
 def get_default_base_url() -> str:
     """Get the default base URL, respecting SCULPT_API_PORT if set."""
     port = os.environ.get("SCULPT_API_PORT", str(DEFAULT_PORT))
     return f"http://localhost:{port}"
+
+
+def build_client(base_url: str) -> Client:
+    """Build a sculpt API client with an explicit, generous request timeout."""
+    return Client(base_url=base_url, timeout=httpx.Timeout(_HTTP_TIMEOUT_SECONDS))
 
 
 MODEL_MAPPING: dict[str, LLMModel] = {
@@ -31,7 +42,7 @@ MODEL_MAPPING: dict[str, LLMModel] = {
 
 def get_authenticated_client(base_url: str) -> Client:
     """Create an authenticated client for the Sculptor API."""
-    client = Client(base_url=base_url)
+    client = build_client(base_url)
     try:
         session_token = get_session_token(client)
     except SessionTokenError as e:

--- a/tools/sculpt/sculpt/auth.py
+++ b/tools/sculpt/sculpt/auth.py
@@ -13,9 +13,8 @@ from sculpt.session import get_session_token
 DEFAULT_PORT = 5050
 
 # httpx silently defaults to a 5s request timeout, which a momentarily slow local
-# backend can exceed (e.g. a large POST while the backend is busy), dropping the
-# request. Pin a longer, explicit ceiling so transient slowness isn't mistaken for
-# failure.
+# backend can exceed, dropping the request. Pin a longer, explicit ceiling so
+# transient slowness isn't mistaken for failure.
 _HTTP_TIMEOUT_SECONDS = 30.0
 
 

--- a/tools/sculpt/sculpt/commands/_follow_helpers.py
+++ b/tools/sculpt/sculpt/commands/_follow_helpers.py
@@ -7,7 +7,7 @@ from typing import assert_never
 import httpx
 import typer
 
-from sculpt.client import Client
+from sculpt.auth import build_client
 from sculpt.commands.data_types import AgentStatusOutput
 from sculpt.formatting import cli_error
 from sculpt.message_formatting import format_message
@@ -21,7 +21,7 @@ from sculpt.ws_client import follow_agent
 def get_session_token_safe(base_url: str, json_output: bool) -> str:
     """Get a session token, exiting on failure."""
     try:
-        return get_session_token(Client(base_url=base_url))
+        return get_session_token(build_client(base_url))
     except SessionTokenError as e:
         cli_error(str(e), json_output=json_output)
     except (httpx.ConnectError, httpx.ConnectTimeout):

--- a/tools/sculpt/sculpt/commands/signal.py
+++ b/tools/sculpt/sculpt/commands/signal.py
@@ -7,14 +7,18 @@ the happy path stays silent and the imports stay light.
 
 import json
 import os
+import time
+from typing import Any
 
 import httpx
 import typer
 
 from sculpt.auth import get_authenticated_client
 from sculpt.auth import get_default_base_url
+from sculpt.client import Client
 from sculpt.client.api.default import post_agent_signal
 from sculpt.client.models.signal_event_request import SignalEventRequest
+from sculpt.client.types import Response
 from sculpt.formatting import cli_error
 from sculpt.formatting import handle_connection_error
 
@@ -22,6 +26,16 @@ signal_app = typer.Typer(help="Report terminal-agent integration signals to Scul
 
 _AGENT_OPTION = typer.Option(None, "--agent", help="Agent ID (or set SCULPT_AGENT_ID)")
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON")
+
+# A registered terminal agent reports its session id from a hook; if that POST is
+# dropped, the agent relaunches instead of resuming after a backend restart. Retry
+# the report through transient backend trouble — connect/read timeouts, a refused
+# connection during a restart, or a 5xx — before giving up. A permanent client
+# error (4xx) is not retried. Other signals are momentary state pings where a
+# dropped report self-corrects on the next transition, so they post once.
+_SESSION_ID_MAX_ATTEMPTS = 5
+_RETRY_BACKOFF_SECONDS = 0.5
+_RETRYABLE_EXCEPTIONS = (httpx.TimeoutException, httpx.ConnectError)
 
 
 def _resolve_agent_id(agent: str | None, json_output: bool) -> str:
@@ -35,14 +49,39 @@ def _resolve_agent_id(agent: str | None, json_output: bool) -> str:
     return agent_id
 
 
-def _post_event(event: str, agent: str | None, json_output: bool, session_id: str | None = None) -> None:
+def _post_signal_with_retries(
+    client: Client, agent_id: str, body: SignalEventRequest, max_attempts: int
+) -> Response[Any] | None:
+    """POST the signal, retrying transient failures with a short linear backoff.
+
+    Retries on connect/read timeouts, a refused connection, and 5xx responses;
+    a non-5xx response (success or a permanent 4xx) ends the loop immediately.
+    Returns the final response, or None when every attempt failed before the
+    backend answered.
+    """
+    response: Response[Any] | None = None
+    for attempt in range(max_attempts):
+        try:
+            response = post_agent_signal.sync_detailed(agent_id=agent_id, client=client, body=body)
+        except _RETRYABLE_EXCEPTIONS:
+            response = None
+        else:
+            if int(response.status_code) < 500:
+                return response
+        if attempt + 1 < max_attempts:
+            time.sleep(_RETRY_BACKOFF_SECONDS * (attempt + 1))
+    return response
+
+
+def _post_event(
+    event: str, agent: str | None, json_output: bool, session_id: str | None = None, *, max_attempts: int = 1
+) -> None:
     """POST one signal event; 204 is silent success, anything else exits 1."""
     agent_id = _resolve_agent_id(agent, json_output)
     client = get_authenticated_client(get_default_base_url())
     body = SignalEventRequest(event=event) if session_id is None else SignalEventRequest(event=event, session_id=session_id)
-    try:
-        response = post_agent_signal.sync_detailed(agent_id=agent_id, client=client, body=body)
-    except (httpx.ConnectError, httpx.ConnectTimeout):
+    response = _post_signal_with_retries(client, agent_id, body, max_attempts)
+    if response is None:
         handle_connection_error(json_output)
     if int(response.status_code) != 204:
         cli_error(
@@ -86,4 +125,4 @@ def session_id(
     json_output: bool = _JSON_OPTION,
 ) -> None:
     """Report the program's session id so Sculptor can resume it after a restart."""
-    _post_event("session-id", agent, json_output, session_id=session_id)
+    _post_event("session-id", agent, json_output, session_id=session_id, max_attempts=_SESSION_ID_MAX_ATTEMPTS)

--- a/tools/sculpt/sculpt/commands/signal.py
+++ b/tools/sculpt/sculpt/commands/signal.py
@@ -54,16 +54,17 @@ def _post_signal_with_retries(
 
     Retries on connect/read timeouts, a refused connection, and 5xx responses;
     a non-5xx response (success or a permanent 4xx) ends the loop immediately.
-    Returns the final response, or None when every attempt failed before the
-    backend answered.
+    Returns the last response the backend returned, or None when every attempt
+    failed before the backend answered.
     """
     response: Response[Any] | None = None
     for attempt in range(max_attempts):
         try:
-            response = post_agent_signal.sync_detailed(agent_id=agent_id, client=client, body=body)
+            attempt_response = post_agent_signal.sync_detailed(agent_id=agent_id, client=client, body=body)
         except _RETRYABLE_EXCEPTIONS:
-            response = None
-        else:
+            attempt_response = None
+        if attempt_response is not None:
+            response = attempt_response
             if int(response.status_code) < 500:
                 return response
         if attempt + 1 < max_attempts:

--- a/tools/sculpt/sculpt/commands/signal.py
+++ b/tools/sculpt/sculpt/commands/signal.py
@@ -27,12 +27,10 @@ signal_app = typer.Typer(help="Report terminal-agent integration signals to Scul
 _AGENT_OPTION = typer.Option(None, "--agent", help="Agent ID (or set SCULPT_AGENT_ID)")
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON")
 
-# A registered terminal agent reports its session id from a hook; if that POST is
-# dropped, the agent relaunches instead of resuming after a backend restart. Retry
-# the report through transient backend trouble — connect/read timeouts, a refused
-# connection during a restart, or a 5xx — before giving up. A permanent client
-# error (4xx) is not retried. Other signals are momentary state pings where a
-# dropped report self-corrects on the next transition, so they post once.
+# A registered terminal agent reports its session id from a hook; a dropped report
+# means it relaunches instead of resuming after a backend restart, so the report is
+# worth retrying. Other signals are momentary state pings that self-correct on the
+# next transition, so they post once.
 _SESSION_ID_MAX_ATTEMPTS = 5
 _RETRY_BACKOFF_SECONDS = 0.5
 _RETRYABLE_EXCEPTIONS = (httpx.TimeoutException, httpx.ConnectError)

--- a/tools/sculpt/tests/unit/test_signal.py
+++ b/tools/sculpt/tests/unit/test_signal.py
@@ -169,3 +169,22 @@ def test_signal_session_id_does_not_retry_permanent_4xx(runner: CliRunner, monke
 
     assert result.exit_code == 1
     assert route.call_count == 1
+
+
+@respx.mock
+def test_signal_session_id_reports_server_status_when_later_retries_lose_connection(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # If an attempt gets a 5xx and later retries can't reach the backend at all,
+    # surface the backend's last answer rather than masking it as a bare
+    # connection error.
+    monkeypatch.setattr(signal, "_RETRY_BACKOFF_SECONDS", 0.0)
+    _mock_session()
+    side_effect = [Response(503)] + [httpx.ReadTimeout("backend slow")] * (signal._SESSION_ID_MAX_ATTEMPTS - 1)
+    route = respx.post(f"{_BASE_URL}/api/v1/agents/{_AGENT_ID}/signal").mock(side_effect=side_effect)
+
+    result = runner.invoke(app, ["signal", "session-id", "sess-xyz", "--agent", _AGENT_ID])
+
+    assert result.exit_code == 1
+    assert "503" in result.stderr
+    assert route.call_count == signal._SESSION_ID_MAX_ATTEMPTS

--- a/tools/sculpt/tests/unit/test_signal.py
+++ b/tools/sculpt/tests/unit/test_signal.py
@@ -111,8 +111,7 @@ def test_signal_server_404_exits_nonzero(runner: CliRunner) -> None:
 
 @respx.mock
 def test_signal_client_pins_explicit_timeout_above_httpx_default() -> None:
-    # httpx silently defaults to a 5s timeout; a momentarily slow local backend
-    # POST can exceed it and be dropped, so the client must pin a longer ceiling.
+    # 5s is httpx's silent default; the client must pin a longer explicit ceiling.
     _mock_session()
 
     client = get_authenticated_client(_BASE_URL)
@@ -145,8 +144,8 @@ def test_signal_session_id_retries_transient_5xx_until_persisted(
 def test_signal_session_id_retries_read_timeout_until_persisted(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # A read timeout (the failure mode behind the old 5s default) is transient;
-    # the report must be retried rather than silently lost.
+    # A read timeout is transient backend slowness; the report must be retried
+    # rather than silently lost.
     monkeypatch.setattr(signal, "_RETRY_BACKOFF_SECONDS", 0.0)
     _mock_session()
     route = respx.post(f"{_BASE_URL}/api/v1/agents/{_AGENT_ID}/signal").mock(

--- a/tools/sculpt/tests/unit/test_signal.py
+++ b/tools/sculpt/tests/unit/test_signal.py
@@ -2,9 +2,12 @@
 
 import json
 
+import httpx
 import pytest
 import respx
 from httpx import Response
+from sculpt.auth import get_authenticated_client
+from sculpt.commands import signal
 from sculpt.main import app
 from typer.testing import CliRunner
 
@@ -104,3 +107,66 @@ def test_signal_server_404_exits_nonzero(runner: CliRunner) -> None:
 
     assert result.exit_code == 1
     assert "404" in result.stderr
+
+
+@respx.mock
+def test_signal_client_pins_explicit_timeout_above_httpx_default() -> None:
+    # httpx silently defaults to a 5s timeout; a momentarily slow local backend
+    # POST can exceed it and be dropped, so the client must pin a longer ceiling.
+    _mock_session()
+
+    client = get_authenticated_client(_BASE_URL)
+
+    timeout = client.get_httpx_client().timeout
+    assert timeout.read is not None and timeout.read > 5.0
+    assert timeout.connect is not None and timeout.connect > 5.0
+
+
+@respx.mock
+def test_signal_session_id_retries_transient_5xx_until_persisted(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A 5xx is transient backend trouble; the session id is too important to drop,
+    # so it must be retried until the backend accepts it.
+    monkeypatch.setattr(signal, "_RETRY_BACKOFF_SECONDS", 0.0)
+    _mock_session()
+    route = respx.post(f"{_BASE_URL}/api/v1/agents/{_AGENT_ID}/signal").mock(
+        side_effect=[Response(503), Response(503), Response(204)]
+    )
+
+    result = runner.invoke(app, ["signal", "session-id", "sess-xyz", "--agent", _AGENT_ID])
+
+    assert result.exit_code == 0, result.stderr
+    assert route.call_count == 3
+    assert json.loads(route.calls.last.request.content) == {"event": "session-id", "sessionId": "sess-xyz"}
+
+
+@respx.mock
+def test_signal_session_id_retries_read_timeout_until_persisted(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A read timeout (the failure mode behind the old 5s default) is transient;
+    # the report must be retried rather than silently lost.
+    monkeypatch.setattr(signal, "_RETRY_BACKOFF_SECONDS", 0.0)
+    _mock_session()
+    route = respx.post(f"{_BASE_URL}/api/v1/agents/{_AGENT_ID}/signal").mock(
+        side_effect=[httpx.ReadTimeout("backend slow"), Response(204)]
+    )
+
+    result = runner.invoke(app, ["signal", "session-id", "sess-xyz", "--agent", _AGENT_ID])
+
+    assert result.exit_code == 0, result.stderr
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_signal_session_id_does_not_retry_permanent_4xx(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 4xx is a permanent client error; retrying it would only waste attempts.
+    monkeypatch.setattr(signal, "_RETRY_BACKOFF_SECONDS", 0.0)
+    _mock_session()
+    route = respx.post(f"{_BASE_URL}/api/v1/agents/{_AGENT_ID}/signal").mock(return_value=Response(404))
+
+    result = runner.invoke(app, ["signal", "session-id", "sess-xyz", "--agent", _AGENT_ID])
+
+    assert result.exit_code == 1
+    assert route.call_count == 1


### PR DESCRIPTION
## Summary

`sculpt`'s HTTP client relied on httpx's silent 5s default timeout, and `sculpt signal session-id` made a single POST with no retry. A registered terminal agent reports its session id from a hook; if the local backend is momentarily slow (the POST exceeds 5s) or returns a transient 5xx, the report was dropped, the id never persisted, and the agent relaunched instead of resuming after a backend restart — losing the user's session.

This is the product-level fix for that robustness gap, which until now was only worked around at the test level.

## Changes

- **Explicit client timeout.** A new `build_client()` factory in `auth.py` pins an explicit 30s `httpx.Timeout`. Both client-construction sites (`get_authenticated_client` and the `--follow` session-token helper) route through it, so transient backend slowness isn't mistaken for failure.
- **Retry on transient failure.** `sculpt signal session-id` now retries on connect/read timeouts, refused connections, and 5xx responses with a short linear backoff; a permanent 4xx is not retried. The other signals stay single-shot, since a dropped state ping self-corrects on the next transition.

## Tests

New unit tests use an httpx mock transport (fast and deterministic) to pin:

- the client carries an explicit timeout above httpx's 5s default,
- `session-id` retries through a transient 5xx until the id is persisted,
- `session-id` retries a read timeout until persisted,
- `session-id` does not retry a permanent 4xx.

## Verification

- `just check` — green (ratchets, typecheck, lint, hygiene).
- `just test-unit-sculpt` — 275 passed.
- pyrefly — 0 errors on the changed files.

(Sent by Claude)
