### PR TITLE
Fix flaky read/unread indicators on agent and workspace tabs (SCU-1573)

### DIFF
--- a/sculptor/frontend/src/common/state/hooks/useMarkRead.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useMarkRead.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook, type RenderHookResult } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactElement, ReactNode } from "react";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as api from "../../../api";
+import type { CodingAgentTaskView } from "../../../api";
+import { taskAtomFamily } from "../atoms/tasks";
+import { useMarkRead } from "./useMarkRead";
+
+// Capture calls to the mark-read endpoint without hitting the network.
+const { mockMarkRead } = vi.hoisted(() => ({ mockMarkRead: vi.fn() }));
+
+vi.mock("../../../api", async () => {
+  const actual = await vi.importActual<typeof api>("../../../api");
+  return { ...actual, markWorkspaceAgentRead: mockMarkRead };
+});
+
+const makeTask = (updatedAt: string, lastReadAt: string | null): CodingAgentTaskView =>
+  ({ id: "agent-1", status: "READY", updatedAt, lastReadAt }) as unknown as CodingAgentTaskView;
+
+const renderMarkRead = (store: ReturnType<typeof createStore>): RenderHookResult<void, unknown> => {
+  const wrapper = ({ children }: { children: ReactNode }): ReactElement => createElement(Provider, { store }, children);
+  return renderHook(() => useMarkRead("ws-1", "agent-1"), { wrapper });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMarkRead.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useMarkRead", () => {
+  it("flushes a pending debounced read when the agent is left mid-debounce", () => {
+    const store = createStore();
+    store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:05.000Z", "2024-01-01T00:00:01.000Z"));
+    const { unmount } = renderMarkRead(store);
+    // The mount marks the agent read once; isolate the flush from it.
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+    mockMarkRead.mockClear();
+
+    // A new update arrives while viewing — schedules a debounced read.
+    act(() => {
+      store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:06.000Z", "2024-01-01T00:00:01.000Z"));
+    });
+
+    // Leaving the agent before the debounce fires must flush the pending read,
+    // so the agent persists as read instead of reappearing unread.
+    act(() => {
+      unmount();
+    });
+
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+    expect(mockMarkRead).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.objectContaining({ agent_id: "agent-1" }) }),
+    );
+  });
+
+  it("does not flush when there is no pending read", () => {
+    const store = createStore();
+    store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:05.000Z", "2024-01-01T00:00:01.000Z"));
+    const { unmount } = renderMarkRead(store);
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+    mockMarkRead.mockClear();
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("does not flush when the user marked the agent unread while a read was pending", () => {
+    const store = createStore();
+    store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:05.000Z", "2024-01-01T00:00:01.000Z"));
+    const { unmount } = renderMarkRead(store);
+    mockMarkRead.mockClear();
+
+    // A new update schedules a debounced read...
+    act(() => {
+      store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:06.000Z", "2024-01-01T00:00:01.000Z"));
+    });
+    // ...then the user explicitly marks it unread (lastReadAt -> null).
+    act(() => {
+      store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:06.000Z", null));
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+});

--- a/sculptor/frontend/src/common/state/hooks/useMarkRead.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useMarkRead.test.ts
@@ -17,8 +17,8 @@ vi.mock("../../../api", async () => {
   return { ...actual, markWorkspaceAgentRead: mockMarkRead };
 });
 
-const makeTask = (updatedAt: string, lastReadAt: string | null): CodingAgentTaskView =>
-  ({ id: "agent-1", status: "READY", updatedAt, lastReadAt }) as unknown as CodingAgentTaskView;
+const makeTask = (updatedAt: string, lastReadAt: string | null, id = "agent-1"): CodingAgentTaskView =>
+  ({ id, status: "READY", updatedAt, lastReadAt }) as unknown as CodingAgentTaskView;
 
 const renderMarkRead = (store: ReturnType<typeof createStore>): RenderHookResult<void, unknown> => {
   const wrapper = ({ children }: { children: ReactNode }): ReactElement => createElement(Provider, { store }, children);
@@ -48,8 +48,7 @@ describe("useMarkRead", () => {
       store.set(taskAtomFamily("agent-1"), makeTask("2024-01-01T00:00:06.000Z", "2024-01-01T00:00:01.000Z"));
     });
 
-    // Leaving the agent before the debounce fires must flush the pending read,
-    // so the agent persists as read instead of reappearing unread.
+    // Leaving the agent before the debounce fires must flush the pending read.
     act(() => {
       unmount();
     });
@@ -94,5 +93,38 @@ describe("useMarkRead", () => {
     });
 
     expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit mark-unread on the agent being left when switching agents", () => {
+    const store = createStore();
+    store.set(taskAtomFamily("agent-x"), makeTask("2024-01-01T00:00:05.000Z", "2024-01-01T00:00:01.000Z", "agent-x"));
+    store.set(taskAtomFamily("agent-y"), makeTask("2024-01-01T00:00:05.000Z", "2024-01-01T00:00:01.000Z", "agent-y"));
+    const wrapper = ({ children }: { children: ReactNode }): ReactElement =>
+      createElement(Provider, { store }, children);
+    const { rerender } = renderHook(({ agentId }: { agentId: string }) => useMarkRead("ws-1", agentId), {
+      wrapper,
+      initialProps: { agentId: "agent-x" },
+    });
+    mockMarkRead.mockClear();
+
+    // agent-x gets an update (schedules a debounced read), then the user marks
+    // agent-x unread before the debounce fires.
+    act(() => {
+      store.set(taskAtomFamily("agent-x"), makeTask("2024-01-01T00:00:06.000Z", "2024-01-01T00:00:01.000Z", "agent-x"));
+    });
+    act(() => {
+      store.set(taskAtomFamily("agent-x"), makeTask("2024-01-01T00:00:06.000Z", null, "agent-x"));
+    });
+
+    // Switching to agent-y must consult agent-x's state (it is unread), not
+    // agent-y's, so the flush must not re-mark agent-x read.
+    act(() => {
+      rerender({ agentId: "agent-y" });
+    });
+
+    const didMarkAgentXRead = mockMarkRead.mock.calls.some(
+      (call) => (call[0] as { path?: { agent_id?: string } })?.path?.agent_id === "agent-x",
+    );
+    expect(didMarkAgentXRead).toBe(false);
   });
 });

--- a/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
+++ b/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
@@ -1,4 +1,4 @@
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { useEffect, useRef } from "react";
 
 import { markWorkspaceAgentRead } from "../../../api";
@@ -9,18 +9,11 @@ const DEBOUNCE_MS = 1000;
 export const useMarkRead = (workspaceID: string, agentID: string): void => {
   const task = useAtomValue(taskAtomFamily(agentID));
   const setTask = useSetAtom(taskAtomFamily(agentID));
+  const store = useStore();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // True while a debounced mark-read is scheduled but hasn't fired yet. Lets us
-  // flush it when the user leaves this agent so the read persists before we
-  // navigate away (see the cleanup below).
+  // True while a debounced mark-read is scheduled but hasn't fired yet, so the
+  // cleanup below can flush it when the user leaves this agent.
   const hasPendingReadRef = useRef(false);
-  // Read inside the debounced setTimeout / cleanup to see the latest state — the
-  // captured `task` closure may be stale by the time the timer fires.
-  const taskRef = useRef(task);
-  // Keep the ref current after every commit so the pending timer reads the latest task.
-  useEffect(() => {
-    taskRef.current = task;
-  });
 
   const markRead = (): void => {
     // Functional update: read the latest atom value at apply time so a stale
@@ -31,10 +24,16 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
     });
   };
 
+  // Whether the user has explicitly marked THIS agent unread (lastReadAt=null).
+  // Read live from the store rather than the rendered `task`: switching agents
+  // re-renders this hook (no remount) before the leaving agent's effect cleanup
+  // runs, so a render-scoped value would describe the agent being switched to,
+  // not the one being left. Keyed by `agentID`, the cleanup's closure still sees
+  // the departing agent.
+  const isExplicitlyUnread = (): boolean => store.get(taskAtomFamily(agentID))?.lastReadAt === null;
+
   // Mark as read on mount / agent change, and flush a still-pending debounced
-  // read when leaving this agent. Without the flush, navigating away within the
-  // debounce window leaves the agent's last update unacknowledged, so it (and
-  // its workspace) reappear as "unread" even though the user just viewed it.
+  // read when leaving this agent so it persists as read before the route changes.
   useEffect(() => {
     if (task) {
       markRead();
@@ -50,7 +49,7 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
         hasPendingReadRef.current = false;
         // Don't undo an explicit mark-unread the user performed while the timer
         // was pending.
-        if (taskRef.current?.lastReadAt !== null) {
+        if (!isExplicitlyUnread()) {
           markRead();
         }
       }
@@ -79,9 +78,9 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
       hasPendingReadRef.current = false;
-      // Skip if the user explicitly marked unread (lastReadAt=null) while the
-      // timer was pending — don't undo their action.
-      if (taskRef.current?.lastReadAt === null) {
+      // Skip if the user explicitly marked unread while the timer was pending —
+      // don't undo their action.
+      if (isExplicitlyUnread()) {
         return;
       }
       markRead();

--- a/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
+++ b/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
@@ -10,8 +10,12 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
   const task = useAtomValue(taskAtomFamily(agentID));
   const setTask = useSetAtom(taskAtomFamily(agentID));
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Read inside the debounced setTimeout to see the latest state — the captured
-  // `task` closure may be stale by the time the timer fires.
+  // True while a debounced mark-read is scheduled but hasn't fired yet. Lets us
+  // flush it when the user leaves this agent so the read persists before we
+  // navigate away (see the cleanup below).
+  const hasPendingReadRef = useRef(false);
+  // Read inside the debounced setTimeout / cleanup to see the latest state — the
+  // captured `task` closure may be stale by the time the timer fires.
   const taskRef = useRef(task);
   // Keep the ref current after every commit so the pending timer reads the latest task.
   useEffect(() => {
@@ -27,12 +31,30 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
     });
   };
 
-  // Mark as read on mount
+  // Mark as read on mount / agent change, and flush a still-pending debounced
+  // read when leaving this agent. Without the flush, navigating away within the
+  // debounce window leaves the agent's last update unacknowledged, so it (and
+  // its workspace) reappear as "unread" even though the user just viewed it.
   useEffect(() => {
-    if (!task) {
-      return;
+    if (task) {
+      markRead();
     }
-    markRead();
+
+    return (): void => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+
+      if (hasPendingReadRef.current) {
+        hasPendingReadRef.current = false;
+        // Don't undo an explicit mark-unread the user performed while the timer
+        // was pending.
+        if (taskRef.current?.lastReadAt !== null) {
+          markRead();
+        }
+      }
+    };
     // Only run on mount and when agentID changes, not on every task update
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentID]);
@@ -53,8 +75,10 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
     if (timerRef.current !== null) {
       clearTimeout(timerRef.current);
     }
+    hasPendingReadRef.current = true;
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
+      hasPendingReadRef.current = false;
       // Skip if the user explicitly marked unread (lastReadAt=null) while the
       // timer was pending — don't undo their action.
       if (taskRef.current?.lastReadAt === null) {

--- a/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
+++ b/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
@@ -25,11 +25,10 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
   };
 
   // Whether the user has explicitly marked THIS agent unread (lastReadAt=null).
-  // Read live from the store rather than the rendered `task`: switching agents
-  // re-renders this hook (no remount) before the leaving agent's effect cleanup
-  // runs, so a render-scoped value would describe the agent being switched to,
-  // not the one being left. Keyed by `agentID`, the cleanup's closure still sees
-  // the departing agent.
+  // Read from the store, not the rendered `task`: on an agent switch the hook
+  // re-renders to the new agent before the departing agent's cleanup runs, so a
+  // render-scoped value would be the wrong agent; the cleanup's `agentID` closure
+  // still points at the departing one.
   const isExplicitlyUnread = (): boolean => store.get(taskAtomFamily(agentID))?.lastReadAt === null;
 
   // Mark as read on mount / agent change, and flush a still-pending debounced

--- a/sculptor/frontend/src/components/WorkspaceTabs.tsx
+++ b/sculptor/frontend/src/components/WorkspaceTabs.tsx
@@ -70,8 +70,14 @@ export const WorkspaceTabs = (): ReactElement => {
   const keybindingsMap = useAtomValue(keybindingsMapAtom);
   const openNewWorkspaceTabIds = useAtomValue(openNewWorkspaceTabIdsAtom);
   const openNewWorkspaceTab = useSetAtom(openNewWorkspaceTabAtom);
-  const { isAddWorkspaceRoute, addWorkspaceDraftId, isHomeRoute, isSettingsRoute, isComponentGalleryRoute } =
-    useImbueLocation();
+  const {
+    isAddWorkspaceRoute,
+    addWorkspaceDraftId,
+    isHomeRoute,
+    isSettingsRoute,
+    isComponentGalleryRoute,
+    agentId: focusedAgentId,
+  } = useImbueLocation();
 
   const { handleClose, handleCloseOthers, handleCloseAll, navigateToNextTab } = useWorkspaceTabActions();
 
@@ -104,11 +110,11 @@ export const WorkspaceTabs = (): ReactElement => {
 
     for (const workspace of workspaces ?? []) {
       const workspaceTasks = activeTasks.filter((task) => task.workspaceId === workspace.objectId);
-      statusMap.set(workspace.objectId, computeWorkspaceDotStatus(workspaceTasks));
+      statusMap.set(workspace.objectId, computeWorkspaceDotStatus(workspaceTasks, focusedAgentId));
     }
 
     return statusMap;
-  }, [workspaces, tasks]);
+  }, [workspaces, tasks, focusedAgentId]);
 
   const handleRenameCommit = useCallback(
     async (workspaceId: string, newName: string): Promise<void> => {

--- a/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
@@ -30,9 +30,7 @@ describe("getAgentDotStatus", () => {
   });
 
   it("reports the focused agent as read when content is newer than the last read", () => {
-    // Focused agent with a prior read timestamp: suppress the racy
-    // "updatedAt > lastReadAt" so the open agent doesn't flash unread while the
-    // debounced mark-read settles.
+    // Focused with a prior read timestamp: focus wins over a newer updatedAt.
     expect(getAgentDotStatus(TaskStatus.READY, READ_AT, UPDATED_AT_LATER, true)).toBe("read");
   });
 

--- a/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { TaskStatus } from "~/api";
+
+import { computeWorkspaceDotStatus, getAgentDotStatus } from "./statusUtils";
+
+// An agent whose content changed after the last recorded read — the raw
+// timestamp comparison classifies it as "unread".
+const READ_AT = "2024-01-01T00:00:00.000Z";
+const UPDATED_AT_LATER = "2024-01-01T00:00:05.000Z";
+
+type WorkspaceTask = {
+  id: string;
+  status: TaskStatus;
+  lastReadAt: string | null;
+  updatedAt: string;
+};
+
+const unreadTask = (id: string): WorkspaceTask => ({
+  id,
+  status: TaskStatus.READY,
+  lastReadAt: READ_AT,
+  updatedAt: UPDATED_AT_LATER,
+});
+
+describe("getAgentDotStatus", () => {
+  it("reports an unfocused agent with newer content as unread", () => {
+    expect(getAgentDotStatus(TaskStatus.READY, READ_AT, UPDATED_AT_LATER)).toBe("unread");
+    expect(getAgentDotStatus(TaskStatus.READY, null, UPDATED_AT_LATER)).toBe("unread");
+  });
+
+  it("reports the focused agent as read even when content is newer than the last read", () => {
+    // The user is actively viewing this agent, so its updates are seen by
+    // definition — it must read as "read" regardless of the debounced
+    // mark-read round-trip having settled.
+    expect(getAgentDotStatus(TaskStatus.READY, READ_AT, UPDATED_AT_LATER, true)).toBe("read");
+    expect(getAgentDotStatus(TaskStatus.READY, null, UPDATED_AT_LATER, true)).toBe("read");
+  });
+
+  it("does not let focus override an in-flight or errored status", () => {
+    expect(getAgentDotStatus(TaskStatus.RUNNING, null, UPDATED_AT_LATER, true)).toBe("running");
+    expect(getAgentDotStatus(TaskStatus.BUILDING, null, UPDATED_AT_LATER, true)).toBe("running");
+    expect(getAgentDotStatus(TaskStatus.WAITING, null, UPDATED_AT_LATER, true)).toBe("waiting");
+    expect(getAgentDotStatus(TaskStatus.ERROR, null, UPDATED_AT_LATER, true)).toBe("error");
+    // A request-level error still surfaces as "error" while focused — the
+    // user should see it failed; it clears via the existing mark-read path.
+    expect(getAgentDotStatus(TaskStatus.REQUEST_ERROR, READ_AT, UPDATED_AT_LATER, true)).toBe("error");
+  });
+});
+
+describe("computeWorkspaceDotStatus", () => {
+  it("flags a workspace as unread when an agent has unseen updates", () => {
+    expect(computeWorkspaceDotStatus([unreadTask("agent-1")]).hasUnread).toBe(true);
+  });
+
+  it("does not flag a workspace whose only unread agent is the focused one", () => {
+    expect(computeWorkspaceDotStatus([unreadTask("agent-1")], "agent-1").hasUnread).toBe(false);
+  });
+
+  it("still flags unread agents in the workspace that are not focused", () => {
+    // The focused agent lives in another workspace; this workspace's agent is
+    // genuinely unread and must keep its indicator.
+    expect(computeWorkspaceDotStatus([unreadTask("agent-1")], "agent-in-other-workspace").hasUnread).toBe(true);
+  });
+});

--- a/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
@@ -31,8 +31,7 @@ describe("getAgentDotStatus", () => {
 
   it("reports the focused agent as read even when content is newer than the last read", () => {
     // The user is actively viewing this agent, so its updates are seen by
-    // definition — it must read as "read" regardless of the debounced
-    // mark-read round-trip having settled.
+    // definition — it reads as "read".
     expect(getAgentDotStatus(TaskStatus.READY, READ_AT, UPDATED_AT_LATER, true)).toBe("read");
     expect(getAgentDotStatus(TaskStatus.READY, null, UPDATED_AT_LATER, true)).toBe("read");
   });

--- a/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
@@ -29,11 +29,17 @@ describe("getAgentDotStatus", () => {
     expect(getAgentDotStatus(TaskStatus.READY, null, UPDATED_AT_LATER)).toBe("unread");
   });
 
-  it("reports the focused agent as read even when content is newer than the last read", () => {
-    // The user is actively viewing this agent, so its updates are seen by
-    // definition — it reads as "read".
+  it("reports the focused agent as read when content is newer than the last read", () => {
+    // Focused agent with a prior read timestamp: suppress the racy
+    // "updatedAt > lastReadAt" so the open agent doesn't flash unread while the
+    // debounced mark-read settles.
     expect(getAgentDotStatus(TaskStatus.READY, READ_AT, UPDATED_AT_LATER, true)).toBe("read");
-    expect(getAgentDotStatus(TaskStatus.READY, null, UPDATED_AT_LATER, true)).toBe("read");
+  });
+
+  it("honors an explicit mark-unread on the focused agent", () => {
+    // lastReadAt === null means the user marked it unread; that must win even
+    // while the agent is focused, so focus does not override it back to read.
+    expect(getAgentDotStatus(TaskStatus.READY, null, UPDATED_AT_LATER, true)).toBe("unread");
   });
 
   it("does not let focus override an in-flight or errored status", () => {

--- a/sculptor/frontend/src/components/statusDot/statusUtils.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.ts
@@ -36,9 +36,11 @@ export function getAgentDotStatus(
     return hasUnreadUpdate(lastReadAt, updatedAt) ? "error" : "read";
   }
 
-  // The agent the user is currently viewing has no unseen updates by
-  // definition — its content is on screen — so it always reads as "read".
-  if (isFocused) {
+  // The agent the user is currently viewing reads as "read" so its dot doesn't
+  // flash unread while the debounced mark-read settles. An explicit mark-unread
+  // (lastReadAt === null) is still honored while focused — the user can mark the
+  // active agent unread and it must stay unread.
+  if (isFocused && lastReadAt !== null) {
     return "read";
   }
 

--- a/sculptor/frontend/src/components/statusDot/statusUtils.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.ts
@@ -36,10 +36,9 @@ export function getAgentDotStatus(
     return hasUnreadUpdate(lastReadAt, updatedAt) ? "error" : "read";
   }
 
-  // The agent the user is currently viewing reads as "read" so its dot doesn't
-  // flash unread while the debounced mark-read settles. An explicit mark-unread
-  // (lastReadAt === null) is still honored while focused — the user can mark the
-  // active agent unread and it must stay unread.
+  // The agent the user is currently viewing has its content on screen, so it
+  // reads as "read". An explicit mark-unread (lastReadAt === null) is the
+  // exception — the user can mark the active agent unread and it must stay so.
   if (isFocused && lastReadAt !== null) {
     return "read";
   }

--- a/sculptor/frontend/src/components/statusDot/statusUtils.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.ts
@@ -12,7 +12,12 @@ function hasUnreadUpdate(lastReadAt: string | null, updatedAt: string): boolean 
   return lastReadAt === null || new Date(updatedAt) > new Date(lastReadAt);
 }
 
-export function getAgentDotStatus(status: TaskStatus, lastReadAt: string | null, updatedAt: string): AgentDotStatus {
+export function getAgentDotStatus(
+  status: TaskStatus,
+  lastReadAt: string | null,
+  updatedAt: string,
+  isFocused: boolean = false,
+): AgentDotStatus {
   if (status === TaskStatus.RUNNING || status === TaskStatus.BUILDING) {
     return "running";
   }
@@ -29,6 +34,16 @@ export function getAgentDotStatus(status: TaskStatus, lastReadAt: string | null,
   // the workspace, then clear to "read" — unlike full ERROR which persists.
   if (status === TaskStatus.REQUEST_ERROR) {
     return hasUnreadUpdate(lastReadAt, updatedAt) ? "error" : "read";
+  }
+
+  // The agent the user is currently viewing has no unseen updates by
+  // definition — its content is on screen — so it always reads as "read".
+  // Deriving its read state from the updatedAt/lastReadAt comparison is racy:
+  // lastReadAt is advanced by a debounced, fire-and-forget mark-read that can
+  // lag the latest update or be clobbered by a stale task snapshot from the
+  // WebSocket stream, which would otherwise leave the open agent stuck unread.
+  if (isFocused) {
+    return "read";
   }
 
   return hasUnreadUpdate(lastReadAt, updatedAt) ? "unread" : "read";
@@ -56,6 +71,7 @@ export const EMPTY_WORKSPACE_DOT_STATUS: WorkspaceDotStatus = {
 };
 
 type AgentTaskLike = {
+  id: string;
   status: TaskStatus;
   lastReadAt: string | null;
   updatedAt: string;
@@ -63,29 +79,30 @@ type AgentTaskLike = {
   isArchived?: boolean;
 };
 
-export function computeWorkspaceDotStatus(tasks: ReadonlyArray<AgentTaskLike>): WorkspaceDotStatus {
+// `focusedAgentId` is the agent the user is currently viewing (or null when no
+// agent is focused, e.g. on the home page). The focused agent is treated as
+// read, so the workspace tab containing it does not flash unread while its
+// debounced mark-read settles — see getAgentDotStatus.
+export function computeWorkspaceDotStatus(
+  tasks: ReadonlyArray<AgentTaskLike>,
+  focusedAgentId: string | null = null,
+): WorkspaceDotStatus {
   const activeTasks = tasks.filter((task) => !task.isDeleted && !task.isArchived);
 
   if (activeTasks.length === 0) {
     return EMPTY_WORKSPACE_DOT_STATUS;
   }
 
-  const hasError = activeTasks.some((task) => {
-    const dotStatus = getAgentDotStatus(task.status, task.lastReadAt, task.updatedAt);
-    return dotStatus === "error";
-  });
+  const dotStatuses = activeTasks.map((task) =>
+    getAgentDotStatus(task.status, task.lastReadAt, task.updatedAt, task.id === focusedAgentId),
+  );
+  const hasError = dotStatuses.some((dotStatus) => dotStatus === "error");
   const hasWaiting = activeTasks.some((task) => task.status === TaskStatus.WAITING);
   const hasRunning = activeTasks.some(
     (task) => task.status === TaskStatus.RUNNING || task.status === TaskStatus.BUILDING,
   );
-  const isAllError = activeTasks.every((task) => {
-    const dotStatus = getAgentDotStatus(task.status, task.lastReadAt, task.updatedAt);
-    return dotStatus === "error";
-  });
-  const hasUnread = activeTasks.some((task) => {
-    const dotStatus = getAgentDotStatus(task.status, task.lastReadAt, task.updatedAt);
-    return dotStatus === "unread";
-  });
+  const isAllError = dotStatuses.every((dotStatus) => dotStatus === "error");
+  const hasUnread = dotStatuses.some((dotStatus) => dotStatus === "unread");
 
   return { hasError, hasWaiting, hasRunning, isAllError, hasUnread };
 }

--- a/sculptor/frontend/src/components/statusDot/statusUtils.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.ts
@@ -38,10 +38,6 @@ export function getAgentDotStatus(
 
   // The agent the user is currently viewing has no unseen updates by
   // definition — its content is on screen — so it always reads as "read".
-  // Deriving its read state from the updatedAt/lastReadAt comparison is racy:
-  // lastReadAt is advanced by a debounced, fire-and-forget mark-read that can
-  // lag the latest update or be clobbered by a stale task snapshot from the
-  // WebSocket stream, which would otherwise leave the open agent stuck unread.
   if (isFocused) {
     return "read";
   }
@@ -80,9 +76,8 @@ type AgentTaskLike = {
 };
 
 // `focusedAgentId` is the agent the user is currently viewing (or null when no
-// agent is focused, e.g. on the home page). The focused agent is treated as
-// read, so the workspace tab containing it does not flash unread while its
-// debounced mark-read settles — see getAgentDotStatus.
+// agent is focused, e.g. on the home page); it is treated as read — see
+// getAgentDotStatus.
 export function computeWorkspaceDotStatus(
   tasks: ReadonlyArray<AgentTaskLike>,
   focusedAgentId: string | null = null,

--- a/sculptor/frontend/src/pages/workspace/components/AgentTabs.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/AgentTabs.tsx
@@ -353,7 +353,7 @@ export const AgentTabs = (): ReactElement | null => {
   // Build TabDefinition array from agents
   const tabs = useMemo((): Array<TabDefinition> => {
     return workspaceAgents.map((agent) => {
-      const dotStatus = getAgentDotStatus(agent.status, agent.lastReadAt, agent.updatedAt);
+      const dotStatus = getAgentDotStatus(agent.status, agent.lastReadAt, agent.updatedAt, agent.id === agentID);
       const isRenaming = renamingAgentId === agent.id;
       const label = pendingTitles[agent.id] ?? agent.title ?? "Untitled";
 
@@ -373,7 +373,7 @@ export const AgentTabs = (): ReactElement | null => {
         ) : undefined,
       };
     });
-  }, [workspaceAgents, renamingAgentId, handleRenameCommit, pendingTitles, setRenamingAgentId]);
+  }, [workspaceAgents, agentID, renamingAgentId, handleRenameCommit, pendingTitles, setRenamingAgentId]);
 
   const handleActivate = useCallback(
     (tabId: string): void => {

--- a/sculptor/tests/integration/frontend/test_read_unread_status.py
+++ b/sculptor/tests/integration/frontend/test_read_unread_status.py
@@ -8,6 +8,8 @@ These tests verify:
 - Read/unread status persists across server restarts
 """
 
+import re
+
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.chat_panel import send_chat_message
@@ -50,16 +52,14 @@ def test_unread_indicator_when_switching_agents_within_workspace(
     agent_tab_bar.get_add_agent_button().click()
     expect(agent_tabs).to_have_count(2)
 
-    # Wait for the route to finish settling onto the new agent before typing.
-    # Adding an agent auto-navigates to it, and the chat input editor is keyed
-    # by task id, so it remounts as the route transitions (the old editor
-    # detaches, a new one mounts a beat later — see type_into_tiptap). Typing
-    # before the chat panel is bound to the new agent can land the draft in the
-    # detaching editor, dropping it and leaving the send button disabled. The
-    # chat panel's data-taskid flips to the new agent only once navigation has
-    # settled, so it is a deterministic settle point.
-    new_agent_id = agent_tabs.last.get_attribute("data-tab-id")
-    assert new_agent_id is not None
+    # Adding an agent auto-navigates to it; the chat input is keyed by task id
+    # and remounts as the route settles. Typing before the chat panel is bound
+    # to the new agent can drop the draft and leave the send button disabled, so
+    # wait for the chat panel's data-taskid to flip to the new agent first.
+    new_agent_tab = agent_tabs.last
+    expect(new_agent_tab).to_have_attribute("data-tab-id", re.compile(r".+"))
+    new_agent_id = new_agent_tab.get_attribute("data-tab-id")
+    assert new_agent_id is not None  # narrowed for the type checker; the expect above guarantees it
     chat_panel = task_page.get_chat_panel()
     expect(chat_panel).to_have_attribute("data-taskid", new_agent_id)
 

--- a/sculptor/tests/integration/frontend/test_read_unread_status.py
+++ b/sculptor/tests/integration/frontend/test_read_unread_status.py
@@ -50,8 +50,20 @@ def test_unread_indicator_when_switching_agents_within_workspace(
     agent_tab_bar.get_add_agent_button().click()
     expect(agent_tabs).to_have_count(2)
 
-    # Send a message on agent 2 so it gets response activity
+    # Wait for the route to finish settling onto the new agent before typing.
+    # Adding an agent auto-navigates to it, and the chat input editor is keyed
+    # by task id, so it remounts as the route transitions (the old editor
+    # detaches, a new one mounts a beat later — see type_into_tiptap). Typing
+    # before the chat panel is bound to the new agent can land the draft in the
+    # detaching editor, dropping it and leaving the send button disabled. The
+    # chat panel's data-taskid flips to the new agent only once navigation has
+    # settled, so it is a deterministic settle point.
+    new_agent_id = agent_tabs.last.get_attribute("data-tab-id")
+    assert new_agent_id is not None
     chat_panel = task_page.get_chat_panel()
+    expect(chat_panel).to_have_attribute("data-taskid", new_agent_id)
+
+    # Send a message on agent 2 so it gets response activity
     send_chat_message(chat_panel, "Do something")
     wait_for_completed_message_count(chat_panel, expected_message_count=2)
 


### PR DESCRIPTION
## Original bug

Linear: [SCU-1573](https://linear.app/imbue/issue/SCU-1573) — a cluster of flaky integration tests in `sculptor/tests/integration/frontend/test_read_unread_status.py`:

- `test_unread_indicator_when_switching_agents_within_workspace`
- `test_focused_agent_stays_read_while_receiving_updates`
- `test_read_status_persists_after_restart`
- `test_unread_workspace_indicator_across_workspaces`

They flaked on `main`/merge-queue with two distinct signatures: a status dot stuck `data-dot-status="unread"` (or a workspace tab stuck `data-has-unread="true"`) for the full 30s assertion window, and a `SEND_BUTTON` that stayed `disabled` so a Playwright click timed out.

## Root cause

Read/unread state is derived purely from comparing a task's `updatedAt` to its `lastReadAt`. `lastReadAt` is advanced by a **debounced (1s), fire-and-forget mark-read RPC** (`useMarkRead`). That settle point is non-deterministic, which produced two separate races:

1. **Focused agent flashes/sticks unread.** The agent the user is actively viewing only becomes read once the debounced mark-read fires *and* its result survives. The optimistic update can be clobbered by a stale task snapshot from the WebSocket stream (`updateTasksAtom` replaces the whole task with no monotonicity guard), so the open agent — and its workspace tab — can read `unread`.

2. **Just-viewed agent/workspace reappears unread after navigating away.** If the user leaves an agent within the 1s debounce window, the pending mark-read never fires, so the (now inactive) agent's last update is left unacknowledged and it shows unread.

A third, test-level race caused the `SEND_BUTTON` failure: the switching test typed into a freshly-added agent whose chat-input editor (keyed by task id) was still remounting as the route settled, so the draft landed in the detaching editor and was dropped, leaving Send disabled.

## Hypotheses considered

1. **Focused-agent display derived from a racy debounced mark-read** — REPRODUCED (signatures 1; the `'read' vs unread` / `'false' vs true` focused assertions).
2. **Pending mark-read not flushed on navigate-away** — REPRODUCED (the inactive-workspace assertion `data-has-unread 'false' vs true` after switching workspaces).
3. **Typing into a remounting chat input on a freshly-added agent drops the draft** — REPRODUCED (the `SEND_BUTTON` disabled / click-timeout signature).

## Fix

**Focused agent is read by definition (deterministic display).** `getAgentDotStatus` / `computeWorkspaceDotStatus` take the focused agent id; the focused agent always resolves to `read` (running/waiting/error/request-error precedence unchanged). `AgentTabs` passes `agent.id === agentID`; `WorkspaceTabs` passes `useImbueLocation().agentId`. This removes the dependence on the debounced round-trip for the on-screen agent. The mark-read RPC still runs to persist read state.

**Flush a pending read when leaving an agent.** `useMarkRead` now flushes a still-pending debounced mark-read in its cleanup when the agent changes/unmounts, so the agent persists as read before the route changes. An explicit mark-unread (lastReadAt = null) is preserved.

**Deterministic settle before typing into a new agent.** The switching test waits for the chat panel's `data-taskid` to bind to the newly-added agent before typing, instead of typing into a remounting editor.

## For each reproduced bug

### Focused agent/workspace shows unread

**Repro steps**: create a workspace+agent with FakeClaude, let it finish, assert the agent tab `data-dot-status="read"` / workspace `data-has-unread="false"` immediately after the response settles.
**Expected vs actual** — Expected: read. Actual (flake): `unread` / `true` for the full 30s window.
**Root cause**: see (1) above — focused read state derived from the debounced, clobberable mark-read.
**Fix**: focused agent resolves to `read` directly in `statusUtils.ts`, wired through `AgentTabs.tsx` and `WorkspaceTabs.tsx`.
**Test** — Path: `sculptor/frontend/src/components/statusDot/statusUtils.test.ts`; Kind: unit (the flake is a timing race Playwright cannot reproduce deterministically; this pins the read-state logic). Integration coverage stays in `test_read_unread_status.py`.

### Just-viewed agent/workspace reappears unread after navigating away

**Repro steps**: view workspace A's agent, send a follow-up, then navigate to workspace B and assert A's tab `data-has-unread="false"`.
**Expected vs actual** — Expected: A stays read. Actual (flake): A shows `true` because A's debounced mark-read had not fired before the route changed.
**Root cause**: see (2) above.
**Fix**: `useMarkRead` flushes a pending read on agent-change/unmount.
**Test** — Path: `sculptor/frontend/src/common/state/hooks/useMarkRead.test.ts`; Kind: unit (effect-cleanup/timer behavior; not reproducible via the UI deterministically). Pins flush-on-leave, no-flush-when-nothing-pending, and no-flush-after-mark-unread.

### SEND_BUTTON disabled after adding an agent

**Repro steps**: add a second agent (auto-navigates), then type + send a message.
**Expected vs actual** — Expected: message sends. Actual (flake): Send stays disabled (draft dropped during the chat-input remount).
**Root cause**: see (3) above.
**Fix**: the test waits for `CHAT_PANEL`'s `data-taskid` to equal the new agent id before typing — a deterministic settle point.
**Test** — Path: `sculptor/tests/integration/frontend/test_read_unread_status.py` (the existing e2e test, now deterministic).

## Proof of work

Non-UI logic/timing bugs, so the evidence is failing-then-passing test output:

- **Before** (from the flake-aware offload check-runs referenced in the ticket): `AssertionError: Locator expected to have attribute 'read' Actual value: unread`; `... 'false' Actual value: true`; `TimeoutError: Locator.click ... SEND_BUTTON ... element is not enabled`.
- **After**: new deterministic unit tests pass (`statusUtils.test.ts`, `useMarkRead.test.ts`); `just format`, `just check`, `just test-unit-frontend` all green; the integration suite in `test_read_unread_status.py` passes.

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
