### PR TITLE
Reliable busy/idle/waiting status for the Claude CLI terminal agent (SCU-1600)

### DIFF
--- a/agent_docs/claude_hooks/design.md
+++ b/agent_docs/claude_hooks/design.md
@@ -1,0 +1,402 @@
+# Reliable busy/idle status for the Claude CLI terminal agent — design
+
+> **Status: proposed.** Makes the registered Claude Code terminal agent report
+> busy/waiting/idle reliably across the turn lifecycle. All decision logic
+> lives **inside the Claude registration**; Sculptor and the `sculpt` CLI stay
+> generic and extension-agnostic.
+>
+> **Scope split (important):** the net hook change is small — `SessionStart`
+> stops idling on a mid-turn `compact` (the **auto-compaction** fix), and an
+> `idle_prompt`→idle **backstop** is added. The third gap, the background-work
+> "flicker," is **reclassified as correct behavior** (a finished turn is idle
+> even with work pending — §5), so `Stop` is left unconditional. The fourth, the
+> **Esc interrupt** (original SCU-1600), has **no reliable fix today** without
+> coupling Sculptor to Claude's internals (see §7) and is deferred to an
+> upstream Claude cancel signal. SCU-1600 is re-scoped to "ship the
+> compaction fix + backstop; interrupt blocked on upstream."
+
+## 1. Problem
+
+The registered Claude Code terminal agent reports its status to Sculptor via
+Claude Code **hooks** that shell out to `sculpt signal <state>`. The current
+wiring is a coarse two-event model — *busy on `UserPromptSubmit`, idle on
+`Stop`* — and it is wrong in three observed situations, plus a fourth that
+hooks cannot see at all:
+
+1. **Esc interrupt → stuck busy.** Pressing Esc to interrupt a turn fires
+   **no hook**, so the last `busy` never clears and the tab spins forever.
+   (This is SCU-1600 — **deferred**, see §7: no reliable fix exists today.)
+2. **Auto-compaction → stuck idle.** When the context auto-compacts mid-turn,
+   the agent keeps working but the tab goes idle and stays there.
+3. **Completes-with-background-work → idle/busy "flicker".** A turn that leaves
+   a background task (or scheduled wake-up) running reports idle, then flips
+   back to busy when the background op wakes the agent, then idle again.
+   (Investigated and **reclassified as correct** — §5: a finished turn *is*
+   idle; the re-wake to busy is accurate, and idle is what produces the tab's
+   completion/unread signal. No change here; `Stop` stays unconditional.)
+4. **(Goal)** Across all of the above: always reliably indicate whether the
+   agent is *actively working* or *truly idle/waiting*.
+
+## 2. Evidence — verified Claude Code hook lifecycle
+
+Everything below was measured against the **real Claude CLI 2.1.190** by
+driving the TUI over a PTY with a settings file that logs every hook event's
+full payload. The probe harness is kept at the Sculptor **workspace root**
+(`run_hook_probe.py`, one level above this repo checkout) as a dev reference —
+it is intentionally *not* committed (it spawns a real Claude and burns tokens);
+the raw timelines below are reproduced here because the design rests on them.
+
+### 2.1 Observed sequences
+
+```
+A. Trivial turn ("PONG")
+   UserPromptSubmit → Stop(bg=0) → [+~3s] SubagentStop → [+60s] Notification idle_prompt
+
+B. Tool turn
+   UserPromptSubmit → PreToolUse(Bash) → PostToolUse(Bash) → Stop(bg=0)
+
+C. Background task (sleep 30 in background, reply STARTED)
+   UserPromptSubmit → PreToolUse → PostToolUse → Stop(bg=1) → SubagentStop(bg=1)
+   …[~30s later, the task completes and RE-WAKES the agent]…
+   UserPromptSubmit(re-wake) → Stop(bg=0)
+
+D. Esc interrupt mid-tool (a ~30s CPU command running)
+   UserPromptSubmit → PreToolUse(Bash) → [ESC] → **NOTHING**
+   (no Stop, no Notification, no idle_prompt within 90s)
+
+E. Compaction (/compact, same hooks as auto-compaction)
+   PreCompact → SubagentStop → SessionStart(source=compact) → PostCompact
+```
+
+### 2.2 Load-bearing facts
+
+- **`Stop` is not "done".** It fires at the end of *every* response, even
+  when background work is still running. Its payload (2.1.190) carries
+  `stop_hook_active`, `last_assistant_message`, and crucially
+  **`background_tasks`** and **`session_crons`** arrays. In scenario C, `Stop`
+  fired with `background_tasks=[{…,status:"running",command:"sleep 30"}]`.
+- **A finishing background task re-wakes the agent as a fresh
+  `UserPromptSubmit`** (scenario C, the second `UserPromptSubmit` that we
+  never typed). That is the source of the flicker.
+- **Auto-compaction re-fires `SessionStart` with `source:"compact"`**
+  (sources are `startup | resume | clear | compact`), plus `PreCompact` and
+  `PostCompact`. The turn then *continues* with no new `UserPromptSubmit`.
+- **Esc fires zero hooks.** Confirmed: no `Stop`, no `Notification`. And the
+  `idle_prompt` notification does **not** fire after an interrupt within 90s —
+  it is armed by a normal turn end, of which there was none. So hooks cannot
+  detect an interrupt at all.
+- **`Notification:idle_prompt` is a fixed ~60s-after-turn-end reminder**
+  (measured 60.1s in A), not an immediate idle signal — usable only as a slow
+  corroborating backstop, never as the primary idle signal, and useless for
+  the interrupt case.
+- **`SubagentStop` fires ~3s after almost every `Stop`** even with no
+  subagent involved — it is noise for status purposes; do not use it.
+- Sandbox note for tests: the foreground `sleep` command is blocked by the
+  harness; background `sleep` works. Use a CPU one-liner
+  (`python3 -c "print(sum(range(900000000)))"`) to force a long foreground
+  tool call.
+
+## 3. Current architecture (what we are changing)
+
+- **Hooks → CLI:** `samples/terminal_agents/claude-code/claude-code-hooks.json`
+  maps hook events to `sculpt signal <state>` commands. `sculpt signal`
+  (`tools/sculpt/sculpt/commands/signal.py`) POSTs to
+  `/api/v1/agents/{agent_id}/signal` with `event ∈ {busy, idle,
+  waiting-on-input, files-changed, session-id}`.
+- **Endpoint → message:** `post_agent_signal` in `sculptor/sculptor/web/app.py`
+  (~L3504–3566) maps the event to `TerminalStatusSignal` and creates an
+  ephemeral `TerminalAgentSignalRunnerMessage`
+  (`sculptor/sculptor/interfaces/agents/agent.py`). `TerminalStatusSignal`
+  is `{BUSY, IDLE, WAITING}`.
+- **Message → status:** `scan_terminal_signal_state`
+  (`sculptor/sculptor/web/derived.py` L99–122) reverse-scans the live
+  messages for the latest signal since the run-start anchor
+  (`EnvironmentAcquiredRunnerMessage`). `CodingAgentTaskView.status`
+  (L490–503) maps `BUSY→RUNNING`, `WAITING→WAITING`, else `READY`; no run
+  yet → `BUILDING`.
+- **PTY I/O:** the terminal WebSocket relay (`_connect_terminal_websocket`
+  in `app.py`, ~L3669–3763) writes raw frontend bytes into the PTY via
+  `LocalTerminalManager.write()`
+  (`…/environment_manager/environments/local_terminal_manager.py`). **Sculptor
+  sees every byte the user types**, including ESC (`0x1b`) and Ctrl-C
+  (`0x03`) — this is what makes the interrupt fix possible.
+- The task handler (`run_terminal_agent/v1.py`) runs a 1s idle poll loop with
+  no per-turn request/response cycle, and injects `SCULPT_*` env (incl.
+  `SCULPT_AGENT_ID`). The agent's Claude transcript path is **not** known to
+  Sculptor (session-id is only used to `--resume`), so transcript
+  introspection is not an available idle source.
+
+## 4. Design principles
+
+1. **`busy` must be cheaply re-assertable.** Any agent activity should be able
+   to flip the tab back to busy, so a premature/incorrect idle self-corrects
+   on the very next action.
+2. **`idle` must be earned, not assumed.** We only go idle when the agent is
+   genuinely waiting — i.e. a turn ended *and* no background work is pending.
+3. **All decision logic lives in the extension — never in Sculptor or
+   `sculpt`.** The backend and the `sculpt` CLI are a generic,
+   extension-agnostic transport: a fixed signal vocabulary (`busy`, `idle`,
+   `waiting`, `files-changed`, `session-id`), the POST endpoint, and the PTY
+   proxy. They know nothing about Claude's hook events or payload schema. The
+   Claude registration decides *when* to emit each signal entirely within its
+   own files — the hooks JSON does any payload inspection in self-contained
+   POSIX shell (the same dependency-free way it already extracts `session_id`
+   with `sed`), and emits only the generic verbs. A second registration could
+   implement completely different logic with zero changes to Sculptor.
+4. **The interrupt has no reliable, principled fix today** — see §7. It is
+   deferred to an upstream Claude cancel signal rather than fixed with a
+   Sculptor-side heuristic that would couple to Claude and still be wrong.
+
+## 5. The hook state machine (target)
+
+Canonical event → signal mapping after this change:
+
+| Source | Condition | Signal |
+|---|---|---|
+| `UserPromptSubmit` | always (incl. background-task re-wake) | **BUSY** |
+| `PreToolUse` | tool ∈ AskUserQuestion, ExitPlanMode | **WAITING** |
+| `Notification` | type = `permission_prompt` / `worker_permission_prompt` | **WAITING** |
+| `PostToolUse` | tool ∈ AskUserQuestion, ExitPlanMode (answered) | **BUSY** |
+| `PostToolUse` | tool ∈ Edit/Write/MultiEdit/NotebookEdit/Bash | `files-changed` (unchanged; not a status) |
+| `Stop` | always (a finished turn is idle, regardless of pending background/scheduled work) | **IDLE** |
+| `SessionStart` | `source ∈ {startup, resume, clear}` | **IDLE** |
+| `SessionStart` | `source = compact` | *no-op* (preserve prior state) |
+| `Notification` | type = `idle_prompt` | **IDLE** (slow corroborating backstop) |
+| Esc / interrupt | — | **deferred** — no reliable signal exists today (see §7) |
+
+New vs. today: `PreToolUse(any)→BUSY` (re-assert), `Stop` becomes
+conditional, `SessionStart` becomes source-gated, `idle_prompt→IDLE` added as
+a backstop, and the Esc handler is new.
+
+### Why this fixes each gap
+
+- **Gap 2 (compact):** the `SessionStart` hook is scoped (by matcher) to
+  `startup|resume|clear`, so a mid-turn `source=compact` start fires nothing
+  and the prior BUSY state simply persists — nothing signals idle until the
+  turn's eventual real `Stop`. The agent stays busy through compaction.
+- **Gap 3 (background "flicker") — reclassified as correct behavior.** `Stop`
+  always signals idle. The status answers "is Claude *actively generating* right
+  now?", so a finished turn is idle even if a background task or a scheduled
+  wake-up is still pending — the agent is genuinely idle at its prompt. The
+  perceived flicker (idle → busy → idle when a background op or timer re-wakes
+  the agent) is accurate: each state reflects what Claude is really doing, and
+  going idle is what produces the tab's completion signal (e.g. the unread/green
+  dot when the tab isn't focused). We therefore do **not** suppress idle for
+  pending work — `Stop` is left unconditional (identical to the prior shipped
+  hooks). A long-lived background process (a `dev` server) correctly reads as
+  idle; a transient one re-wakes to busy and settles back to idle.
+- **Gap 1 (Esc):** deferred — §7 shows no reliable signal exists today.
+- **Backstop:** if a `Stop` is somehow missed, `idle_prompt` corrects the tab to
+  idle within ~60s of a genuine idle (it will not falsely fire during work, and
+  — verified — it does not fire after an interrupt).
+
+> **Product decision (background/scheduled-work status).** A finished turn is
+> IDLE regardless of pending `background_tasks` or `session_crons`. We
+> considered holding the tab BUSY while a scheduled wake-up (cron) is pending,
+> but rejected it: "busy" should mean *actively generating*, and holding blue
+> while merely waiting on a timer both misrepresents the state and swallows the
+> completion (unread/green) signal an unfocused tab should show. So `Stop`
+> stays unconditional `sculpt signal idle`; the agent re-wakes to BUSY on its
+> own (a fresh `UserPromptSubmit`) when the timer/background op actually fires.
+> (This diverges from Claude's own `idle_prompt` suppression during background
+> tasks, which is a notification nicety, not a status contract.)
+
+## 6. Hook-side changes — entirely within the Claude registration
+
+**No change to the `sculpt` CLI or the backend signal endpoint.** They keep
+the generic vocabulary. The decisions are made inside
+`samples/terminal_agents/claude-code/claude-code-hooks.json` and call only the
+generic `sculpt signal` verbs. There is no payload-inspecting shell at all:
+filtering is done by Claude's matchers (`SessionStart` source, `Notification`
+type, tool name), and `Stop` is unconditional.
+
+**Stop** — a finished turn is always idle (see §5):
+
+```jsonc
+"Stop": [{ "hooks": [{ "type": "command", "command": "sculpt signal idle || true" }] }]
+```
+
+**SessionStart** — go idle on a real (re)start, but not on a mid-turn
+compaction. Unlike `Stop`, `SessionStart` supports a `source` matcher, so the
+filtering is done declaratively by Claude (no shell needed): the hook is scoped
+to `startup|resume|clear`, so a `source=compact` start matches no group and
+fires nothing, leaving the prior BUSY state intact.
+
+```jsonc
+"SessionStart": [
+  { "matcher": "startup|resume|clear",
+    "hooks": [{ "type": "command", "command": "sculpt signal idle || true" }] }
+]
+```
+
+The full `claude-code-hooks.json` (the one conditional — `Stop` — inlined as a
+one-liner, since `Stop` has no matcher and must read its payload):
+
+```jsonc
+{
+  "skipDangerousModePermissionPrompt": true,
+  "hooks": {
+    "SessionStart": [{ "matcher": "startup|resume|clear",
+      "hooks": [{ "type": "command", "command": "sculpt signal idle || true" }] }],
+    "UserPromptSubmit": [{ "hooks": [
+      { "type": "command", "command": "sculpt signal busy || true" },
+      { "type": "command", "command": "sid=$(sed -n 's/.*\"session_id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p' | head -n1); [ -n \"$sid\" ] && sculpt signal session-id \"$sid\" || true" }
+    ] }],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "sculpt signal idle || true" }] }],
+    "Notification": [
+      { "matcher": "permission_prompt|worker_permission_prompt", "hooks": [{ "type": "command", "command": "sculpt signal waiting || true" }] },
+      { "matcher": "idle_prompt", "hooks": [{ "type": "command", "command": "sculpt signal idle || true" }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "AskUserQuestion|ExitPlanMode", "hooks": [{ "type": "command", "command": "sculpt signal waiting || true" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash", "hooks": [{ "type": "command", "command": "sculpt signal files-changed || true" }] },
+      { "matcher": "AskUserQuestion|ExitPlanMode", "hooks": [{ "type": "command", "command": "sculpt signal busy || true" }] }
+    ]
+  }
+}
+```
+
+Notes:
+- The `UserPromptSubmit` busy hook also catches the **background-task re-wake**
+  (whose prompt is a `<task-notification>` injected by Claude) → busy, which is
+  correct.
+- `PreToolUse` only carries the question/plan→WAITING matcher. We deliberately
+  do **not** add a generic `PreToolUse(any tool)→busy` re-assert: with the
+  interrupt deferred there is no spurious mid-turn idle for it to correct, and
+  it would need a stale-prone tool list plus extra signal volume. BUSY is
+  asserted by `UserPromptSubmit` (incl. the re-wake) and by the answered-question
+  `PostToolUse`.
+- The `idle_prompt` matcher is **added** to `Notification`. The earlier
+  deliberate omission (so the 60s reminder couldn't fake the dot) is now safe
+  because `idle_prompt` only ever drives the tab *to idle* and agrees with the
+  real idle we derive.
+- All filtering is done by Claude's matchers (`SessionStart` source,
+  `Notification` type, tool name); no hook inspects the payload in shell, so
+  there is no `jq`/`python` dependency and nothing to break across Claude
+  versions. The only remaining shell is the `UserPromptSubmit` `sed` that
+  extracts the session id (unchanged from the prior shipped hooks).
+
+## 7. Interrupt handling (SCU-1600) — no reliable fix today; defer upstream
+
+The interrupt cannot be fixed both *reliably* and *without coupling Sculptor to
+Claude's behavior* with the mechanisms Claude exposes today. This is the result
+of exhaustive probing (CLI 2.1.190), not an assumption:
+
+| Candidate signal | Verdict |
+|---|---|
+| **Any hook** (full documented set enabled) | A real cancel fires **nothing** — verified for both a running-tool interrupt and a text-generation interrupt (0 events in 30s). |
+| **A dedicated cancel/interrupt hook** | Does not exist; `Stop` doesn't fire on interrupt; `SessionEnd` reasons don't include it. |
+| **`idle_prompt` Notification** | Does **not** fire after an interrupt (it's armed by a normal turn end) — so even the Section 5 backstop can't catch this. |
+| **Statusline command** | No turn-state/"is-working" field, and it doesn't run on interrupt (only after a new assistant message, `/compact`, permission-mode/vim change, or `refreshInterval`). |
+| **Keystroke heuristic (ESC/Ctrl-C in the PTY)** | Unreliable *and* coupling: ESC is overloaded **inside Claude** (it also dismisses TUI menus, leaving the turn running), and "which key cancels" is itself Claude-specific. Sculptor can't tell a cancel from a menu-dismiss from the byte alone. |
+| **Watch the Claude transcript** | The only internal record, and it *could* live in an extension-owned watcher (keeping Sculptor generic) — but it couples to Claude's **undocumented** transcript format, the interrupt-marker shape is unverified, and in our sandbox transcripts were not even persisted. Fragile; not recommended. |
+
+**Why a keystroke fix is wrong (the decisive point).** The same ESC byte means
+"cancel the turn" or "close a menu" depending on Claude's internal UI state,
+which only Claude knows. No declaration (an `interrupt_bytes` field) or
+Sculptor-side rule can disambiguate it, so any such fix would sometimes mark a
+working agent idle. The earlier "self-corrects on the next PreToolUse"
+mitigation does not hold: during a long model-generation or a quiet
+long-running tool there may be no hook for many seconds, so the tab would show
+a wrong idle for that whole window.
+
+**Decision: defer the interrupt to upstream and scope it out of this change.**
+
+1. **File a Claude Code feature request** for a turn-cancel signal — ideally a
+   hook that fires on interrupt, or a turn-state field on the statusline input,
+   or a `Stop` that fires (with a reason) on interrupt. Once any of these
+   exists, the fix is **pure-extension, zero Sculptor change**: the hooks JSON
+   maps it to `sculpt signal idle`.
+2. **Until then, accept the residual.** After an Esc-cancel the tab stays on
+   the spinner, but it **self-heals on the user's next interaction**: their
+   next prompt fires UserPromptSubmit -> busy and ends at a real Stop -> idle.
+   The bad window is "interrupted, then left untouched."
+3. **No interrupt test is carried.** We don't commit a permanently-skipped
+   Playwright test for behavior we can't implement; the desired behavior and
+   its upstream block are documented here and on SCU-1600. Add the test when an
+   upstream cancel signal exists.
+
+If product decides the stuck-spinner-until-next-prompt residual is
+unacceptable before upstream lands, the only option that keeps Sculptor generic
+is the **extension-owned transcript watcher** (a helper the Claude registration
+launches, that tails Claude's transcript and calls generic `sculpt signal`);
+it must first be validated that interrupts are recorded distinguishably and
+stably across versions. Flagged, not recommended.
+
+## 8. Rollout / migration
+
+The registration files are **installed once and then user-owned** —
+edits/deletes stick and staleness is accepted (see
+`agent_docs/terminal-agents/builtin-claude-code-design.md`). So shipping a new
+`claude-code-hooks.json` in `samples/` does **not** update existing installs,
+and the §5/§6 behavior depends on the new wiring. Required:
+
+- **Hash-stamp refresh of the managed files.** The installer
+  (`services/terminal_agent_registry/bundled.py`) keeps, per file, the sha256 of
+  every version Sculptor has shipped (`_KNOWN_MANAGED_FILE_SHA256`). On every
+  start, for each managed file (the TOML *and* the hooks JSON), if the installed
+  copy's hash is in that file's set (i.e. it is an unmodified Sculptor copy) and
+  differs from the bundle, it is overwritten with the bundle. A user-edited file
+  (unknown hash) or a deleted file (absent) is left alone. The two files refresh
+  **independently**, so editing one (e.g. customizing the TOML's launch command)
+  never blocks upgrading the other (e.g. a hooks fix). When a bundled file
+  changes, its new hash is appended to its set.
+- **No `sculpt` CLI / endpoint / client changes**, so no
+  `just generate-sculpt-client` and no version floor on `sculpt`. The new
+  behavior is entirely in the registration's hooks JSON, and (since no hook
+  inspects the payload) it is insensitive to Claude payload changes.
+- **Interrupt migration** depends on the §7 decision: a backend-only generic
+  rule needs no migration; a registration-schema field needs the same
+  installer refresh as the hooks JSON (and a `RegisteredTerminalAgentConfig`
+  field, regenerated types).
+
+## 9. Test plan
+
+1. **Real-Claude regression (`@real_claude`).** Adapt the workspace-root probe
+   (`run_hook_probe.py`) into a permanent test
+   under `sculptor/tests/integration/real_claude/` that asserts the verified
+   sequences in §2.1: compact→`SessionStart(source=compact)`, background
+   task→`Stop(bg≥1)` then re-wake, and (already covered)
+   busy/idle/waiting. Burns tokens; keep it minimal and skippable like the
+   existing `test_claude_code_terminal_agent`.
+2. **Bundled-hooks structure tests** (`registry_test.py`, no tokens) — assert
+   the shipped JSON's matcher semantics directly: `SessionStart` idles on
+   `startup|resume|clear` but not `compact`; `Notification` signals `waiting`
+   for permission prompts but never for `idle_prompt` (which signals idle);
+   questions drive `waiting`→`busy` via PreToolUse/PostToolUse; the session id
+   is reported from `UserPromptSubmit`, not `SessionStart`.
+3. **Installer refresh tests** (`bundled_test.py`) — for each managed file
+   (TOML and hooks JSON): an unmodified copy is refreshed to the bundle on
+   upgrade; a user-edited or deleted file is left untouched; and editing one
+   file does not block refreshing the other.
+4. **No interrupt test** is committed — the behavior is blocked upstream (§7),
+   and a permanently-skipped Playwright test earns nothing. Add it when an
+   upstream cancel signal lands.
+5. **Existing tests** must stay green:
+   `test_claude_code_terminal_agent`, the terminal-input guard tests, and the
+   CI-babysitter readiness gate (which reads `scan_terminal_signal_state`).
+
+## 10. Out of scope / explicitly not doing
+
+- Using `SubagentStop` for status (noise).
+- Making `idle_prompt` the primary idle signal (60s-lagging; absent after
+  interrupts).
+- Reading the Claude transcript to infer idle (Sculptor doesn't have the
+  path, and it's program-internal).
+- Any change to how chat (SDK) agents report status — this is terminal-agent
+  only.
+
+## 11. File-touch summary
+
+| Area | File | Change |
+|---|---|---|
+| **Extension only** | `samples/terminal_agents/claude-code/claude-code-hooks.json` | `SessionStart` source matcher + `idle_prompt`→idle (§6); `Stop` unchanged |
+| Installer | `services/terminal_agent_registry/bundled.py` | per-file hash-stamp + independent refresh of the managed TOML and hooks JSON (user-owned copies) |
+| Interrupt | **deferred (blocked upstream, §7)** | no code, no test; file the Claude FR |
+| Tests | `services/terminal_agent_registry/{registry,bundled}_test.py`, `tests/integration/frontend/test_registered_terminal_agent.py` | §9 |
+| Probe | `run_hook_probe.py` (workspace root, **not** committed) | dev reference harness |
+
+Note: `sculpt` CLI, the signal endpoint, and `derived.py` are **unchanged** —
+they stay generic.

--- a/samples/terminal_agents/claude-code/claude-code-hooks.json
+++ b/samples/terminal_agents/claude-code/claude-code-hooks.json
@@ -3,6 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume|clear",
         "hooks": [
           {
             "type": "command",
@@ -42,6 +43,15 @@
           {
             "type": "command",
             "command": "sculpt signal waiting || true"
+          }
+        ]
+      },
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sculpt signal idle || true"
           }
         ]
       }

--- a/sculptor/sculptor/services/terminal_agent_registry/bundled.py
+++ b/sculptor/sculptor/services/terminal_agent_registry/bundled.py
@@ -9,10 +9,18 @@ registrations directory, where they are ordinary user-owned files:
 - A sentinel records that the install happened, so deleting the files is
   permanent — they are not re-installed on the next start.
 
+The exception is refresh: on every start, any *unmodified* Sculptor-managed
+file (the TOML and the hooks JSON) is brought up to the current bundled version
+in place, so fixes ship to existing installs. The two files are refreshed
+**independently** — a hand-edited copy (its hash is unknown) and a deleted file
+(it is absent) are each left untouched, so editing one file never blocks
+upgrading the other, and the edits-stick / delete-sticks contract holds.
+
 The registry itself stays unaware of all this: after installation the
 registration is indistinguishable from a hand-written one.
 """
 
+import hashlib
 from pathlib import Path
 
 from loguru import logger
@@ -22,6 +30,33 @@ from sculptor.services.terminal_agent_registry.registry import get_registrations
 
 _SENTINEL_FILE_NAME = ".claude-code.installed"
 _BUNDLED_FILE_NAMES = ("claude-code.toml", "claude-code-hooks.json")
+
+# Per managed file: the sha256 of every version Sculptor has ever shipped of it.
+# An installed copy whose hash is in its file's set is an unmodified
+# Sculptor-managed file and may be refreshed in place to the current bundled
+# version; any other content is a user edit and is never touched. The files are
+# keyed independently, so the two upgrade separately. When a bundled file
+# changes, ADD its new hash to that file's set (keep the old ones so the prior
+# version still auto-upgrades).
+_KNOWN_MANAGED_FILE_SHA256: dict[str, frozenset[str]] = {
+    "claude-code.toml": frozenset(
+        {
+            "f04ba8bc5b7a0730420f05aab2e7bee45d187429322d970c38cd4b4fa4e8dcc3",
+        }
+    ),
+    "claude-code-hooks.json": frozenset(
+        {
+            "6d608ca2b7a4ed433bd161cdf7c29823120236772c377987dc21306bed898e17",
+            "1482d2aa0ae1818205bc33354336173d829754dfefd31823955059e311a9f184",
+            "08f8809991efc40d3cc01eca64bfbf3072635c88dbd592a917f25d179d470803",
+            "14414cf548315f4da5443a283842f6a0574198205ed8bc5a3deb4ea1cbeb5817",
+        }
+    ),
+}
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 def get_bundled_claude_code_dir() -> Path | None:
@@ -63,28 +98,55 @@ def install_bundled_registrations() -> None:
 
 def _install_claude_code_registration() -> None:
     registrations_dir = get_registrations_dir()
-    sentinel = registrations_dir / _SENTINEL_FILE_NAME
-    if sentinel.exists():
-        return
     source_dir = get_bundled_claude_code_dir()
     if source_dir is None:
         logger.info("Bundled Claude Code sample not found; skipping registration install")
         return
 
-    registrations_dir.mkdir(parents=True, exist_ok=True)
-    # Files are copied verbatim: the TOML's {terminal_agents_directory}
-    # placeholder is resolved at command-render time (see render_terminal_command),
-    # not rewritten here, so the installed registration survives a moved
-    # Sculptor folder.
-    for file_name in _BUNDLED_FILE_NAMES:
-        destination = registrations_dir / file_name
-        if destination.exists():
-            # The user (or a previous partial install) already has this file.
-            continue
-        destination.write_text((source_dir / file_name).read_text())
-        logger.info("Installed bundled terminal-agent file {}", destination)
-    sentinel.write_text(
-        "The bundled Claude Code registration was installed once into this directory.\n"
-        + "This marker makes deleting claude-code.toml permanent — remove it to have\n"
-        + "Sculptor re-install the registration on the next start.\n"
-    )
+    sentinel = registrations_dir / _SENTINEL_FILE_NAME
+    if not sentinel.exists():
+        registrations_dir.mkdir(parents=True, exist_ok=True)
+        # Files are copied verbatim: the TOML's {terminal_agents_directory}
+        # placeholder is resolved at command-render time (see render_terminal_command),
+        # not rewritten here, so the installed registration survives a moved
+        # Sculptor folder.
+        for file_name in _BUNDLED_FILE_NAMES:
+            destination = registrations_dir / file_name
+            if destination.exists():
+                # The user (or a previous partial install) already has this file.
+                continue
+            destination.write_text((source_dir / file_name).read_text())
+            logger.info("Installed bundled terminal-agent file {}", destination)
+        sentinel.write_text(
+            "The bundled Claude Code registration was installed once into this directory.\n"
+            + "This marker makes deleting claude-code.toml permanent — remove it to have\n"
+            + "Sculptor re-install the registration on the next start.\n"
+        )
+
+    # Always (post-install too): bring each unmodified managed file up to the
+    # current bundled version so fixes reach existing installs. User edits and a
+    # deleted file are left untouched, independently per file.
+    for file_name, known_hashes in _KNOWN_MANAGED_FILE_SHA256.items():
+        _refresh_managed_file(registrations_dir, source_dir, file_name, known_hashes)
+
+
+def _refresh_managed_file(
+    registrations_dir: Path, source_dir: Path, file_name: str, known_hashes: frozenset[str]
+) -> None:
+    """Overwrite one managed file with the bundled version iff it is unmodified.
+
+    "Unmodified" means its current content hashes to a version Sculptor shipped
+    (`known_hashes`). An absent file (user deleted it) or an unknown hash (user
+    edited it) is left exactly as-is.
+    """
+    destination = registrations_dir / file_name
+    if not destination.exists():
+        return
+    current = destination.read_text()
+    bundled = (source_dir / file_name).read_text()
+    if current == bundled:
+        return
+    if _sha256(current) not in known_hashes:
+        return
+    destination.write_text(bundled)
+    logger.info("Refreshed Sculptor-managed terminal-agent file {}", destination)

--- a/sculptor/sculptor/services/terminal_agent_registry/bundled_test.py
+++ b/sculptor/sculptor/services/terminal_agent_registry/bundled_test.py
@@ -82,3 +82,69 @@ def test_missing_sample_is_not_fatal(sculptor_folder: Path, monkeypatch: pytest.
     install_bundled_registrations()
 
     assert not (sculptor_folder / "terminal_agents" / _SENTINEL).exists()
+
+
+@pytest.mark.parametrize("file_name", ["claude-code.toml", "claude-code-hooks.json"])
+def test_unmodified_managed_file_is_refreshed(
+    sculptor_folder: Path, monkeypatch: pytest.MonkeyPatch, file_name: str
+) -> None:
+    install_bundled_registrations()
+    path = sculptor_folder / "terminal_agents" / file_name
+
+    # Simulate a stale-but-unmodified managed copy left by a prior release: its
+    # hash is "known" (Sculptor shipped it once) but it differs from the bundle.
+    stale = "stale-but-managed\n"
+    path.write_text(stale)
+    monkeypatch.setattr(
+        bundled_module,
+        "_KNOWN_MANAGED_FILE_SHA256",
+        {file_name: frozenset({bundled_module._sha256(stale)})},
+    )
+
+    install_bundled_registrations()
+
+    sample_dir = get_bundled_claude_code_dir()
+    assert sample_dir is not None
+    assert path.read_text() == (sample_dir / file_name).read_text()
+
+
+@pytest.mark.parametrize("file_name", ["claude-code.toml", "claude-code-hooks.json"])
+def test_user_edited_managed_file_is_not_refreshed(sculptor_folder: Path, file_name: str) -> None:
+    install_bundled_registrations()
+    path = sculptor_folder / "terminal_agents" / file_name
+
+    # An edit Sculptor never shipped (hash not in the known set) is never touched.
+    edited = "my own customizations\n"
+    path.write_text(edited)
+
+    install_bundled_registrations()
+
+    assert path.read_text() == edited
+
+
+def test_editing_one_managed_file_does_not_block_refreshing_the_other(
+    sculptor_folder: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_bundled_registrations()
+    registrations_dir = sculptor_folder / "terminal_agents"
+    toml_path = registrations_dir / "claude-code.toml"
+    hooks_path = registrations_dir / "claude-code-hooks.json"
+
+    # The user customized their TOML; the hooks file is a stale managed copy.
+    edited_toml = 'display_name = "Mine"\nlaunch_command = "my-claude"\n'
+    toml_path.write_text(edited_toml)
+    stale_hooks = '{"stale": "managed hooks"}\n'
+    hooks_path.write_text(stale_hooks)
+    monkeypatch.setattr(
+        bundled_module,
+        "_KNOWN_MANAGED_FILE_SHA256",
+        {"claude-code-hooks.json": frozenset({bundled_module._sha256(stale_hooks)})},
+    )
+
+    install_bundled_registrations()
+
+    sample_dir = get_bundled_claude_code_dir()
+    assert sample_dir is not None
+    # The hooks file upgraded even though the TOML was edited; the edit stuck.
+    assert hooks_path.read_text() == (sample_dir / "claude-code-hooks.json").read_text()
+    assert toml_path.read_text() == edited_toml

--- a/sculptor/sculptor/services/terminal_agent_registry/registry_test.py
+++ b/sculptor/sculptor/services/terminal_agent_registry/registry_test.py
@@ -151,11 +151,13 @@ def test_bundled_claude_cli_hooks_only_signal_waiting_for_genuine_attention() ->
     """The shipped hooks must not turn the tab yellow without a question.
 
     The TUI's Notification hook fires for every notification type it emits --
-    including the after-60s-idle ``idle_prompt`` reminder -- so an unfiltered
-    Notification->waiting mapping shows the attention dot with nothing to
-    answer. Questions themselves never fire a Notification at all: the
-    AskUserQuestion / ExitPlanMode tool lifecycle is the question signal
-    (PreToolUse = question shown -> waiting; PostToolUse = answered -> busy).
+    including the after-60s-idle ``idle_prompt`` reminder. That reminder may map
+    to ``idle`` (it confirms the agent has settled), but it must NEVER map to
+    ``waiting``: an unfiltered Notification->waiting mapping would show the
+    attention dot with nothing to answer. Questions themselves never fire a
+    Notification at all: the AskUserQuestion / ExitPlanMode tool lifecycle is the
+    question signal (PreToolUse = question shown -> waiting; PostToolUse =
+    answered -> busy).
     """
     sample_dir = get_bundled_claude_code_dir()
     assert sample_dir is not None, "bundled claude-code sample not found"
@@ -163,12 +165,23 @@ def test_bundled_claude_cli_hooks_only_signal_waiting_for_genuine_attention() ->
 
     notification_groups = hooks["Notification"]
     waiting_matchers = []
+    idle_matchers = []
     for group in notification_groups:
         matcher = group.get("matcher")
-        assert matcher, "Notification hooks must filter by notification type (idle_prompt is not attention)"
-        assert re.search(matcher, "idle_prompt") is None, f"matcher {matcher!r} would fire on the idle reminder"
+        assert matcher, "Notification hooks must filter by notification type"
         if any("signal waiting" in hook["command"] for hook in group["hooks"]):
             waiting_matchers.append(matcher)
+        if any("signal idle" in hook["command"] for hook in group["hooks"]):
+            idle_matchers.append(matcher)
+    # The after-60s idle reminder must never raise the attention (waiting) dot...
+    for matcher in waiting_matchers:
+        assert re.search(matcher, "idle_prompt") is None, (
+            f"matcher {matcher!r} must not signal waiting on the idle reminder"
+        )
+    # ...though it is allowed (and expected) to drive the tab to idle.
+    assert any(matcher and re.search(matcher, "idle_prompt") for matcher in idle_matchers), (
+        "idle_prompt should signal idle (it confirms the agent has settled)"
+    )
     for notification_type in ("permission_prompt", "worker_permission_prompt"):
         assert any(re.search(matcher, notification_type) for matcher in waiting_matchers), (
             f"permission notifications must signal waiting: {notification_type}"
@@ -213,4 +226,29 @@ def test_bundled_claude_cli_hooks_report_session_id_on_first_prompt_not_startup(
     )
     assert any("session-id" in command for command in commands_for("UserPromptSubmit")), (
         "UserPromptSubmit must report the session id (first moment a resumable conversation exists)"
+    )
+
+
+def test_bundled_claude_cli_session_start_idles_on_real_starts_not_compaction() -> None:
+    """SessionStart signals idle for a genuine (re)start but not a compaction.
+
+    A mid-turn auto-compaction re-fires SessionStart with source=compact while
+    the agent is still working, so the hook must not signal idle then. The
+    filtering is done by Claude's ``source`` matcher (startup|resume|clear), so
+    we assert the matcher semantics rather than executing a command.
+    """
+    sample_dir = get_bundled_claude_code_dir()
+    assert sample_dir is not None, "bundled claude-code sample not found"
+    groups = json.loads((sample_dir / "claude-code-hooks.json").read_text())["hooks"]["SessionStart"]
+    idle_matchers = [
+        group["matcher"] for group in groups if any("signal idle" in hook["command"] for hook in group["hooks"])
+    ]
+
+    assert idle_matchers, "SessionStart must signal idle on a real start"
+    for source in ("startup", "resume", "clear"):
+        assert any(re.search(matcher, source) for matcher in idle_matchers), (
+            f"SessionStart must idle on source={source}"
+        )
+    assert not any(re.search(matcher, "compact") for matcher in idle_matchers), (
+        "SessionStart must NOT idle on a mid-turn compaction"
     )


### PR DESCRIPTION
Makes the registered Claude Code terminal agent report busy/idle/waiting reliably across the turn lifecycle. All decision logic lives inside the bundled registration's `claude-code-hooks.json` (using only the generic `sculpt signal` vocabulary); the Sculptor backend, the `sculpt` CLI, and `derived.py` are unchanged and stay extension-agnostic. Behavior was verified against real Claude CLI 2.1.190 with a PTY hook-probe. Full write-up in `agent_docs/claude_hooks/design.md`.

## What changes

- **Auto-compaction no longer flips the tab to idle.** `SessionStart` now uses a `source` matcher scoped to `startup|resume|clear`, so a mid-turn `source=compact` re-fire signals nothing and the agent stays busy while it keeps working.
- **`idle_prompt` → idle backstop** added to `Notification` (a ~60s-after-turn-end reminder; only ever drives the tab *to* idle, never to the attention dot).
- **`Stop` stays unconditional idle.** A finished turn is idle even if a background task or scheduled wake-up is pending — status answers "is Claude actively generating?" — and the agent re-wakes to busy on its own when the timer/op fires. (An earlier iteration held the tab busy while a cron was pending; that misrepresented "waiting on a timer" as "working" and swallowed the completion signal an unfocused tab shows, so it was dropped.)
- **Installer refresh for user-owned files.** The bundled registration is install-once and user-owned, so shipping new hooks would never reach existing installs. The installer now keeps, per file, the sha256 of every shipped version (`_KNOWN_MANAGED_FILE_SHA256`) and refreshes an *unmodified* managed copy in place — for the TOML and the hooks JSON **independently**, so editing one file never blocks upgrading the other, and deletions/edits still stick.

## Scope / what's deferred

- No `sculpt` CLI / endpoint / `derived.py` changes; no hook inspects the Claude payload (all filtering is via Claude's matchers), so it is payload-version-proof.
- **Esc interrupt is deferred (blocked upstream).** Exhaustively verified there is no reliable signal today: a real interrupt fires no hook or notification, `idle_prompt` doesn't fire after one, the statusline has no turn-state, and the Esc key is ambiguous inside Claude (it also dismisses TUI menus). It needs an upstream Claude cancel signal; until then the spinner self-heals on the user's next prompt. Details in design §7.

## Testing

- `registry_test.py` — bundled-hooks matcher semantics (SessionStart idles on real starts not compaction; Notification signals waiting for permission prompts but never for `idle_prompt`; questions drive waiting→busy; session id reported from `UserPromptSubmit`).
- `bundled_test.py` — per-file installer refresh (unmodified→refreshed, user-edited/deleted→untouched, editing one file doesn't block refreshing the other).
- `just format` / `just check` / `just test-unit` all green.

To pick up the new hooks on an existing install, restart Sculptor (the installer refreshes the user-owned hooks file on startup), then start a fresh terminal agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)