### PR TITLE
Show an in-flight state when sending a chat message (SCU-1619)

### DIFF
--- a/sculptor/frontend/src/components/Editor.tsx
+++ b/sculptor/frontend/src/components/Editor.tsx
@@ -349,11 +349,7 @@ export const Editor = ({
   }, [disabled, editor]);
 
   return (
-    <div
-      className={
-        wrapperClassName ? wrapperClassName : mergeClasses(optional(disabled, styles.disabled), styles.editorWrapper)
-      }
-    >
+    <div className={mergeClasses(wrapperClassName ?? styles.editorWrapper, optional(disabled, styles.disabled))}>
       <div className={mergeClasses(styles.scrollArea, scrollAreaClassName)}>
         <EditorContent editor={editor} />
       </div>

--- a/sculptor/frontend/src/components/SendButton.tsx
+++ b/sculptor/frontend/src/components/SendButton.tsx
@@ -12,6 +12,12 @@ type SendButtonProps = {
   testId: string;
   /** Rendered as `data-last-send-error`; attribute is omitted when null. */
   lastSendError?: string | null;
+  /**
+   * While a send is in flight: swaps the arrow for Radix's spinner (which also
+   * makes the button non-interactive). Mirrored as `data-loading` so tests can
+   * assert the in-flight state without reaching into Radix internals.
+   */
+  loading?: boolean;
 };
 
 export const SendButton = ({
@@ -21,14 +27,17 @@ export const SendButton = ({
   ariaLabel,
   testId,
   lastSendError,
+  loading = false,
 }: SendButtonProps): ReactElement => (
   <Tooltip content={tooltip}>
     <IconButton
       onClick={onClick}
       disabled={disabled}
+      loading={loading}
       className={styles.button}
       aria-label={ariaLabel}
       data-testid={testId}
+      {...(loading ? { "data-loading": "true" } : {})}
       {...(lastSendError !== null && lastSendError !== undefined ? { "data-last-send-error": lastSendError } : {})}
     >
       <ArrowRightIcon size={16} />

--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -169,6 +169,13 @@ export const ChatInput = ({
   // Mirrored onto the send button as `data-last-send-error` so callers can
   // observe send failures without depending on the toast lifecycle.
   const [lastSendError, setLastSendError] = useState<string | null>(null);
+  // True while a message POST is in flight. Drives the send-button spinner and
+  // the read-only editor so a slow backend gives visible feedback. The ref is
+  // the actual re-entrancy guard: setState is async, so a fast second Enter
+  // (or click) would slip past a state-only check and double-queue the message;
+  // the ref flips synchronously and is read before any new send proceeds.
+  const [isSending, setIsSending] = useState(false);
+  const isSendingRef = useRef(false);
   const isAlwaysInterruptAndSend = useAtomValue(isAlwaysInterruptAndSendAtom);
   const sendMessageBinding = useKeybinding("send_message");
   const sendHint = useKeybindingDisplayText("send_message");
@@ -330,6 +337,12 @@ export const ChatInput = ({
       return;
     }
 
+    // Ignore re-entrant sends while a POST is already in flight (e.g. a second
+    // Enter on a slow backend) so the same draft can't be queued twice.
+    if (isSendingRef.current) {
+      return;
+    }
+
     if (editorRef.current) {
       const parsed = parsePseudoSkillCommand(editorRef.current, promptDraft ?? "");
       if (parsed !== null) {
@@ -338,6 +351,8 @@ export const ChatInput = ({
       }
     }
 
+    isSendingRef.current = true;
+    setIsSending(true);
     setLastSendError(null);
     try {
       await sendWorkspaceAgentMessages({
@@ -381,6 +396,9 @@ export const ChatInput = ({
         ),
         type: ToastType.ERROR,
       });
+    } finally {
+      isSendingRef.current = false;
+      setIsSending(false);
     }
   }, [
     promptDraft,
@@ -401,6 +419,9 @@ export const ChatInput = ({
   ]);
 
   const handleSend = useCallback(async (): Promise<void> => {
+    // A send is already in flight; ignore the trigger entirely so we neither
+    // re-send nor fire the trailing interrupt below for a send that no-ops.
+    if (isSendingRef.current) return;
     const isBtwDraft = draftIsBypassCommand(promptDraft);
     if (isDisabled && !isBtwDraft) return;
     await sendMessage();
@@ -417,6 +438,7 @@ export const ChatInput = ({
   }, [isDisabled, promptDraft, sendMessage, isAlwaysInterruptAndSend, isAgentBusy, taskID, workspaceID]);
 
   const handleInterruptAndSend = useCallback(async (): Promise<void> => {
+    if (isSendingRef.current) return;
     if (!promptDraft?.trim() || !taskID) return;
     await sendMessage();
     if (isAgentBusy) {
@@ -647,6 +669,9 @@ export const ChatInput = ({
             wrapperClassName={styles.editorInner}
             placeholder="Enter a prompt..."
             value={promptDraft || ""}
+            // Read-only while a send is in flight: prevents edits from being
+            // wiped by the on-success clear, and visually signals "sending".
+            disabled={isSending}
             onChange={(newValue: string) => setPromptDraft(newValue)}
             onKeyDown={handleKeyPress}
             tagName="CHAT_INPUT"
@@ -730,7 +755,8 @@ export const ChatInput = ({
               </Flex>
               <SendButton
                 onClick={handleSend}
-                disabled={(isDisabled && !draftIsBypassCommand(promptDraft)) || !promptDraft?.trim()}
+                disabled={isSending || (isDisabled && !draftIsBypassCommand(promptDraft)) || !promptDraft?.trim()}
+                loading={isSending}
                 tooltip={`${sendHint} to send message`}
                 ariaLabel="Send message"
                 testId={ElementIds.SEND_BUTTON}

--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { HTTPException } from "~/common/Errors.ts";
 import { isTextBlock } from "~/common/Guards.ts";
+import { useTimedLatch } from "~/common/Hooks.ts";
 import { useKeybinding, useKeybindingDisplayText } from "~/common/keybindings/hooks.ts";
 import { getModelCapabilities } from "~/common/modelCapabilities.ts";
 import { type ParsedPseudoSkillCommand, parsePseudoSkillCommand } from "~/common/pseudoSkills.ts";
@@ -85,6 +86,13 @@ const CLEAR_CONTEXT_TIMEOUT_MS = 30_000;
 const HTTP_STATUS_CONFLICT = 409;
 // Delay before the mention-picker tooltip appears, to avoid flicker on hover.
 const MENTION_TOOLTIP_DELAY_MS = 500;
+
+// A normal send resolves in well under a second, so a spinner on every send is
+// just noise. Lock the input immediately but only reveal the spinner once a send
+// has stayed in flight this long (a slow backend), then hold it briefly so it
+// doesn't flash if the response lands right after it appears.
+const SEND_SPINNER_START_DELAY_MS = 1_000;
+const SEND_SPINNER_MIN_HOLD_MS = 500;
 
 /**
  * Cheap predicate used to decide whether the SendButton / handleSend should
@@ -176,6 +184,9 @@ export const ChatInput = ({
   // the ref flips synchronously and is read before any new send proceeds.
   const [isSending, setIsSending] = useState(false);
   const isSendingRef = useRef(false);
+  // The lock/read-only state tracks `isSending` directly (instant), but the
+  // spinner is gated through a timed latch so only slow sends ever show it.
+  const shouldShowSendSpinner = useTimedLatch(isSending, SEND_SPINNER_MIN_HOLD_MS, SEND_SPINNER_START_DELAY_MS);
   const isAlwaysInterruptAndSend = useAtomValue(isAlwaysInterruptAndSendAtom);
   const sendMessageBinding = useKeybinding("send_message");
   const sendHint = useKeybindingDisplayText("send_message");
@@ -756,7 +767,7 @@ export const ChatInput = ({
               <SendButton
                 onClick={handleSend}
                 disabled={isSending || (isDisabled && !draftIsBypassCommand(promptDraft)) || !promptDraft?.trim()}
-                loading={isSending}
+                loading={shouldShowSendSpinner}
                 tooltip={`${sendHint} to send message`}
                 ariaLabel="Send message"
                 testId={ElementIds.SEND_BUTTON}

--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -89,10 +89,11 @@ const MENTION_TOOLTIP_DELAY_MS = 500;
 
 // A normal send resolves in well under a second, so a spinner on every send is
 // just noise. Lock the input immediately but only reveal the spinner once a send
-// has stayed in flight this long (a slow backend), then hold it briefly so it
-// doesn't flash if the response lands right after it appears.
+// has stayed in flight this long (a slow backend). No trailing min-hold: the
+// backend echoes the message over the WebSocket just before the POST resolves,
+// so once it's in the chat and the agent is streaming, a lingering spinner only
+// distracts — drop it the instant the send completes.
 const SEND_SPINNER_START_DELAY_MS = 1_000;
-const SEND_SPINNER_MIN_HOLD_MS = 500;
 
 /**
  * Cheap predicate used to decide whether the SendButton / handleSend should
@@ -185,8 +186,9 @@ export const ChatInput = ({
   const [isSending, setIsSending] = useState(false);
   const isSendingRef = useRef(false);
   // The lock/read-only state tracks `isSending` directly (instant), but the
-  // spinner is gated through a timed latch so only slow sends ever show it.
-  const shouldShowSendSpinner = useTimedLatch(isSending, SEND_SPINNER_MIN_HOLD_MS, SEND_SPINNER_START_DELAY_MS);
+  // spinner is gated through a start-delay latch so only slow sends ever show
+  // it; the 0 min-hold drops the spinner as soon as the send completes.
+  const shouldShowSendSpinner = useTimedLatch(isSending, 0, SEND_SPINNER_START_DELAY_MS);
   const isAlwaysInterruptAndSend = useAtomValue(isAlwaysInterruptAndSendAtom);
   const sendMessageBinding = useKeybinding("send_message");
   const sendHint = useKeybindingDisplayText("send_message");

--- a/sculptor/tests/integration/frontend/test_chat_input_send_loading.py
+++ b/sculptor/tests/integration/frontend/test_chat_input_send_loading.py
@@ -1,8 +1,9 @@
 """In-flight send contract: while a `POST .../messages` is outstanding, the
-send button shows a spinner and is disabled, the editor goes read-only while
-keeping the typed prompt, and a second send attempt is a no-op so the same
-message can't be queued twice. Once the POST resolves, the editor clears and
-the in-flight state lifts.
+send button disables and the editor goes read-only immediately (keeping the
+typed prompt), the spinner appears once the send is slow enough to outlast its
+start delay, and a second send attempt is a no-op so the same message can't be
+queued twice. Once the POST resolves, the editor clears and the in-flight state
+lifts.
 
 Regression: the send was fire-and-forget with no in-flight feedback or
 re-entrancy guard, so on a slow backend the user saw nothing happen and a
@@ -56,13 +57,15 @@ def test_in_flight_send_shows_spinner_locks_editor_and_blocks_double_send(
         expect(send_button).to_be_enabled()
         send_button.click()
 
-        # While the POST is held: the button spins and is disabled, and the
-        # editor is read-only but still shows the typed prompt (not lost, not
+        # The input locks immediately: the send button disables and the editor
+        # goes read-only while still showing the typed prompt (not lost, not
         # cleared until the send succeeds).
-        expect(send_button).to_have_attribute("data-loading", "true")
         expect(send_button).to_be_disabled()
         expect(chat_input).to_have_attribute("contenteditable", "false")
         expect(chat_input).to_have_text("second message")
+        # The spinner is latched behind a start delay so quick sends never flash
+        # it. This send is held in flight, so it appears once the delay elapses.
+        expect(send_button).to_have_attribute("data-loading", "true")
 
         # Try to send again while the first send is still in flight. The button
         # is disabled (can't be clicked) and the keyboard path is guarded. A

--- a/sculptor/tests/integration/frontend/test_chat_input_send_loading.py
+++ b/sculptor/tests/integration/frontend/test_chat_input_send_loading.py
@@ -65,22 +65,26 @@ def test_in_flight_send_shows_spinner_locks_editor_and_blocks_double_send(
         expect(chat_input).to_have_text("second message")
 
         # Try to send again while the first send is still in flight. The button
-        # is disabled (can't be clicked) and the keyboard path is guarded, so no
-        # second POST is issued.
+        # is disabled (can't be clicked) and the keyboard path is guarded. A
+        # broken guard would dispatch a second POST here; the count is checked
+        # below once the editor-clear barrier guarantees the network has settled.
         chat_input.click()
         page.keyboard.press("Enter")
-        page.wait_for_timeout(300)
+
+        # Release the held send and wait on a positive condition rather than a
+        # fixed sleep: the editor clears (and re-enables) and the spinner lifts
+        # only after the single send's success response. A stray second request
+        # is dispatched synchronously at the Enter above, so by the time the
+        # first POST has round-tripped it would already have hit the route
+        # counter — making this a reliable happens-after barrier for the assert.
+        state["release"] = True
+        expect(chat_input).to_have_text("")
+        expect(chat_input).to_have_attribute("contenteditable", "true")
+        expect(send_button).not_to_have_attribute("data-loading", "true")
+        # Exactly one message ever hit the network: the re-entrancy guard held.
         assert state["post_count"] == 1, f"expected a single send, saw {state['post_count']}"
     finally:
+        # Release in case an assertion above failed while the send was still held,
+        # then tear down the route.
         state["release"] = True
-        # Let the held request continue before tearing down the route.
-        page.wait_for_timeout(100)
         page.unroute(_SEND_MESSAGE_PATTERN, hold_send)
-
-    # Once the send resolves, the in-flight state lifts: the editor clears and
-    # becomes editable again, and the spinner is gone.
-    expect(chat_input).to_have_text("")
-    expect(chat_input).to_have_attribute("contenteditable", "true")
-    expect(send_button).not_to_have_attribute("data-loading", "true")
-    # Exactly one message ever hit the network.
-    assert state["post_count"] == 1, f"expected a single send, saw {state['post_count']}"

--- a/sculptor/tests/integration/frontend/test_chat_input_send_loading.py
+++ b/sculptor/tests/integration/frontend/test_chat_input_send_loading.py
@@ -1,0 +1,86 @@
+"""In-flight send contract: while a `POST .../messages` is outstanding, the
+send button shows a spinner and is disabled, the editor goes read-only while
+keeping the typed prompt, and a second send attempt is a no-op so the same
+message can't be queued twice. Once the POST resolves, the editor clears and
+the in-flight state lifts.
+
+Regression: the send was fire-and-forget with no in-flight feedback or
+re-entrancy guard, so on a slow backend the user saw nothing happen and a
+re-send queued the message a second time.
+"""
+
+import re
+
+from playwright.sync_api import Route
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.base import type_into_tiptap
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# `$` anchor keeps DELETE .../messages/{id} from being intercepted.
+_SEND_MESSAGE_PATTERN = re.compile(r"/api/v1/workspaces/[^/]+/agents/[^/]+/messages$")
+
+
+@user_story("to see a sending state (and not double-queue) when the backend is slow to accept my message")
+def test_in_flight_send_shows_spinner_locks_editor_and_blocks_double_send(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    page = sculptor_instance_.page
+
+    # Set the workspace + agent up first; only hold subsequent sends in flight.
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt="hello",
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # Hold the next message POST in flight until the test releases it, and count
+    # how many POSTs actually reach the network so a double-send is observable.
+    state = {"release": False, "post_count": 0}
+
+    def hold_send(route: Route) -> None:
+        if route.request.method == "POST":
+            state["post_count"] += 1
+            while not state["release"]:
+                page.wait_for_timeout(50)
+        route.continue_()
+
+    page.route(_SEND_MESSAGE_PATTERN, hold_send)
+
+    try:
+        chat_input = chat_panel.get_chat_input()
+        type_into_tiptap(page, chat_input, "second message")
+        send_button = chat_panel.get_send_button()
+        expect(send_button).to_be_enabled()
+        send_button.click()
+
+        # While the POST is held: the button spins and is disabled, and the
+        # editor is read-only but still shows the typed prompt (not lost, not
+        # cleared until the send succeeds).
+        expect(send_button).to_have_attribute("data-loading", "true")
+        expect(send_button).to_be_disabled()
+        expect(chat_input).to_have_attribute("contenteditable", "false")
+        expect(chat_input).to_have_text("second message")
+
+        # Try to send again while the first send is still in flight. The button
+        # is disabled (can't be clicked) and the keyboard path is guarded, so no
+        # second POST is issued.
+        chat_input.click()
+        page.keyboard.press("Enter")
+        page.wait_for_timeout(300)
+        assert state["post_count"] == 1, f"expected a single send, saw {state['post_count']}"
+    finally:
+        state["release"] = True
+        # Let the held request continue before tearing down the route.
+        page.wait_for_timeout(100)
+        page.unroute(_SEND_MESSAGE_PATTERN, hold_send)
+
+    # Once the send resolves, the in-flight state lifts: the editor clears and
+    # becomes editable again, and the spinner is gone.
+    expect(chat_input).to_have_text("")
+    expect(chat_input).to_have_attribute("contenteditable", "true")
+    expect(send_button).not_to_have_attribute("data-loading", "true")
+    # Exactly one message ever hit the network.
+    assert state["post_count"] == 1, f"expected a single send, saw {state['post_count']}"


### PR DESCRIPTION
## Problem

Sending a message to an agent was fire-and-forget. The chat input awaited the message `POST` with **no visible feedback** and **no re-entrancy guard**, and only cleared the editor once the response returned. On a slow backend the user saw nothing happen, re-sent, and the **same message was queued twice**.

## Change

While a send is in flight:

- the send button shows Radix's spinner and is disabled;
- the editor goes **read-only** (and dimmed), so an in-progress edit can't be clobbered by the on-success clear, and the "sending" state reads clearly;
- the typed prompt is **preserved** and cleared only once the send succeeds (still preserved on failure, as before).

The actual fix for the double-queue is a synchronous `useRef` guard: `setState` is async, so a fast second Enter would slip past a state-only check. The ref flips before the `await` and is re-checked at every send entry point, so a re-entrant send — and its trailing interrupt — is a no-op.

`Editor` already supported a `disabled` prop (it calls `setEditable(false)`); this also makes its dimming class apply when a `wrapperClassName` is passed (the chat input's case), which it previously dropped.

### Behavior

| state | input text | editor | send button |
|---|---|---|---|
| in flight | preserved, visible | read-only, dimmed | spinner, disabled |
| success | cleared | editable | normal |
| failure | preserved | editable | normal, error surfaced |

## Out of scope

- **Aborting / cancelling an in-flight send.** The `POST` is non-idempotent and the backend owns the queue, so a client-side cancel can't know whether the request already landed — that would reintroduce the same double-state ambiguity. Retracting a *queued* message is a separate, backend-authoritative concern.
- An optimistic "message appears in chat instantly" bubble — worth a follow-up, but it touches the message-state reducers and reconciliation, so it's kept out of this targeted fix.

## Testing

- New frontend integration test `test_chat_input_send_loading.py`: holds the message `POST` in flight and asserts the spinner + disabled button, the read-only editor that keeps the prompt, that a second send attempt issues no second `POST`, and that the editor clears and the in-flight state lifts once the send resolves. Passes (`1 passed in 41s`).
- `just format`, `just check`, and the frontend `tsc`/`lint` all pass. `just test-unit` is green except for one unrelated, pre-existing timing flake (`threads_test.py::test_source_polls_and_emits_values`), which passes in isolation.

(Sent by Claude)