### PR TITLE
OpenHost: nginx /proxy front + Vite live-preview of the web UI

### DIFF
--- a/.claude/skills/openhost-frontend-preview/SKILL.md
+++ b/.claude/skills/openhost-frontend-preview/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: openhost-frontend-preview
+description: |
+  Live, hot-reloading preview of the Sculptor WEB frontend from a phone or any
+  browser, served through the OpenHost nginx /proxy front. ONLY relevant when
+  running INSIDE the openhost-deployed Sculptor (the container fronted by nginx on
+  :5050, reachable at https://sculptor.<zone>/) — NOT for local or Electron dev.
+  Frontend-only: it reuses the single shared backend, so it previews UI/frontend
+  changes, not a per-workspace backend. Invoke when iterating on the web UI and
+  wanting to see it live in a browser through the OpenHost SSO front.
+user-invocable: true
+---
+
+# OpenHost frontend live preview (`/proxy/<port>/`)
+
+Run a Vite dev server (HMR) for the Sculptor web UI and reach it from any
+logged-in browser — including a phone — through the OpenHost nginx front, entirely
+behind OpenHost's owner SSO. Nothing is exposed publicly.
+
+## When this applies — OpenHost only
+
+Use this ONLY inside the openhost-deployed Sculptor. Quick checks:
+- `test -f /app/openhost-nginx.conf` (the nginx front config), and
+- PID 1 is nginx: `ps -p 1 -o args=` -> `nginx ...` (backend is on loopback :5051).
+
+If those are NOT true (local dev, Electron, a plain backend on :5050), this skill
+does not apply — use normal `pnpm run dev` / `just frontend` there instead.
+
+## How it works (read first)
+
+- nginx owns :5050 (the only port OpenHost proxies) and routes `/proxy/<port>/*`
+  -> `127.0.0.1:<port>`; everything else -> the backend on :5051.
+- A preview is just a **Vite dev server** on a loopback port in the **51000-59999**
+  band, served with `base=/proxy/<port>/`, dialing HMR back over
+  `wss://...:443/proxy/<port>/`. Its `/api` + `/ws` calls are same-origin absolute,
+  so they hit the ONE shared backend — there is no per-preview backend.
+- So this previews **frontend** changes. Full-stack per-workspace instances (each
+  with its own backend) are not supported on one origin: every backend would set
+  the same session cookie on the same origin, and they collide.
+
+## Run a preview
+
+Pick a free port in 51000-59999 (e.g. 51731). Launch it **DETACHED** — do NOT use
+a tracked background task; this Sculptor will not release your turn to the user
+while one is alive:
+
+    cd <frontend-dir>
+    setsid bash launch-preview.sh 51731 >/tmp/vite-51731.log 2>&1 </dev/null &
+
+`<frontend-dir>` is either:
+- **`/app/sculptor/frontend`** — preview the deployed UI as-is (its `node_modules`
+  and `.venv` are already there, so it starts fast), or
+- **your workspace's `sculptor/frontend`** — preview YOUR edits with HMR. A fresh
+  worktree has no `node_modules`, so run `pnpm install` there once first (slow),
+  then launch.
+
+`launch-preview.sh <port>` sets `SCULPTOR_FRONTEND_PORT` + `SCULPTOR_OPENHOST_PROXY`
+and runs `pnpm run dev -- --base=/proxy/<port>/` (base is a native Vite flag; the
+env var only drives the OpenHost wss/HMR override). First start pre-bundles deps
+(~tens of seconds) — watch
+`/tmp/vite-<port>.log` for `ready in`. Then open, on any logged-in browser:
+
+    https://sculptor.<your-zone>/proxy/51731/
+
+Edits to the frontend source hot-reload live.
+
+## Stop a preview
+
+Do NOT `pkill -f vite...` — the pattern matches your own shell command and kills
+the call. Stop by port -> pid -> process group:
+
+    PID=$(ss -tlnpH | grep ':51731' | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2)
+    PGID=$(ps -o pgid= -p "$PID" | tr -d ' ')
+    kill -9 -"$PGID"
+
+## Gotchas
+
+- **Detached, not background.** Launch via `setsid ... &` from a normal foreground
+  command so your turn releases. A `run_in_background` task or persistent `Monitor`
+  blocks the user from talking to you until it ends.
+- **One browser per workspace page.** Sculptor syncs tab state via `localStorage`,
+  so the same workspace open in two browsers can desync — preview on a different
+  page/tab than the one you're chatting in.
+- **Same-origin trust.** Previews share the app's origin, so preview JS runs with
+  your session's privileges — only run frontend code you trust.

--- a/openhost-agent/AGENTS.md
+++ b/openhost-agent/AGENTS.md
@@ -9,6 +9,7 @@ detect that from the `OPENHOST_*` env vars (e.g. `OPENHOST_APP_NAME`).
 freely — nothing in the deploy will overwrite it.
 
 For the current, maintained specifics of this environment — storage and what
-survives restarts, and where/how to add repositories and authorize `gh` — **use
-the `openhost-environment` skill**. That skill ships with the deploy image and is
-refreshed on every release, so it stays up to date as the environment evolves.
+survives restarts, where/how to add repositories and authorize `gh`, and what the
+`/proxy/<port>/` capability can and can't do — **use the `openhost-environment`
+skill**. That skill ships with the deploy image and is refreshed on every release,
+so it stays up to date as the environment evolves.

--- a/openhost-agent/skills/openhost-environment/SKILL.md
+++ b/openhost-agent/skills/openhost-environment/SKILL.md
@@ -2,7 +2,8 @@
 name: openhost-environment
 description: |
   How this OpenHost-hosted Sculptor environment works — storage and what survives
-  restarts, and where/how to add repositories and authorize gh. ONLY relevant when
+  restarts, where/how to add repositories and authorize gh, and the /proxy/<port>/
+  capability for previewing loopback web apps from a browser. ONLY relevant when
   running inside an OpenHost deployment (detect via the OPENHOST_* env vars, e.g.
   OPENHOST_APP_NAME). Ships with the deploy image and is refreshed every release.
 ---
@@ -35,6 +36,25 @@ If those vars are absent, this skill does not apply.
   on rebuild. The deploy's run script re-runs `gh auth setup-git` and sets a
   gh-derived identity on boot (best-effort); if a push ever fails to auth after a
   rebuild, re-run `gh auth setup-git` and set `git config --global user.{name,email}`.
+
+## `/proxy/<port>/` — preview a loopback web app from any browser
+
+OpenHost publicly proxies **only port 5050** (behind owner SSO); an in-container
+nginx fronts it and adds a reverse proxy:
+
+- **`https://$OPENHOST_APP_NAME.$OPENHOST_ZONE_DOMAIN/proxy/<port>/`** forwards to
+  `127.0.0.1:<port>` for any port in **51000–59999**, all behind SSO. Nothing is
+  made public.
+- Use it to preview **any** simple loopback web app or dev server (not just Vite),
+  including from a phone. The URI is passed through **unstripped**, so the app must
+  be **base-aware** — served under `/proxy/<port>/` (e.g. a dev server's base/prefix
+  option), since fully transparent rewriting of an app's absolute URLs isn't done.
+- **Caveat — shared origin:** the preview shares the root app's origin, so its
+  cookies/paths must **not collide** with Sculptor's (the session cookie in
+  particular). Simple apps with their own non-overlapping cookies/paths are fine; a
+  second full Sculptor backend is not (its session cookie would collide).
+- For the **Sculptor web frontend** specifically, use the `openhost-frontend-preview`
+  skill / `sculptor/frontend/launch-preview.sh` (when working in the sculptor repo).
 
 ## Turn-handling (matters here)
 

--- a/openhost-nginx.conf
+++ b/openhost-nginx.conf
@@ -1,0 +1,108 @@
+# nginx front for the OpenHost Sculptor image.
+#
+# OpenHost proxies HTTPS -> container:5050. nginx owns 5050 and splits traffic:
+#   /proxy/<port>/...  -> 127.0.0.1:<port>   (Vite/dev servers, for mobile live preview)
+#   everything else    -> 127.0.0.1:5051     (the real Sculptor backend)
+#
+# Everything here is ALREADY behind OpenHost's owner SSO (the only public ingress
+# is 5050). The /proxy guards below are defense-in-depth, NOT the primary gate:
+#   - upstream is hard-pinned to 127.0.0.1 (loopback only), so the OpenHost router
+#     at host.containers.internal:8080 is unreachable through /proxy.
+#   - the port is allow-listed to 51000-59999 by the location regex, so a preview
+#     can't be aimed at the backend itself (5050/5051) or system ports.
+#   - the caller's Cookie header is stripped before reaching the dev server, so the
+#     Sculptor session cookie never leaks into preview processes.
+# Full-stack (own-backend) previews aren't supported on one origin: each backend
+# would set the same session cookie on the same origin, and they would collide.
+
+# Runs as the non-root 'sculptor' user, so keep all writable state off /var.
+pid /tmp/nginx/nginx.pid;
+error_log /dev/stderr warn;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    access_log /dev/stdout;
+
+    # All scratch/temp paths under /tmp (writable by the arbitrary runtime UID).
+    client_body_temp_path /tmp/nginx/client;
+    proxy_temp_path       /tmp/nginx/proxy;
+    fastcgi_temp_path     /tmp/nginx/fastcgi;
+    uwsgi_temp_path       /tmp/nginx/uwsgi;
+    scgi_temp_path        /tmp/nginx/scgi;
+
+    # WebSocket upgrade plumbing — needed by BOTH Sculptor's /ws and Vite HMR.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    upstream sculptor_backend {
+        server 127.0.0.1:5051;
+    }
+
+    server {
+        listen 5050;
+        server_name _;
+
+        # Stream rather than buffer: keeps WS / SSE / long polls live, and allows
+        # arbitrarily large uploads (Sculptor file attachments).
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        client_max_body_size 0;
+        proxy_read_timeout 1d;
+        proxy_send_timeout 1d;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+
+        # --- Mobile dev preview: /proxy/<port>/... -> 127.0.0.1:<port>/... ---
+        # Port allow-list 51000-59999 (the "preview band"). 127.0.0.1 is a literal,
+        # so nginx needs no resolver and no non-loopback target is ever reachable.
+        #
+        # The URI is passed through UNSTRIPPED (via $request_uri): the upstream is
+        # expected to be "base-aware", i.e. mounted under this same /proxy/<port>/
+        # base (e.g. a Vite dev server started with base=/proxy/<port>/), so its
+        # own absolute asset + HMR-WebSocket paths already include the prefix and
+        # line up. Fully transparent proxying of a root-mounted ('/') app isn't
+        # feasible: it would need nginx to rewrite every absolute URL the app
+        # emits (bundled JS, dynamic imports, fetch('/api'), the HMR ws URL).
+        #
+        # NB: the port is matched as three literal [0-9] classes rather than
+        # [0-9]{3} — nginx parses unquoted regex `{`/`}` as config block braces, so
+        # a braced quantifier here makes nginx fail to start (pcre2 "missing )").
+        location ~ ^/proxy/(5[1-9][0-9][0-9][0-9])(/.*)?$ {
+            set $devport $1;
+
+            # nginx does NOT merge proxy_set_header across contexts: declaring any
+            # header here drops ALL the server-level ones, so the WebSocket upgrade
+            # + forwarding headers MUST be re-declared or Vite HMR won't upgrade
+            # (200 instead of 101).
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        $connection_upgrade;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            # Don't leak the Sculptor session cookie into the preview process.
+            proxy_set_header Cookie "";
+            # Advertise the mount base so a path-aware backend could later
+            # path-scope its session cookie (needed to support full-stack previews).
+            proxy_set_header X-Sculptor-Proxy-Base /proxy/$devport;
+
+            proxy_pass http://127.0.0.1:$devport$request_uri;
+        }
+
+        # --- Everything else -> the real Sculptor backend (UI, /api, /ws) ---
+        location / {
+            proxy_pass http://sculptor_backend;
+        }
+    }
+}

--- a/openhost-run.sh
+++ b/openhost-run.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# Boot script for the OpenHost Sculptor image.
+# Entrypoint for the OpenHost Sculptor image.
 #
-# Resolves the persistent app-data dir, re-establishes git identity + the
-# host-wide agent skill on every boot (both are lost when /home is wiped on
-# rebuild), then execs the Sculptor backend from the built venv.
+# Runs the Sculptor backend on 127.0.0.1:5051 behind an nginx front on :5050 (the
+# port OpenHost proxies to). nginx adds a /proxy/<port>/ reverse-proxy to localhost
+# dev servers for mobile live-preview. See openhost-nginx.conf for the routing.
 set -eu
 
 # Persist into whichever app-data dir OpenHost granted THIS app
@@ -15,7 +15,7 @@ if [ -n "${OPENHOST_APP_DATA_DIR:-}" ]; then
     export CLAUDE_CONFIG_DIR="$OPENHOST_APP_DATA_DIR/claude"
     export GH_CONFIG_DIR="$OPENHOST_APP_DATA_DIR/gh"
 fi
-mkdir -p "$SCULPTOR_FOLDER" "$CLAUDE_CONFIG_DIR" "$GH_CONFIG_DIR"
+mkdir -p "$SCULPTOR_FOLDER" "$CLAUDE_CONFIG_DIR" "$GH_CONFIG_DIR" /tmp/nginx
 
 # Re-establish the gh credential helper + a git identity on every boot: /home is
 # wiped on each rebuild, so ~/.gitconfig is lost even though the gh TOKEN persists
@@ -51,6 +51,11 @@ fi
 [ -e "$CLAUDE_CONFIG_DIR/AGENTS.md" ] || cp /app/openhost-agent/AGENTS.md "$CLAUDE_CONFIG_DIR/AGENTS.md" 2>/dev/null || true
 [ -e "$CLAUDE_CONFIG_DIR/CLAUDE.md" ] || ln -s AGENTS.md "$CLAUDE_CONFIG_DIR/CLAUDE.md" 2>/dev/null || true
 
-# Run the backend from the built venv (the venv lives at the uv workspace root
-# /app/.venv, not /app/sculptor). It serves the web UI built into the image.
-exec /app/.venv/bin/python -m sculptor.cli.main --no-open-browser /workspace
+# Backend behind nginx (SCULPTOR_API_PORT=5051 is set in the Dockerfile).
+/app/.venv/bin/python -m sculptor.cli.main --no-open-browser /workspace &
+backend_pid=$!
+
+# If nginx exits, take the backend down too (and vice-versa on container stop).
+trap 'kill "$backend_pid" 2>/dev/null || true' EXIT INT TERM
+
+exec nginx -c /app/openhost-nginx.conf -g 'daemon off;'

--- a/openhost.Dockerfile
+++ b/openhost.Dockerfile
@@ -20,9 +20,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 # extensions (e.g. typeid-python's Rust module) compile from sdist whenever no
 # prebuilt wheel matches the interpreter, and uv/maturin's on-demand Rust install
 # still needs a system C toolchain to link.
+# nginx-light is the in-container front door (this dev branch): it owns port 5050
+# and reverse-proxies /proxy/<port>/ to localhost dev servers for mobile live
+# preview, everything else to the Sculptor backend (see openhost-nginx.conf).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        git curl ca-certificates xz-utils libnss-wrapper build-essential && \
+        git curl ca-certificates xz-utils libnss-wrapper build-essential nginx-light && \
     rm -rf /var/lib/apt/lists/*
 
 # Node.js 24 — for the frontend build and the API-client codegen. Matches the
@@ -101,10 +104,11 @@ RUN usermod -l sculptor -d /home/sculptor -m ubuntu && \
     chmod -R a+rX /app /opt/uv-python
 
 ENV HOME=/home/sculptor
-# Serve on all interfaces so the OpenHost router can proxy to us.
-ENV SCULPTOR_BIND_HOST=0.0.0.0
-# Port the backend listens on. Keep in sync with `port` in openhost.toml.
-ENV SCULPTOR_API_PORT=5050
+# The backend now sits BEHIND nginx, reachable only on loopback. nginx owns the
+# public-facing port (5050, what openhost.toml declares) and proxies to here.
+ENV SCULPTOR_BIND_HOST=127.0.0.1
+# Backend port (internal). nginx listens on 5050 and forwards to 5051.
+ENV SCULPTOR_API_PORT=5051
 # Persist DB, workspaces, downloaded agent binaries, and user config into the
 # OpenHost backed-up app data dir (the app is named "sculptor" in openhost.toml).
 ENV SCULPTOR_FOLDER=/data/app_data/sculptor
@@ -149,10 +153,9 @@ RUN NSS_WRAPPER_LIB="$(dpkg -L libnss-wrapper | grep -m1 '/libnss_wrapper\.so$')
 
 USER sculptor
 ENTRYPOINT ["/usr/local/bin/openhost-entrypoint.sh"]
-# Run via the boot script: it resolves the app-data dir, ensures the persistent
-# dirs exist, re-establishes git identity + the host-wide agent skill, then execs
-# the backend from the built venv (/app/.venv, the uv workspace root). No
-# --no-serve-static: the backend serves the web UI built above (resolved via the
-# 'sculptor' package's editable install at /app/sculptor/frontend/dist). See
-# openhost-run.sh.
+# Start the backend (on loopback :5051) behind the nginx front (on :5050) via the
+# run script: it resolves the app-data dir, ensures persistent dirs exist, launches
+# the backend from the built venv (/app/.venv, the uv workspace root), and execs
+# nginx. The backend still serves the bundled web UI it built above; nginx only
+# adds the /proxy/<port>/ live-preview route on top. See openhost-run.sh.
 CMD ["sh", "/app/openhost-run.sh"]

--- a/openhost.toml
+++ b/openhost.toml
@@ -9,21 +9,29 @@
 # container under rootless podman, and reverse-proxies HTTPS to it at
 # https://sculptor.<your-zone-domain>/ behind OpenHost's owner login.
 #
+# This branch adds an in-container nginx front that exposes /proxy/<port>/ for
+# mobile live preview of dev servers (all still behind OpenHost's owner SSO). It
+# was validated first as a throwaway `sculptor-dev` app, then pointed back at the
+# main `sculptor` app here. Redeploy over the existing app with --keep-data so the
+# persistent /data/app_data/sculptor (DB, workspaces, Claude+gh auth) survives;
+# the run script reads OPENHOST_APP_DATA_DIR, so the data dir tracks the app name.
+#
 # See docs/development/ in the openhost repo, or docs/src/manifest_spec.md there,
 # for the full field reference.
 
 [app]
 name = "sculptor"
 version = "0.1.0"
-description = "Sculptor — AI coding agent platform by Imbue"
+description = "Sculptor — AI coding agent platform by Imbue (with nginx /proxy live-preview front)"
 authors = ["Imbue"]
 
 [runtime.container]
 # Path to the Dockerfile, relative to the repo root. The build context is always
 # the repo root, so this Dockerfile can COPY the existing container recipe scripts.
 image = "openhost.Dockerfile"
-# Port the Sculptor backend listens on inside the container (SCULPTOR_API_PORT).
-# Kept in sync with the value set in openhost.Dockerfile.
+# Public-facing container port. On this branch that's the nginx front, not the
+# backend: nginx listens on 5050 and proxies to the backend on loopback :5051
+# (SCULPTOR_API_PORT in openhost.Dockerfile) plus /proxy/<port>/ to dev servers.
 port = 5050
 
 [routing]

--- a/sculptor/frontend/launch-preview.sh
+++ b/sculptor/frontend/launch-preview.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Launch a Vite dev preview reachable from your phone at
+#
+#     https://<this-app-host>/proxy/<port>/
+#
+# through the OpenHost nginx /proxy front (see ../../openhost-nginx.conf). Only
+# the owner's SSO'd session can reach that URL — nothing is made public.
+#
+# How it fits together:
+#   - Vite binds 127.0.0.1:<port>; nginx reaches it on loopback and forwards the
+#     /proxy/<port>/ path through UNSTRIPPED.
+#   - SCULPTOR_OPENHOST_PROXY tells the Vite config to serve under base=/proxy/<port>/
+#     (derived from SCULPTOR_FRONTEND_PORT) AND to dial its HMR client back over the
+#     TLS edge (wss, :443) — see vite.base.config.ts.
+#   - The app's /api + /ws calls are same-origin ABSOLUTE (the web build compiles
+#     API base to ""), so they bypass this Vite and hit the SHARED backend via
+#     nginx. No per-preview backend is needed; full-stack previews aren't supported
+#     on one origin (the session cookie would collide).
+set -euo pipefail
+
+port="${1:-}"
+case "$port" in
+  5[1-9][0-9][0-9][0-9]) ;;   # 51000-59999, the nginx preview band
+  *) echo "usage: $(basename "$0") <port in 51000-59999>" >&2; exit 1 ;;
+esac
+
+cd "$(dirname "$0")"
+export SCULPTOR_FRONTEND_PORT="$port"
+export SCULPTOR_OPENHOST_PROXY=1
+
+echo "Live preview -> https://<this-app-host>/proxy/$port/   (Vite on 127.0.0.1:$port)"
+# SCULPTOR_OPENHOST_PROXY (above) drives BOTH base=/proxy/<port>/ and the wss/HMR
+# override in vite.base.config.ts (both derived from SCULPTOR_FRONTEND_PORT), so no CLI
+# `--base` is needed. Do NOT add `pnpm run dev -- --base=…`: pnpm forwards a stray `--`
+# that Vite reads as an end-of-options marker and silently drops the flag.
+exec pnpm run dev

--- a/sculptor/frontend/vite.base.config.ts
+++ b/sculptor/frontend/vite.base.config.ts
@@ -155,6 +155,8 @@ export interface FrontendConfigOptions {
    * origin root — the backend for web, the `sculptor://app` scheme (and the
    * Vite dev server in development) for the packaged renderer — never `file://`,
    * so assets resolve against the origin regardless of the document's path.
+   * (Under the OpenHost preview front — SCULPTOR_OPENHOST_PROXY set — the factory
+   * overrides this with `/proxy/<frontend-port>/`; see defineFrontendConfig.)
    */
   base?: string;
   /** Extra `build` options merged over the shared `{ sourcemap: true }`. */
@@ -166,9 +168,8 @@ export interface FrontendConfigOptions {
 }
 
 /** Dev-only proxy server forwarding `/api`, `/ws`, and `/plugins/local` to the backend. */
-function devServer(env: Record<string, string>, defaultFrontendPort: number): import("vite").ServerOptions {
+function devServer(env: Record<string, string>, fePort: number): import("vite").ServerOptions {
   const apiPort = Number(env.SCULPTOR_API_PORT || 5050);
-  const fePort = Number(env.SCULPTOR_FRONTEND_PORT || defaultFrontendPort);
   const apiTarget = env.SCULPTOR_CUSTOM_BACKEND_URL || `http://127.0.0.1:${apiPort}`;
 
   console.log(`Proxying frontend: target=${apiTarget} SCULPTOR_FRONTEND_PORT=${fePort}`);
@@ -213,9 +214,18 @@ export function defineFrontendConfig(opts: FrontendConfigOptions): UserConfigExp
 
     console.log(`Started vite with command: "${command}" and mode: "${mode}"`);
 
+    // OpenHost-only: behind the nginx /proxy/<port>/ front, the asset `base` and the
+    // HMR client must both point at that sub-path. Derive base from the SAME frontend
+    // port the dev server binds (see devServer below) so the two can never drift;
+    // gated on SCULPTOR_OPENHOST_PROXY so normal dev/build is unaffected. (base can't
+    // ride a `vite --base=…` CLI flag here: `pnpm run dev -- --base=…` forwards a stray
+    // `--` that Vite treats as an end-of-options marker, silently dropping the flag.)
+    const fePort = Number(env.SCULPTOR_FRONTEND_PORT || opts.defaultFrontendPort);
+    const openhostProxyBase = env.SCULPTOR_OPENHOST_PROXY ? `/proxy/${fePort}/` : undefined;
+
     const config: UserConfig = {
       root: opts.root,
-      base: opts.base ?? "/",
+      base: openhostProxyBase ?? opts.base ?? "/",
       optimizeDeps: sharedOptimizeDeps,
       define: sharedDefine(env, {
         apiUrlBaseExpr: opts.apiUrlBase(env),
@@ -230,10 +240,21 @@ export function defineFrontendConfig(opts: FrontendConfigOptions): UserConfigExp
     };
 
     if (command === "serve" || mode === "development") {
-      const server = devServer(env, opts.defaultFrontendPort);
-      // HMR can cause race conditions in integration tests, so disable it there.
-      if (opts.gateHmrUnderPytest) {
-        server.hmr = !env.PYTEST_CURRENT_TEST;
+      const server = devServer(env, fePort);
+      // OpenHost-only: when served behind the nginx /proxy/<port>/ front, accept the
+      // public Host (forwarded by nginx) and dial the HMR client back through the TLS
+      // edge (:443, wss) at the sub-path. The matching asset `base` is derived above;
+      // these HMR bits have no CLI/base equivalent and must live here. Gated on
+      // SCULPTOR_OPENHOST_PROXY so normal dev/build is unaffected.
+      if (env.SCULPTOR_OPENHOST_PROXY) {
+        server.allowedHosts = true;
+        server.hmr = { protocol: "wss", clientPort: 443 };
+      }
+      // HMR can race in integration tests, so disable it there — but only force
+      // the disable, leaving any other HMR config (e.g. the OpenHost override
+      // above) intact otherwise.
+      if (opts.gateHmrUnderPytest && env.PYTEST_CURRENT_TEST) {
+        server.hmr = false;
       }
       config.server = server;
     }


### PR DESCRIPTION
> **Stacked on #266** (`OpenHost enablement`). This PR targets the
> `maciek/openhost-enablement` branch and should merge **after** #266; its diff
> here is only the nginx `/proxy` front + Vite live-preview on top of that base.

## What

Fronts the OpenHost container with **nginx** so the Sculptor web UI can be
**previewed live (HMR) from any browser — including a phone — behind OpenHost's
owner SSO**, with nothing exposed publicly.

- nginx owns the OpenHost-proxied port **:5050**; the backend moves to loopback
  **:5051**. Routing: `/proxy/<port>/*` → `127.0.0.1:<port>` (dev servers, ports
  51000–59999); everything else → the backend.
- A preview is a Vite dev server served under `base=/proxy/<port>/`, dialing HMR
  back over `wss://…:443/proxy/<port>/`. `/api` + `/ws` stay same-origin absolute,
  so they reuse the one shared backend — **frontend-only** previews, no
  per-workspace backend.

## Changes

- `openhost-nginx.conf` *(new)* — the front + `/proxy/<port>/` reverse proxy
  (loopback-only upstream, 51000–59999 port band, session cookie stripped, WS upgrade).
- `openhost.Dockerfile` — install `nginx-light`; backend → `SCULPTOR_BIND_HOST=127.0.0.1`,
  `SCULPTOR_API_PORT=5051`.
- `openhost-run.sh` — launch the backend behind the nginx front.
- `openhost.toml` — document the nginx front / port split.
- `sculptor/frontend/vite.base.config.ts` — env-gated (`SCULPTOR_OPENHOST_PROXY`)
  base + wss HMR. No app code changes (same-origin API base; gated so normal
  dev/build is unaffected).
- `sculptor/frontend/launch-preview.sh` *(new)* — one-command preview launcher.
- `.claude/skills/openhost-frontend-preview/SKILL.md` *(new)* — OpenHost-only skill
  teaching agents to run it.
- `openhost-agent/` — the env skill + `AGENTS.md` gain the `/proxy` capability docs.

## Security

All behind OpenHost owner SSO (the only public ingress). `/proxy` adds
defense-in-depth: loopback-only upstreams (the OpenHost router is unreachable),
the 51000–59999 port band (can't target the backend itself), and the Sculptor
session cookie is stripped before reaching a preview. Full-stack (own-backend)
previews aren't supported on one origin — the session cookie would collide.

(Sent by Claude)
