### PR TITLE
docs(specs): document build-context data-folder resolution

### DIFF
--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -950,16 +950,30 @@ file-hygiene and shell checks.
 Sculptor has three surfaces over one backend (GUI, CLI, API), kept from drifting by **generation
 rather than hand-maintenance**: TypeScript types and the frontend API client are generated from the
 FastAPI/OpenAPI schema, the `sculpt` client is generated similarly, and a **frozen model-schema
-snapshot** (→ §10.8) detects unintended backend-model changes. A backend-model change that isn't reflected across surfaces shows
+snapshot** (→ §10.9) detects unintended backend-model changes. A backend-model change that isn't reflected across surfaces shows
 up as a regenerated diff or a failing check, not a runtime surprise.
 
-#### 10.8 Data-durability machinery
+#### 10.8 Build-context data-folder resolution & isolation
+Where Sculptor keeps its data is resolved from **build context**, not hardcoded. A single
+`get_sculptor_folder()` routine picks `<repo>/.dev_sculptor` when **running from source** (detected by
+walking up the tree for a `.git` directory), `~/.dev-sculptor` for a **packaged dev build** (detected
+by a `.dev` version suffix), and `~/.sculptor` for a **packaged production build** — where "packaged"
+means a PyInstaller bundle (`sys.frozen`), mirrored on the Electron side as `app.isPackaged` so the
+shell resolves the same path. Above all of these, a **`SCULPTOR_FOLDER` env override wins outright**,
+and that override is the **isolation lever the whole test substrate rests on**: each test — and each
+parallel sandbox on offload (§10.5) — runs against a throwaway temp folder (the `custom_sculptor_folder`
+marker, §10.3), so suites never touch or race on a developer's real `~/.sculptor` state, and a source
+checkout, a dev build, and the shipped app can coexist on one machine without colliding. This
+build-context split is exactly what lets the harness run hundreds of backends in parallel against
+isolated state.
+
+#### 10.9 Data-durability machinery
 User data lives in a local SQLite database, and migrations are first-class: every Alembic migration
 ships with a **version test** that exercises the upgrade against representative data, and a frozen
 Pydantic-schema snapshot is wired in to guard the versioned JSON fields against unintended change. This is what lets the product evolve its
 data model across releases without corrupting users' existing state.
 
-#### 10.9 Diagnosability
+#### 10.10 Diagnosability
 Finally, infrastructure for understanding failures that escape the tests: distributed **tracing**,
 **Sentry** error reporting, structured logging conventions, in-app **debug / diagnostics** views
 (per-agent diagnostics, the chat debug view), the **auto-qa** headless-browser harness for
@@ -1008,7 +1022,7 @@ inconsistent about the §9-product-behavior vs. §10-engineering-substrate line:
 
 - **Do user-facing diagnostics belong in §7 or §10?** The diagnostics a user can actually open — the
   chat **debug view** (and its timestamp toggle), per-agent **diagnostics** from the agent context
-  menu, and the **diagnostics** in the version popover — are currently filed under §10.9
+  menu, and the **diagnostics** in the version popover — are currently filed under §10.10
   (Diagnosability) as engineering substrate, yet they're user-visible features that would otherwise
   belong in §7. They're documented in neither place right now. Decide the rule (user-openable ⇒ §7?)
   and apply it.

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -224,17 +224,23 @@ packaging Sculptor):
 
 ---
 
-## 4. Data persistence, durability & migration (→ SPEC §9.5, §10.8)
+## 4. Data persistence, durability & migration (→ SPEC §9.5, §10.9)
 
 `SPEC.md` quarantines SQLite/Alembic as implementation. They are first-class here because the product
 makes durability and upgrade-survival guarantees (§9.5) that rest directly on this layer.
 
 ### 4.1 On-disk layout & store
 
-- **REQ-DATA-001 (MUST).** User data lives in a single **Sculptor folder**: `~/.sculptor` (stable),
-  `~/.dev-sculptor` (dev builds), or `<repo>/.dev_sculptor` (running from source), overridable via the
-  `SCULPTOR_FOLDER` env var; the workspaces path is separately overridable via
-  `SCULPTOR_WORKSPACES_FOLDER` (`sculptor/sculptor/utils/build.py`).
+- **REQ-DATA-001 (MUST).** User data lives in a single **Sculptor folder**, resolved from **build
+  context** in strict precedence (`get_sculptor_folder()`, `sculptor/sculptor/utils/build.py`): (1) the
+  **`SCULPTOR_FOLDER` env var**, if set, wins outright; else (2) **running from source** — detected by
+  walking parents for a `.git` directory — uses `<repo>/.dev_sculptor` (or `~/.dev-sculptor` if no repo
+  root is found); else (3) a **packaged dev build** — detected by a `.dev` version suffix — uses
+  `~/.dev-sculptor`; else (4) a **packaged production build** uses `~/.sculptor`. "Packaged" means a
+  PyInstaller bundle (`hasattr(sys, "frozen")`), mirrored on the Electron side as `app.isPackaged`. The
+  workspaces sub-path is separately overridable via `SCULPTOR_WORKSPACES_FOLDER`. The Electron shell
+  resolves the same folder independently and **must stay consistent** with the backend
+  (`sculptor/frontend/src/electron/logger.ts` `getSculptorFolder`).
 - **REQ-DATA-002 (MUST).** Within it: `internal/database.db` (SQLite), `internal/config.toml`
   (settings), `internal/logs/`, `internal/uploads/`, `internal/artifacts/`, `workspaces/`, and a
   top-level `.format_version` marker (`sculptor/sculptor/utils/build.py`, `sculptor/sculptor/utils/migration.py`).
@@ -245,6 +251,14 @@ makes durability and upgrade-survival guarantees (§9.5) that rest directly on t
 - **REQ-DATA-004 (MUST).** Persisted entities: **UserSettings, Project, Workspace, Task,
   SavedAgentMessage, Notification** (`sculptor/sculptor/database/models.py`). _("Task" is the vestigial internal
   primitive backing an Agent — see `SPEC.md` §6; it is a storage concern, not a product concept.)_
+- **REQ-DATA-005 (MUST).** The `SCULPTOR_FOLDER` override is the **test/dev isolation lever** the test
+  substrate rests on (→ `SPEC.md` §10.8): every integration-test backend is launched with
+  `SCULPTOR_FOLDER` pointed at a throwaway temp dir (`get_testing_environment`,
+  `sculptor/sculptor/testing/server_utils.py`), so tests never read or mutate a developer's real
+  `~/.sculptor`/`~/.dev-sculptor` and can run reproducibly in parallel; the `custom_sculptor_folder`
+  pytest marker (`SPEC.md` §10.3) tags tests that require their own folder. Because
+  `get_sculptor_folder()` is process-cached (`functools.cache`), tests that vary the env must clear the
+  cache (`get_sculptor_folder.cache_clear()`).
 
 ### 4.2 Durability & upgrade survival
 


### PR DESCRIPTION
## What

Sculptor resolves its data folder from **build context** — running-from-source vs. packaged dev build vs. packaged production — with a `SCULPTOR_FOLDER` env override on top. This is a critical part of the testability substrate (the override is what gives every test and every parallel CI sandbox an isolated data folder), but it wasn't captured anywhere in the product specs. This PR documents the verified behavior.

## Verified behavior

Resolution precedence (`get_sculptor_folder()` in `sculptor/sculptor/utils/build.py`, mirrored in the Electron shell's `logger.ts getSculptorFolder`):

1. `SCULPTOR_FOLDER` env var, if set, wins outright.
2. **Running from source** (detected by walking parents for a `.git` dir) → `<repo>/.dev_sculptor` (or `~/.dev-sculptor` if no repo root found).
3. **Packaged dev build** (detected by a `.dev` version suffix) → `~/.dev-sculptor`.
4. **Packaged production build** → `~/.sculptor`.

"Packaged" means a PyInstaller bundle (`hasattr(sys, "frozen")`), mirrored Electron-side as `app.isPackaged`. Workspaces are separately overridable via `SCULPTOR_WORKSPACES_FOLDER`. The function is process-cached, so tests that vary the env clear the cache.

## Changes

- **`SPEC.md`** — new §10 subsection **"Build-context data-folder resolution & isolation"** under the Testability & Engineering Substrate section, framing the source-vs-packaged split and the env override as the isolation lever the test harness rests on. Renumbered the two following subsections (Data-durability machinery → §10.9, Diagnosability → §10.10) and updated the cross-references.
- **`requirements.md`** — enriched **REQ-DATA-001** with the full resolution precedence and detection signals (previously it listed only the three paths); added **REQ-DATA-005** for the test/dev isolation guarantee, the `custom_sculptor_folder` marker, and the per-process cache caveat.

Docs-only; `just format` and `just check` pass clean (unit tests are unaffected by markdown edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)