### PR TITLE
Fix terminal freezing after macOS system sleep

### DIFF
--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
 import { getDefaultStore } from "jotai";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -389,8 +389,7 @@ class FakeWebSocket {
 
 describe("useTerminal — WebSocket reconnect on close", () => {
   const TERMINAL_PATH = "/api/v1/workspaces/ws_test/terminal/0/ws";
-  const RECONNECT_WAIT_MS = 4500; // comfortably exceeds the hook's 2s retry delay
-  const NO_RECONNECT_WAIT_MS = 2500; // past the 2s retry delay, under the test timeout
+  const RETRY_DELAY_MS = 2000; // mirrors TERMINAL_RECONNECT_RETRY_DELAY_MS
 
   // The hook only initialises xterm once the container reports non-zero
   // dimensions; jsdom reports 0, so force a size for the duration of these tests.
@@ -403,7 +402,26 @@ describe("useTerminal — WebSocket reconnect on close", () => {
     return <div ref={terminalContainerRef} />;
   };
 
+  // The first connection resolves the WS URL through a promise, so drain the
+  // microtask queue before asserting. Promise microtasks run independently of
+  // fake timers, so this works without advancing them.
+  const flushMicrotasks = async (): Promise<void> => {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  const mountAndConnect = async (): Promise<ReturnType<typeof render>> => {
+    const result = render(<ReconnectHarness />);
+    await flushMicrotasks();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    return result;
+  };
+
   beforeEach(() => {
+    // Fake timers keep the 2s reconnect delay deterministic and near-instant
+    // instead of waiting in real time.
+    vi.useFakeTimers();
     FakeWebSocket.instances = [];
     vi.stubGlobal("WebSocket", FakeWebSocket);
     // resolveTerminalWsBaseUrl reads the API_URL_BASE build-time global; define it
@@ -415,40 +433,57 @@ describe("useTerminal — WebSocket reconnect on close", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
     delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight;
   });
 
-  it("reconnects after the connection drops with a non-4404 close (e.g. host sleep, code 1006)", async () => {
-    render(<ReconnectHarness />);
-
-    // The first connection is established asynchronously (the WS URL resolves via a
-    // promise), so wait for it rather than asserting synchronously.
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+  it("reconnects after the connection drops with code 1006 (e.g. host sleep)", async () => {
+    await mountAndConnect();
 
     // Simulate the socket being torn down out from under us — the close a macOS
     // sleep produces. The pre-fix handler only retried on code 4404, so this close
-    // left the terminal frozen; the fix retries on any close while still mounted.
+    // left the terminal frozen; the fix retries on any recoverable close.
     FakeWebSocket.instances[0].onclose?.({ code: 1006 } as CloseEvent);
+    vi.advanceTimersByTime(RETRY_DELAY_MS);
 
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2), { timeout: RECONNECT_WAIT_MS });
+    expect(FakeWebSocket.instances).toHaveLength(2);
   });
 
   it("still reconnects when the backend has not started the PTY yet (close code 4404)", async () => {
     // The original retry case must keep working after the fix broadened the trigger.
-    render(<ReconnectHarness />);
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    await mountAndConnect();
 
     FakeWebSocket.instances[0].onclose?.({ code: 4404 } as CloseEvent);
+    vi.advanceTimersByTime(RETRY_DELAY_MS);
 
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2), { timeout: RECONNECT_WAIT_MS });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("does NOT reconnect after a normal close (code 1000)", async () => {
+    // A clean, intentional close means nothing went wrong — retrying would be noise.
+    await mountAndConnect();
+
+    FakeWebSocket.instances[0].onclose?.({ code: 1000 } as CloseEvent);
+    vi.advanceTimersByTime(RETRY_DELAY_MS);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does NOT reconnect when the session token is rejected (code 4401)", async () => {
+    // The token is still invalid on a retry, so reconnecting would loop forever
+    // until the user re-authenticates.
+    await mountAndConnect();
+
+    FakeWebSocket.instances[0].onclose?.({ code: 4401 } as CloseEvent);
+    vi.advanceTimersByTime(RETRY_DELAY_MS);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
   it("does NOT reconnect when the close is our own teardown (unmount)", async () => {
-    const { unmount } = render(<ReconnectHarness />);
-    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-
+    const { unmount } = await mountAndConnect();
     const initialSocket = FakeWebSocket.instances[0];
 
     // Unmounting flips the effect's `isCleanedUp` guard. A close firing after that
@@ -456,10 +491,8 @@ describe("useTerminal — WebSocket reconnect on close", () => {
     // a terminal would resurrect its connection.
     unmount();
     initialSocket.onclose?.({ code: 1006 } as CloseEvent);
+    vi.advanceTimersByTime(RETRY_DELAY_MS);
 
-    // Give any (erroneously) scheduled retry the full delay to fire, then confirm
-    // no new connection was opened.
-    await new Promise((resolve) => setTimeout(resolve, NO_RECONNECT_WAIT_MS));
     expect(FakeWebSocket.instances).toHaveLength(1);
   });
 });

--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { render, renderHook, waitFor } from "@testing-library/react";
 import { getDefaultStore } from "jotai";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +11,45 @@ import {
   shouldForwardQueryResponse,
   useTerminal,
 } from "./useTerminal.ts";
+
+// Mock xterm.js and its addons so the hook's terminal-init effect runs to
+// completion in jsdom (setting `isXtermReady`, which gates the WebSocket
+// effect) without a real canvas/WebGL terminal. The mocks implement only the
+// members the hook touches.
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    rows = 24;
+    cols = 80;
+    options: Record<string, unknown> = {};
+    buffer = { active: { cursorY: 0, baseY: 0, getLine: (): null => null } };
+    loadAddon(): void {}
+    open(): void {}
+    onData(): void {}
+    attachCustomKeyEventHandler(): void {}
+    dispose(): void {}
+    focus(): void {}
+    blur(): void {}
+    refresh(): void {}
+    clear(): void {}
+    write(): void {}
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: class {
+    constructor(_handler: unknown) {}
+  },
+}));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class {
+    onContextLoss(): void {}
+    dispose(): void {}
+  },
+}));
 
 // jsdom's KeyboardEvent constructor drops metaKey/ctrlKey from the init
 // dict, so the existing `ShortcutUtils.test.ts` plain-object pattern is the
@@ -317,5 +356,110 @@ describe("useTerminal — clear-terminal keydown listener lifecycle", () => {
     unmount();
     const afterUnmount = keydownRemoveCalls().length;
     expect(afterUnmount).toBeGreaterThan(beforeUnmount);
+  });
+});
+
+// A minimal WebSocket stand-in. Each construction is recorded so a reconnect is
+// observable as a second instance; the hook assigns `onclose`, which the tests
+// invoke to drive the real close handler.
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: Array<FakeWebSocket> = [];
+
+  binaryType = "blob";
+  readyState: number = FakeWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(): void {}
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+
+describe("useTerminal — WebSocket reconnect on close", () => {
+  const TERMINAL_PATH = "/api/v1/workspaces/ws_test/terminal/0/ws";
+  const RECONNECT_WAIT_MS = 4500; // comfortably exceeds the hook's 2s retry delay
+  const NO_RECONNECT_WAIT_MS = 2500; // past the 2s retry delay, under the test timeout
+
+  // The hook only initialises xterm once the container reports non-zero
+  // dimensions; jsdom reports 0, so force a size for the duration of these tests.
+  const sizeOverride: PropertyDescriptor = { configurable: true, get: () => 100 };
+
+  // Render a real element that wires the hook's container ref to the DOM, so the
+  // terminal-init effect (and therefore the WebSocket effect) actually runs.
+  const ReconnectHarness = (): ReactElement => {
+    const { terminalContainerRef } = useTerminal({ terminalPath: TERMINAL_PATH, isVisible: true });
+    return <div ref={terminalContainerRef} />;
+  };
+
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    // resolveTerminalWsBaseUrl reads the API_URL_BASE build-time global; define it
+    // (as undefined) so the lookup falls through to the window.location fallback
+    // instead of throwing a ReferenceError.
+    vi.stubGlobal("API_URL_BASE", undefined);
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", sizeOverride);
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", sizeOverride);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight;
+  });
+
+  it("reconnects after the connection drops with a non-4404 close (e.g. host sleep, code 1006)", async () => {
+    render(<ReconnectHarness />);
+
+    // The first connection is established asynchronously (the WS URL resolves via a
+    // promise), so wait for it rather than asserting synchronously.
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    // Simulate the socket being torn down out from under us — the close a macOS
+    // sleep produces. The pre-fix handler only retried on code 4404, so this close
+    // left the terminal frozen; the fix retries on any close while still mounted.
+    FakeWebSocket.instances[0].onclose?.({ code: 1006 } as CloseEvent);
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2), { timeout: RECONNECT_WAIT_MS });
+  });
+
+  it("still reconnects when the backend has not started the PTY yet (close code 4404)", async () => {
+    // The original retry case must keep working after the fix broadened the trigger.
+    render(<ReconnectHarness />);
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    FakeWebSocket.instances[0].onclose?.({ code: 4404 } as CloseEvent);
+
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2), { timeout: RECONNECT_WAIT_MS });
+  });
+
+  it("does NOT reconnect when the close is our own teardown (unmount)", async () => {
+    const { unmount } = render(<ReconnectHarness />);
+    await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const initialSocket = FakeWebSocket.instances[0];
+
+    // Unmounting flips the effect's `isCleanedUp` guard. A close firing after that
+    // (the unmount closes the socket) must NOT schedule a reconnect, or tearing down
+    // a terminal would resurrect its connection.
+    unmount();
+    initialSocket.onclose?.({ code: 1006 } as CloseEvent);
+
+    // Give any (erroneously) scheduled retry the full delay to fire, then confirm
+    // no new connection was opened.
+    await new Promise((resolve) => setTimeout(resolve, NO_RECONNECT_WAIT_MS));
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 });

--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
@@ -76,10 +76,7 @@ const TERMINAL_OUTPUT_DECODER = new TextDecoder();
 // response is unlikely to fall inside it.
 const SOLICITED_QUERY_RESPONSE_WINDOW_MS = 1000;
 
-// A fresh terminal WebSocket can close with this code when the backend has the
-// terminal URL but hasn't started the PTY yet (e.g. workspace just created,
-// first agent still starting). We retry the connection after a short delay.
-const TERMINAL_NOT_STARTED_CLOSE_CODE = 4404;
+// Delay before retrying the terminal WebSocket after an unexpected close.
 const TERMINAL_RECONNECT_RETRY_DELAY_MS = 2000;
 
 /**
@@ -559,18 +556,22 @@ export const useTerminal = ({
         console.error("Terminal WebSocket error:", error);
       };
 
-      // If the terminal isn't running yet (4404), retry after a delay.
-      // This handles the case where the frontend has the terminal URL
-      // (derived from environment ID) but the backend hasn't started the
-      // PTY yet (e.g., workspace just created, first agent still starting).
-      ws.onclose = (event: CloseEvent): void => {
-        if (!isCleanedUp && event.code === TERMINAL_NOT_STARTED_CLOSE_CODE) {
-          setTimeout(() => {
-            if (!isCleanedUp) {
-              connectWebSocket(wsUrl);
-            }
-          }, TERMINAL_RECONNECT_RETRY_DELAY_MS);
-        }
+      // Reconnect on any unexpected close. The PTY is kept alive on the backend
+      // across disconnects and replays its buffered session on reconnect, so
+      // reconnecting restores a responsive terminal. This covers both a terminal
+      // not started yet (the backend closes with code 4404 while the PTY is still
+      // registering — e.g. workspace just created, first agent still starting)
+      // and a connection dropped out from under us (code 1006 — e.g. the host
+      // sleeping or a backend restart), which would otherwise leave the terminal
+      // frozen. Our own teardown (unmount, terminalPath change) skips this via
+      // isCleanedUp.
+      ws.onclose = (): void => {
+        if (isCleanedUp) return;
+        setTimeout(() => {
+          if (!isCleanedUp) {
+            connectWebSocket(wsUrl);
+          }
+        }, TERMINAL_RECONNECT_RETRY_DELAY_MS);
       };
     };
 

--- a/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/useTerminal.ts
@@ -79,6 +79,19 @@ const SOLICITED_QUERY_RESPONSE_WINDOW_MS = 1000;
 // Delay before retrying the terminal WebSocket after an unexpected close.
 const TERMINAL_RECONNECT_RETRY_DELAY_MS = 2000;
 
+// Close codes we do NOT retry, because reconnecting can't recover the session:
+// - 1000 is a normal, intentional close — nothing went wrong, so don't loop.
+// - 4401 is the backend rejecting our session token (it mirrors HTTP 401). The
+//   token is still invalid on a retry, so reconnecting would spin forever until
+//   the user re-authenticates. Mirrors the backend's
+//   WEBSOCKET_INVALID_SESSION_TOKEN_CLOSE_CODE.
+const WEBSOCKET_NORMAL_CLOSE_CODE = 1000;
+const TERMINAL_UNAUTHORIZED_CLOSE_CODE = 4401;
+const TERMINAL_NON_RETRYABLE_CLOSE_CODES = new Set<number>([
+  WEBSOCKET_NORMAL_CLOSE_CODE,
+  TERMINAL_UNAUTHORIZED_CLOSE_CODE,
+]);
+
 /**
  * Detect a terminal QUERY in live PTY output that xterm.js will answer with a
  * response `isTerminalQueryResponse` would otherwise filter.
@@ -556,17 +569,22 @@ export const useTerminal = ({
         console.error("Terminal WebSocket error:", error);
       };
 
-      // Reconnect on any unexpected close. The PTY is kept alive on the backend
-      // across disconnects and replays its buffered session on reconnect, so
-      // reconnecting restores a responsive terminal. This covers both a terminal
-      // not started yet (the backend closes with code 4404 while the PTY is still
-      // registering — e.g. workspace just created, first agent still starting)
-      // and a connection dropped out from under us (code 1006 — e.g. the host
-      // sleeping or a backend restart), which would otherwise leave the terminal
-      // frozen. Our own teardown (unmount, terminalPath change) skips this via
-      // isCleanedUp.
-      ws.onclose = (): void => {
-        if (isCleanedUp) return;
+      // Reconnect after an unexpected close so the terminal recovers on its own.
+      // The PTY is kept alive on the backend across disconnects and replays its
+      // buffered session on reconnect, so a fresh connection restores a responsive
+      // terminal. This covers a terminal not started yet (close code 4404 while
+      // the PTY is still registering — e.g. workspace just created, first agent
+      // still starting) and a connection dropped out from under us (code 1006 —
+      // e.g. the host sleeping or a backend restart), both of which would
+      // otherwise leave the terminal frozen.
+      //
+      // Skip the retry when reconnecting can't help: our own teardown (unmount /
+      // terminalPath change, via isCleanedUp) and the non-retryable close codes
+      // (a normal 1000 close, or a 4401 rejected session token that would loop).
+      ws.onclose = (event: CloseEvent): void => {
+        if (isCleanedUp || TERMINAL_NON_RETRYABLE_CLOSE_CODES.has(event.code)) {
+          return;
+        }
         setTimeout(() => {
           if (!isCleanedUp) {
             connectWebSocket(wsUrl);


### PR DESCRIPTION
Fixes #182. SCU-1621.

On macOS, terminals froze after the machine slept. Sleep tears down the terminal WebSocket and the browser fires `onclose` with code 1006; the reconnect handler only retried on code 4404 (PTY-not-started), so the dropped socket was never reconnected.

This reconnects on any unexpected close while still mounted. The backend keeps the PTY alive across disconnects and replays its buffer on reconnect, so the terminal is restored for both the not-started (4404) and dropped (1006) cases.

Thanks to @alxwrd-gelt for the clear report and diagnosis — this matches the fix you proposed.

**Test:** a Vitest unit test drives the real `onclose` handler with a fake WebSocket; it fails without the change (1006 → no reconnect) and passes with it.

(Sent by Claude)