### PR TITLE
fix(web): restore origin fallback for the web session-token URL

### DIFF
--- a/sculptor/frontend/src/common/Auth.ts
+++ b/sculptor/frontend/src/common/Auth.ts
@@ -10,7 +10,9 @@ let sessionToken: string | undefined = undefined;
 export const initializeSessionToken = async (): Promise<void> => {
   if (!window.sculptor) {
     // As a backup, outside of the electron context, initialize the session token through the samesite cookie.
-    const sessionTokenInitializationURL = new URL(SESSION_TOKEN_ENDPOINT, API_URL_BASE ?? window.location.origin);
+    // API_URL_BASE is "" for the web build (same-origin); use `||` (not `??`) so the empty string
+    // falls back to the page origin — `new URL(endpoint, "")` throws "is not a valid URL".
+    const sessionTokenInitializationURL = new URL(SESSION_TOKEN_ENDPOINT, API_URL_BASE || window.location.origin);
     // This sets the session token cookie.
     await fetch(sessionTokenInitializationURL.toString(), { method: "GET" });
   } else {


### PR DESCRIPTION
## What

The non-Electron / web path of `initializeSessionToken` builds the session-token endpoint URL as:

```ts
new URL(SESSION_TOKEN_ENDPOINT, API_URL_BASE ?? window.location.origin)
```

For the web build, `API_URL_BASE` is compiled to the **empty string** `""` (same-origin). `??` only falls back on `null`/`undefined`, so the base stayed `""` and `new URL("api/v1/session-token", "")` threw `TypeError: URL constructor:  is not a valid URL`. Session-token (CSRF) initialization then failed on every non-Electron page load — the error is caught so the app keeps running, but the session-token cookie is never set.

## Fix

Use `||` instead of `??` so an empty `API_URL_BASE` falls back to `window.location.origin`. Electron is unaffected: it takes the `window.sculptor` branch and never reaches this line.

## How it regressed

`e11f846` ("Apply frontend review-rule cleanup to src/common") mechanically swapped `||` → `??`. The empty string is a meaningful value here, so nullish coalescing is the wrong operator. A comment now records the intent so a future cleanup doesn't reintroduce it.

## Testing

- `eslint` (type-aware, `--max-warnings 0`) and `prettier --check` pass on the file.
- Verified in a live web preview: the `URL constructor … is not a valid URL` console error is gone after the change, and session-token init proceeds.

(Sent by Claude)