### PR TITLE
Batch GitHub PR-status polling to stop rate-limit saturation

### DIFF
--- a/agent_docs/gh_rate_limit/design.md
+++ b/agent_docs/gh_rate_limit/design.md
@@ -1,0 +1,757 @@
+# GitHub PR-Status Polling — Rate-Limit Redesign
+
+## Executive Summary
+
+Sculptor maintains its knowledge of every workspace's PR status by
+**polling** GitHub (via `gh api graphql`). The
+poller is **per-workspace**: each workspace issues its own GraphQL query on an
+interval. GitHub's GraphQL primary rate limit is **5,000 points/hour per user
+token**, so cost scales as `O(workspaces / interval)`. At ~20 open workspaces on
+the default 30s interval this saturates the budget, polling stalls, and PR
+status goes stale across the whole app.
+
+**Root cause (measured, not estimated):** each per-workspace query costs **2
+points**, and 20 workspaces × 120 polls/hr × 2 = **~4,800 points/hr — ~96% of
+the 5,000 budget.** This exactly reproduces the reported "breaks around 20
+workspaces" symptom.
+
+**Chosen solution:** replace the per-workspace query with a **single
+`search`-based GraphQL query per user token per poll round** that fetches *all*
+of the user's open PRs across all repos in one request, plus two supporting
+changes (a terminal-state follow-up fetch and a proactive rate-budget governor).
+Measured cost of the search query for 20 PRs is **7 points** with
+`reviewThreads first:30` → ~840 points/hr (17% of budget); the **shipped** query
+trims that to `first:10` (Change 1b) for **~3 points → ~360 points/hr (~7%)**.
+Either way it is a **~6×-or-better reduction** that turns the cost model from
+`O(workspaces)` into roughly `O(distinct open PRs ÷ page size)`. Because each
+round is so cheap, the freshness knob stays the polling **interval** (kept short
+for everyone) rather than any local event trigger — see "Freshness" below.
+
+**Before:** N workspaces ⇒ N GraphQL queries per round ⇒ ~2N points/round.
+20 workspaces saturates the hourly budget.
+
+**After:** N workspaces ⇒ 1 GraphQL query per round (paginated only beyond 100
+open PRs) ⇒ ~3 points/round for 20 PRs (shipped `threads:10`; ~7 at the
+`threads:30` upper bound). The same token comfortably supports 50–100
+workspaces, and degrades gracefully (auto-lengthening interval) rather than
+hitting a wall.
+
+---
+
+## Problem Statement
+
+### Current behavior
+
+- **Service:** `sculptor/web/pr_polling_service.py` — an app-level
+  `PrPollingService` with a fixed pool of 4 worker threads pulling per-workspace
+  `_PollJob`s off a priority queue.
+- **Query:** `sculptor/web/pr_status.py::_GRAPHQL_PR_QUERY` — one
+  `repository(...).pullRequests(headRefName, first: 5)` query per workspace,
+  pulling check rollup, reviews, and unresolved review threads.
+- **Cadence:** `UserConfig.pr_poll_interval_seconds` (default **30s**) for open
+  workspaces; `× pr_poll_closed_multiplier` (default 6) for closed workspaces;
+  `× _TERMINAL_STATE_MULTIPLIER` (10) for merged/closed PRs; floor
+  `_MIN_POLL_INTERVAL_SECONDS` (10s).
+- **Existing rate defenses:** global 1.5s spacing between poll starts
+  (`_GLOBAL_MIN_POLL_SPACING_SECONDS`), and a reactive 60s cooldown on rate-limit
+  errors (`_RATE_LIMIT_COOLDOWN_SECONDS`) over one global budget. These shape
+  *bursts* but do **not** lower steady-state hourly spend.
+- **Auth:** the user's own `gh` credentials (per-user token, no shared app
+  token). The rate limit is therefore **per user**, shared across all of that
+  user's workspaces.
+- **Fan-out to UI:** an observer pattern (`add_observer`) pushes
+  `PrStatusInfo` (`sculptor/web/data_types.py`) updates into the per-connection
+  `stream_everything` generator (`sculptor/web/streams.py`) and into the CI
+  babysitter (`services/ci_babysitter_service/coordinator.py`).
+
+### Why it fails
+
+GitHub GraphQL **primary** limit = 5,000 points/hour/user. Cost is
+`O(workspaces / interval)`:
+
+| Workspaces | Queries/hr (30s) | Cost/query | Points/hr | % of 5,000 |
+|-----------:|-----------------:|-----------:|----------:|-----------:|
+| 10 | 1,200 | 2 | 2,400 | 48% |
+| **20** | **2,400** | **2** | **4,800** | **96%** ← saturates |
+| 50 | 6,000 | 2 | 12,000 | 240% (broken) |
+
+The reactive cooldown then kicks in repeatedly, so updates arrive late or not at
+all. The user observes "PR status stops updating once I have ~20+ workspaces."
+
+---
+
+## The Cost Model (measured)
+
+GitHub computes a query's cost as: *number of connection-fetches, assuming every
+`first`/`last` reaches its limit, summed, ÷ 100, rounded, **minimum 1 point**.*
+Nested connections multiply by parent cardinality.
+
+All numbers below were measured live against `imbue-ai/sculptor` by adding
+`rateLimit { cost }` to each query shape (see Appendix A for the raw runs).
+
+### Where the current 2 points/query goes
+
+For the current query (`pullRequests first:5`, `reviewThreads first:30`,
+`comments first:1`):
+
+| connection | fetched | count |
+|---|---|---:|
+| `pullRequests(first:5)` | once | 1 |
+| `commits(last:1)` | per PR | 5 |
+| `latestReviews(first:20)` | per PR | 5 |
+| `reviewThreads(first:30)` | per PR | 5 |
+| `comments(first:1)` under each thread | per PR × per thread | **150** |
+| **total** | | **166 → ÷100 → cost 2** |
+
+> **How to read this table.** GitHub charges "requests needed to fulfill each
+> connection" = the connection's *parent cardinality*; a connection's own `first`
+> only multiplies cost for connections nested *beneath* it. So `comments` (nested
+> under `reviewThreads`, under the PRs) costs 5×30=150, whereas `latestReviews` —
+> which has nothing nested under it — costs just 5 (one per PR), and its own
+> `first:20` is **cost-free**. Every row here matches the live `rateLimit.cost`
+> measurements in Appendix A (e.g. varying `latestReviews` from `first:1` to
+> `first:100` leaves the round at `cost 2`, confirming it is not a multiplier).
+> The measured `cost` remains the final authority — re-measure the exact
+> production query (Risk #4) before the governor relies on any projection.
+
+**~90% of the cost is the `comments`-under-`reviewThreads` fan-out.** The
+`pullRequests(first: 5)` multiplies that dominant term by 5, and the
+`reviewThreads(first: 30)` is the other multiplier. Both are larger than needed:
+
+- `pullRequests first:N` — `1→3` cost **1**, `5` cost **2**, `10` cost **3**.
+- `reviewThreads first:M` (at PRs=5) — `1→10` cost **1**, `30` cost **2**,
+  `50` cost **3**.
+
+So today every poll pays **2** where **1** would do — a flat ~2× overpay, in
+every workspace, every round.
+
+### Why batching by `search` wins (and aliasing does not)
+
+Measured, identical field selection, 4 PRs:
+
+| Approach | cost |
+|---|---:|
+| 4 separate per-workspace queries | 2+2+2+2 = **8** |
+| 1 query, 4 PRs via `repository` **aliases** | **7** (near-wash) |
+| 1 **`search`** query, 4 PRs | **1** |
+
+Naive aliasing is a near-wash — it just sums the same per-branch connection
+costs — which is the intuitively-correct "points are conserved" result.
+`search` wins because it changes the *shape*: it fetches **exactly the PRs
+needed** through a single top-level connection (no 5×-per-branch over-fetch),
+so the per-PR cost amortizes to ~0.33 instead of 2.
+
+Collapsing N requests/round into one also relieves GitHub's **secondary** rate
+limits (per-minute points and concurrent-request caps), which the primary-budget
+math above doesn't capture and which `_GLOBAL_MIN_POLL_SPACING_SECONDS` exists
+today to dodge — a bonus the REST-with-ETag alternative (below) does *not* get,
+since 304s aren't documented to exempt the secondary limits.
+
+### Search scaling (measured)
+
+| Open PRs | 1 `search` query | N separate queries (~2 ea) | ratio |
+|---------:|-----------------:|---------------------------:|------:|
+| 1 | 1 | 2 | 2× |
+| 4 | 1 | 8 | 8× |
+| 10 | 3 | 20 | 6.7× |
+| **20** | **7** | **40** | **5.7×** |
+| 50 | 17 | 100 | 5.9× |
+| 100 | 33 | 200 | 6× |
+
+Steady state ≈ **0.33 points/PR** vs **2 points/query** today — a durable ~6×.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+1. PR status stays timely for users with 50+ workspaces on a single token.
+2. Cost model becomes `O(distinct open PRs ÷ page size)`, not `O(workspaces)`.
+3. Degrade **gracefully** (auto-lengthen interval) instead of hitting a wall.
+4. No regression in surfaced data: state, check rollup, reviews/approvals,
+   unresolved threads, base-branch mismatch detection, merged/closed transitions.
+5. No new hosted infrastructure; keep using the user's own `gh` token.
+
+### Non-Goals
+1. Webhooks / push-based delivery (requires hosted ingress — see Rejected).
+2. Sub-second freshness. Status remains poll-based; the target is "timely,"
+   not "instant."
+3. Changing the UI contract (`PrStatusInfo`) or the observer/stream fan-out.
+4. Surfacing PRs **not authored by the token owner.** Every PR a Sculptor
+   workspace opens is created by the agent running `gh` with the user's own
+   credentials (the "Create PR" prompt — `user_config.py:208` — instructs the
+   agent to "create a pull request using the GitHub CLI"), so it is authored by
+   `@me`. Sculptor is a **single-user desktop app**, so the PR-creating agent and
+   the polling host share that one user's `gh` identity — the search's
+   `author:@me`, evaluated with the same identity, always matches the workspace's
+   own PRs. The current query surfaces a *teammate's* PR on a tracked branch only
+   incidentally (it doesn't filter by author); that was never a designed
+   feature, and `author:@me` intentionally drops it. This keeps the cost model
+   from being shaped by an out-of-scope case (see Change 2).
+
+---
+
+## Chosen Design
+
+Three changes, in priority order. **Change 1 is the core fix**; 2–3 harden it.
+
+### Change 1 — One `search` query per token per round (core)
+
+Replace per-workspace `_GRAPHQL_PR_QUERY` with a single per-token query:
+
+```graphql
+query($q: String!, $prCount: Int!, $after: String) {
+  search(query: $q, type: ISSUE, first: $prCount, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        number title url state baseRefName
+        repository { nameWithOwner }
+        headRefName
+        mergeable                       # REQUIRED — drives has_conflicts → MERGE_CONFLICT (see note)
+        commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
+        latestReviews(first: 20) { nodes { state author { login } } }  # left at 20: cost-free (no nested connection)
+        reviewThreads(first: 10) {      # trimmed 30 → 10 (see Change 1b)
+          totalCount                    # ALL threads (resolved+unresolved); not an unresolved count — see Change 1b caveat
+          nodes { isResolved comments(first: 1) { nodes { author { login } path line body } } }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining limit resetAt }
+}
+```
+
+with `$q = "is:pr state:open author:@me archived:false sort:updated"`.
+
+> **`sort:updated` is required, not cosmetic.** `_first_matching_target`
+> (`pr_status.py:112`) returns the *first* PR matching a base branch and relies
+> on the query ordering PRs most-recently-updated first (today's per-branch
+> query sets `orderBy: {field: UPDATED_AT, direction: DESC}` —
+> `pr_status.py:166`). `search` defaults to *best-match* relevance order, so
+> without `sort:updated` the "most recently touched PR wins" tie-break breaks
+> when one branch carries two open PRs against the same base. Adding it to `$q`
+> preserves today's semantics.
+
+> **`mergeable` is not optional.** The current per-workspace query fetches it
+> (`pr_status.py::_GRAPHQL_PR_QUERY`) and `_parse_conflict_status` maps it to the
+> tri-state `has_conflicts`, which `classify_transitions`
+> (`ci_babysitter_service/transitions.py`) reads *directly* to fire
+> `Transition.MERGE_CONFLICT`. It is a scalar (no connection), so it adds ~zero
+> point cost. Omitting it would make `has_conflicts` permanently `None` and
+> silently kill the babysitter's merge-conflict prompt for open PRs — a Goal-#4
+> regression. It must ride on every open-PR node in the hot search query: a PR
+> that the search *matches* never triggers Change 2's unmatched-branch fetch, so
+> its conflict signal has nowhere else to come from.
+
+> **`latestReviews(first: 20)` is left at 20 — do *not* trim it.** It looks like
+> a fan-out term but is not: it has no nested connection, so (measured) its
+> `first` value has **zero** effect on cost — `first:1` and `first:100` both leave
+> the round at the same `cost`. Only `reviewThreads` (which nests `comments`) is
+> worth trimming. Keeping 20 preserves every reviewer's latest state at no cost.
+
+> **`rateLimit { ... limit ... }`** is selected so Change 3's governor can target
+> a fraction of the *actual* limit rather than hardcoding 5,000 (GitHub App
+> tokens, were Sculptor ever to use one, get a higher limit).
+
+**Key properties:**
+- **One query spans all repos.** `author:@me` is not repo-scoped, so a single
+  request covers every workspace's PR across every repo the token can see — no
+  repo enumeration needed. (See the `author:@me` trade-off below, and Risk #1.)
+  Note this drops the `{owner}/{repo}` cwd-expansion the current query relies on
+  (`gh` fills those from the working dir's `origin` — `pr_status.py:207`): the
+  token-global search runs from no specific repo, so the fan-out must derive each
+  workspace's `nameWithOwner` by **parsing its `origin` URL** (today the poller
+  only calls `_is_github_url(origin_url)` and never parses owner/repo — this is
+  new, small, work).
+- **Mapping — index for fan-out, but cache per workspace.** Build a transient
+  index `(repository.nameWithOwner, headRefName) -> list[PrNode]` from the round
+  (a *list*, because one source branch can carry several PRs targeting different
+  bases). The **persisted cache stays keyed by `WorkspaceID`**
+  (`_cache: dict[WorkspaceID, PrStatusInfo]`, unchanged from today) — *not* by
+  `(repo, branch)`. This matters because `PrStatusInfo` is **workspace-relative**:
+  it carries `workspace_id` and the `mismatched_pr_*` fields, which are computed
+  by comparing each PR's `baseRefName` to *that workspace's* `target_branch`. Two
+  workspaces can share the same `(repo, headRefName)` but have different targets,
+  so the *same* PR node yields a "match" `PrStatusInfo` for one and a "mismatch"
+  one for the other. For each tracked workspace, look up its `(repo, branch)` in
+  the index, pick the open PR whose `baseRefName` matches its target (the
+  existing `_first_matching_target` logic), derive a per-workspace `PrStatusInfo`,
+  diff it against the cached one for that `WorkspaceID`, and emit only changes
+  through the existing observer pattern.
+- **`author:@me` is correct for the goal, with one intentional behavior change.**
+  The current query does *not* filter by author
+  (`pullRequests(headRefName: $branch)` returns PRs on the branch regardless of
+  who opened them). Because every PR a workspace opens is authored by the token
+  owner (Non-Goal #4), `author:@me` matches all of them — it is the right filter.
+  The only thing it drops is the *incidental* surfacing of a **teammate's** PR on
+  a tracked branch, which is an explicit non-goal; it is not preserved and does
+  not drive any fallback. The unmatched-branch fetch in Change 2 exists for a
+  different reason: the user's *own* PR can leave `state:open` (merged/closed),
+  be absent at cold-start, or transiently drop out of the search index. See
+  Change 2 and Risk #1.
+- **Pagination.** `first: 100`; follow `pageInfo` only when a user genuinely has
+  >100 open PRs (rare). `log()` if pagination ever triggers so silent truncation
+  can't masquerade as "all covered." Note the cost is `O(all the user's open
+  PRs)`, *including PRs in repos with no Sculptor workspace* — see the cost
+  caveat below.
+- **Self-throttling input.** `rateLimit { cost remaining limit resetAt }` rides
+  in the same response, feeding Change 3 with zero extra calls.
+
+> **Cost scope caveat.** Because `author:@me` is token-global, the search pays for
+> *every* open PR the user has across *every* repo — not just the ones backing a
+> Sculptor workspace. A user with 150 unrelated open PRs pays the paginated cost
+> (~33 pts/round at 100, more beyond) even with two workspaces open. Scoping the
+> query with explicit `repo:` qualifiers would bound this to workspace repos, but
+> reintroduces the repo enumeration this design deliberately avoids and risks
+> overrunning the search query-length limit; left out by choice. Revisit if a
+> user's unrelated-PR volume proves to dominate the budget in practice.
+
+**Change 1b — trim the `reviewThreads` page size.** Independently of search,
+`reviewThreads(first: 30 → 10)` halves the dominant cost term (measured: at
+PRs=5 it takes cost 2→1; in the search shape, at 20 PRs, it takes the round from
+cost 7 → ~3). `reviewThreads` is the *only* page size worth trimming — it nests
+`comments`, so its `first` multiplies the cost; `latestReviews` nests nothing and
+its `first` is cost-free, so leave it at 20 (see the note in Change 1). Ten
+threads is ample for the UI in practice.
+
+> **Caveat on the "+N more" affordance.** `reviewThreads.totalCount` counts
+> **all** review threads (resolved *and* unresolved), but the UI surfaces only
+> *unresolved* ones (`_parse_review_comments` filters on `isResolved` —
+> `pr_status.py:294`), and the `reviewThreads` connection has **no server-side
+> `isResolved` filter**, so there is no cheap way to get an exact unresolved
+> count beyond the page we fetch. So `totalCount` is *not* an unresolved count
+> and "+N more unresolved" computed from it would over-count. Options: (a) label
+> the affordance as total review threads, not unresolved; (b) only show "+N
+> more" when the fetched page is full (`len(unresolved) == first` after
+> filtering), accepting that we can't give an exact remainder; or (c) drop the
+> count and show a generic "more threads on GitHub →" link. Pick one in
+> implementation; do not present `totalCount` as the unresolved remainder.
+
+This is a one-line query change and should land first as an interim mitigation
+even before the search refactor (see Rollout Phase 0).
+
+### Change 2 — Per-workspace fallback for any branch the search doesn't match
+
+`state:open author:@me` returns only the user's currently-open PRs. It can never
+*affirmatively* report "this branch has no PR" — a branch with no open authored
+PR is simply absent from the results, indistinguishable from one that didn't
+match. So a workspace is **"unmatched"** whenever no node in the round's
+`(repo, branch) -> list[PrNode]` index satisfies its target, and that spans two
+very different populations:
+
+- **Transient / terminal** (the cases the search *should* have covered): the
+  user's own PR merged/closed (left `state:open`), was already terminal at cold
+  start, or transiently dropped out of the search index for one round.
+- **Steady-state no-open-PR** (common, and *not* a transition): a feature branch
+  with no PR opened yet, or a workspace sitting on its target/base branch (no PR
+  is possible). A teammate-only PR also lands here — it is a non-goal (Non-Goal
+  #4), so it just resolves to `none`; we do not chase it.
+
+**First, skip what cannot have a PR** — preserve today's short-circuits *before* a
+branch enters the unmatched set. A workspace with no branch info / not yet ready,
+or whose `current_branch == strip_remote_prefix(target_branch)`
+(`pr_polling_service.py:699`), resolves to `none` with **no fetch at all**.
+
+**For the rest, fall back to per-workspace polling — at the workspace's own
+cadence, *not* once per search round.** Each unmatched workspace issues one
+targeted, author-agnostic, all-states fetch via the existing
+`_fetch_prs_with_details` query (`repository(owner,name){ pullRequests(headRefName,
+first:5, ...) }`, all states, includes `mergeable`) — *exactly today's
+per-workspace poll*. Its next fetch is scheduled by `_compute_poll_delay` (base
+interval, with the closed/terminal multipliers), **independent of the
+search-round interval**. This decoupling is load-bearing: the search round may be
+shortened (the batch is cheap), but the fallback fetches must keep their own
+cadence — otherwise shortening the round would multiply per-workspace cost for
+every no-open-PR branch. Outcomes:
+
+- **Terminal PR** (`MERGED`/`CLOSED`) → emit terminal `PrStatusInfo`; the
+  `_TERMINAL_STATE_MULTIPLIER` backoff puts it on the slow terminal cadence.
+- **Open PR** (a search-index drop-out that is actually still open) → full open
+  `PrStatusInfo`, as today.
+- **No PR** (no-PR-yet, base-branch already filtered above, or teammate-only) →
+  `pr_state="none"`, re-checked at the base cadence. If a prior round showed it
+  open and this is a one-round index blip, the empty result is a **no-op** —
+  never emit a spurious terminal transition; the next round resolves it.
+
+Route these fallback fetches through the **same `_HostThrottle`** as the search
+(global spacing + rate-limit cooldown) and reuse the per-workspace
+`first_failure` / cooldown handling that already wraps `fetch_pr_status`.
+
+**Cost, stated honestly.** The redesign is *cheap for workspaces with a
+currently-open authored PR* — they ride the one batched search for free.
+Workspaces *without* one (no-PR-yet, terminal, base-branch) still cost one
+per-workspace `gh` call at their normal cadence — **the same as today**. So the
+saving scales with the fraction of tracked workspaces that have an open PR; in
+the 20+-active-workspace scenario that motivated this, that fraction is high, so
+the batch absorbs most of the spend. What the design removes is the
+*per-open-PR-per-round* blow-up that saturates the budget; what it does **not**
+remove is baseline per-workspace polling for branches with no open PR. The
+governor (Change 3) sees the combined spend via `remaining` regardless. One
+transient remains: a **cold-start burst** — on the first round every
+already-terminal / no-PR workspace is unmatched and fetched once before settling
+onto its (slow or base) cadence; bounded, one-time, `log()` the count.
+
+This preserves the merged-conflict / merged-success transitions and the open-PR
+`mergeable`/`has_conflicts` signal the CI babysitter
+(`ci_babysitter_service/coordinator.py`, `transitions.py`) depends on.
+
+### Change 3 — Proactive rate-budget governor
+
+Today the only defense is a *reactive* 60s cooldown after a 403. Add a
+**proactive** governor driven by the `rateLimit` block returned in every search
+response:
+
+- Maintain a target ceiling at `pr_poll_budget_fraction` of the `limit` reported
+  in the response (default **80%** → ~4,000 points/hr on a 5,000 token). Reading
+  `limit` from the response rather than hardcoding 5,000 keeps this correct if
+  the token's budget ever differs (e.g. a GitHub App token).
+- After each round, compute the projected hourly spend and, if it would exceed
+  the ceiling, **lengthen the interval** (multiplicative back-off) until
+  projected spend fits, recovering toward the configured interval when headroom
+  returns.
+- **Drive the projection off `remaining`, not just the search query's `cost`.**
+  The search response's `cost` covers only the one batched query; the Change 2
+  unmatched-branch fetches each spend separately (their own `gh` calls, with
+  their own `rateLimit` blocks) and are *not* in the search response's `cost`.
+  `remaining` (and `resetAt`), by contrast, reflect the token's **global**
+  GraphQL budget across every query that hour, so basing back-off on the
+  observed *rate of decline of `remaining`* — or on `(limit - remaining)`
+  extrapolated to the hour — captures search **and** unmatched-fetch spend
+  together. Use the per-round `cost` only as a lower-bound sanity check.
+- If `remaining` is already low, defer the next round until `resetAt`.
+
+Result: the system *never* hits the wall; it trades freshness for budget
+smoothly and visibly (surface "PR updates throttled to respect GitHub rate
+limits" in the UI rather than failing silently).
+
+### Freshness — the interval is the only reliable knob
+
+We deliberately do **not** try to trigger polls on a local push (to justify a
+longer interval by catching the user's own changes via an event), for two
+reasons:
+
+- **A local push is not reliably observable.** There is no push event and no
+  HEAD-sha in the stream — `WorkspaceBranchInfo` carries only `current_branch`
+  (`data_types.py:51`), and `on_branch_changed` fires on a branch *switch*
+  (`streams.py:749`: `prev != current_branch`), not on new commits to the same
+  branch. And a user can push from anywhere — another machine, the GitHub web
+  UI, a rebase in a different checkout — none of which Sculptor's single managed
+  working dir can see.
+- **A local push is the wrong signal anyway.** It is a *minority* of what
+  changes PR status: reviews, approvals, comments, someone else merging, the
+  base branch moving, and **CI completing** are all *remote* events with no
+  local correlate. CI is also *asynchronous* — checks go pending on push and
+  resolve minutes later — so even a perfectly-detected push fires too early to
+  observe the outcome you care about; interval polling has to catch it regardless.
+
+For a local-first app with no webhook ingress, **PR-status freshness is
+fundamentally bounded by the polling interval** — the authoritative state lives
+on GitHub and changes for reasons we cannot observe locally. The redesign does
+not fight this; it makes the *batched* round *cheap*. Because a batched round is
+~3–7 points (20 open PRs, `threads:10`–`30`) vs ~4,800 points/hr today, there is
+no need to lengthen the interval — the default 30s sits at ~7–17% of budget, and
+the governor (Change 3) only stretches it under genuine pressure. One caveat if
+you *shorten* it below 30s: the batch stays cheap, but Change 2's per-workspace
+fallback fetches (for no-open-PR branches) are **not** batched, so they must keep
+their own per-workspace cadence rather than firing once per (shortened) round —
+see Change 2. Shortening the search round speeds up open-PR freshness without
+multiplying fallback cost only if that decoupling holds.
+
+The existing immediate re-poll on `on_branch_changed` / `on_workspace_ready`
+(`streams.py:748–750`) is **retained** — it gives instant feedback on a
+branch-switch or freshly-created PR, which is reliable and reuses code that
+already exists. It is existing behavior, *not* a push trigger, and is not
+relied on to relax the interval.
+
+*Optional / future:* if sub-interval freshness on specific PRs is ever wanted,
+the *reliable* lever is **foreground/visibility** — poll the workspace the user
+is actively viewing more often — because focus is a local, observable signal,
+unlike a push. That needs a focus signal from the frontend and is out of scope
+here.
+
+### Resulting cost (20 workspaces *that each have an open PR*, 30s interval)
+
+| | Queries/hr | Points/hr | % of 5,000 |
+|---|---:|---:|---:|
+| Current (per-workspace) | 2,400 | ~4,800 | 96% |
+| Change 1 alone (search, threads:10) | 120 | ~360 | 7% |
+| Change 1, threads:30 | 120 | ~840 | 17% |
+| + interim Phase 0 trim only (no search) | 2,400 | ~2,400 | 48% |
+
+At 50 workspaces the search design is ~2,040 pts/hr (41%); at 100, ~3,960 (79%,
+where Change 3 begins stretching the interval). The wall is gone.
+
+> **These figures are the search-query cost for the open-PR population only.**
+> Three things to keep in mind:
+> (1) **They assume every counted workspace has an open authored PR**, so it
+> rides the batch. Workspaces *without* one (no-PR-yet, terminal, base-branch)
+> are **not** in these numbers — they still cost one per-workspace `gh` call at
+> their own cadence (Change 2), i.e. ~today's cost for that subpopulation. Total
+> spend ≈ (one batched search per round) + (per-workspace polling of the
+> no-open-PR workspaces). The saving scales with the open-PR fraction.
+> (2) The 50/100-workspace projections use the **`threads:30`** cost (17/33
+> pts/round); the **shipped** query uses `threads:10` (Change 1b), ~2.3× cheaper,
+> so the open-PR cost is well under these (100 open-PR workspaces ≈ ~1,560 pts/hr,
+> ~31%). The table keeps `threads:30` as the pessimistic bound.
+> (3) The governor (Change 3) sees the *combined* spend — batch + per-workspace
+> fallbacks + cold-start burst — via `remaining`, not by summing these per-query
+> costs, so it backs off correctly regardless of the open-PR fraction.
+
+---
+
+## Component-Level Changes
+
+> Paths below are abbreviated `sculptor/web/...`; the real tree is nested
+> `sculptor/sculptor/web/...` (and `PrStatusInfo` is defined in
+> `sculptor/sculptor/web/data_types.py`, re-exported via `web/derived.py`).
+
+- **`sculptor/web/pr_status.py`**
+  - Add `fetch_open_prs_for_token(working_dir) -> list[PrNode]` issuing the
+    search query (Change 1) and parsing nodes into the existing intermediate
+    shape used by `_parse_reviews` / `_parse_review_comments`.
+  - **Reuse `fetch_pr_status` / `_fetch_prs_with_details` verbatim for Change
+    2's unmatched-branch fetch** — that existing path is already an
+    author-agnostic, all-states, single-branch query that includes `mergeable`
+    and builds the full open *or* terminal `PrStatusInfo`. No new
+    `fetch_terminal_pr` is needed; the only addition is the new search-based
+    `fetch_open_prs_for_token`.
+  - Trim `reviewThreads` to `first: 10` (Change 1b); leave `latestReviews` at
+    `first: 20` (cost-free, no nested connection). Keep `_PR_QUERY_LIMIT` for the
+    unmatched-branch fetch path.
+  - **Keep `mergeable` in the search query** (Change 1 note) so open-PR
+    `has_conflicts` survives.
+- **`sculptor/web/pr_polling_service.py`**
+  - Re-architect the worker model from **per-workspace jobs** to **one
+    per-token poll round** that builds a transient
+    `(repo, branch) -> list[PrNode]` index and derives a **per-`WorkspaceID`**
+    `PrStatusInfo` from it (see Change 1 "Mapping"), plus a small queue of
+    unmatched-branch fetches (Change 2). The 4-thread pool collapses to a single
+    periodic poller per distinct token (typically one), with a side-worker for
+    the unmatched-branch fetches.
+  - Keep the observer registry and the cache **keyed by `WorkspaceID`**
+    (`_cache: dict[WorkspaceID, PrStatusInfo]`, unchanged) — the `(repo, branch)`
+    index is transient and for fan-out only, *not* the cache key.
+  - Implement Change 3 (governor) here, reading the `rateLimit` block.
+  - Retain the immediate re-poll on `on_branch_changed` / `on_workspace_ready`
+    (routed through the token-level poller); do **not** add a push trigger (see
+    "Freshness").
+  - Constants: `_GLOBAL_MIN_POLL_SPACING_SECONDS` is near-moot with one batched
+    query per round (it still spaces Change 2's fallback fetches);
+    `pr_poll_interval_seconds` can stay at its 30s default (batching removes the
+    budget pressure to raise it). The `_HostThrottle` is a single global budget,
+    so the governor slots in directly.
+  - **Cadence knobs govern the per-workspace *fallback*, not the batch.**
+    `pr_poll_closed_multiplier` and `_TERMINAL_STATE_MULTIPLIER` do not affect a
+    workspace *with* an open PR — those ride the batch for free, open or closed.
+    They are **load-bearing for Change 2's fallback fetches**: a closed or
+    terminal workspace with no open authored PR still polls per-workspace, and
+    these multipliers are what keep that fallback cheap (poll a closed/terminal
+    no-PR workspace rarely). Keep and apply both in `_compute_poll_delay` for the
+    fallback path.
+- **`sculptor/web/streams.py`**
+  - `_notify_pr_polling_service`: route branch/workspace events to the new
+    token-level poller (the existing `on_workspace_created` / `on_workspace_ready`
+    / `on_branch_changed` / `on_workspace_deleted` calls and the
+    `PrStatusInfoCleared` injection are unchanged). No push trigger.
+- **`sculptor/web/data_types.py`**
+  - Optional cleanup: `error_provider: Literal["github"] | None` is single-valued
+    (GitHub is the only provider) — drop it, or leave as a documented no-op. Not
+    required by this change, but a natural tidy while here.
+- **`sculptor/sculptor/config/user_config.py`**
+  - Keep `pr_polling_enabled`, `pr_poll_interval_seconds`, and
+    `pr_poll_closed_multiplier` (it sets the cadence of Change 2's per-workspace
+    fallback for closed/no-PR workspaces; see the poller bullet above). Add
+    `pr_poll_budget_fraction` (default 0.8) for Change 3. The default interval
+    stays at 30s — batching removes any budget pressure to raise it.
+- **Tests** — `pr_polling_service_test.py`, `pr_status_test.py`,
+  `test_backend_pr_polling.py`: update for the search shape, add unmatched-branch
+  fetch coverage (terminal / cold-start / index-blip no-op + terminal-cadence
+  exclusion), `mergeable`→`has_conflicts`, governor back-off math, and the
+  shared-branch / different-target fan-out. See **Testing Strategy** for the full
+  list.
+
+---
+
+## Rejected / Deferred Alternatives
+
+### Webhooks + hosted relay (deferred — the "real" long-term fix)
+A GitHub App delivering `pull_request` / `pull_request_review` /
+`check_suite` / `issue_comment` events to a **hosted Sculptor relay** that
+pushes to the local client over the existing WebSocket would make cost `O(1)` in
+workspace count and updates instant. **Deferred** because Sculptor is local-first
+with **no public ingress**: this requires hosting infra, a GitHub App, user
+installation, and org-policy handling — a model change well beyond this issue.
+Revisit if/when Sculptor grows a hosted component.
+
+### REST conditional requests (ETag / 304) (deferred — not the cheapest here)
+`304 Not Modified` responses don't count against the **primary** limit, so
+"most PRs don't change" sounds like a free win. Rejected as the primary lever
+because: (a) the four signals we show live on **separate REST resources with
+separate ETags**, turning one GraphQL call into ~4 REST calls per PR; (b) the
+**secondary** per-minute/concurrency limits are **not** documented to exempt
+304s, so request *volume* still bites at scale; (c) it does nothing about the
+per-workspace structure and adds multi-resource ETag bookkeeping plus a drop
+from `gh api graphql` to raw REST. `search` solves the same quota problem more
+cheaply and with less code. Keep on the shelf if foreground-freshness ever needs
+shaving.
+
+### Naive GraphQL aliasing (rejected — near-wash)
+Combining per-workspace queries via `repository` aliases measured **7 vs 8**
+points for 4 PRs — essentially no benefit, because cost sums the same per-branch
+connection-fetches. Only the `search` *shape* (exact `first:N`, single top
+connection) delivers the reduction.
+
+---
+
+## Rollout Plan
+
+- **Phase 0 (hours, interim):** ship Change 1b alone — `reviewThreads 30 → 10`.
+  One line, halves current cost (96% → ~48% at 20 workspaces), buys headroom
+  while the refactor lands. Caveat: this lowers the unresolved-comment cap from
+  30 to 10 threads per PR, so a PR with >10 unresolved threads would surface
+  fewer comments — ship the "+N more" affordance alongside it (see the
+  `totalCount` caveat in Change 1b — it counts all threads, not unresolved
+  ones), or accept the lower cap.
+- **Phase 1 (core):** implement Change 1 (search poller + per-workspace fan-out
+  mapping, **including `mergeable`**) and Change 2 (unmatched-branch fetch),
+  **replacing** the per-workspace poll path outright — no feature flag. Before
+  merging, validate the production query's real `cost` with `rateLimit { cost }`
+  and confirm `has_conflicts` / MERGE_CONFLICT still fire (the existing
+  integration suite, extended per Testing Strategy, is the gate).
+- **Phase 2 (harden):** Change 3 (governor). Keep the interval short — batching
+  removes any need to lengthen it (see "Freshness").
+
+No feature flags: the search path replaces the per-workspace path directly, and
+each phase stands alone (Phase 0 is a one-line query edit; Phase 2 only adds the
+governor on top of Phase 1). The existing `pr_polling_enabled` kill switch is
+retained — it is the user-facing on/off for polling, not a rollout flag. The
+safety net is the test suite and a clean revert, not a runtime toggle.
+
+---
+
+## Risks & Open Questions
+
+1. **`author:@me` scoping (resolved by design, not left open).** `author:@me
+   state:open` is the *correct* filter, not a compromise: every PR a workspace
+   opens is authored by the token owner (Non-Goal #4), so it matches all of
+   them. The cases where a tracked branch's own PR is absent from the round — it
+   merged/closed (including at cold start), or got dropped by a search-index
+   blip — are **handled by default** via Change 2's targeted all-states fetch
+   for unmatched branches. (A teammate-authored PR is intentionally *not*
+   chased — see Non-Goal #4.) The residual question is *cost*, and it is **not**
+   just the transition rate: the unmatched set also includes the steady-state
+   **no-open-PR** population (feature branches with no PR yet — base-branch
+   workspaces are short-circuited before fetching), which keeps polling
+   per-workspace at the base cadence (≈ today's cost). Measure the open-PR
+   fraction across real fleets: that fraction is what the batch saves, and the
+   remainder sets the per-workspace residual the governor must absorb. The win is
+   largest when most active workspaces have an open PR (the motivating scenario).
+2. **Search-index lag.** GitHub's search index can trail live state by
+   seconds–minutes, so the `search` round can briefly miss a just-changed PR.
+   Two backstops already in the design: a still-open PR that transiently drops
+   out is re-resolved by Change 2's unmatched-branch fetch (and an empty result
+   is treated as a no-op, never a spurious terminal transition); and the next
+   round catches anything the index was lagging on. If foreground freshness ever
+   feels laggy, the targeted single-branch fetch (Change 2's query, author-
+   agnostic and index-free) can be run directly for the viewed PR.
+3. **`mergeable` UNKNOWN.** Computed async; may need a re-poll. Pre-existing
+   behavior, not a regression, but the governor must not thrash on it.
+4. **Measured `cost` is selection-dependent.** At 20 PRs the round costs ~7 with
+   `reviewThreads first:30` and ~3 with `first:10`; **re-measure the exact
+   production query** with `rateLimit { cost }` before committing the governor's
+   projections.
+5. **Multiple tokens *and* multiple hosts.** The single token-global search runs
+   against one GitHub host with one identity. If a Sculptor instance ever spans
+   multiple GitHub identities, run one poll round per distinct token (the
+   per-token budget is independent). Note also that `_is_github_url`
+   (`pr_polling_service.py:213`) matches *any* hostname containing "github",
+   which includes **GitHub Enterprise** hosts — workspaces could point at
+   `github.com` and a GHE instance simultaneously. A single search round can't
+   cover both, so the poller must key its round (and its `gh` invocation's host
+   resolution) by **(host, token)**, not assume one global GitHub. Common case
+   today is a single (host, token); this is the generalization point.
+
+---
+
+## Testing Strategy
+
+- **Unit (`pr_status_test.py`):** search-response parsing → `PrStatusInfo`,
+  including check rollup, approvals, unresolved threads, base mismatch, **and
+  `mergeable` → `has_conflicts`** (CONFLICTING/MERGEABLE/UNKNOWN/missing →
+  True/False/None/None); unmatched-branch all-states fetch parsing (open,
+  merged, closed).
+- **Unit (`pr_polling_service_test.py`):**
+  - (repo,branch)→workspace fan-out, **including two workspaces sharing one
+    `(repo, headRefName)` with different `target_branch`** → one gets a match,
+    the other a `mismatched_pr_*` `PrStatusInfo` (proves the cache is keyed by
+    `WorkspaceID`, not `(repo, branch)`).
+  - unmatched-branch fetch for each cause: merged/closed → terminal; cold start
+    (no prior round) → resolved; and a one-round search-index drop-out → **no
+    spurious terminal transition** (empty terminal result is a no-op).
+  - **short-circuit before fetching**: a workspace whose `current_branch ==
+    target` (or with no branch info / not ready) resolves to `none` with **zero
+    `gh` calls** — assert no fallback fetch is issued.
+  - **fallback cadence is decoupled from the search round**: a no-PR-yet feature
+    branch is re-checked at the **base interval** (`_compute_poll_delay`), *not*
+    once per search round — assert that halving the search-round interval does
+    **not** change its fallback fetch frequency; and a closed/no-PR workspace
+    polls at the `pr_poll_closed_multiplier` cadence.
+  - **terminal-cadence exclusion**: a workspace resolved to merged/closed is
+    *not* re-fetched on every subsequent search round (it moves to the terminal
+    cadence) — assert the unmatched-fetch count tracks the transition rate +
+    no-open-PR population at their cadences, not O(workspaces) per round.
+  - governor back-off/recover math against the response's `limit`/`remaining`
+    (including spend from Change 2 fetches, via `remaining` decline);
+  - pagination trigger + `log` on >100 PRs; cold-start burst `log`.
+- **Integration (`test_backend_pr_polling.py`):** end-to-end WebSocket — open →
+  approved → **conflict (has_conflicts True, MERGE_CONFLICT fires)** → merged
+  transition still surfaces; a branch switch (`on_branch_changed`) triggers an
+  immediate re-poll.
+- **Cost regression guard:** a test (or CI check) that asserts the production
+  query's `rateLimit.cost` stays within an expected band, so a future field
+  addition that balloons the fan-out is caught early.
+
+---
+
+## Appendix A — Raw Measurements
+
+Measured live against `imbue-ai/sculptor` with an authenticated `gh` token
+(GraphQL budget 5,000/hr), by appending `rateLimit { cost }` to each shape.
+
+```
+# Separate (current per-workspace shape), 4 real branches
+  saeed/scu-1523                          -> cost 2
+  maciek/scu-1522-disable-plugins         -> cost 2
+  saeed/scu-1504                          -> cost 2
+  bry/scu-1524-restack-stacked-branches   -> cost 2
+  SUM = 8
+
+# Combined, 4 PRs via repository aliases   -> cost 7   (near-wash)
+# Search, 4 PRs                            -> cost 1
+
+# pullRequests(first:N), single branch
+  N=1 ->1   N=2 ->1   N=3 ->1   N=5 ->2   N=10 ->3
+
+# reviewThreads(first:M) at pullRequests first:5
+  M=1 ->1   M=5 ->1   M=10 ->1   M=30 ->2   M=50 ->3
+
+# search(first:N), one query, threads first:30
+  N=1 ->1   N=4 ->1   N=10 ->3   N=20 ->7   N=50 ->17   N=100 ->33
+```
+
+## Appendix B — Key References
+
+- Poller: `sculptor/sculptor/web/pr_polling_service.py`
+- GitHub query: `sculptor/sculptor/web/pr_status.py` (`_GRAPHQL_PR_QUERY`,
+  `_PR_QUERY_LIMIT`, `_parse_conflict_status`)
+- Data type: `sculptor/sculptor/web/data_types.py` (`PrStatusInfo`)
+- Stream fan-out: `sculptor/sculptor/web/streams.py` (`stream_everything`,
+  `_notify_pr_polling_service`)
+- CI babysitter consumer:
+  `sculptor/sculptor/services/ci_babysitter_service/coordinator.py`,
+  `transitions.py`
+- Config: `sculptor/sculptor/config/user_config.py` (`pr_polling_enabled`,
+  `pr_poll_interval_seconds`, `pr_poll_closed_multiplier`)
+- GitHub docs: [GraphQL rate & query limits](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api),
+  [REST rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)

--- a/sculptor/sculptor/config/user_config.py
+++ b/sculptor/sculptor/config/user_config.py
@@ -220,6 +220,10 @@ class UserConfig(SerializableModel):
         default=6,
         description="Closed workspaces poll every pr_poll_interval_seconds * pr_poll_closed_multiplier seconds. Crank this up to poll closed workspaces much less often.",
     )
+    pr_poll_budget_fraction: float = Field(
+        default=0.8,
+        description="Fraction of GitHub's hourly API budget PR polling may use before it automatically slows down. Lower this to leave more budget for other GitHub usage.",
+    )
     pr_default_target_branch: str = Field(
         default="origin/main",
         description="Default target branch for new workspaces",

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -101,7 +101,6 @@ class PrStatusInfo(SerializableModel):
     error_category: (
         Literal["cli_missing", "not_authenticated", "no_access", "network_error", "rate_limited", "transient"] | None
     ) = None
-    error_provider: Literal["github"] | None = None
     error_message: str | None = None
     mismatched_pr_iid: int | None = None
     mismatched_pr_target_branch: str | None = None

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -16,6 +16,7 @@ import shutil
 import threading
 import time
 import urllib.parse
+from collections.abc import Sequence
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
@@ -37,9 +38,13 @@ from sculptor.primitives.service import Service
 from sculptor.services.data_model_service.api import DataModelService
 from sculptor.services.user_config.user_config import get_user_config_instance
 from sculptor.services.workspace_service.api import WorkspaceService
+from sculptor.web.cli_status_utils import CliStatusError
 from sculptor.web.cli_status_utils import strip_remote_prefix
 from sculptor.web.data_types import StreamingUpdateSourceTypes
 from sculptor.web.derived import PrStatusInfo
+from sculptor.web.pr_status import GithubRateLimit
+from sculptor.web.pr_status import build_status_from_open_nodes
+from sculptor.web.pr_status import fetch_open_prs_for_token
 from sculptor.web.pr_status import fetch_pr_status
 
 # The terminal/non-terminal PR states. Matches ``PrStatusInfo.pr_state``.
@@ -98,6 +103,18 @@ def _compute_poll_delay(config: UserConfig, *, is_open: bool, pr_state: _PrState
     if pr_state in ("merged", "closed"):
         multiplier = max(multiplier, float(_TERMINAL_STATE_MULTIPLIER))
     return base * multiplier
+
+
+def _compute_round_interval(config: UserConfig) -> float:
+    """Interval between batched search rounds.
+
+    One batched ``search`` round is cheap regardless of workspace count, so the
+    round just runs at the configured base interval (floored at
+    ``_MIN_POLL_INTERVAL_SECONDS``). The Task 4.1 governor will stretch this
+    under budget pressure; the per-workspace fallback keeps its own
+    ``_compute_poll_delay`` cadence either way.
+    """
+    return max(float(config.pr_poll_interval_seconds), _MIN_POLL_INTERVAL_SECONDS)
 
 
 class _CooldownDeferred:
@@ -166,6 +183,45 @@ class _PollJob:
 
     def __lt__(self, other: "_PollJob") -> bool:
         return self.scheduled_time < other.scheduled_time
+
+
+@dataclass(frozen=True)
+class _RoundCandidate:
+    """A workspace eligible to be matched against a batched search round.
+
+    Carries everything the fan-out needs without re-reading git: the workspace's
+    repo identity (``name_with_owner``, ``None`` if the origin couldn't be parsed
+    into owner/repo — such a workspace is always unmatched and falls back) and
+    its ``current_branch`` (the index key), plus its ``target_branch`` for the
+    per-workspace derivation. Short-circuited workspaces (no branch / on target /
+    non-GitHub) never become candidates.
+    """
+
+    workspace_id: WorkspaceID
+    state: "_WorkspacePollState"
+    working_dir: Path
+    current_branch: str
+    target_branch: str
+    host: str
+    name_with_owner: str | None
+
+
+def _build_pr_index(nodes: Sequence[dict]) -> dict[tuple[str, str], list[dict]]:
+    """Index a round's open-PR nodes by ``(nameWithOwner, headRefName)``.
+
+    Transient and per-round — for fan-out only, never a cache key. Preserves node
+    order within each bucket (search returns most-recently-updated first, which
+    ``_first_matching_target`` relies on). One ``(repo, branch)`` can carry
+    several PRs (different bases), hence a list per key.
+    """
+    index: dict[tuple[str, str], list[dict]] = {}
+    for node in nodes:
+        repo = (node.get("repository") or {}).get("nameWithOwner")
+        head = node.get("headRefName")
+        if repo is None or head is None:
+            continue
+        index.setdefault((repo, head), []).append(node)
+    return index
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +397,20 @@ class PrPollingService(Service):
     # commands are GraphQL-backed and the rate limit is per-user, so spacing
     # and cooldown must be coordinated across the whole pool, not per workspace.
     _throttle: _HostThrottle = PrivateAttr(default_factory=lambda: _HostThrottle(_GLOBAL_MIN_POLL_SPACING_SECONDS))
+    # Workspaces matched by the most recent batched search round. A matched
+    # workspace rides the cheap batch, so its per-workspace fallback stops
+    # rescheduling (checked in _poll_and_handle_result). add/discard are atomic
+    # under the GIL; the fallback worker only does a membership test.
+    _matched_workspaces: set[WorkspaceID] = PrivateAttr(default_factory=set)
+    # Latest ``rateLimit`` snapshot from each host's search round, exposed for
+    # the Task 4.1 governor. Keyed by host so a github.com round and a GHE round
+    # keep separate budgets.
+    _rate_limit_by_host: dict[str, GithubRateLimit | None] = PrivateAttr(default_factory=dict)
+    # Hosts whose search round is currently failing (transient), for once-only
+    # logging until the round recovers.
+    _round_failed_hosts: set[str] = PrivateAttr(default_factory=set)
+    # Hosts whose cold-start unmatched-fetch count has already been logged (rule 6).
+    _cold_start_logged_hosts: set[str] = PrivateAttr(default_factory=set)
 
     def __init__(
         self,
@@ -395,7 +465,10 @@ class PrPollingService(Service):
         for workspace in active_workspaces:
             self._add_workspace_poll_state(workspace)
 
-        # Poll open workspaces first (user is looking at them), then closed.
+        # Seed an immediate per-workspace fetch for each workspace (open first —
+        # the user is looking at them) for instant first status. The batched
+        # round (started below) takes over any workspace it matches; this seed
+        # is the bounded, one-time cold-start coverage for the rest.
         open_workspaces = [w for w in active_workspaces if w.is_open]
         closed_workspaces = [w for w in active_workspaces if not w.is_open]
         delay = 0.0
@@ -406,6 +479,9 @@ class PrPollingService(Service):
             self._enqueue(workspace.object_id, delay=delay)
             delay += 0.5
 
+        # Fallback worker pool: drains the per-workspace fetch queue (the
+        # unmatched-branch fallback + immediate re-polls). Most of the old
+        # scheduling machinery survives here, repurposed for the fallback only.
         self._worker_events = [threading.Event() for _ in range(_WORKER_POOL_SIZE)]
         for i in range(_WORKER_POOL_SIZE):
             self.concurrency_group.start_new_thread(
@@ -413,8 +489,15 @@ class PrPollingService(Service):
                 args=(i,),
                 name=f"pr-poll-worker-{i}",
             )
+        # Round driver: one thread that, each interval, issues one batched
+        # ``search`` query per distinct host and fans the results out per
+        # workspace (Change-1). Replaces per-workspace polling for matched PRs.
+        self.concurrency_group.start_new_thread(
+            target=self._round_loop,
+            name="pr-poll-round-driver",
+        )
         logger.debug(
-            "PR polling service started with {} workers, {} workspaces",
+            "PR polling service started with {} fallback workers + round driver, {} workspaces",
             _WORKER_POOL_SIZE,
             len(self._workspace_poll_state),
         )
@@ -472,6 +555,7 @@ class PrPollingService(Service):
         if state is not None:
             state.is_deleted = True
         self._cache.pop(workspace_id, None)
+        self._matched_workspaces.discard(workspace_id)
 
     def on_branch_changed(self, workspace_id: WorkspaceID) -> None:
         """Invalidate cached result and force-enqueue for immediate poll.
@@ -483,6 +567,9 @@ class PrPollingService(Service):
         loop iteration and silently drop it when the queue is ``None``.
         """
         self._cache.pop(workspace_id, None)
+        # The workspace's identity changed — any "matched by the last round" flag
+        # is stale, so don't let it suppress this immediate fallback fetch.
+        self._matched_workspaces.discard(workspace_id)
         state = self._workspace_poll_state.get(workspace_id)
         if state is not None:
             state.first_failure = None
@@ -521,6 +608,169 @@ class PrPollingService(Service):
         # Jobs with delay=0 (branch changes) always sort before delay=30 re-polls.
         self._job_queue.put(job)
         self._wake_sleepiest_worker(delay)
+
+    # -- Round driver (batched search) -------------------------------------
+    #
+    # One thread issues a single ``search`` query per distinct host each
+    # interval and fans the results out per workspace. A workspace whose open
+    # PR matches its target rides this cheap batch (no per-workspace gh call);
+    # every other workspace falls back to the per-workspace fetch path on its
+    # own cadence (decoupled from the round).
+
+    def _round_loop(self) -> None:
+        while not self._shutdown_event.is_set():
+            config = get_user_config_instance()
+            # Kill switch: skip the batched round too, re-check in ~a minute.
+            if not config.pr_polling_enabled:
+                self._shutdown_event.wait(_DISABLED_RECHECK_SECONDS)
+                continue
+            try:
+                self._run_round(config)
+            except Exception as e:
+                # Never let the round thread die — a single bad round must not
+                # stop all batched polling.
+                log_exception(e, message="PR search round crashed", priority=ExceptionPriority.LOW_PRIORITY)
+            self._shutdown_event.wait(_compute_round_interval(config))
+
+    def _run_round(self, config: UserConfig) -> None:
+        """Run one batched search round per distinct host across tracked workspaces."""
+        candidates_by_host: dict[str, list[_RoundCandidate]] = {}
+        for workspace_id, state in list(self._workspace_poll_state.items()):
+            if state.is_deleted:
+                continue
+            candidate = self._resolve_round_candidate(workspace_id, state)
+            if candidate is not None:
+                candidates_by_host.setdefault(candidate.host, []).append(candidate)
+
+        for host, candidates in candidates_by_host.items():
+            self._run_host_round(host, candidates)
+
+    def _run_host_round(self, host: str, candidates: list[_RoundCandidate]) -> None:
+        """Issue one ``search`` query for ``host`` and fan its results out."""
+        deferred = self._respect_throttle()
+        if deferred is not None:
+            # In rate-limit cooldown — skip the batched round; the next round
+            # (or the fallback, once the cooldown expires) re-resolves.
+            return
+        working_dir = candidates[0].working_dir
+        try:
+            search_result = fetch_open_prs_for_token(working_dir)
+        except CliStatusError as e:
+            self._handle_round_failure(host, e)
+            return
+
+        self._round_failed_hosts.discard(host)
+        self._rate_limit_by_host[host] = search_result.rate_limit
+        index = _build_pr_index(search_result.nodes)
+
+        unmatched_count = 0
+        for candidate in candidates:
+            nodes = (
+                index.get((candidate.name_with_owner, candidate.current_branch)) if candidate.name_with_owner else None
+            )
+            status = (
+                build_status_from_open_nodes(candidate.workspace_id, nodes, candidate.target_branch) if nodes else None
+            )
+            if status is not None and status.pr_state == "open":
+                # Matched: the workspace's open PR rides the batch. Mark it so its
+                # per-workspace fallback stops rescheduling.
+                self._matched_workspaces.add(candidate.workspace_id)
+                self._emit_status(candidate.workspace_id, status)
+            else:
+                # Unmatched (no open PR satisfies its target — terminal, no-PR,
+                # mismatch, or a one-round index drop-out): resolve it via the
+                # per-workspace fallback at its own cadence.
+                self._matched_workspaces.discard(candidate.workspace_id)
+                unmatched_count += 1
+                self._enqueue(candidate.workspace_id, delay=0.0)
+
+        if host not in self._cold_start_logged_hosts:
+            self._cold_start_logged_hosts.add(host)
+            logger.info(
+                "PR poll cold start on {}: {} of {} workspace(s) unmatched, fetched via per-workspace fallback",
+                host,
+                unmatched_count,
+                len(candidates),
+            )
+
+    def _handle_round_failure(self, host: str, error: CliStatusError) -> None:
+        """Route a failed search round: cool down on rate limits, log once on transient."""
+        if error.category == "rate_limited":
+            self._throttle.enter_cooldown(_RATE_LIMIT_COOLDOWN_SECONDS)
+            logger.debug("PR search rate-limited on {}, cooling down {:.0f}s", host, _RATE_LIMIT_COOLDOWN_SECONDS)
+            return
+        if host not in self._round_failed_hosts:
+            self._round_failed_hosts.add(host)
+            log_exception(
+                error, message=f"PR search round failed on host {host}", priority=ExceptionPriority.LOW_PRIORITY
+            )
+        else:
+            logger.trace("PR search round still failing on {}: {}", host, error)
+
+    def _resolve_round_candidate(
+        self, workspace_id: WorkspaceID, state: _WorkspacePollState
+    ) -> _RoundCandidate | None:
+        """Resolve a workspace for the round, or short-circuit it to ``none``.
+
+        Applies today's short-circuits (rule 4) *before* a workspace can enter a
+        round or fallback: not ready (no working_dir) → skip silently; no branch
+        info / on the target branch / non-GitHub origin → emit ``none`` with zero
+        gh calls. Returns a candidate only for a GitHub workspace off its target
+        branch (the population the search can match).
+        """
+        working_dir = self._resolve_working_dir(workspace_id, state)
+        if working_dir is None:
+            return None
+
+        current_branch = _get_workspace_current_branch(working_dir)
+        target_branch = state.target_branch
+        if current_branch is None or target_branch is None:
+            self._emit_status(workspace_id, PrStatusInfo(workspace_id=workspace_id, pr_state="none"))
+            return None
+        if current_branch == strip_remote_prefix(target_branch):
+            self._emit_status(workspace_id, PrStatusInfo(workspace_id=workspace_id, pr_state="none"))
+            return None
+
+        origin_url = _get_origin_url(working_dir)
+        if origin_url is None or not _is_github_url(origin_url):
+            self._emit_status(workspace_id, PrStatusInfo(workspace_id=workspace_id, pr_state="none"))
+            return None
+        if not self._is_gh_available():
+            self._emit_status(
+                workspace_id,
+                PrStatusInfo(
+                    workspace_id=workspace_id,
+                    pr_state="none",
+                    error_category="cli_missing",
+                    error_provider="github",
+                    error_message="gh CLI not found in PATH",
+                ),
+            )
+            return None
+
+        owner_repo = _parse_origin_owner_repo(origin_url)
+        name_with_owner = f"{owner_repo[0]}/{owner_repo[1]}" if owner_repo is not None else None
+        return _RoundCandidate(
+            workspace_id=workspace_id,
+            state=state,
+            working_dir=working_dir,
+            current_branch=current_branch,
+            target_branch=target_branch,
+            host=_extract_hostname(origin_url),
+            name_with_owner=name_with_owner,
+        )
+
+    def _emit_status(self, workspace_id: WorkspaceID, status: PrStatusInfo) -> None:
+        """Cache and fan out a status, but only if it changed.
+
+        Holds ``_observer_lock`` across the cache write and the fan-out put() so
+        an observer that registers concurrently sees a consistent snapshot.
+        """
+        with self._observer_lock:
+            if status != self._cache.get(workspace_id):
+                self._cache[workspace_id] = status
+                for observer_queue in self._observers:
+                    observer_queue.put(status)
 
     # -- Worker loop -------------------------------------------------------
     #
@@ -637,14 +887,31 @@ class PrPollingService(Service):
             self._enqueue(job.workspace_id, delay=_NOT_READY_RETRY_SECONDS)
             return
 
-        # Push to all observers if the status changed. Hold _observer_lock
-        # across the cache write and the fan-out put() so an observer that
-        # registers concurrently sees a consistent cache snapshot.
-        with self._observer_lock:
-            if result != self._cache.get(job.workspace_id):
-                self._cache[job.workspace_id] = result
-                for observer_queue in self._observers:
-                    observer_queue.put(result)
+        # Rule 5 (search-index blip): if we were showing this workspace open and
+        # the per-workspace fetch comes back with no PR at all, treat it as a
+        # one-round drop-out and keep the cached open status — don't emit a
+        # spurious open→none. A real merge/close returns ``merged``/``closed``
+        # (never ``none``), so genuine terminal transitions are unaffected; the
+        # next round/fallback resolves a true disappearance.
+        prev = self._cache.get(job.workspace_id)
+        is_open_to_empty_blip = (
+            prev is not None
+            and prev.pr_state == "open"
+            and result.pr_state == "none"
+            and result.error_category is None
+            and result.mismatched_pr_iid is None
+        )
+        if is_open_to_empty_blip:
+            logger.trace("PR fallback {}: suppressing open→none blip", job.workspace_id)
+        else:
+            self._emit_status(job.workspace_id, result)
+
+        # A workspace matched by the batched round rides the cheap batch — stop
+        # the per-workspace fallback from rescheduling it (rule 3 cost control).
+        # If it later drops out of the search, the round re-enqueues a fallback.
+        if job.workspace_id in self._matched_workspaces:
+            logger.trace("PR fallback {}: matched by search round, not rescheduling fallback", job.workspace_id)
+            return
 
         if result.error_category == "rate_limited":
             # A cooldown was just set — wait it out rather than re-polling at
@@ -725,25 +992,36 @@ class PrPollingService(Service):
             self._throttle.enter_cooldown(_RATE_LIMIT_COOLDOWN_SECONDS)
             logger.debug("PR poll: rate-limited, cooling down {:.0f}s", _RATE_LIMIT_COOLDOWN_SECONDS)
 
+    def _resolve_working_dir(self, workspace_id: WorkspaceID, state: _WorkspacePollState) -> Path | None:
+        """Resolve a workspace's working directory, re-reading from the DB if needed.
+
+        Returns ``None`` if the workspace is gone (marks it deleted) or its
+        environment hasn't initialized a working_dir yet. Shared by the batched
+        round and the per-workspace fallback fetch.
+        """
+        working_dir = state.working_dir
+        if working_dir is not None:
+            return working_dir
+        with self._data_model_service.open_transaction(RequestID()) as transaction:
+            workspace = transaction.get_workspace(workspace_id)
+        if workspace is None or workspace.is_deleted:
+            logger.trace("PR poll {}: workspace deleted or missing in DB", workspace_id)
+            state.is_deleted = True
+            return None
+        working_dir = self._workspace_service.get_workspace_working_directory(workspace)
+        if working_dir is None:
+            logger.trace("PR poll {}: no working_dir yet", workspace_id)
+            return None
+        state.working_dir = working_dir
+        state.target_branch = workspace.target_branch
+        return working_dir
+
     def _fetch_status(
         self, workspace_id: WorkspaceID, state: _WorkspacePollState
     ) -> PrStatusInfo | _CooldownDeferred | None:
-        working_dir = state.working_dir
-
-        # Re-read from DB if working_dir not yet available (environment may have initialized)
+        working_dir = self._resolve_working_dir(workspace_id, state)
         if working_dir is None:
-            with self._data_model_service.open_transaction(RequestID()) as transaction:
-                workspace = transaction.get_workspace(workspace_id)
-            if workspace is None or workspace.is_deleted:
-                logger.trace("PR poll {}: workspace deleted or missing in DB", workspace_id)
-                state.is_deleted = True
-                return None
-            working_dir = self._workspace_service.get_workspace_working_directory(workspace)
-            if working_dir is None:
-                logger.trace("PR poll {}: no working_dir yet", workspace_id)
-                return None
-            state.working_dir = working_dir
-            state.target_branch = workspace.target_branch
+            return None
 
         current_branch = _get_workspace_current_branch(working_dir)
         target_branch = state.target_branch

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -106,15 +106,101 @@ def _compute_poll_delay(config: UserConfig, *, is_open: bool, pr_state: _PrState
 
 
 def _compute_round_interval(config: UserConfig) -> float:
-    """Interval between batched search rounds.
+    """Base interval between batched search rounds (before the governor).
 
     One batched ``search`` round is cheap regardless of workspace count, so the
-    round just runs at the configured base interval (floored at
-    ``_MIN_POLL_INTERVAL_SECONDS``). The Task 4.1 governor will stretch this
-    under budget pressure; the per-workspace fallback keeps its own
-    ``_compute_poll_delay`` cadence either way.
+    base is just the configured interval (floored at ``_MIN_POLL_INTERVAL_SECONDS``).
+    The governor (``_compute_governed_interval``) stretches this under budget
+    pressure; the per-workspace fallback keeps its own ``_compute_poll_delay``
+    cadence either way.
     """
     return max(float(config.pr_poll_interval_seconds), _MIN_POLL_INTERVAL_SECONDS)
+
+
+# GitHub's GraphQL rate limit is a rolling one-hour budget that refills at
+# ``resetAt``; the governor projects hourly spend over this window.
+_RATE_LIMIT_WINDOW_SECONDS = 3600.0
+# Multiplicative step the governor takes per round to lengthen (×) or recover (÷)
+# the interval, and the cap on how far it may stretch beyond the base.
+_GOVERNOR_STEP_FACTOR = 1.5
+_GOVERNOR_MAX_INTERVAL_MULTIPLIER = 20.0
+# Recover toward base only once projected spend drops below this fraction of the
+# ceiling (hysteresis, so the interval doesn't oscillate round-to-round).
+_GOVERNOR_RECOVER_FRACTION = 0.5
+# When ``remaining`` falls below this fraction of ``limit`` the wall is near —
+# stop polling until the window resets rather than nibbling the last of the budget.
+_GOVERNOR_DEFER_REMAINING_FRACTION = 0.05
+# A single search round costs only a few points; a cost far above this signals a
+# field addition that ballooned the fan-out (complements the Task 4.2 guard).
+_MAX_PLAUSIBLE_SEARCH_COST = 50
+
+
+def _seconds_until_reset(reset_at: str | None) -> float:
+    """Parse GitHub's ISO-8601 ``resetAt`` into seconds from now (defensively).
+
+    Returns a full window on a missing/unparseable value or backward clock skew,
+    and clamps a far-future value to one window — so a bad timestamp degrades to
+    the base cadence rather than crashing or deferring forever.
+    """
+    if not reset_at:
+        return _RATE_LIMIT_WINDOW_SECONDS
+    try:
+        reset_dt = datetime.datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
+    except ValueError:
+        return _RATE_LIMIT_WINDOW_SECONDS
+    delta = (reset_dt - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
+    if delta <= 0:
+        return 0.0
+    return min(delta, _RATE_LIMIT_WINDOW_SECONDS)
+
+
+def _compute_governed_interval(
+    base_interval: float,
+    current_interval: float,
+    rate_limit: "GithubRateLimit | None",
+    budget_fraction: float,
+    seconds_until_reset: float,
+) -> tuple[float, bool]:
+    """Return ``(next round interval, is_throttled)`` for the rate-budget governor.
+
+    Proactively lengthens the round interval before the token's hourly GraphQL
+    budget is exhausted. The projection is driven off ``remaining`` (the token's
+    *global* budget across every query that hour — search **and** the per-workspace
+    fallback fetches), not the search query's ``cost`` alone, which would
+    under-count the fallback spend. ``limit`` is read from the response so the
+    ceiling scales for tokens with a non-default budget (e.g. GitHub App tokens).
+
+    Behavior: defer to ``reset_at`` when ``remaining`` is critically low; back off
+    multiplicatively (up to a cap) when projected hourly spend exceeds
+    ``budget_fraction × limit``; recover toward ``base_interval`` (never below it)
+    once spend drops comfortably under the ceiling.
+    """
+    if rate_limit is None or rate_limit.limit <= 0:
+        return base_interval, False
+    limit = float(rate_limit.limit)
+    remaining = float(rate_limit.remaining)
+    current_interval = max(current_interval, base_interval)
+
+    # Critically low budget — wait out the window instead of hitting the wall.
+    if remaining <= _GOVERNOR_DEFER_REMAINING_FRACTION * limit:
+        return max(seconds_until_reset, _MIN_POLL_INTERVAL_SECONDS), True
+
+    ceiling = budget_fraction * limit
+    elapsed = min(
+        max(_RATE_LIMIT_WINDOW_SECONDS - seconds_until_reset, _MIN_POLL_INTERVAL_SECONDS), _RATE_LIMIT_WINDOW_SECONDS
+    )
+    spent = max(0.0, limit - remaining)
+    projected_hourly_spend = spent / elapsed * _RATE_LIMIT_WINDOW_SECONDS
+
+    max_interval = base_interval * _GOVERNOR_MAX_INTERVAL_MULTIPLIER
+    if projected_hourly_spend > ceiling:
+        next_interval = min(current_interval * _GOVERNOR_STEP_FACTOR, max_interval)
+        return max(next_interval, base_interval), True
+    if projected_hourly_spend < ceiling * _GOVERNOR_RECOVER_FRACTION:
+        next_interval = max(current_interval / _GOVERNOR_STEP_FACTOR, base_interval)
+        return next_interval, next_interval > base_interval
+    # Comfortable band — hold the current (possibly already-stretched) interval.
+    return current_interval, current_interval > base_interval
 
 
 class _CooldownDeferred:
@@ -402,10 +488,13 @@ class PrPollingService(Service):
     # rescheduling (checked in _poll_and_handle_result). add/discard are atomic
     # under the GIL; the fallback worker only does a membership test.
     _matched_workspaces: set[WorkspaceID] = PrivateAttr(default_factory=set)
-    # Latest ``rateLimit`` snapshot from each host's search round, exposed for
-    # the Task 4.1 governor. Keyed by host so a github.com round and a GHE round
+    # Latest ``rateLimit`` snapshot from each host's search round, read by the
+    # rate-budget governor. Keyed by host so a github.com round and a GHE round
     # keep separate budgets.
     _rate_limit_by_host: dict[str, GithubRateLimit | None] = PrivateAttr(default_factory=dict)
+    # The governor's current (possibly stretched) round interval. None until the
+    # first round produces a rateLimit; multiplicative back-off accumulates here.
+    _governed_interval: float | None = PrivateAttr(default=None)
     # Hosts whose search round is currently failing (transient), for once-only
     # logging until the round recovers.
     _round_failed_hosts: set[str] = PrivateAttr(default_factory=set)
@@ -630,7 +719,50 @@ class PrPollingService(Service):
                 # Never let the round thread die — a single bad round must not
                 # stop all batched polling.
                 log_exception(e, message="PR search round crashed", priority=ExceptionPriority.LOW_PRIORITY)
-            self._shutdown_event.wait(_compute_round_interval(config))
+            self._shutdown_event.wait(self._compute_next_round_interval(config))
+
+    def _compute_next_round_interval(self, config: UserConfig) -> float:
+        """Apply the rate-budget governor to pick the next round's interval.
+
+        Reads the most-constrained host's latest ``rateLimit`` and stretches /
+        recovers the interval (state in ``_governed_interval``). On a hard defer
+        (``remaining`` critically low), also enters the shared rate-limit cooldown
+        so the per-workspace fallback backs off too — leaving the cache untouched,
+        like ``_CooldownDeferred``, so the user keeps seeing last-known status.
+        """
+        base_interval = _compute_round_interval(config)
+        rate_limit = self._most_constrained_rate_limit()
+        if rate_limit is None:
+            self._governed_interval = base_interval
+            return base_interval
+
+        current_interval = self._governed_interval if self._governed_interval is not None else base_interval
+        seconds_until_reset = _seconds_until_reset(rate_limit.reset_at)
+        next_interval, is_throttled = _compute_governed_interval(
+            base_interval, current_interval, rate_limit, config.pr_poll_budget_fraction, seconds_until_reset
+        )
+        self._governed_interval = next_interval
+        is_deferring = rate_limit.remaining <= _GOVERNOR_DEFER_REMAINING_FRACTION * rate_limit.limit
+        if is_throttled:
+            logger.debug(
+                "PR governor throttling: next round in {:.0f}s (remaining={}/{}, base={:.0f}s)",
+                next_interval,
+                rate_limit.remaining,
+                rate_limit.limit,
+                base_interval,
+            )
+        if is_deferring:
+            # Reuse the reactive rate-limit cooldown so fallback fetches pause too
+            # until the budget resets (same mechanism a 403 triggers).
+            self._throttle.enter_cooldown(max(seconds_until_reset, _MIN_POLL_INTERVAL_SECONDS))
+        return next_interval
+
+    def _most_constrained_rate_limit(self) -> GithubRateLimit | None:
+        """The latest per-host ``rateLimit`` with the least headroom (lowest remaining fraction)."""
+        snapshots = [rl for rl in self._rate_limit_by_host.values() if rl is not None]
+        if not snapshots:
+            return None
+        return min(snapshots, key=lambda rl: (rl.remaining / rl.limit) if rl.limit > 0 else 1.0)
 
     def _run_round(self, config: UserConfig) -> None:
         """Run one batched search round per distinct host across tracked workspaces."""
@@ -661,6 +793,15 @@ class PrPollingService(Service):
 
         self._round_failed_hosts.discard(host)
         self._rate_limit_by_host[host] = search_result.rate_limit
+        if search_result.rate_limit is not None and search_result.rate_limit.cost > _MAX_PLAUSIBLE_SEARCH_COST:
+            # A search round should cost only a few points; a spike means a field
+            # addition ballooned the fan-out (lower-bound sanity check for the governor).
+            logger.warning(
+                "PR search round on {} cost {} points (expected <= {})",
+                host,
+                search_result.rate_limit.cost,
+                _MAX_PLAUSIBLE_SEARCH_COST,
+            )
         index = _build_pr_index(search_result.nodes)
 
         unmatched_count = 0

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -668,18 +668,20 @@ class PrPollingService(Service):
             nodes = (
                 index.get((candidate.name_with_owner, candidate.current_branch)) if candidate.name_with_owner else None
             )
-            status = (
-                build_status_from_open_nodes(candidate.workspace_id, nodes, candidate.target_branch) if nodes else None
-            )
-            if status is not None and status.pr_state == "open":
-                # Matched: the workspace's open PR rides the batch. Mark it so its
-                # per-workspace fallback stops rescheduling.
+            if nodes:
+                # The branch carries at least one of the user's open PRs — derive
+                # this workspace's status directly from them (open if one targets
+                # its base, else a "switch target" mismatch). Either way the round
+                # resolves it for free; mark it so its per-workspace fallback
+                # stops rescheduling.
                 self._matched_workspaces.add(candidate.workspace_id)
+                status = build_status_from_open_nodes(candidate.workspace_id, nodes, candidate.target_branch)
                 self._emit_status(candidate.workspace_id, status)
             else:
-                # Unmatched (no open PR satisfies its target — terminal, no-PR,
-                # mismatch, or a one-round index drop-out): resolve it via the
-                # per-workspace fallback at its own cadence.
+                # No open authored PR on this branch — terminal (merged/closed),
+                # no-PR-yet, or a one-round index drop-out. Resolve it via the
+                # per-workspace fallback at its own cadence (the search can't tell
+                # these apart, so a targeted all-states fetch is required).
                 self._matched_workspaces.discard(candidate.workspace_id)
                 unmatched_count += 1
                 self._enqueue(candidate.workspace_id, delay=0.0)

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -885,7 +885,6 @@ class PrPollingService(Service):
                     workspace_id=workspace_id,
                     pr_state="none",
                     error_category="cli_missing",
-                    error_provider="github",
                     error_message="gh CLI not found in PATH",
                 ),
             )
@@ -1193,7 +1192,6 @@ class PrPollingService(Service):
                     workspace_id=workspace_id,
                     pr_state="none",
                     error_category="cli_missing",
-                    error_provider="github",
                     error_message="gh CLI not found in PATH",
                 )
             deferred = self._respect_throttle()

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -131,7 +131,7 @@ _GOVERNOR_RECOVER_FRACTION = 0.5
 # stop polling until the window resets rather than nibbling the last of the budget.
 _GOVERNOR_DEFER_REMAINING_FRACTION = 0.05
 # A single search round costs only a few points; a cost far above this signals a
-# field addition that ballooned the fan-out (complements the Task 4.2 guard).
+# field addition that ballooned the fan-out.
 _MAX_PLAUSIBLE_SEARCH_COST = 50
 
 
@@ -361,7 +361,7 @@ class _OriginInfo:
     """Parsed identity of a workspace's ``origin`` remote.
 
     ``host`` keys the per-(host, token) poll round, so a ``github.com`` workspace
-    and a GitHub Enterprise workspace get separate rounds (Risk-5).
+    and a GitHub Enterprise workspace get separate rounds.
     ``name_with_owner`` (``owner/name``, ``.git`` stripped) is compared *exactly*
     against a search node's ``repository.nameWithOwner`` to map the node back to
     this workspace. GitHub returns canonical casing there, so a casing mismatch
@@ -498,7 +498,7 @@ class PrPollingService(Service):
     # Hosts whose search round is currently failing (transient), for once-only
     # logging until the round recovers.
     _round_failed_hosts: set[str] = PrivateAttr(default_factory=set)
-    # Hosts whose cold-start unmatched-fetch count has already been logged (rule 6).
+    # Hosts whose cold-start unmatched-fetch count has already been logged.
     _cold_start_logged_hosts: set[str] = PrivateAttr(default_factory=set)
 
     def __init__(
@@ -580,7 +580,7 @@ class PrPollingService(Service):
             )
         # Round driver: one thread that, each interval, issues one batched
         # ``search`` query per distinct host and fans the results out per
-        # workspace (Change-1). Replaces per-workspace polling for matched PRs.
+        # workspace. Replaces per-workspace polling for matched PRs.
         self.concurrency_group.start_new_thread(
             target=self._round_loop,
             name="pr-poll-round-driver",
@@ -855,7 +855,7 @@ class PrPollingService(Service):
     ) -> _RoundCandidate | None:
         """Resolve a workspace for the round, or short-circuit it to ``none``.
 
-        Applies today's short-circuits (rule 4) *before* a workspace can enter a
+        Applies today's short-circuits *before* a workspace can enter a
         round or fallback: not ready (no working_dir) → skip silently; no branch
         info / on the target branch / non-GitHub origin → emit ``none`` with zero
         gh calls. Returns a candidate only for a GitHub workspace off its target
@@ -1049,7 +1049,7 @@ class PrPollingService(Service):
             self._emit_status(job.workspace_id, result)
 
         # A workspace matched by the batched round rides the cheap batch — stop
-        # the per-workspace fallback from rescheduling it (rule 3 cost control).
+        # the per-workspace fallback from rescheduling it (avoids redundant gh calls).
         # If it later drops out of the search, the round re-enqueues a fallback.
         if job.workspace_id in self._matched_workspaces:
             logger.trace("PR fallback {}: matched by search round, not rescheduling fallback", job.workspace_id)

--- a/sculptor/sculptor/web/pr_polling_service.py
+++ b/sculptor/sculptor/web/pr_polling_service.py
@@ -214,6 +214,69 @@ def _is_github_url(url: str) -> bool:
     return "github" in _extract_hostname(url).lower()
 
 
+@dataclass(frozen=True)
+class _OriginInfo:
+    """Parsed identity of a workspace's ``origin`` remote.
+
+    ``host`` keys the per-(host, token) poll round, so a ``github.com`` workspace
+    and a GitHub Enterprise workspace get separate rounds (Risk-5).
+    ``name_with_owner`` (``owner/name``, ``.git`` stripped) is compared *exactly*
+    against a search node's ``repository.nameWithOwner`` to map the node back to
+    this workspace. GitHub returns canonical casing there, so a casing mismatch
+    would simply drop the workspace to the per-workspace fallback (acceptable
+    degradation).
+    """
+
+    host: str
+    owner: str
+    name: str
+
+    @property
+    def name_with_owner(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+
+def _parse_origin_owner_repo(url: str) -> tuple[str, str] | None:
+    """Parse ``(owner, name)`` from a git ``origin`` URL, ``.git`` stripped.
+
+    Handles the scp-like (``git@host:owner/repo.git``), ``ssh://``, and http(s)
+    forms. Pure string parsing — no git call. Returns ``None`` for any URL that
+    does not yield exactly an owner and a repo, so a malformed remote degrades
+    (the workspace falls to the fallback) instead of crashing the round.
+    """
+    if ":" in url and not url.startswith(("https://", "http://", "ssh://")):
+        # scp-like ``git@host:owner/repo.git`` — the path follows the first ':'.
+        path = url.split(":", 1)[1]
+    else:
+        path = urllib.parse.urlparse(url).path
+    parts = path.strip("/").split("/")
+    if len(parts) != 2:
+        return None
+    owner, repo = parts
+    if repo.endswith(".git"):
+        repo = repo[: -len(".git")]
+    if not owner or not repo:
+        return None
+    return owner, repo
+
+
+def _parse_origin(url: str) -> _OriginInfo | None:
+    """Parse a git ``origin`` URL into its ``(host, owner, name)`` identity.
+
+    Reuses ``_extract_hostname`` (consistent with ``_is_github_url``) for the
+    host and ``_parse_origin_owner_repo`` for the path. Returns ``None`` if
+    either the host or the ``owner/repo`` can't be parsed.
+    """
+    host = _extract_hostname(url)
+    if not host:
+        return None
+    owner_repo = _parse_origin_owner_repo(url)
+    if owner_repo is None:
+        return None
+    owner, name = owner_repo
+    return _OriginInfo(host=host, owner=owner, name=name)
+
+
 # ---------------------------------------------------------------------------
 # Per-workspace poll state
 # ---------------------------------------------------------------------------

--- a/sculptor/sculptor/web/pr_polling_service_test.py
+++ b/sculptor/sculptor/web/pr_polling_service_test.py
@@ -614,9 +614,7 @@ def test_note_rate_limit_starts_cooldown_only_for_rate_limited() -> None:
     svc._note_rate_limit(ok)
     assert svc._throttle.cooldown_remaining() == 0.0
 
-    limited = PrStatusInfo(
-        workspace_id=workspace_id, pr_state="none", error_category="rate_limited", error_provider="github"
-    )
+    limited = PrStatusInfo(workspace_id=workspace_id, pr_state="none", error_category="rate_limited")
     svc._note_rate_limit(limited)
     assert svc._throttle.cooldown_remaining() > 0.0
 
@@ -656,9 +654,7 @@ def test_rate_limited_result_re_enqueues_after_cooldown() -> None:
 
     # Simulate the cooldown the poll would have set via _note_rate_limit.
     svc._throttle.enter_cooldown(_RATE_LIMIT_COOLDOWN_SECONDS)
-    limited = PrStatusInfo(
-        workspace_id=workspace_id, pr_state="none", error_category="rate_limited", error_provider="github"
-    )
+    limited = PrStatusInfo(workspace_id=workspace_id, pr_state="none", error_category="rate_limited")
     config = _make_user_config(pr_poll_interval_seconds=30)
 
     with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=config):

--- a/sculptor/sculptor/web/pr_polling_service_test.py
+++ b/sculptor/sculptor/web/pr_polling_service_test.py
@@ -22,7 +22,9 @@ from sculptor.web.pr_polling_service import _PollJob
 from sculptor.web.pr_polling_service import _RATE_LIMIT_COOLDOWN_SECONDS
 from sculptor.web.pr_polling_service import _TERMINAL_STATE_MULTIPLIER
 from sculptor.web.pr_polling_service import _WorkspacePollState
+from sculptor.web.pr_polling_service import _build_pr_index
 from sculptor.web.pr_polling_service import _compute_poll_delay
+from sculptor.web.pr_polling_service import _compute_round_interval
 from sculptor.web.pr_polling_service import _parse_origin
 from sculptor.web.pr_polling_service import _parse_origin_owner_repo
 from sculptor.web.streams import _notify_pr_polling_service
@@ -54,6 +56,10 @@ def _make_service() -> PrPollingService:
     svc._worker_sleep_lock = threading.Lock()
     svc._gh_available = None
     svc._throttle = _HostThrottle(_GLOBAL_MIN_POLL_SPACING_SECONDS)
+    svc._matched_workspaces = set()
+    svc._rate_limit_by_host = {}
+    svc._round_failed_hosts = set()
+    svc._cold_start_logged_hosts = set()
     object.__setattr__(svc, "_data_model_service", MagicMock())
     object.__setattr__(svc, "_workspace_service", MagicMock())
     return svc
@@ -699,3 +705,47 @@ def test_parse_origin_owner_repo_strips_dot_git() -> None:
     # nameWithOwner from GitHub's API never carries .git; origin URLs usually do.
     assert _parse_origin_owner_repo("https://github.com/imbue-ai/sculptor.git") == ("imbue-ai", "sculptor")
     assert _parse_origin_owner_repo("git@github.com:imbue-ai/sculptor.git") == ("imbue-ai", "sculptor")
+
+
+# ---------------------------------------------------------------------------
+# Transient per-round (repo, branch) -> nodes index (Change-1 fan-out).
+# ---------------------------------------------------------------------------
+
+
+def _node(number: int, repo: str = "org/repo", head: str = "feat-1", base: str = "main") -> dict:
+    return {
+        "number": number,
+        "repository": {"nameWithOwner": repo},
+        "headRefName": head,
+        "baseRefName": base,
+    }
+
+
+def test_build_pr_index_keys_by_repo_and_head_branch() -> None:
+    nodes = [_node(1, head="feat-1"), _node(2, repo="org/other", head="feat-2")]
+    index = _build_pr_index(nodes)
+    assert set(index.keys()) == {("org/repo", "feat-1"), ("org/other", "feat-2")}
+    assert [n["number"] for n in index[("org/repo", "feat-1")]] == [1]
+
+
+def test_build_pr_index_groups_multiple_prs_on_one_branch_preserving_order() -> None:
+    # One source branch can carry several PRs (different bases); order is
+    # preserved (search returns most-recently-updated first).
+    nodes = [_node(10, head="feat-1", base="develop"), _node(11, head="feat-1", base="main")]
+    index = _build_pr_index(nodes)
+    assert [n["number"] for n in index[("org/repo", "feat-1")]] == [10, 11]
+
+
+def test_build_pr_index_skips_nodes_missing_repo_or_head() -> None:
+    nodes = [{"number": 1, "headRefName": "feat-1"}, {"number": 2, "repository": {"nameWithOwner": "org/repo"}}]
+    assert _build_pr_index(nodes) == {}
+
+
+def test_compute_round_interval_floors_at_minimum() -> None:
+    config = _make_user_config(pr_poll_interval_seconds=1)
+    assert _compute_round_interval(config) == _MIN_POLL_INTERVAL_SECONDS
+
+
+def test_compute_round_interval_uses_configured_interval() -> None:
+    config = _make_user_config(pr_poll_interval_seconds=45)
+    assert _compute_round_interval(config) == 45.0

--- a/sculptor/sculptor/web/pr_polling_service_test.py
+++ b/sculptor/sculptor/web/pr_polling_service_test.py
@@ -5,6 +5,8 @@ from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
+
 from sculptor.config.user_config import UserConfig
 from sculptor.primitives.ids import WorkspaceID
 from sculptor.web.data_types import StreamingUpdateSourceTypes
@@ -21,6 +23,8 @@ from sculptor.web.pr_polling_service import _RATE_LIMIT_COOLDOWN_SECONDS
 from sculptor.web.pr_polling_service import _TERMINAL_STATE_MULTIPLIER
 from sculptor.web.pr_polling_service import _WorkspacePollState
 from sculptor.web.pr_polling_service import _compute_poll_delay
+from sculptor.web.pr_polling_service import _parse_origin
+from sculptor.web.pr_polling_service import _parse_origin_owner_repo
 from sculptor.web.streams import _notify_pr_polling_service
 
 # ---------------------------------------------------------------------------
@@ -649,3 +653,49 @@ def test_rate_limited_result_re_enqueues_after_cooldown() -> None:
     delay = rescheduled.scheduled_time - time.monotonic()
     # Re-enqueued at ~the remaining cooldown (60s), not the 30s base interval.
     assert _RATE_LIMIT_COOLDOWN_SECONDS - 2 <= delay <= _RATE_LIMIT_COOLDOWN_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# origin URL -> (host, owner, name) parsing (Change-1 fan-out, Risk-5 GHE hosts).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url, host, owner, name",
+    [
+        ("https://github.com/imbue-ai/sculptor.git", "github.com", "imbue-ai", "sculptor"),
+        ("git@github.com:imbue-ai/sculptor.git", "github.com", "imbue-ai", "sculptor"),
+        ("ssh://git@github.com/imbue-ai/sculptor.git", "github.com", "imbue-ai", "sculptor"),
+        ("https://github.com/imbue-ai/sculptor", "github.com", "imbue-ai", "sculptor"),
+        ("https://github.example.com/org/repo.git", "github.example.com", "org", "repo"),
+    ],
+)
+def test_parse_origin_valid_forms(url: str, host: str, owner: str, name: str) -> None:
+    info = _parse_origin(url)
+    assert info is not None
+    assert info.host == host
+    assert info.owner == owner
+    assert info.name == name
+    # name_with_owner is what the poller compares against repository.nameWithOwner.
+    assert info.name_with_owner == f"{owner}/{name}"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/onlyowner",
+        "git@github.com:onlyowner.git",
+        "https://github.com/",
+        "https://github.com/a/b/c",
+        "not a url",
+        "",
+    ],
+)
+def test_parse_origin_malformed_returns_none(url: str) -> None:
+    assert _parse_origin(url) is None
+
+
+def test_parse_origin_owner_repo_strips_dot_git() -> None:
+    # nameWithOwner from GitHub's API never carries .git; origin URLs usually do.
+    assert _parse_origin_owner_repo("https://github.com/imbue-ai/sculptor.git") == ("imbue-ai", "sculptor")
+    assert _parse_origin_owner_repo("git@github.com:imbue-ai/sculptor.git") == ("imbue-ai", "sculptor")

--- a/sculptor/sculptor/web/pr_polling_service_test.py
+++ b/sculptor/sculptor/web/pr_polling_service_test.py
@@ -1,6 +1,7 @@
 import queue
 import threading
 import time
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -9,6 +10,7 @@ import pytest
 
 from sculptor.config.user_config import UserConfig
 from sculptor.primitives.ids import WorkspaceID
+from sculptor.web.cli_status_utils import CliStatusError
 from sculptor.web.data_types import StreamingUpdateSourceTypes
 from sculptor.web.derived import PrStatusInfo
 from sculptor.web.derived import WorkspaceBranchInfo
@@ -20,6 +22,7 @@ from sculptor.web.pr_polling_service import _HostThrottle
 from sculptor.web.pr_polling_service import _MIN_POLL_INTERVAL_SECONDS
 from sculptor.web.pr_polling_service import _PollJob
 from sculptor.web.pr_polling_service import _RATE_LIMIT_COOLDOWN_SECONDS
+from sculptor.web.pr_polling_service import _RoundCandidate
 from sculptor.web.pr_polling_service import _TERMINAL_STATE_MULTIPLIER
 from sculptor.web.pr_polling_service import _WorkspacePollState
 from sculptor.web.pr_polling_service import _build_pr_index
@@ -27,6 +30,8 @@ from sculptor.web.pr_polling_service import _compute_poll_delay
 from sculptor.web.pr_polling_service import _compute_round_interval
 from sculptor.web.pr_polling_service import _parse_origin
 from sculptor.web.pr_polling_service import _parse_origin_owner_repo
+from sculptor.web.pr_status import GithubRateLimit
+from sculptor.web.pr_status import OpenPrSearchResult
 from sculptor.web.streams import _notify_pr_polling_service
 
 # ---------------------------------------------------------------------------
@@ -749,3 +754,328 @@ def test_compute_round_interval_floors_at_minimum() -> None:
 def test_compute_round_interval_uses_configured_interval() -> None:
     config = _make_user_config(pr_poll_interval_seconds=45)
     assert _compute_round_interval(config) == 45.0
+
+
+# ---------------------------------------------------------------------------
+# Batched search round: fan-out, Change-2 fallback, short-circuits, cadence.
+# ---------------------------------------------------------------------------
+
+
+_WORKING_DIR = Path("/tmp/repo")
+
+
+def _open_search_node(
+    number: int,
+    repo: str = "org/repo",
+    head: str = "feat-1",
+    base: str = "main",
+    mergeable: str | None = None,
+    check_state: str | None = None,
+    reviews: list[dict] | None = None,
+    threads: list[dict] | None = None,
+) -> dict:
+    """Build one ``... on PullRequest`` search node (open state)."""
+    rollup = {"state": check_state} if check_state is not None else None
+    node = {
+        "number": number,
+        "title": f"PR #{number}",
+        "url": f"https://github.com/{repo}/pull/{number}",
+        "state": "OPEN",
+        "baseRefName": base,
+        "repository": {"nameWithOwner": repo},
+        "headRefName": head,
+        "commits": {"nodes": [{"commit": {"statusCheckRollup": rollup}}]},
+        "latestReviews": {"nodes": reviews or []},
+        "reviewThreads": {"nodes": threads or []},
+    }
+    if mergeable is not None:
+        node["mergeable"] = mergeable
+    return node
+
+
+def _search_result(nodes: list[dict], rate_limit: GithubRateLimit | None = None) -> OpenPrSearchResult:
+    if rate_limit is None:
+        rate_limit = GithubRateLimit(cost=3, remaining=4997, limit=5000, reset_at="2026-01-01T00:00:00Z")
+    return OpenPrSearchResult(nodes=nodes, rate_limit=rate_limit)
+
+
+def _candidate(
+    svc: PrPollingService,
+    workspace_id: WorkspaceID,
+    target_branch: str,
+    current_branch: str = "feat-1",
+    repo: str = "org/repo",
+    host: str = "github.com",
+    is_open: bool = True,
+) -> _RoundCandidate:
+    """Register a poll state and build a matching round candidate (no git I/O)."""
+    state = _WorkspacePollState(
+        workspace_id=workspace_id,
+        working_dir=_WORKING_DIR,
+        target_branch=target_branch,
+        is_open=is_open,
+    )
+    svc._workspace_poll_state[workspace_id] = state
+    return _RoundCandidate(
+        workspace_id=workspace_id,
+        state=state,
+        working_dir=_WORKING_DIR,
+        current_branch=current_branch,
+        target_branch=target_branch,
+        host=host,
+        name_with_owner=repo,
+    )
+
+
+def test_round_shared_branch_different_target_keys_by_workspace_id() -> None:
+    # Two workspaces on the SAME (repo, head branch) but different targets. One
+    # open node (base=main) must yield "open" for the main-targeting workspace
+    # and "none + mismatched" for the develop-targeting one — proving the cache
+    # is keyed by WorkspaceID, not (repo, branch).
+    svc = _make_service()
+    ws_main = WorkspaceID()
+    ws_dev = WorkspaceID()
+    cand_main = _candidate(svc, ws_main, target_branch="main")
+    cand_dev = _candidate(svc, ws_dev, target_branch="develop")
+    node = _open_search_node(100, base="main")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            return_value=_search_result([node]),
+        ):
+            svc._run_host_round("github.com", [cand_main, cand_dev])
+
+    assert svc._cache[ws_main].pr_state == "open"
+    assert svc._cache[ws_main].pr_iid == 100
+    assert svc._cache[ws_dev].pr_state == "none"
+    assert svc._cache[ws_dev].mismatched_pr_iid == 100
+    assert svc._cache[ws_dev].mismatched_pr_target_branch == "main"
+    # Both were resolved by the round, so neither needs a per-workspace fallback.
+    assert ws_main in svc._matched_workspaces
+    assert ws_dev in svc._matched_workspaces
+    assert svc._job_queue.empty()
+
+
+def test_round_conflicting_node_sets_has_conflicts() -> None:
+    # mergeable rides the search node, so a matched open PR's merge-conflict
+    # signal survives the round (Goal-4: the CI babysitter's MERGE_CONFLICT).
+    svc = _make_service()
+    ws = WorkspaceID()
+    cand = _candidate(svc, ws, target_branch="main")
+    node = _open_search_node(200, base="main", mergeable="CONFLICTING")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            return_value=_search_result([node]),
+        ):
+            svc._run_host_round("github.com", [cand])
+
+    assert svc._cache[ws].pr_state == "open"
+    assert svc._cache[ws].has_conflicts is True
+
+
+def test_round_unmatched_branch_enqueues_fallback_and_does_not_emit() -> None:
+    # A workspace whose branch has no open authored PR in the search is unmatched:
+    # the round emits nothing for it and enqueues a per-workspace fallback.
+    svc = _make_service()
+    ws = WorkspaceID()
+    cand = _candidate(svc, ws, target_branch="main", current_branch="feat-no-pr")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            return_value=_search_result([_open_search_node(1, head="other-branch")]),
+        ):
+            svc._run_host_round("github.com", [cand])
+
+    assert ws not in svc._cache
+    assert ws not in svc._matched_workspaces
+    assert ws in svc._pending
+    assert not svc._job_queue.empty()
+
+
+def test_round_stashes_rate_limit_for_governor() -> None:
+    svc = _make_service()
+    cand = _candidate(svc, WorkspaceID(), target_branch="main")
+    rate_limit = GithubRateLimit(cost=3, remaining=4000, limit=5000, reset_at="2026-01-01T00:00:00Z")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            return_value=_search_result([], rate_limit=rate_limit),
+        ):
+            svc._run_host_round("github.com", [cand])
+
+    assert svc._rate_limit_by_host["github.com"] == rate_limit
+
+
+def test_round_logs_cold_start_unmatched_count_once() -> None:
+    svc = _make_service()
+    cand = _candidate(svc, WorkspaceID(), target_branch="main", current_branch="feat-no-pr")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            return_value=_search_result([]),
+        ):
+            with patch("sculptor.web.pr_polling_service.logger") as mock_logger:
+                svc._run_host_round("github.com", [cand])
+                # Second round on the same host must not re-log the cold start.
+                svc._run_host_round("github.com", [cand])
+
+    cold_start_logs = [c for c in mock_logger.info.call_args_list if "cold start" in c.args[0]]
+    assert len(cold_start_logs) == 1
+
+
+def test_round_rate_limited_search_enters_cooldown_and_does_not_emit() -> None:
+    svc = _make_service()
+    ws = WorkspaceID()
+    cand = _candidate(svc, ws, target_branch="main")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            side_effect=CliStatusError("rate_limited", "HTTP 403: API rate limit exceeded"),
+        ):
+            svc._run_host_round("github.com", [cand])
+
+    assert svc._throttle.cooldown_remaining() > 0
+    assert ws not in svc._cache
+
+
+def test_round_skips_search_when_in_cooldown() -> None:
+    # When _respect_throttle reports an active cooldown, the round issues NO
+    # search query at all.
+    svc = _make_service()
+    cand = _candidate(svc, WorkspaceID(), target_branch="main")
+
+    with patch.object(PrPollingService, "_respect_throttle", return_value=_CooldownDeferred(30.0)):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            side_effect=AssertionError("search must not run during cooldown"),
+        ):
+            svc._run_host_round("github.com", [cand])
+
+
+def test_round_short_circuit_on_target_issues_no_search() -> None:
+    # A workspace on its target branch resolves to `none` with zero gh calls —
+    # it never becomes a round candidate, so no search query runs.
+    svc = _make_service()
+    ws = WorkspaceID()
+    _add_workspace_poll_state(svc, ws)
+    svc._workspace_poll_state[ws].working_dir = _WORKING_DIR
+    svc._workspace_poll_state[ws].target_branch = "origin/main"
+    config = _make_user_config()
+
+    with patch("sculptor.web.pr_polling_service._get_workspace_current_branch", return_value="main"):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            side_effect=AssertionError("no search for an on-target workspace"),
+        ):
+            svc._run_round(config)
+
+    assert svc._cache[ws].pr_state == "none"
+
+
+def test_round_short_circuit_no_branch_issues_no_search() -> None:
+    svc = _make_service()
+    ws = WorkspaceID()
+    _add_workspace_poll_state(svc, ws)
+    svc._workspace_poll_state[ws].working_dir = _WORKING_DIR
+    config = _make_user_config()
+
+    with patch("sculptor.web.pr_polling_service._get_workspace_current_branch", return_value=None):
+        with patch(
+            "sculptor.web.pr_polling_service.fetch_open_prs_for_token",
+            side_effect=AssertionError("no search for a branchless workspace"),
+        ):
+            svc._run_round(config)
+
+    assert svc._cache[ws].pr_state == "none"
+
+
+def test_fallback_index_blip_open_to_none_is_noop() -> None:
+    # Prior cache shows open; the per-workspace fallback returns no PR at all (a
+    # one-round search-index drop-out). Rule 5: keep the open status, emit
+    # nothing — no spurious open→none transition.
+    svc = _make_service()
+    ws = WorkspaceID()
+    _add_workspace_poll_state(svc, ws)
+    state = svc._workspace_poll_state[ws]
+    svc._pending.add(ws)
+    open_status = PrStatusInfo(workspace_id=ws, pr_state="open", pr_iid=7)
+    svc._cache[ws] = open_status
+
+    observer: queue.Queue = queue.Queue()
+    svc.add_observer(observer)
+    observer.get_nowait()  # drain the replayed open status from add_observer
+
+    empty = PrStatusInfo(workspace_id=ws, pr_state="none")
+    with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=_make_user_config()):
+        with patch.object(PrPollingService, "_execute_poll", return_value=empty):
+            svc._poll_and_handle_result(_PollJob(0.0, ws), state)
+
+    assert svc._cache[ws] == open_status
+    assert observer.empty()
+
+
+def test_fallback_terminal_merged_reschedules_at_terminal_cadence() -> None:
+    svc = _make_service()
+    ws = WorkspaceID()
+    _add_workspace_poll_state(svc, ws)
+    state = svc._workspace_poll_state[ws]
+    svc._pending.add(ws)
+    merged = PrStatusInfo(workspace_id=ws, pr_state="merged", pr_iid=9)
+    config = _make_user_config(pr_poll_interval_seconds=30)
+
+    with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=config):
+        with patch.object(PrPollingService, "_execute_poll", return_value=merged):
+            svc._poll_and_handle_result(_PollJob(0.0, ws), state)
+
+    assert svc._cache[ws].pr_state == "merged"
+    rescheduled = svc._job_queue.get_nowait()
+    delay = rescheduled.scheduled_time - time.monotonic()
+    expected = 30.0 * _TERMINAL_STATE_MULTIPLIER
+    assert expected - 2 <= delay <= expected
+
+
+def test_fallback_no_pr_reschedules_at_base_interval_independent_of_round() -> None:
+    # A no-PR-yet workspace polls at the base interval via the fallback,
+    # decoupled from the round — the round interval doesn't enter the math.
+    svc = _make_service()
+    ws = WorkspaceID()
+    _add_workspace_poll_state(svc, ws)
+    state = svc._workspace_poll_state[ws]
+    svc._pending.add(ws)
+    none_status = PrStatusInfo(workspace_id=ws, pr_state="none")
+    config = _make_user_config(pr_poll_interval_seconds=45)
+
+    with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=config):
+        with patch.object(PrPollingService, "_execute_poll", return_value=none_status):
+            svc._poll_and_handle_result(_PollJob(0.0, ws), state)
+
+    rescheduled = svc._job_queue.get_nowait()
+    delay = rescheduled.scheduled_time - time.monotonic()
+    assert 43 <= delay <= 45
+
+
+def test_fallback_matched_workspace_stops_rescheduling() -> None:
+    # Once the round has matched a workspace, a stale fallback fetch emits its
+    # result but does NOT reschedule — the round now owns it (rule 3 cost control).
+    svc = _make_service()
+    ws = WorkspaceID()
+    _add_workspace_poll_state(svc, ws)
+    state = svc._workspace_poll_state[ws]
+    svc._pending.add(ws)
+    svc._matched_workspaces.add(ws)
+    open_status = PrStatusInfo(workspace_id=ws, pr_state="open", pr_iid=5)
+
+    with patch("sculptor.web.pr_polling_service.get_user_config_instance", return_value=_make_user_config()):
+        with patch.object(PrPollingService, "_execute_poll", return_value=open_status):
+            svc._poll_and_handle_result(_PollJob(0.0, ws), state)
+
+    assert svc._cache[ws] == open_status
+    assert svc._job_queue.empty()
+    assert ws not in svc._pending

--- a/sculptor/sculptor/web/pr_polling_service_test.py
+++ b/sculptor/sculptor/web/pr_polling_service_test.py
@@ -1,3 +1,4 @@
+import datetime
 import queue
 import threading
 import time
@@ -22,14 +23,17 @@ from sculptor.web.pr_polling_service import _HostThrottle
 from sculptor.web.pr_polling_service import _MIN_POLL_INTERVAL_SECONDS
 from sculptor.web.pr_polling_service import _PollJob
 from sculptor.web.pr_polling_service import _RATE_LIMIT_COOLDOWN_SECONDS
+from sculptor.web.pr_polling_service import _RATE_LIMIT_WINDOW_SECONDS
 from sculptor.web.pr_polling_service import _RoundCandidate
 from sculptor.web.pr_polling_service import _TERMINAL_STATE_MULTIPLIER
 from sculptor.web.pr_polling_service import _WorkspacePollState
 from sculptor.web.pr_polling_service import _build_pr_index
+from sculptor.web.pr_polling_service import _compute_governed_interval
 from sculptor.web.pr_polling_service import _compute_poll_delay
 from sculptor.web.pr_polling_service import _compute_round_interval
 from sculptor.web.pr_polling_service import _parse_origin
 from sculptor.web.pr_polling_service import _parse_origin_owner_repo
+from sculptor.web.pr_polling_service import _seconds_until_reset
 from sculptor.web.pr_status import GithubRateLimit
 from sculptor.web.pr_status import OpenPrSearchResult
 from sculptor.web.streams import _notify_pr_polling_service
@@ -65,6 +69,7 @@ def _make_service() -> PrPollingService:
     svc._rate_limit_by_host = {}
     svc._round_failed_hosts = set()
     svc._cold_start_logged_hosts = set()
+    svc._governed_interval = None
     object.__setattr__(svc, "_data_model_service", MagicMock())
     object.__setattr__(svc, "_workspace_service", MagicMock())
     return svc
@@ -1079,3 +1084,109 @@ def test_fallback_matched_workspace_stops_rescheduling() -> None:
     assert svc._cache[ws] == open_status
     assert svc._job_queue.empty()
     assert ws not in svc._pending
+
+
+# ---------------------------------------------------------------------------
+# Rate-budget governor (Change-3): back-off / recover / defer.
+# ---------------------------------------------------------------------------
+
+
+_BASE = 30.0
+_BUDGET_FRACTION = 0.8
+
+
+def _rate_limit(
+    remaining: int, limit: int = 5000, cost: int = 3, reset_at: str = "2026-01-01T00:00:00Z"
+) -> GithubRateLimit:
+    return GithubRateLimit(cost=cost, remaining=remaining, limit=limit, reset_at=reset_at)
+
+
+def test_governor_holds_at_base_with_plenty_of_headroom() -> None:
+    # Barely any of the budget spent → stay at the base interval.
+    interval, throttled = _compute_governed_interval(
+        _BASE, _BASE, _rate_limit(remaining=4900), _BUDGET_FRACTION, seconds_until_reset=3000.0
+    )
+    assert interval == _BASE
+    assert throttled is False
+
+
+def test_governor_backs_off_when_projected_spend_exceeds_ceiling() -> None:
+    # 4000 of 5000 spent in the first 600s of the window → ~24000/hr projected,
+    # far above the 4000/hr ceiling → lengthen the interval.
+    interval, throttled = _compute_governed_interval(
+        _BASE, _BASE, _rate_limit(remaining=1000), _BUDGET_FRACTION, seconds_until_reset=3000.0
+    )
+    assert interval > _BASE
+    assert throttled is True
+
+
+def test_governor_backoff_accumulates_up_to_cap() -> None:
+    over_budget = _rate_limit(remaining=1000)
+    # Each round multiplies the interval; it never exceeds base * the cap multiplier.
+    first, _ = _compute_governed_interval(_BASE, _BASE, over_budget, _BUDGET_FRACTION, 3000.0)
+    second, _ = _compute_governed_interval(_BASE, first, over_budget, _BUDGET_FRACTION, 3000.0)
+    assert second > first
+    capped, _ = _compute_governed_interval(_BASE, 100_000.0, over_budget, _BUDGET_FRACTION, 3000.0)
+    assert capped == _BASE * 20.0
+
+
+def test_governor_recovers_toward_base_when_headroom_returns() -> None:
+    # Stretched to 100s, but spend is now well under the ceiling → step back down,
+    # never below the base interval.
+    headroom = _rate_limit(remaining=4900)
+    recovered, throttled = _compute_governed_interval(_BASE, 100.0, headroom, _BUDGET_FRACTION, 3000.0)
+    assert _BASE <= recovered < 100.0
+    assert throttled is True  # still above base — recovering, not yet recovered
+    at_base, throttled_at_base = _compute_governed_interval(_BASE, _BASE, headroom, _BUDGET_FRACTION, 3000.0)
+    assert at_base == _BASE
+    assert throttled_at_base is False
+
+
+def test_governor_defers_to_reset_when_remaining_is_critically_low() -> None:
+    # remaining below 5% of limit → wait out the window (≈ seconds until reset).
+    interval, throttled = _compute_governed_interval(
+        _BASE, _BASE, _rate_limit(remaining=100), _BUDGET_FRACTION, seconds_until_reset=1800.0
+    )
+    assert interval == 1800.0
+    assert throttled is True
+
+
+def test_governor_ceiling_scales_with_reported_limit_not_hardcoded() -> None:
+    # Same spend rate (≈5000/hr): over the 4000 ceiling for a 5000-point token,
+    # but well under the 12000 ceiling for a 15000-point App token.
+    small_token = _rate_limit(remaining=4167, limit=5000)
+    big_token = _rate_limit(remaining=14167, limit=15000)
+    small_interval, small_throttled = _compute_governed_interval(_BASE, _BASE, small_token, _BUDGET_FRACTION, 3000.0)
+    big_interval, big_throttled = _compute_governed_interval(_BASE, _BASE, big_token, _BUDGET_FRACTION, 3000.0)
+    assert small_throttled is True and small_interval > _BASE
+    assert big_throttled is False and big_interval == _BASE
+
+
+def test_governor_backs_off_on_remaining_decline_even_with_tiny_cost() -> None:
+    # A small search cost but a large drop in remaining (the fallback fetches
+    # spent it) must still trigger back-off — proving the governor drives off
+    # remaining, not the search query's cost.
+    interval, throttled = _compute_governed_interval(
+        _BASE, _BASE, _rate_limit(remaining=1000, cost=3), _BUDGET_FRACTION, seconds_until_reset=3000.0
+    )
+    assert throttled is True
+    assert interval > _BASE
+
+
+def test_seconds_until_reset_parses_future_timestamp() -> None:
+    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=600)
+    seconds = _seconds_until_reset(future.isoformat().replace("+00:00", "Z"))
+    assert 590 <= seconds <= 600
+
+
+def test_seconds_until_reset_handles_missing_and_invalid() -> None:
+    assert _seconds_until_reset(None) == _RATE_LIMIT_WINDOW_SECONDS
+    assert _seconds_until_reset("") == _RATE_LIMIT_WINDOW_SECONDS
+    assert _seconds_until_reset("not-a-timestamp") == _RATE_LIMIT_WINDOW_SECONDS
+
+
+def test_seconds_until_reset_floors_past_and_caps_far_future() -> None:
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=120)
+    assert _seconds_until_reset(past.isoformat().replace("+00:00", "Z")) == 0.0
+    far_future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=99999)
+    assert _seconds_until_reset(far_future.isoformat().replace("+00:00", "Z")) == _RATE_LIMIT_WINDOW_SECONDS

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -223,6 +224,201 @@ def _fetch_prs_with_details(working_dir: Path, source_branch: str) -> list[dict]
     if repository is None:
         return []
     return (repository.get("pullRequests") or {}).get("nodes") or []
+
+
+# Page size for the token-wide search query. One page covers every open PR for
+# a user with up to this many open PRs (the overwhelmingly common case); the
+# fetch only paginates beyond it (and logs when it does).
+_SEARCH_PAGE_SIZE = 100
+
+# The GitHub search filter. ``author:@me`` scopes the search to the token
+# owner's own PRs (every PR a Sculptor workspace opens is authored by the token
+# owner), so a single token-global query spans every repo with no repo
+# enumeration. ``sort:updated`` is required, not cosmetic: ``_first_matching_target``
+# returns the *first* PR matching a base branch and relies on most-recently-updated
+# ordering, but ``search`` otherwise defaults to relevance order.
+_SEARCH_QUERY_STRING = "is:pr state:open author:@me archived:false sort:updated"
+
+# Token-wide search query that replaces one ``_GRAPHQL_PR_QUERY`` per workspace
+# with one query per (host, token) per round. ``author:@me`` returns all of the
+# user's open PRs across every repo at once, each node carrying the same
+# check/review/comment/``mergeable`` detail the per-workspace query does, plus
+# ``repository { nameWithOwner }`` and ``headRefName`` so the poller can index a
+# node back to the workspace(s) it belongs to. The sibling ``rateLimit`` block
+# rides in the same response so the governor can read the token's budget with no
+# extra call. ``reviewThreads`` is trimmed to 10 (Change-1b) and
+# ``latestReviews`` left at 20 (cost-free — it nests no connection).
+_SEARCH_PR_QUERY = """
+query($q: String!, $prCount: Int!, $after: String) {
+  search(query: $q, type: ISSUE, first: $prCount, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        state
+        baseRefName
+        repository { nameWithOwner }
+        headRefName
+        mergeable
+        commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
+        latestReviews(first: 20) { nodes { state author { login } } }
+        reviewThreads(first: 10) {
+          nodes { isResolved comments(first: 1) { nodes { author { login } path line body } } }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining limit resetAt }
+}
+"""
+
+
+@dataclass(frozen=True)
+class GithubRateLimit:
+    """GitHub API rate-budget snapshot parsed from a query's ``rateLimit`` block.
+
+    ``cost`` is the points the query consumed; ``remaining`` / ``limit`` and the
+    ISO-8601 ``reset_at`` describe the token's hourly budget. Consumed by the
+    rate-budget governor to back off proactively before the wall.
+    """
+
+    cost: int
+    remaining: int
+    limit: int
+    reset_at: str
+
+
+@dataclass(frozen=True)
+class OpenPrSearchResult:
+    """All of a token owner's open-PR nodes plus the round's rate-budget snapshot.
+
+    ``nodes`` are raw ``... on PullRequest`` dicts (open state only — terminal
+    PRs are not in a ``state:open`` search); ``rate_limit`` is the response's
+    ``rateLimit`` block, or ``None`` when it is absent from a malformed response.
+    """
+
+    nodes: list[dict]
+    rate_limit: GithubRateLimit | None
+
+
+def fetch_open_prs_for_token(working_dir: Path) -> OpenPrSearchResult:
+    """Fetch every open PR authored by the token owner in one search query.
+
+    Issues a single ``gh api graphql`` ``search`` request (``author:@me``,
+    token-global — not repo-scoped) returning all of the user's open PRs across
+    every repo, each with the per-PR check/review/comment detail the
+    per-workspace query carries. Paginates only when the user has more than
+    ``_SEARCH_PAGE_SIZE`` open PRs (rare), logging a warning when it does so
+    silent truncation can't masquerade as full coverage. Returns the
+    accumulated nodes plus the token's ``rateLimit`` snapshot (``None`` if the
+    block is absent) for the governor.
+
+    Raises CliStatusError on any CLI failure (classified via
+    ``classify_cli_error``) or invalid JSON, so the poller can surface it and
+    back off.
+    """
+    nodes: list[dict] = []
+    rate_limit: GithubRateLimit | None = None
+    after: str | None = None
+    page = 1
+    while True:
+        payload = _run_search_query(working_dir, after)
+        search = (payload.get("data") or {}).get("search") or {}
+        nodes.extend(search.get("nodes") or [])
+        rate_limit = _parse_rate_limit(payload)
+        page_info = search.get("pageInfo") or {}
+        if not (page_info.get("hasNextPage") and page_info.get("endCursor")):
+            break
+        after = page_info["endCursor"]
+        page += 1
+        logger.warning(
+            "PR search returned more than {} open PRs; following pagination to page {}",
+            _SEARCH_PAGE_SIZE,
+            page,
+        )
+    return OpenPrSearchResult(nodes=nodes, rate_limit=rate_limit)
+
+
+def _run_search_query(working_dir: Path, after: str | None) -> dict:
+    """Run one page of the token-wide search query and return its parsed payload.
+
+    Unlike ``_fetch_prs_with_details`` there is no ``owner``/``name`` arg —
+    search is token-global, not repo-scoped — but ``gh`` still needs a directory
+    to resolve the token/host. Raises CliStatusError on CLI failure or invalid
+    JSON, mirroring ``_fetch_prs_with_details``.
+    """
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={_SEARCH_PR_QUERY}",
+        "-f",
+        f"q={_SEARCH_QUERY_STRING}",
+        "-F",
+        f"prCount={_SEARCH_PAGE_SIZE}",
+    ]
+    if after is not None:
+        cmd += ["-f", f"after={after}"]
+    result = run_cli_with_retry(cmd, working_dir)
+    if result.returncode != 0:
+        raise CliStatusError(classify_cli_error(result.stderr), result.stderr)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise CliStatusError("transient", f"Invalid JSON from gh api graphql: {result.stdout[:200]}") from e
+
+
+def _parse_rate_limit(payload: dict) -> GithubRateLimit | None:
+    """Parse a response's ``rateLimit`` block, or ``None`` if it is absent.
+
+    Kept tolerant of a missing or partial block so a malformed response degrades
+    (governor falls back to its default budget) instead of crashing the round.
+    """
+    block = (payload.get("data") or {}).get("rateLimit")
+    if not isinstance(block, dict):
+        return None
+    cost = block.get("cost")
+    remaining = block.get("remaining")
+    limit = block.get("limit")
+    reset_at = block.get("resetAt")
+    if cost is None or remaining is None or limit is None or reset_at is None:
+        return None
+    return GithubRateLimit(cost=cost, remaining=remaining, limit=limit, reset_at=reset_at)
+
+
+def build_status_from_open_nodes(
+    workspace_id: WorkspaceID,
+    open_nodes: Sequence[dict],
+    target_branch: str,
+) -> PrStatusInfo:
+    """Derive one workspace's open-PR status from the token-wide search nodes.
+
+    Pure (no I/O): given the open-PR nodes already filtered to this workspace's
+    ``(repo, head branch)``, pick the PR whose base matches its target and reuse
+    the per-node parsers. Handles only the open and no-open-PR cases — terminal
+    (merged/closed) PRs are absent from a ``state:open`` search and are recovered
+    by the per-workspace fallback. Mirrors ``_fetch_pr_status_inner``'s open and
+    mismatch branches so behavior matches today for the open case.
+    """
+    stripped_target = strip_remote_prefix(target_branch)
+    open_match = _first_matching_target(open_nodes, stripped_target)
+    if open_match is not None:
+        return _build_open_pr_status(workspace_id, open_match)
+    # No open PR targets this branch — if one exists against a different target,
+    # surface it so the frontend can offer to switch targets.
+    if open_nodes:
+        mismatched_pr = open_nodes[0]
+        return PrStatusInfo(
+            workspace_id=workspace_id,
+            pr_state="none",
+            mismatched_pr_iid=mismatched_pr["number"],
+            mismatched_pr_target_branch=mismatched_pr.get("baseRefName"),
+            mismatched_pr_web_url=mismatched_pr.get("url"),
+        )
+    return PrStatusInfo(workspace_id=workspace_id, pr_state="none")
 
 
 def _parse_conflict_status(pr_node: dict) -> bool | None:

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -245,8 +245,8 @@ _SEARCH_QUERY_STRING = "is:pr state:open author:@me archived:false sort:updated"
 # ``repository { nameWithOwner }`` and ``headRefName`` so the poller can index a
 # node back to the workspace(s) it belongs to. The sibling ``rateLimit`` block
 # rides in the same response so the governor can read the token's budget with no
-# extra call. ``reviewThreads`` is trimmed to 10 (Change-1b) and
-# ``latestReviews`` left at 20 (cost-free — it nests no connection).
+# extra call. ``reviewThreads`` is trimmed to 10 and ``latestReviews`` left at 20
+# (cost-free — it nests no connection).
 _SEARCH_PR_QUERY = """
 query($q: String!, $prCount: Int!, $after: String) {
   search(query: $q, type: ISSUE, first: $prCount, after: $after) {

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -173,7 +173,7 @@ query($owner: String!, $name: String!, $branch: String!, $limit: Int!) {
         mergeable
         commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
         latestReviews(first: 20) { nodes { state author { login } } }
-        reviewThreads(first: 30) {
+        reviewThreads(first: 10) {
           nodes { isResolved comments(first: 1) { nodes { author { login } path line body } } }
         }
       }

--- a/sculptor/sculptor/web/pr_status.py
+++ b/sculptor/sculptor/web/pr_status.py
@@ -43,7 +43,6 @@ def fetch_pr_status(
             workspace_id=workspace_id,
             pr_state="none",
             error_category=e.category,
-            error_provider="github",
             error_message=str(e),
         )
 

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -331,7 +331,9 @@ def test_graphql_query_requests_the_fields_the_parser_reads() -> None:
         assert field in query, f"query is missing field {field!r}"
     # `reviewThreads` is requested directly (it is a valid GraphQL PullRequest
     # field, unlike `gh pr view --json`'s curated subset that shipped the bug).
-    assert "reviewThreads" in query
+    # Its page size is trimmed to 10 (Change-1b) — `reviewThreads` is the
+    # dominant cost term, so this caps the per-poll GraphQL point cost.
+    assert "reviewThreads(first: 10)" in query
 
 
 # ---------------------------------------------------------------------------

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 from pathlib import Path
 from unittest.mock import patch
@@ -12,6 +13,9 @@ from sculptor.primitives.ids import WorkspaceID
 from sculptor.web.cli_status_utils import CliStatusError
 from sculptor.web.pr_status import _GRAPHQL_PR_QUERY
 from sculptor.web.pr_status import _PR_QUERY_LIMIT
+from sculptor.web.pr_status import _SEARCH_PAGE_SIZE
+from sculptor.web.pr_status import _SEARCH_PR_QUERY
+from sculptor.web.pr_status import _SEARCH_QUERY_STRING
 from sculptor.web.pr_status import build_status_from_open_nodes
 from sculptor.web.pr_status import fetch_open_prs_for_token
 from sculptor.web.pr_status import fetch_pr_status
@@ -649,3 +653,78 @@ def test_build_status_from_open_nodes_conflicting_sets_has_conflicts() -> None:
 
     assert result.pr_state == "open"
     assert result.has_conflicts is True
+
+
+# ---------------------------------------------------------------------------
+# Cost-regression guard for the production search query (design Risk-4, Goal-2).
+#
+# GraphQL charges a connection by its parent cardinality times what nests
+# beneath it, so an added nested `first:`/`last:` connection silently balloons
+# the per-round point cost — and the governor's projections assume a known cost.
+# The structural guard below runs always (no `gh`) and fails loudly if a new
+# nested connection creeps in; the opt-in live test re-measures the real cost.
+# ---------------------------------------------------------------------------
+
+
+def test_search_query_has_no_unexpected_nested_connections() -> None:
+    # The complete set of paginated connections in the production search query.
+    # `reviewThreads`/`comments` are the only cost-multiplying nest; adding any
+    # other `first:`/`last:` here is what blows up the per-round cost.
+    expected_pagination = sorted(
+        [
+            "first: $prCount",  # search(...) page size
+            "last: 1",  # commits(last: 1)
+            "first: 20",  # latestReviews — cost-free (no nested connection)
+            "first: 10",  # reviewThreads — the dominant cost term (Change-1b)
+            "first: 1",  # comments under reviewThreads
+        ]
+    )
+    found = sorted(
+        f"{keyword}: {value}" for keyword, value in re.findall(r"\b(first|last):\s*([^\s,)]+)", _SEARCH_PR_QUERY)
+    )
+    assert found == expected_pagination, (
+        f"search query pagination changed: {found} != {expected_pagination}; "
+        + "a new nested first:/last: connection would balloon the per-round GraphQL cost"
+    )
+    # Lock the two page sizes that matter for cost (trimmed) and coverage.
+    assert "reviewThreads(first: 10)" in _SEARCH_PR_QUERY
+    assert "latestReviews(first: 20)" in _SEARCH_PR_QUERY
+
+
+# Measured production cost (per design): ~3 points at reviewThreads(first: 10)
+# for ~20 open PRs (~7 at first: 30). The ceiling has headroom for fleet-size
+# variation; the authority for the governor's projections is this *measured*
+# live cost, not the projection itself (Risk-4) — re-measure if it trips.
+_SEARCH_QUERY_COST_CEILING = 10
+
+
+@pytest.mark.skipif(
+    not os.environ.get("SCULPTOR_PR_STATUS_LIVE_GH_TEST"),
+    reason="opt-in: set SCULPTOR_PR_STATUS_LIVE_GH_TEST=1 to measure cost against real GitHub",
+)
+def test_search_query_cost_within_band() -> None:
+    if shutil.which("gh") is None:
+        pytest.skip("gh CLI not available")
+    result = run_blocking(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={_SEARCH_PR_QUERY}",
+            "-f",
+            f"q={_SEARCH_QUERY_STRING}",
+            "-F",
+            f"prCount={_SEARCH_PAGE_SIZE}",
+        ],
+        timeout=30.0,
+        is_checked=False,
+        cwd=Path(__file__).parent,
+    )
+    assert result.returncode == 0, f"gh api graphql rejected the search query: {result.stderr}"
+    payload = json.loads(result.stdout)
+    cost = payload["data"]["rateLimit"]["cost"]
+    assert cost <= _SEARCH_QUERY_COST_CEILING, (
+        f"search query cost {cost} exceeds the expected band (<= {_SEARCH_QUERY_COST_CEILING}); "
+        + "re-measure and re-check the governor's projections (design Risk-4)"
+    )

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -9,8 +9,11 @@ import pytest
 from sculptor.foundation.processes.local_process import run_blocking
 from sculptor.foundation.subprocess_utils import FinishedProcess
 from sculptor.primitives.ids import WorkspaceID
+from sculptor.web.cli_status_utils import CliStatusError
 from sculptor.web.pr_status import _GRAPHQL_PR_QUERY
 from sculptor.web.pr_status import _PR_QUERY_LIMIT
+from sculptor.web.pr_status import build_status_from_open_nodes
+from sculptor.web.pr_status import fetch_open_prs_for_token
 from sculptor.web.pr_status import fetch_pr_status
 
 
@@ -453,3 +456,196 @@ def test_graphql_query_is_valid_against_live_github() -> None:
     payload = json.loads(result.stdout)
     nodes = payload["data"]["repository"]["pullRequests"]["nodes"]
     assert isinstance(nodes, list)
+
+
+# ---------------------------------------------------------------------------
+# Token-wide `search` fetch + per-workspace derivation (Change-1 building blocks).
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_RATE_LIMIT = {"cost": 1, "remaining": 4999, "limit": 5000, "resetAt": "2026-01-01T00:00:00Z"}
+
+
+def _search_node(
+    number: int,
+    base_ref: str = "main",
+    head_ref: str = "feat-1",
+    repo: str = "org/repo",
+    **kwargs,  # noqa: ANN003
+) -> dict:
+    """Build one search ``... on PullRequest`` node (always OPEN — search is state:open).
+
+    Extends the per-workspace ``_pr_node`` shape with the two fields only the
+    search query carries: ``repository.nameWithOwner`` and ``headRefName``.
+    """
+    node = _pr_node(number, "OPEN", base_ref, **kwargs)
+    node["repository"] = {"nameWithOwner": repo}
+    node["headRefName"] = head_ref
+    return node
+
+
+def _search_stdout(
+    nodes: list[dict],
+    *,
+    has_next: bool = False,
+    end_cursor: str | None = None,
+    rate_limit: dict | None = _DEFAULT_RATE_LIMIT,
+) -> str:
+    """Wrap search nodes in the envelope gh emits for the token-wide search query."""
+    return json.dumps(
+        {
+            "data": {
+                "search": {
+                    "nodes": nodes,
+                    "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+                },
+                "rateLimit": rate_limit,
+            }
+        }
+    )
+
+
+def _captured_search_string(cmd: list[str]) -> str:
+    """Return the `-f q=...` search filter passed in a gh command (not `query=`)."""
+    for arg in cmd:
+        if arg.startswith("q="):
+            return arg[len("q=") :]
+    raise AssertionError(f"no q= argument found in command: {cmd}")
+
+
+def test_fetch_open_prs_for_token_single_page() -> None:
+    captured: list[list] = []
+
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        captured.append(cmd)
+        return _make_finished(_search_stdout([_search_node(100), _search_node(101)]))
+
+    with _patch_cli(handler):
+        result = fetch_open_prs_for_token(WORKING_DIR)
+
+    assert [n["number"] for n in result.nodes] == [100, 101]
+    assert result.rate_limit is not None
+    assert result.rate_limit.cost == 1
+    assert result.rate_limit.remaining == 4999
+    assert result.rate_limit.limit == 5000
+    assert result.rate_limit.reset_at == "2026-01-01T00:00:00Z"
+
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert cmd[:3] == ["gh", "api", "graphql"]
+    # The search is token-global, not repo-scoped — no owner/name args.
+    assert not any(arg.startswith("owner=") or arg.startswith("name=") for arg in cmd)
+    search_string = _captured_search_string(cmd)
+    assert "author:@me" in search_string
+    assert "state:open" in search_string
+    assert "sort:updated" in search_string
+    query = _captured_query(cmd)
+    for field in ("mergeable", "nameWithOwner", "headRefName", "reviewThreads(first: 10)", "rateLimit"):
+        assert field in query, f"search query is missing {field!r}"
+
+
+def test_fetch_open_prs_for_token_paginates() -> None:
+    captured: list[list] = []
+
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        captured.append(cmd)
+        if len(captured) == 1:
+            return _make_finished(_search_stdout([_search_node(1)], has_next=True, end_cursor="CURSOR_1"))
+        return _make_finished(_search_stdout([_search_node(2)], has_next=False))
+
+    with patch("sculptor.web.pr_status.logger") as mock_logger:
+        with _patch_cli(handler):
+            result = fetch_open_prs_for_token(WORKING_DIR)
+
+    assert [n["number"] for n in result.nodes] == [1, 2]
+    assert len(captured) == 2
+    assert any(arg == "after=CURSOR_1" for arg in captured[1]), "second page must pass after=<cursor>"
+    # Pagination must be logged so silent truncation can't masquerade as full coverage.
+    assert mock_logger.warning.called
+    assert "pagination" in mock_logger.warning.call_args[0][0]
+
+
+def test_fetch_open_prs_for_token_missing_rate_limit_is_tolerated() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        return _make_finished(_search_stdout([_search_node(1)], rate_limit=None))
+
+    with _patch_cli(handler):
+        result = fetch_open_prs_for_token(WORKING_DIR)
+
+    assert [n["number"] for n in result.nodes] == [1]
+    assert result.rate_limit is None
+
+
+def test_fetch_open_prs_for_token_cli_failure_raises_classified() -> None:
+    def handler(cmd, _working_dir):  # noqa: ANN001
+        return _make_finished("", returncode=1, stderr="HTTP 403: API rate limit exceeded for user")
+
+    with _patch_cli(handler):
+        with pytest.raises(CliStatusError) as exc_info:
+            fetch_open_prs_for_token(WORKING_DIR)
+
+    assert exc_info.value.category == "rate_limited"
+
+
+def test_build_status_from_open_nodes_open_match() -> None:
+    node = _search_node(
+        100,
+        base_ref="main",
+        check_state="SUCCESS",
+        reviews=[{"state": "APPROVED", "author": {"login": "alice"}}],
+        threads=[
+            {
+                "isResolved": False,
+                "comments": {"nodes": [{"author": {"login": "bob"}, "path": "a.py", "line": 3, "body": "fix"}]},
+            }
+        ],
+        mergeable="MERGEABLE",
+    )
+
+    result = build_status_from_open_nodes(WORKSPACE_ID, [node], "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.pr_iid == 100
+    assert result.pipeline_status == "passed"
+    assert [a.name for a in result.approvals] == ["alice"]
+    assert [c.author for c in result.unresolved_comments] == ["bob"]
+    assert result.has_conflicts is False
+
+
+def test_build_status_from_open_nodes_mismatched_target() -> None:
+    node = _search_node(200, base_ref="develop")
+
+    result = build_status_from_open_nodes(WORKSPACE_ID, [node], "origin/main")
+
+    assert result.pr_state == "none"
+    assert result.mismatched_pr_iid == 200
+    assert result.mismatched_pr_target_branch == "develop"
+    assert result.mismatched_pr_web_url == "https://github.com/org/repo/pull/200"
+
+
+def test_build_status_from_open_nodes_empty() -> None:
+    result = build_status_from_open_nodes(WORKSPACE_ID, [], "origin/main")
+
+    assert result.pr_state == "none"
+    assert result.mismatched_pr_iid is None
+
+
+def test_build_status_from_open_nodes_picks_matching_among_two() -> None:
+    # Two open PRs on the same source branch targeting different bases; only the
+    # one matching the workspace's target should be returned (uses
+    # _first_matching_target, which relies on sort:updated ordering).
+    nodes = [_search_node(300, base_ref="develop"), _search_node(301, base_ref="main")]
+
+    result = build_status_from_open_nodes(WORKSPACE_ID, nodes, "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.pr_iid == 301
+
+
+def test_build_status_from_open_nodes_conflicting_sets_has_conflicts() -> None:
+    node = _search_node(400, base_ref="main", mergeable="CONFLICTING")
+
+    result = build_status_from_open_nodes(WORKSPACE_ID, [node], "origin/main")
+
+    assert result.pr_state == "open"
+    assert result.has_conflicts is True

--- a/sculptor/sculptor/web/pr_status_test.py
+++ b/sculptor/sculptor/web/pr_status_test.py
@@ -358,7 +358,6 @@ def test_transient_cli_failure_surfaces_error() -> None:
 
     assert result.pr_state == "none"
     assert result.error_category == "transient"
-    assert result.error_provider == "github"
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +388,6 @@ def test_rate_limit_surfaces_error() -> None:
 
     assert result.pr_state == "none"
     assert result.error_category == "rate_limited"
-    assert result.error_provider == "github"
 
 
 def test_secondary_rate_limit_surfaces_error() -> None:
@@ -400,7 +398,6 @@ def test_secondary_rate_limit_surfaces_error() -> None:
         result = fetch_pr_status(WORKSPACE_ID, WORKING_DIR, "feat-1", "origin/main")
 
     assert result.error_category == "rate_limited"
-    assert result.error_provider == "github"
 
 
 # ---------------------------------------------------------------------------

--- a/sculptor/tests/integration/frontend/test_backend_pr_polling.py
+++ b/sculptor/tests/integration/frontend/test_backend_pr_polling.py
@@ -8,9 +8,19 @@ Each test installs its own fake ``gh`` CLI into
 ``sculptor_instance_.fake_bin_dir`` (which is always on the backend
 subprocess's PATH).  ``SculptorInstance._pre_test`` empties the directory
 between tests, so fake CLIs don't leak across tests.
+
+After the rate-limit redesign the live poll round issues one token-wide
+``search`` query (``is:pr state:open author:@me``) and fans the results out per
+workspace; any branch the search doesn't match (terminal / no-PR) falls back to
+the per-branch ``repository.pullRequests`` query. The fake ``gh`` below branches
+on the query: an invocation carrying ``author:@me`` gets the **search** envelope;
+the per-branch fallback (carrying ``branch=`` / ``owner=``) gets the
+**repository** envelope.
 """
 
+import json
 import stat
+import subprocess
 import textwrap
 from pathlib import Path
 
@@ -26,45 +36,109 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
 _FAKE_GITHUB_REMOTE = "https://github.com/test-org/test-repo.git"
+_NAME_WITH_OWNER = "test-org/test-repo"
 
-# Fake gh CLI that always returns an open PR.
-# The backend issues a single `gh api graphql` query that returns every PR on
-# the source branch (across all states) with its check/review/comment detail
-# bundled in, and dispatches on each node's "state" field. So the fake emits
-# the GraphQL response envelope with one node tagged "state": "OPEN" (no checks,
-# reviews, or threads). ``statusCheckRollup`` is null when no checks have run.
-_FAKE_GH_OPEN_PR_SCRIPT = """\
+# Open PR surfaced through the SEARCH path. The search node's ``headRefName`` is
+# the workspace's actual branch (read live via git, since the fake runs with
+# cwd=working_dir), and ``nameWithOwner`` matches the fake origin, so the poller
+# maps the node to this workspace. The per-branch fallback returns nothing — the
+# open badge can only come from the search match, exercising the search path.
+_FAKE_GH_SEARCH_OPEN = """\
 #!/bin/bash
-if [[ "$*" == *"graphql"* ]]; then
-    echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ "$*" == *"author:@me"* ]]; then
+    echo '{"data":{"search":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","repository":{"nameWithOwner":"test-org/test-repo"},"headRefName":"'"$BRANCH"'","mergeable":"MERGEABLE","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":3,"remaining":4997,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+elif [[ "$*" == *"graphql"* ]]; then
+    echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
 fi
 """
 
-# Fake gh CLI that returns a closed-not-merged PR. The backend dispatches on
-# each node's "state" field, so the node is tagged "state": "CLOSED".
-_FAKE_GH_CLOSED_PR_SCRIPT = """\
+# Closed-not-merged PR. A closed PR is NOT in ``state:open`` search results, so
+# this is driven entirely through the per-branch FALLBACK query returning a
+# ``CLOSED`` node — exercising Change-2's terminal-state recovery.
+_FAKE_GH_CLOSED = """\
 #!/bin/bash
-if [[ "$*" == *"graphql"* ]]; then
+if [[ "$*" == *"author:@me"* ]]; then
+    echo '{"data":{"search":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":1,"remaining":4999,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+elif [[ "$*" == *"graphql"* ]]; then
     echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":77,"title":"Closed PR","url":"https://github.com/test/repo/pull/77","state":"CLOSED","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
 fi
 """
 
-# Fake gh that switches behavior via mode file (no_pr → open_pr). Each mode
-# emits the GraphQL response envelope; no_pr returns an empty node list.
-# The mode-file path is injected via ``.replace("{mode_file}", ...)`` (not
-# ``.format``) so the JSON braces below don't need escaping.
-_FAKE_GH_MODE_SCRIPT = """\
+# Search envelope whose nodes come from a file the test rewrites, so the test
+# controls exactly which branches have open PRs regardless of which workspace
+# dir the token-wide search runs from. The per-branch fallback returns nothing.
+# Mode/nodes paths are injected via ``.replace(...)`` (not ``.format``) so the
+# JSON braces don't need escaping.
+_FAKE_GH_SEARCH_NODES_FILE = """\
 #!/bin/bash
-MODE=$(cat "{mode_file}")
-case "$MODE" in
-    no_pr)
-        echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
-        ;;
-    open_pr)
-        echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
-        ;;
-esac
+if [[ "$*" == *"author:@me"* ]]; then
+    NODES=$(cat "{nodes_file}")
+    echo '{"data":{"search":{"nodes":'"$NODES"',"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":3,"remaining":4997,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+elif [[ "$*" == *"graphql"* ]]; then
+    echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
+fi
 """
+
+# Drives one branch through open(clean) -> open(conflict) -> merged via a mode
+# file. The two open states ride the SEARCH envelope (mergeable MERGEABLE then
+# CONFLICTING, so has_conflicts flows to the CI babysitter); the merged state
+# leaves ``state:open`` so it comes through the per-branch FALLBACK as MERGED.
+_FAKE_GH_CONFLICT_MODE = """\
+#!/bin/bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+MODE=$(cat "{mode_file}")
+if [[ "$*" == *"author:@me"* ]]; then
+    if [[ "$MODE" == "open_clean" ]]; then
+        echo '{"data":{"search":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","repository":{"nameWithOwner":"test-org/test-repo"},"headRefName":"'"$BRANCH"'","mergeable":"MERGEABLE","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":3,"remaining":4997,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+    elif [[ "$MODE" == "open_conflict" ]]; then
+        echo '{"data":{"search":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","repository":{"nameWithOwner":"test-org/test-repo"},"headRefName":"'"$BRANCH"'","mergeable":"CONFLICTING","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":3,"remaining":4997,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+    else
+        echo '{"data":{"search":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":1,"remaining":4999,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+    fi
+elif [[ "$*" == *"graphql"* ]]; then
+    if [[ "$MODE" == "merged" ]]; then
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"MERGED","baseRefName":"main","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}}'
+    else
+        echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
+    fi
+fi
+"""
+
+# open_pr -> no_pr via a mode file: the search returns the branch's open node, or
+# nothing. Used for the branch-switch test (switch branch + flip to no_pr).
+_FAKE_GH_SWITCH_MODE = """\
+#!/bin/bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+MODE=$(cat "{mode_file}")
+if [[ "$*" == *"author:@me"* ]]; then
+    if [[ "$MODE" == "open_pr" ]]; then
+        echo '{"data":{"search":{"nodes":[{"number":42,"title":"Test PR","url":"https://github.com/test/repo/pull/42","state":"OPEN","baseRefName":"main","repository":{"nameWithOwner":"test-org/test-repo"},"headRefName":"'"$BRANCH"'","mergeable":"MERGEABLE","commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]},"latestReviews":{"nodes":[]},"reviewThreads":{"nodes":[]}}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":3,"remaining":4997,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+    else
+        echo '{"data":{"search":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"rateLimit":{"cost":1,"remaining":4999,"limit":5000,"resetAt":"2026-01-01T00:00:00Z"}}}'
+    fi
+elif [[ "$*" == *"graphql"* ]]; then
+    echo '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
+fi
+"""
+
+
+def _open_search_nodes_json(branch: str, number: int = 42) -> str:
+    """Build a one-node search ``nodes`` array (JSON) for a workspace branch."""
+    node = {
+        "number": number,
+        "title": "Test PR",
+        "url": f"https://github.com/test/repo/pull/{number}",
+        "state": "OPEN",
+        "baseRefName": "main",
+        "repository": {"nameWithOwner": _NAME_WITH_OWNER},
+        "headRefName": branch,
+        "mergeable": "MERGEABLE",
+        "commits": {"nodes": [{"commit": {"statusCheckRollup": None}}]},
+        "latestReviews": {"nodes": []},
+        "reviewThreads": {"nodes": []},
+    }
+    return json.dumps([node])
 
 
 def _install_fake_gh(fake_bin_dir: Path, script: str) -> None:
@@ -85,8 +159,31 @@ def _set_remote(instance: SculptorInstance, url: str) -> None:
     full_spa_reload(instance.page)
 
 
+def _get_worktree_working_dir(instance: SculptorInstance) -> Path:
+    """Return the (single) workspace worktree's working directory.
+
+    Worktree-mode workspaces share the user repo's ``.git``, so ``git worktree
+    list`` on the user repo enumerates them; the one path that isn't the main
+    checkout is the workspace's working dir.
+    """
+    user_repo_path = instance.project_path
+    result = subprocess.run(
+        ["git", "-C", str(user_repo_path), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    main_path = Path(user_repo_path).resolve()
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            worktree_path = Path(line.removeprefix("worktree ").strip()).resolve()
+            if worktree_path != main_path:
+                return worktree_path
+    raise AssertionError(f"No workspace worktree found under {user_repo_path}")
+
+
 def _wait_for_open_pr_button(task_page: PlaywrightTaskPage) -> None:
-    """Wait for the open PR button to appear (backend poll completed)."""
+    """Wait for the open PR button to appear (a search round resolved it)."""
     open_button = task_page.get_pr_button_open()
     expect(open_button).to_be_visible(timeout=60_000)
     expect(open_button).to_contain_text("PR #42")
@@ -94,8 +191,8 @@ def _wait_for_open_pr_button(task_page: PlaywrightTaskPage) -> None:
 
 @user_story("to see PR status badges on the home page workspace list")
 def test_home_page_shows_pr_badge(sculptor_instance_: SculptorInstance) -> None:
-    """When the backend polls an open PR, the home page workspace row shows a PR badge."""
-    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_OPEN_PR_SCRIPT)
+    """When the batched search finds an open PR, the home page workspace row shows a PR badge."""
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_SEARCH_OPEN)
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
     task_page = start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
@@ -113,7 +210,7 @@ def test_home_page_shows_pr_badge(sculptor_instance_: SculptorInstance) -> None:
 @user_story("to see cached PR status immediately when navigating between pages")
 def test_cached_pr_status_no_loading_on_navigation(sculptor_instance_: SculptorInstance) -> None:
     """After the first poll, navigating away and back shows cached status without a loading spinner."""
-    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_OPEN_PR_SCRIPT)
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_SEARCH_OPEN)
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
     task_page = start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
@@ -138,33 +235,35 @@ def test_cached_pr_status_no_loading_on_navigation(sculptor_instance_: SculptorI
 def test_multiple_workspaces_independent_pr_status(sculptor_instance_: SculptorInstance, tmp_path: Path) -> None:
     """Each workspace gets its own PR status from the PrPollingService.
 
-    Create two workspaces: one with an open PR, one without. Verify they
-    show the correct independent states on the home page.
+    Workspace 1 has an open PR (its branch is in the search nodes); workspace 2
+    does not (its branch is absent from the search, so it falls back to the
+    per-branch query, which returns nothing → "Create PR"). This exercises the
+    search fan-out *and* Change-2's fallback end-to-end.
     """
-    mode_file = tmp_path / "gh_mode"
-    mode_file.write_text("open_pr")
-    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_MODE_SCRIPT.replace("{mode_file}", str(mode_file)))
+    nodes_file = tmp_path / "search_nodes"
+    nodes_file.write_text("[]")
+    _install_fake_gh(
+        sculptor_instance_.fake_bin_dir, _FAKE_GH_SEARCH_NODES_FILE.replace("{nodes_file}", str(nodes_file))
+    )
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
-    # Workspace 1: open PR
+    # Workspace 1: create it, then publish an open PR node for its branch.
     task_page = start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
+    branch_1 = task_page.get_branch_name()
+    nodes_file.write_text(_open_search_nodes_json(branch_1))
     _wait_for_open_pr_button(task_page)
 
-    # Switch to no_pr and create workspace 2
-    mode_file.write_text("no_pr")
+    # Workspace 2: its branch is absent from the search nodes → "Create PR".
     task_page_2 = start_task_and_wait_for_ready(sculptor_instance_.page, "say goodbye")
-
-    # Workspace 2 should show "Create PR" (no PR exists)
     create_button = task_page_2.get_pr_button_create()
-    expect(create_button).to_be_visible()
+    expect(create_button).to_be_visible(timeout=60_000)
 
-    # Navigate to home page — workspace 1 should still show the PR badge
+    # Navigate to home page — workspace 1 should still show the PR badge.
     navigate_to_home_page(sculptor_instance_.page)
     home_page = PlaywrightHomePage(sculptor_instance_.page)
     workspace_rows = home_page.get_workspace_rows()
     expect(workspace_rows).to_have_count(2)
 
-    # At least one workspace row should have the open PR button
     pr_buttons = home_page.get_pr_buttons_open()
     expect(pr_buttons).to_have_count(1)
     expect(pr_buttons.first).to_contain_text("PR #42")
@@ -175,11 +274,10 @@ def test_closed_not_merged_pr_shows_closed_state(sculptor_instance_: SculptorIns
     """When the only PR on this branch was closed without being merged, the PR
     button reflects the closed state instead of falling back to "Create PR".
 
-    The fake ``gh`` CLI returns a single PR node tagged ``state: CLOSED``, so a
-    backend that ignores closed PRs (the bug) would render "Create PR" and the
-    assertion below would fail.
+    A closed PR is absent from the ``state:open`` search, so it is recovered by
+    the per-branch fallback query returning a ``state: CLOSED`` node.
     """
-    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_CLOSED_PR_SCRIPT)
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_CLOSED)
     _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
 
     start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
@@ -189,3 +287,67 @@ def test_closed_not_merged_pr_shows_closed_state(sculptor_instance_: SculptorIns
     expect(merged_or_closed_button).to_contain_text("PR #77")
     expect(merged_or_closed_button).to_contain_text("closed")
     expect(merged_or_closed_button).to_have_attribute("data-pr-state", "closed")
+
+
+@user_story("to see a PR's status update as it goes from open through a merge conflict to merged")
+def test_open_to_conflict_to_merged_transition(sculptor_instance_: SculptorInstance, tmp_path: Path) -> None:
+    """An open PR that develops a merge conflict and is then merged surfaces the
+    open → merged transition (passing through the conflict state).
+
+    The conflict (``mergeable: CONFLICTING``) rides the open search node and
+    drives ``has_conflicts`` for the CI babysitter; it has no dedicated PR-button
+    affordance, so this asserts the open badge persists through the conflict
+    state and the merged badge appears after — the behavioral transition. The
+    ``has_conflicts`` flow itself is covered by the poller unit tests.
+    """
+    mode_file = tmp_path / "gh_mode"
+    mode_file.write_text("open_clean")
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_CONFLICT_MODE.replace("{mode_file}", str(mode_file)))
+    _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
+
+    task_page = start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
+    _wait_for_open_pr_button(task_page)
+
+    # The PR develops a merge conflict — still open, badge persists.
+    mode_file.write_text("open_conflict")
+    open_button = task_page.get_pr_button_open()
+    expect(open_button).to_be_visible()
+    expect(open_button).to_contain_text("PR #42")
+
+    # The PR is merged — it leaves state:open, so the fallback reports MERGED.
+    mode_file.write_text("merged")
+    merged_button = sculptor_instance_.page.get_by_test_id(ElementIDs.PR_BUTTON_MERGED)
+    expect(merged_button).to_be_visible(timeout=60_000)
+    expect(merged_button).to_contain_text("PR #42")
+    expect(merged_button).to_contain_text("merged")
+    expect(merged_button).to_have_attribute("data-pr-state", "merged")
+
+
+@user_story("to see PR status re-resolve immediately when I switch the workspace's branch")
+def test_branch_switch_triggers_immediate_repoll(sculptor_instance_: SculptorInstance, tmp_path: Path) -> None:
+    """Switching the workspace's current branch clears the cached PR status and
+    immediately re-resolves it (the retained on_branch_changed re-poll).
+    """
+    mode_file = tmp_path / "gh_mode"
+    mode_file.write_text("open_pr")
+    _install_fake_gh(sculptor_instance_.fake_bin_dir, _FAKE_GH_SWITCH_MODE.replace("{mode_file}", str(mode_file)))
+    _set_remote(sculptor_instance_, _FAKE_GITHUB_REMOTE)
+
+    task_page = start_task_and_wait_for_ready(sculptor_instance_.page, "say hello")
+    _wait_for_open_pr_button(task_page)
+
+    # Switch to a fresh branch with no PR. The branch poller detects the change,
+    # fires on_branch_changed (clears the cached status), and re-polls — the
+    # fallback now finds no PR, so the badge re-resolves to "Create PR".
+    mode_file.write_text("no_pr")
+    workspace_dir = _get_worktree_working_dir(sculptor_instance_)
+    subprocess.run(
+        ["git", "checkout", "-b", "pr-switch-target"],
+        cwd=workspace_dir,
+        check=True,
+        capture_output=True,
+    )
+
+    create_button = task_page.get_pr_button_create()
+    expect(create_button).to_be_visible(timeout=30_000)
+    expect(task_page.get_pr_button_open()).to_be_hidden()


### PR DESCRIPTION
## Problem

Sculptor keeps each workspace's PR status fresh by polling GitHub with one
GraphQL query **per workspace per round**. GitHub's GraphQL primary rate limit
is 5,000 points/hour per user token, so cost scales `O(workspaces)`. At ~20 open
workspaces on the default 30s interval the query spend reaches ~96% of the
hourly budget; the reactive cooldown then kicks in and PR status goes stale
across the whole app. This reproduces the reported "PR status stops updating
once I have ~20+ workspaces."

## Solution

Replace the per-workspace query with **one `search`-based GraphQL query per
(host) per poll round** that fetches all of the user's open PRs across every
repo in a single request (`is:pr state:open author:@me`). Measured cost drops
from ~2 points/workspace/round to ~3 points/round total for ~20 PRs — a durable
~6× reduction that turns the cost model into roughly `O(open PRs ÷ page size)`.

Three coordinated changes:

1. **Batched search round (core).** One token-wide `search` query per round,
   fanned out to each workspace by `(repo, head branch)`. The persisted cache
   stays keyed by `WorkspaceID`, so two workspaces sharing a branch but with
   different target branches still get independent status (one match, one
   "switch target" mismatch). Also trims the dominant `reviewThreads` page size
   from 30 → 10 (the nested `comments` fan-out is ~90% of per-query cost).
2. **Per-workspace fallback.** A `state:open` search can't report terminal or
   no-PR branches, so any branch the search doesn't match falls back to the
   existing per-workspace all-states query — at its own cadence, decoupled from
   the search round. A one-round search-index drop-out is treated as a no-op
   (no spurious open→none), and merged/closed transitions are preserved.
3. **Proactive rate-budget governor.** Reads the `rateLimit` block returned with
   every search response and lengthens the round interval *before* the budget is
   exhausted (default ceiling 80% of the reported limit, configurable via
   `pr_poll_budget_fraction`), recovering when headroom returns and deferring to
   the reset window when nearly spent. The system degrades gracefully instead of
   hitting a wall.

No new infrastructure, no webhooks, no feature flags — the search path replaces
the per-workspace path directly, and the existing `pr_polling_enabled` kill
switch and the immediate re-poll on branch-switch are retained. The
`mergeable` → `has_conflicts` signal the CI babysitter depends on is preserved.

The full design (problem analysis, measured GraphQL cost model, rejected
alternatives, and rollout plan) is in `agent_docs/gh_rate_limit/design.md`.

Also drops the single-valued `error_provider` field from `PrStatusInfo` (GitHub
is the only provider, so it carried no information).

## Testing

- **Unit:** search-response parsing, pagination, rate-limit tolerance; the
  `WorkspaceID`-keyed fan-out (including shared-branch/different-target);
  `mergeable` → `has_conflicts`; the full governor behavior (hold / back-off /
  recover / defer, driven off `remaining` not just `cost`); short-circuits with
  zero `gh` calls; decoupled fallback cadence; index-blip no-op; and a
  cost-regression guard that fails if a future field addition balloons the
  per-PR fan-out.
- **Integration (Playwright, 6 tests):** open-PR badge via the search path,
  cached status on navigation, two independent workspaces (search match +
  fallback), closed-PR recovery via the fallback, an open → merge-conflict →
  merged transition, and a branch-switch immediate re-poll.
- `just format` / `just check` (lint + typecheck + ratchets) and `just
  test-unit` are green; all 6 PR-polling integration tests pass.

## Notes

Rounds are keyed by host (not (host, token)) and the governor uses a single
interval across hosts — both are deliberate simplifications, correct for the
single-token-per-host case that is universal today, and called out as future
generalization points in the design doc.

(Sent by Claude)
