### PR TITLE
Fix active-workspace delete stranding the user on a blank /ws/new tab

### DIFF
--- a/sculptor/frontend/src/components/useWorkspaceTabActions.ts
+++ b/sculptor/frontend/src/components/useWorkspaceTabActions.ts
@@ -70,8 +70,12 @@ export const useWorkspaceTabActions = (): {
         navigateToAddWorkspace();
         return;
       }
+      // closedTabId may already be gone from effectiveOpenTabIds — e.g. an
+      // optimistic delete removed the tab before this runs — making indexOf
+      // return -1. Clamp to a valid range so we land on the first surviving tab
+      // instead of reading remaining[-1] (undefined).
       const closedIndex = effectiveOpenTabIds.indexOf(closedTabId);
-      const nextTab = remaining[Math.min(closedIndex, remaining.length - 1)];
+      const nextTab = remaining[Math.min(Math.max(closedIndex, 0), remaining.length - 1)];
       if (nextTab === HOME_TAB_ID) {
         navigateToHome();
       } else if (nextTab === SETTINGS_TAB_ID) {

--- a/sculptor/frontend/src/pages/workspace/WorkspacePage.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspacePage.tsx
@@ -18,6 +18,7 @@ import { usePanelLayoutSync } from "../../common/state/hooks/usePanelLayoutSync.
 import { usePerWorkspacePanelLayout } from "../../common/state/hooks/usePerWorkspacePanelLayout.ts";
 import { useWorkspaceFiles } from "../../common/state/hooks/useWorkspaceFiles.ts";
 import { DockingLayout } from "../../components/panels/DockingLayout";
+import { useWorkspaceTabActions } from "../../components/useWorkspaceTabActions.ts";
 import { AgentTabs } from "./components/AgentTabs.tsx";
 import { BottomBar } from "./components/BottomBar";
 import { ChatPanelContent } from "./components/ChatPanelContent.tsx";
@@ -74,7 +75,8 @@ const WorkspacePageContent = ({ taskID }: { taskID: string }): ReactElement => {
 
 export const WorkspacePage = (): ReactElement | null => {
   const { workspaceID, agentID: agentIDFromUrl } = useWorkspacePageParams();
-  const { navigateToAgent, navigateToAddWorkspace } = useImbueNavigate();
+  const { navigateToAgent } = useImbueNavigate();
+  const { navigateToNextTab } = useWorkspaceTabActions();
   const tasks = useAtomValue(tasksArrayAtom);
   const workspaceIds = useAtomValue(workspaceIdsAtom);
   const savedAgentIdAtom = useMemo(() => agentIdForWorkspaceAtomFamily(workspaceID), [workspaceID]);
@@ -89,9 +91,16 @@ export const WorkspacePage = (): ReactElement | null => {
   useEffect(() => {
     if (workspaceIds === undefined) return; // first WS snapshot hasn't arrived
     if (!workspaceIds.includes(workspaceID)) {
-      // Workspace was deleted between sessions — drop the tab and bail out.
+      // The workspace backing this route is gone. This fires when the workspace
+      // was deleted out from under us — either the active tab we just deleted
+      // (whose confirmation drops it from workspaceIds while this route still
+      // holds the stale param) or a deletion from another session. Drop the now-
+      // stale tab and land on the next surviving tab; navigateToNextTab only
+      // falls back to the add-workspace page when no tabs remain. Routing
+      // through it (instead of always going to /ws/new) keeps us on a sibling
+      // workspace and avoids spawning a phantom new-workspace tab.
       removeTab(workspaceID);
-      navigateToAddWorkspace();
+      navigateToNextTab(workspaceID);
       return;
     }
     if (agentIDFromUrl) return; // URL is authoritative, nothing to fix up
@@ -114,7 +123,7 @@ export const WorkspacePage = (): ReactElement | null => {
     tasks,
     savedAgentId,
     navigateToAgent,
-    navigateToAddWorkspace,
+    navigateToNextTab,
     setAgentForWorkspace,
     removeTab,
   ]);


### PR DESCRIPTION
## Summary

Deleting the workspace you are **currently viewing** could intermittently land you on a blank `/ws/new` page with a phantom new-workspace tab, instead of on a surviving sibling tab. This also showed up as an intermittent failure of the integration test `test_deleting_active_workspace_clamps_active_index` on the slow test runner.

## Root cause

It is a race in the optimistic-delete flow:

1. Deleting the active workspace optimistically removes it from the tab order and navigates to a surviving sibling.
2. A short time later the backend delete confirmation arrives and drops the workspace from `workspaceIds`.
3. If the still-mounted `WorkspacePage` route is holding the now-stale, just-deleted workspace param at that instant, its cleanup effect (the "workspace is gone" branch) sees the workspace missing in `workspaceIds` and unconditionally redirects to the add-workspace page.
4. That redirect to `/ws/new/<id>` opens a new-workspace pseudo-tab, so the persisted tab order stays at length two and the user is dumped on a blank page instead of the sibling tab.

## Fix

- Route the `WorkspacePage` "workspace is gone" cleanup through `navigateToNextTab` so it lands on the next surviving tab, falling back to `/ws/new` only when no tabs remain. This makes the outcome correct regardless of who wins the race, and is also the right behavior for the genuine "workspace deleted in another session" case (survivors → sibling tab; nothing left → add-workspace page). A naive guard that simply suppressed the redirect would have broken the cross-session case, since the same path also records stream-deleted IDs.
- Clamp `navigateToNextTab`'s index so a `closedTabId` that is already gone from the tab order resolves to the first surviving tab rather than reading `remaining[-1]` (`undefined`).

## Testing

- `test_deleting_active_workspace_clamps_active_index` (the flaky test): passed 4/4 runs locally, including a 3× serial repeat.
- Full `test_optimistic_deletion.py` file: green (the only failures in one parallel pass were unrelated `START_TASK_BUTTON` load timeouts during test setup under `-n auto`, which all pass when re-run serially).
- `just format`, `just check` (lint/typecheck/ratchets), and `just test-unit` (backend, frontend, foundation, sculpt): all green.

(Sent by Claude)
