### PR TITLE
Show an in-flight state when submitting question answers (SCU-1620)

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/AskUserQuestion.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/AskUserQuestion.tsx
@@ -283,7 +283,8 @@ export const AskUserQuestion = ({ taskId, questionData, onSubmit, onDismiss }: A
     } finally {
       // On success the panel unmounts (the WebSocket clears the pending
       // question), so this is moot; on failure it re-enables the button so the
-      // user can retry. setState after unmount is a no-op in React 19.
+      // user can retry. React ignores a state update on an unmounted component,
+      // so this needs no is-mounted guard.
       isSubmittingRef.current = false;
       setIsSubmitting(false);
     }

--- a/sculptor/frontend/src/pages/workspace/components/AskUserQuestion.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/AskUserQuestion.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { AskUserQuestionData } from "~/api";
 import { ElementIds } from "~/api";
+import { useTimedLatch } from "~/common/Hooks.ts";
 import { useKeybinding } from "~/common/keybindings/hooks.ts";
 import { useModifiedEnter } from "~/common/ShortcutUtils";
 import { draftQuestionStateAtomFamily, EMPTY_DRAFT_QUESTION_STATE } from "~/common/state/atoms/taskDetails";
@@ -18,10 +19,18 @@ import styles from "./AskUserQuestion.module.scss";
 const OTHER_OPTION_LABEL = "Provide an alternative";
 const OTHER_PLACEHOLDER = "Provide an alternative";
 
+// Submitting answers locks the button immediately, but the spinner only appears
+// once the submit has stayed in flight this long (a slow backend); a normal
+// submit resolves well under this, so the common case shows no spinner. There's
+// no trailing hold — the panel unmounts on success, and on failure the button
+// should re-enable at once.
+const SUBMIT_SPINNER_START_DELAY_MS = 1_000;
+
 type AskUserQuestionProps = {
   taskId: string;
   questionData: AskUserQuestionData;
-  onSubmit: (answers: Record<string, string>, notes: Record<string, string>) => void;
+  // May be async; `handleSubmit` awaits it to drive the in-flight state.
+  onSubmit: (answers: Record<string, string>, notes: Record<string, string>) => void | Promise<void>;
   onDismiss?: () => void;
 };
 
@@ -59,6 +68,14 @@ export const AskUserQuestion = ({ taskId, questionData, onSubmit, onDismiss }: A
   const otherInputRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sendMessageBinding = useKeybinding("send_message");
+
+  // True while the answer POST is in flight. Drives the disabled state (instant
+  // lock). The ref is the actual re-entrancy guard: setState is async, so a fast
+  // second click or Enter would slip past a state-only check and submit twice.
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
+  // Gate the spinner through a start-delay latch so only slow submits show it.
+  const shouldShowSubmitSpinner = useTimedLatch(isSubmitting, 0, SUBMIT_SPINNER_START_DELAY_MS);
 
   const currentQuestion = questions[currentIndex];
   const isMultiSelect = currentQuestion.multiSelect;
@@ -239,8 +256,11 @@ export const AskUserQuestion = ({ taskId, questionData, onSubmit, onDismiss }: A
     containerRef.current?.focus();
   }, [questions, hasAnswer]);
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     if (!isAllAnswered) return;
+    // Ignore re-entrant submits while a POST is already in flight (e.g. a second
+    // Enter on a slow backend) so the same answers can't be submitted twice.
+    if (isSubmittingRef.current) return;
     // Build the per-question `notes` map: whenever the user typed freeform
     // text in the "Other" textarea (and Other is selected), surface that
     // text as a separate annotation. The backend formatter renders it as
@@ -256,7 +276,17 @@ export const AskUserQuestion = ({ taskId, questionData, onSubmit, onDismiss }: A
         }
       }
     }
-    onSubmit(Object.fromEntries(answers), notes);
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(Object.fromEntries(answers), notes);
+    } finally {
+      // On success the panel unmounts (the WebSocket clears the pending
+      // question), so this is moot; on failure it re-enables the button so the
+      // user can retry. setState after unmount is a no-op in React 19.
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+    }
   }, [isAllAnswered, answers, questions, otherSelected, otherTexts, onSubmit]);
 
   const handleModifiedEnter = useModifiedEnter({
@@ -523,9 +553,11 @@ export const AskUserQuestion = ({ taskId, questionData, onSubmit, onDismiss }: A
             {!hasUnansweredElsewhere ? (
               <Button
                 className={styles.submitButton}
-                disabled={!isAllAnswered}
+                disabled={!isAllAnswered || isSubmitting}
+                loading={shouldShowSubmitSpinner}
                 onClick={handleSubmit}
                 data-testid={ElementIds.ASK_USER_QUESTION_SUBMIT}
+                {...(shouldShowSubmitSpinner ? { "data-loading": "true" } : {})}
               >
                 Submit
               </Button>

--- a/sculptor/tests/integration/frontend/test_ask_user_question_submit_loading.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question_submit_loading.py
@@ -1,0 +1,103 @@
+"""In-flight answer-submit contract: while a `POST .../answer_question` is
+outstanding, the Submit button disables immediately, the spinner appears once
+the submit is slow enough to outlast its start delay, and a second submit
+attempt is a no-op so the same answers can't be submitted twice. Once the POST
+resolves, the panel dismisses.
+
+Regression: the Submit button had no in-flight feedback or re-entrancy guard, so
+on a slow backend the user got no feedback and a re-submit (click or Enter) sent
+the answers a second time.
+"""
+
+import re
+
+from playwright.sync_api import Route
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# `$` anchor keeps any other agent sub-route from being intercepted.
+_ANSWER_PATTERN = re.compile(r"/api/v1/workspaces/[^/]+/agents/[^/]+/answer_question$")
+
+_ASK_PROMPT = """\
+fake_claude:ask_user_question `{
+  "questions": [
+    {
+      "question": "What programming language do you prefer?",
+      "header": "Language",
+      "options": [
+        {"label": "Python", "description": "A versatile language"},
+        {"label": "JavaScript", "description": "For web development"},
+        {"label": "Rust", "description": "For systems programming"}
+      ],
+      "multiSelect": false
+    }
+  ]
+}`"""
+
+
+@user_story("to see a submitting state (and not double-submit) when the backend is slow to accept my answer")
+def test_in_flight_answer_submit_locks_button_and_blocks_double_submit(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=_ASK_PROMPT,
+        wait_for_agent_to_finish=False,
+    )
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel).to_be_visible(timeout=30_000)
+
+    submit_button = ask_panel.get_submit_button()
+    expect(submit_button).to_be_disabled()
+    ask_panel.get_options().first.click()
+    expect(submit_button).to_be_enabled()
+
+    # Hold the answer POST in flight until released, counting POSTs so a double
+    # submit is observable.
+    state = {"release": False, "post_count": 0}
+
+    def hold_answer(route: Route) -> None:
+        if route.request.method == "POST":
+            state["post_count"] += 1
+            while not state["release"]:
+                page.wait_for_timeout(50)
+        route.continue_()
+
+    page.route(_ANSWER_PATTERN, hold_answer)
+
+    try:
+        submit_button.click()
+
+        # The button locks immediately and the panel stays up while the submit
+        # is in flight.
+        expect(submit_button).to_be_disabled()
+        expect(ask_panel).to_be_visible()
+        # The spinner is latched behind a start delay so quick submits never
+        # flash it. This submit is held, so it appears once the delay elapses.
+        expect(submit_button).to_have_attribute("data-loading", "true")
+
+        # Try to submit again while the first submit is in flight. The button is
+        # disabled (can't be clicked) and the Enter path is guarded; the count is
+        # checked below once the panel-dismissal barrier guarantees the network
+        # has settled.
+        page.keyboard.press("Enter")
+
+        # Release and wait on a positive condition rather than a fixed sleep: the
+        # panel dismisses only after the single answer's success response clears
+        # the pending question over the WebSocket. A stray second request is
+        # dispatched synchronously at the Enter above, so by the time the first
+        # POST has round-tripped it would already have hit the route counter.
+        state["release"] = True
+        expect(ask_panel).not_to_be_visible(timeout=30_000)
+        assert state["post_count"] == 1, f"expected a single answer submit, saw {state['post_count']}"
+    finally:
+        # Release in case an assertion above failed while the POST was still held,
+        # then tear down the route.
+        state["release"] = True
+        page.unroute(_ANSWER_PATTERN, hold_answer)

--- a/sculptor/tests/integration/frontend/test_ask_user_question_submit_loading.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question_submit_loading.py
@@ -51,7 +51,7 @@ def test_in_flight_answer_submit_locks_button_and_blocks_double_submit(
         wait_for_agent_to_finish=False,
     )
     ask_panel = get_ask_user_question_panel(page)
-    expect(ask_panel).to_be_visible(timeout=30_000)
+    expect(ask_panel).to_be_visible()
 
     submit_button = ask_panel.get_submit_button()
     expect(submit_button).to_be_disabled()
@@ -94,10 +94,12 @@ def test_in_flight_answer_submit_locks_button_and_blocks_double_submit(
         # dispatched synchronously at the Enter above, so by the time the first
         # POST has round-tripped it would already have hit the route counter.
         state["release"] = True
-        expect(ask_panel).not_to_be_visible(timeout=30_000)
+        expect(ask_panel).not_to_be_visible()
         assert state["post_count"] == 1, f"expected a single answer submit, saw {state['post_count']}"
     finally:
-        # Release in case an assertion above failed while the POST was still held,
-        # then tear down the route.
+        # Release in case an assertion above failed while the POST was still
+        # held, and give the handler a beat to observe the flag and reach
+        # route.continue_() before tearing the route down.
         state["release"] = True
+        page.wait_for_timeout(100)
         page.unroute(_ANSWER_PATTERN, hold_answer)


### PR DESCRIPTION
## Problem

The **Submit** button in the Ask User Question panel was fire-and-forget. `handleSubmit` posted the answers (`POST .../answer_question`) with **no re-entrancy guard**, stayed clickable during the request, and gave **no feedback**. On a slow backend the user saw nothing happen and a re-submit — by click *or* Enter (the panel binds Enter to submit) — sent the answers a second time.

This is the same defect class as the chat-input send (SCU-1619) and gets the same treatment.

## Change

Self-contained in `AskUserQuestion.tsx` (the panel unmounts on success when the WebSocket clears the pending question, so there's no draft to preserve):

- A synchronous `useRef` re-entrancy guard so a second submit while one is in flight is a no-op — covers both the click and the Enter path.
- The button **disables immediately** on submit (`disabled={!isAllAnswered || isSubmitting}`).
- A **delayed** spinner via the existing `useTimedLatch` (Radix `Button` `loading`): instant lock, but the spinner only appears once a submit outlasts a ~1s start delay, with **no trailing hold** — so quick submits never flash it and it clears the moment the submit lands.
- On failure the existing error toast still fires and the button re-enables for a retry.
- `onSubmit` is widened to `=> void | Promise<void>` so the handler can `await` the backend round trip.

## Out of scope

Optimistically dismissing the panel before the backend confirms — it still unmounts on the WebSocket update.

## Testing

- New integration test `test_ask_user_question_submit_loading.py`: holds the `answer_question` POST in flight and asserts the instant disable, the delayed spinner, that a second submit (Enter) issues no second POST, and that the panel dismisses once the POST resolves (a happens-after barrier, no fixed sleeps). Passes (`1 passed in 14s`).
- `just check` green (lint/typecheck/ratchets).

(Sent by Claude)