### PR TITLE
Add homepage plugin slot with a persisted view switcher (SCU-1610)

### DIFF
--- a/agent_docs/scu-1610-homepage-plugin-slot/mocks.html
+++ b/agent_docs/scu-1610-homepage-plugin-slot/mocks.html
@@ -1,0 +1,411 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SCU-1610 — Homepage plugin slot mocks</title>
+    <style>
+      :root {
+        --gray-1: #111113;
+        --gray-2: #18191b;
+        --gray-3: #212225;
+        --gray-4: #292a2e;
+        --gray-5: #303136;
+        --gray-6: #3a3b40;
+        --gray-border: #2b2c30;
+        --text-hi: #ededef;
+        --text-mid: #b0b0b8;
+        --text-lo: #7c7d85;
+        --accent: #5b9dff;
+        --accent-dim: #2c3a52;
+        --green: #46c46e;
+        --amber: #e0a23b;
+        --red: #e5564b;
+        --blue: #5b9dff;
+        --radius: 10px;
+        font-synthesis: none;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; height: 100%; }
+      body {
+        background: var(--gray-1);
+        color: var(--text-hi);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        font-size: 14px;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ---------- mode switcher (not part of the product) ---------- */
+      .modebar {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 16px;
+        background: #0c0c0e;
+        border-bottom: 1px solid var(--gray-border);
+      }
+      .modebar .label { color: var(--text-lo); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .modebar button {
+        appearance: none;
+        border: 1px solid var(--gray-border);
+        background: var(--gray-3);
+        color: var(--text-mid);
+        padding: 7px 14px;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 13px;
+        font-family: inherit;
+      }
+      .modebar button.active { background: var(--accent-dim); border-color: var(--accent); color: var(--text-hi); }
+      .modebar .spacer { flex: 1; }
+      .modebar .note { color: var(--text-lo); font-size: 12px; }
+
+      /* ---------- app frame ---------- */
+      .app {
+        height: calc(100vh - 53px);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .topbar {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 12px;
+        height: 44px;
+        background: var(--gray-2);
+        border-bottom: 1px solid var(--gray-border);
+        flex: 0 0 auto;
+      }
+      .iconbtn {
+        width: 30px; height: 30px;
+        display: grid; place-items: center;
+        border-radius: 7px;
+        color: var(--text-mid);
+        cursor: pointer;
+      }
+      .iconbtn:hover { background: var(--gray-4); color: var(--text-hi); }
+      .iconbtn.active { background: var(--gray-4); color: var(--text-hi); }
+      .tabs { display: flex; gap: 6px; align-items: center; }
+      .tab {
+        display: flex; align-items: center; gap: 7px;
+        padding: 5px 11px; border-radius: 7px;
+        background: transparent; color: var(--text-mid);
+        font-size: 13px; cursor: pointer;
+      }
+      .tab:hover { background: var(--gray-3); }
+      .tab .dot { width: 7px; height: 7px; border-radius: 50%; }
+      .grow { flex: 1; }
+
+      /* ---------- homepage body ---------- */
+      .home {
+        flex: 1;
+        min-height: 0;
+        background: var(--gray-2);
+        overflow: hidden;
+        display: flex;
+        justify-content: center;
+        padding: 56px 24px 24px 24px;
+      }
+      .col {
+        width: 100%;
+        max-width: 850px;
+        height: 100%;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      .searchbar {
+        display: flex; align-items: center; gap: 10px;
+        background: var(--gray-3);
+        border: 1px solid var(--gray-border);
+        border-radius: var(--radius);
+        padding: 11px 14px;
+        color: var(--text-lo);
+        margin-bottom: 18px;
+        flex: 0 0 auto;
+      }
+      .section-label {
+        color: var(--text-lo);
+        font-size: 12px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        margin: 4px 2px 12px;
+      }
+      .ws-list { overflow: auto; min-height: 0; display: flex; flex-direction: column; gap: 8px; padding-right: 4px; }
+      .ws-row {
+        display: flex; align-items: center; gap: 14px;
+        padding: 13px 14px;
+        background: var(--gray-3);
+        border: 1px solid var(--gray-border);
+        border-radius: var(--radius);
+        cursor: pointer;
+      }
+      .ws-row:hover { background: var(--gray-4); }
+      .status { display: flex; gap: 3px; width: 22px; justify-content: center; flex: 0 0 auto; }
+      .dot { width: 9px; height: 9px; border-radius: 50%; }
+      .dot.running { background: var(--green); box-shadow: 0 0 0 3px rgba(70,196,110,0.18); }
+      .dot.waiting { background: var(--amber); box-shadow: 0 0 0 3px rgba(224,162,59,0.16); }
+      .dot.error { background: var(--red); }
+      .dot.unread { background: var(--blue); }
+      .dot.idle { background: var(--gray-6); }
+      .ws-main { flex: 1; min-width: 0; }
+      .ws-title { color: var(--text-hi); font-size: 14px; margin-bottom: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .ws-meta { color: var(--text-lo); font-size: 12px; display: flex; gap: 10px; align-items: center; }
+      .branch { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .pr {
+        font-size: 11px; padding: 3px 8px; border-radius: 6px;
+        background: var(--accent-dim); color: var(--accent);
+        border: 1px solid #34507a; flex: 0 0 auto;
+      }
+      .ws-time { color: var(--text-lo); font-size: 12px; flex: 0 0 auto; }
+
+      .slot-tag {
+        font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase;
+        color: var(--accent); border: 1px dashed #3a567d;
+        padding: 2px 7px; border-radius: 6px; background: rgba(91,157,255,0.06);
+      }
+
+      /* ---------- Direction 1: side widget ---------- */
+      .home.d1 .col { max-width: 1180px; flex-direction: row; gap: 22px; }
+      .home.d1 .main-col { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+      .rail {
+        width: 320px; flex: 0 0 auto;
+        display: flex; flex-direction: column; gap: 14px;
+        min-height: 0;
+      }
+      .widget {
+        background: var(--gray-3);
+        border: 1px solid var(--gray-border);
+        border-radius: var(--radius);
+        padding: 14px;
+        display: flex; flex-direction: column; min-height: 0;
+      }
+      .widget.plugin { border-color: #34507a; box-shadow: inset 0 0 0 1px rgba(91,157,255,0.06); }
+      .widget-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+      .widget-title { font-size: 13px; color: var(--text-hi); display: flex; align-items: center; gap: 8px; }
+      .widget-body { overflow: auto; min-height: 0; display: flex; flex-direction: column; gap: 9px; }
+      .task-line { display: flex; align-items: center; gap: 10px; padding: 8px; border-radius: 8px; background: var(--gray-2); }
+      .task-line:hover { background: var(--gray-4); }
+      .task-line .tl-main { flex: 1; min-width: 0; }
+      .task-line .tl-title { font-size: 13px; color: var(--text-hi); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .task-line .tl-sub { font-size: 11px; color: var(--text-lo); }
+      .group-h { font-size: 11px; color: var(--text-lo); text-transform: uppercase; letter-spacing: 0.05em; margin: 4px 2px 2px; }
+      .pill-count { font-size: 11px; color: var(--text-mid); background: var(--gray-5); border-radius: 999px; padding: 1px 8px; }
+
+      /* ---------- Direction 2: replacement view ---------- */
+      .view-switch { display: flex; gap: 4px; background: var(--gray-3); border: 1px solid var(--gray-border); border-radius: 9px; padding: 3px; margin-bottom: 18px; flex: 0 0 auto; align-self: flex-start; }
+      .view-switch button {
+        appearance: none; border: 0; background: transparent; color: var(--text-mid);
+        padding: 6px 14px; border-radius: 7px; cursor: pointer; font-size: 13px; font-family: inherit;
+        display: flex; align-items: center; gap: 7px;
+      }
+      .view-switch button.active { background: var(--gray-5); color: var(--text-hi); }
+      .board { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; overflow: hidden; min-height: 0; flex: 1; }
+      .board.full { grid-template-columns: repeat(3, 1fr); }
+      .lane { display: flex; flex-direction: column; min-height: 0; background: var(--gray-3); border: 1px solid var(--gray-border); border-radius: var(--radius); }
+      .lane-head { display: flex; align-items: center; gap: 9px; padding: 12px 14px; border-bottom: 1px solid var(--gray-border); font-size: 13px; }
+      .lane-body { overflow: auto; padding: 12px; display: flex; flex-direction: column; gap: 10px; min-height: 0; }
+      .card { background: var(--gray-2); border: 1px solid var(--gray-border); border-radius: 9px; padding: 12px; cursor: pointer; }
+      .card:hover { background: var(--gray-4); }
+      .card-title { font-size: 13px; color: var(--text-hi); margin-bottom: 6px; }
+      .card-meta { display: flex; align-items: center; gap: 9px; color: var(--text-lo); font-size: 11px; flex-wrap: wrap; }
+      .chip { background: var(--gray-5); border-radius: 6px; padding: 2px 7px; font-size: 11px; color: var(--text-mid); }
+      .stream { color: var(--green); font-size: 11px; display: flex; align-items: center; gap: 6px; }
+      .full-tag { position: absolute; }
+
+      .hidden { display: none !important; }
+      .d2-wrap { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+      .d2-head { display: flex; align-items: center; justify-content: space-between; flex: 0 0 auto; }
+    </style>
+  </head>
+  <body>
+    <div class="modebar">
+      <span class="label">Mock</span>
+      <button data-mode="today" class="active">Today (baseline)</button>
+      <button data-mode="d1">Direction 1 — Side widget</button>
+      <button data-mode="d2">Direction 2 — Replacement view</button>
+      <span class="spacer"></span>
+      <span class="note">SCU-1610 · homepage plugin slot · dashed accent = plugin-contributed surface</span>
+    </div>
+
+    <div class="app">
+      <!-- top bar (shared) -->
+      <div class="topbar">
+        <div class="iconbtn active" title="Home">⌂</div>
+        <div class="tabs">
+          <div class="tab"><span class="dot" style="background:var(--green)"></span> auth-refactor</div>
+          <div class="tab"><span class="dot" style="background:var(--amber)"></span> flaky-test-fix</div>
+          <div class="tab"><span class="dot" style="background:var(--blue)"></span> docs-pass</div>
+        </div>
+        <div class="grow"></div>
+        <div class="iconbtn" title="Search">⌕</div>
+        <div class="iconbtn" title="Settings">⚙</div>
+        <div class="iconbtn" title="Help">?</div>
+      </div>
+
+      <!-- ===================== TODAY ===================== -->
+      <div class="home today" id="view-today">
+        <div class="col">
+          <div class="searchbar">⌕&nbsp; Search workspaces…</div>
+          <div class="section-label">Recent workspaces</div>
+          <div class="ws-list" id="ws-list-today"></div>
+        </div>
+      </div>
+
+      <!-- ===================== DIRECTION 1 ===================== -->
+      <div class="home d1 hidden" id="view-d1">
+        <div class="col">
+          <div class="main-col">
+            <div class="searchbar">⌕&nbsp; Search workspaces…</div>
+            <div class="section-label">Recent workspaces</div>
+            <div class="ws-list" id="ws-list-d1"></div>
+          </div>
+          <div class="rail">
+            <div class="widget plugin" style="flex:1">
+              <div class="widget-head">
+                <span class="widget-title">⚡ Current tasks <span class="slot-tag">plugin widget</span></span>
+                <span class="pill-count">7 active</span>
+              </div>
+              <div class="widget-body" id="rail-tasks"></div>
+            </div>
+            <div class="widget">
+              <div class="widget-head"><span class="widget-title">＋ Quick actions</span></div>
+              <div class="widget-body">
+                <div class="task-line"><span class="dot idle"></span><div class="tl-main"><div class="tl-title">New workspace</div></div></div>
+                <div class="task-line"><span class="dot idle"></span><div class="tl-main"><div class="tl-title">Open settings</div></div></div>
+              </div>
+              <div style="margin-top:10px"><span class="slot-tag">another slot could live here</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ===================== DIRECTION 2 ===================== -->
+      <div class="home d2 hidden" id="view-d2">
+        <div class="col" style="max-width:1180px">
+          <div class="d2-wrap">
+            <div class="d2-head">
+              <div class="view-switch">
+                <button data-d2="recent">≣ Recent</button>
+                <button data-d2="board" class="active">▦ Tasks board <span class="slot-tag" style="margin-left:4px">plugin view</span></button>
+              </div>
+              <div class="searchbar" style="margin-bottom:18px; width:280px">⌕&nbsp; Filter tasks…</div>
+            </div>
+
+            <!-- recent (built-in) sub-view -->
+            <div id="d2-recent" class="hidden" style="display:flex; flex-direction:column; min-height:0; flex:1">
+              <div class="section-label">Recent workspaces</div>
+              <div class="ws-list" id="ws-list-d2"></div>
+            </div>
+
+            <!-- board (plugin) sub-view -->
+            <div id="d2-board" class="board"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const workspaces = [
+        { st: ["running"], title: "Refactor auth token validation", branch: "auth-refactor", project: "sculptor", pr: "#214", time: "2m ago" },
+        { st: ["waiting"], title: "Fix flaky offload integration test", branch: "scu-1577-flaky", project: "sculptor", pr: null, time: "11m ago" },
+        { st: ["error", "unread"], title: "Migrate panel registry to atoms", branch: "panel-atoms", project: "sculptor", pr: "#208", time: "26m ago" },
+        { st: ["unread"], title: "Docs pass for plugin SDK", branch: "docs-pass", project: "sculptor", pr: null, time: "1h ago" },
+        { st: ["running"], title: "Compact workspace layout", branch: "scu-1474-compact", project: "sculptor", pr: "#198", time: "1h ago" },
+        { st: ["idle"], title: "Linear example plugin", branch: "scu-1495-linear", project: "sculptor-plugins", pr: "#74", time: "yesterday" },
+        { st: ["idle"], title: "Top-level coordinator agent", branch: "top-level-agent", project: "sculptor", pr: null, time: "2d ago" },
+      ];
+
+      function wsRow(w) {
+        const dots = w.st.map((s) => `<span class="dot ${s}"></span>`).join("");
+        return `<div class="ws-row">
+          <div class="status">${dots}</div>
+          <div class="ws-main">
+            <div class="ws-title">${w.title}</div>
+            <div class="ws-meta"><span class="branch">⎇ ${w.branch}</span><span>${w.project}</span></div>
+          </div>
+          ${w.pr ? `<span class="pr">PR ${w.pr}</span>` : ""}
+          <span class="ws-time">${w.time}</span>
+        </div>`;
+      }
+      const listHTML = workspaces.map(wsRow).join("");
+      ["ws-list-today", "ws-list-d1", "ws-list-d2"].forEach((id) => (document.getElementById(id).innerHTML = listHTML));
+
+      // rail tasks for D1 (grouped by status)
+      const railGroups = [
+        { h: "Running", items: [
+          { c: "running", t: "Refactor auth token validation", s: "auth-refactor · streaming" },
+          { c: "running", t: "Compact workspace layout", s: "scu-1474 · calling tools" },
+        ]},
+        { h: "Waiting on you", items: [
+          { c: "waiting", t: "Fix flaky offload test", s: "needs a decision" },
+        ]},
+        { h: "Needs review", items: [
+          { c: "error", t: "Migrate panel registry", s: "agent hit an error" },
+          { c: "unread", t: "Docs pass for plugin SDK", s: "2 unread updates" },
+        ]},
+      ];
+      document.getElementById("rail-tasks").innerHTML = railGroups.map((g) =>
+        `<div class="group-h">${g.h}</div>` + g.items.map((i) =>
+          `<div class="task-line"><span class="dot ${i.c}"></span><div class="tl-main"><div class="tl-title">${i.t}</div><div class="tl-sub">${i.s}</div></div></div>`
+        ).join("")
+      ).join("");
+
+      // board for D2
+      const lanes = [
+        { h: "Running", c: "running", cards: [
+          { t: "Refactor auth token validation", chips: ["auth-refactor", "PR #214"], stream: "streaming…" },
+          { t: "Compact workspace layout", chips: ["scu-1474", "PR #198"], stream: "calling tools…" },
+        ]},
+        { h: "Waiting on you", c: "waiting", cards: [
+          { t: "Fix flaky offload integration test", chips: ["scu-1577-flaky"], q: "“Should I bump the timeout or re-resolve the locator?”" },
+        ]},
+        { h: "Needs review", c: "error", cards: [
+          { t: "Migrate panel registry to atoms", chips: ["panel-atoms", "PR #208"], err: "agent errored" },
+          { t: "Docs pass for plugin SDK", chips: ["docs-pass"], note: "2 unread updates" },
+        ]},
+      ];
+      document.getElementById("d2-board").innerHTML = lanes.map((l) =>
+        `<div class="lane">
+          <div class="lane-head"><span class="dot ${l.c}"></span> ${l.h} <span class="pill-count" style="margin-left:auto">${l.cards.length}</span></div>
+          <div class="lane-body">${l.cards.map((card) =>
+            `<div class="card">
+              <div class="card-title">${card.t}</div>
+              <div class="card-meta">${card.chips.map((c) => `<span class="chip">${c}</span>`).join("")}</div>
+              ${card.stream ? `<div class="stream" style="margin-top:8px">● ${card.stream}</div>` : ""}
+              ${card.q ? `<div class="card-meta" style="margin-top:8px; color:var(--amber)">${card.q}</div>` : ""}
+              ${card.err ? `<div class="card-meta" style="margin-top:8px; color:var(--red)">${card.err}</div>` : ""}
+              ${card.note ? `<div class="card-meta" style="margin-top:8px; color:var(--blue)">${card.note}</div>` : ""}
+            </div>`
+          ).join("")}</div>
+        </div>`
+      ).join("");
+
+      // mode switching
+      const views = { today: "view-today", d1: "view-d1", d2: "view-d2" };
+      document.querySelectorAll(".modebar button").forEach((b) =>
+        b.addEventListener("click", () => {
+          document.querySelectorAll(".modebar button").forEach((x) => x.classList.remove("active"));
+          b.classList.add("active");
+          Object.values(views).forEach((id) => document.getElementById(id).classList.add("hidden"));
+          document.getElementById(views[b.dataset.mode]).classList.remove("hidden");
+        })
+      );
+
+      // D2 sub-view switch
+      document.querySelectorAll("[data-d2]").forEach((b) =>
+        b.addEventListener("click", () => {
+          document.querySelectorAll("[data-d2]").forEach((x) => x.classList.remove("active"));
+          b.classList.add("active");
+          const board = b.dataset.d2 === "board";
+          document.getElementById("d2-board").classList.toggle("hidden", !board);
+          document.getElementById("d2-recent").classList.toggle("hidden", board);
+        })
+      );
+    </script>
+  </body>
+</html>

--- a/sculptor/frontend/plugins/README.md
+++ b/sculptor/frontend/plugins/README.md
@@ -83,8 +83,9 @@ the exact set the import map provides, derived from `RUNTIME_MODULE_SPECIFIERS`
 - `openExternal(url)` — open a URL in the user's browser (a new tab on the web;
   the system browser in the desktop app). Use this rather than `window.open`.
 - `PanelHeader`, domain types, and the `PluginHostApi` / `PanelDefinition` /
-  `WorkspaceWidgetDefinition` registration types (so plugins type `activate(api)`
-  against the host contract instead of re-declaring it).
+  `WorkspaceWidgetDefinition` / `HomeViewDefinition` registration types (so
+  plugins type `activate(api)` against the host contract instead of re-declaring
+  it).
 
 ### Contribution points (`activate(api)`)
 
@@ -99,6 +100,12 @@ the exact set the import map provides, derived from `RUNTIME_MODULE_SPECIFIERS`
   the host's own banner items occupy a few small integers. The name is
   placement-agnostic on purpose — the same registration is what a future
   per-workspace vertical-tabs layout would render.
+- `registerHomeView(def)` — a full-page alternative homepage body. The homepage
+  shows a view switcher whenever at least one is registered; picking one replaces
+  the built-in recent-workspaces list with the plugin's component. The choice is
+  remembered (per browser) and falls back to the built-in view if the plugin is
+  unloaded. Like an overlay it is app-global (no `WorkspacePluginContext`), so it
+  reads app state through the SDK hooks.
 
 ## Caching fetched data (`@tanstack/react-query`)
 

--- a/sculptor/frontend/src/common/state/hooks/useWorkspaceNavigation.ts
+++ b/sculptor/frontend/src/common/state/hooks/useWorkspaceNavigation.ts
@@ -6,6 +6,7 @@ import { useImbueLocation, useImbueNavigate } from "../../NavigateUtils.ts";
 import { agentIdsByWorkspaceAtom, convertHomeTabToWorkspaceAtom, openWorkspaceTabAtom } from "../atoms/workspaces.ts";
 
 type WorkspaceNavigationResult = {
+  navigateToWorkspaceById: (workspaceId: string) => void;
   handleWorkspaceClick: (workspace: RecentWorkspaceResponse) => void;
   handleOpenInNewTab: (workspace: RecentWorkspaceResponse) => void;
 };
@@ -21,28 +22,37 @@ export const useWorkspaceNavigation = (): WorkspaceNavigationResult => {
   const agentIdsByWorkspace = useAtomValue(agentIdsByWorkspaceAtom);
   const openTab = useSetAtom(openWorkspaceTabAtom);
   const convertHomeTab = useSetAtom(convertHomeTabToWorkspaceAtom);
-  const handleWorkspaceClick = useCallback(
-    (workspace: RecentWorkspaceResponse): void => {
+  // The id-keyed core of the click handler, so callers that only hold a
+  // workspace id (e.g. the plugin SDK's navigate verb) get the same tab-opening
+  // and MRU-agent resolution without reconstructing a RecentWorkspaceResponse.
+  const navigateToWorkspaceById = useCallback(
+    (workspaceId: string): void => {
       // When navigating from the home page, replace the home tab with the workspace tab.
       if (isHomeRoute) {
-        convertHomeTab(workspace.objectId);
+        convertHomeTab(workspaceId);
       } else {
         // Ensure the workspace has an open tab (re-opens closed tabs)
-        openTab(workspace.objectId);
+        openTab(workspaceId);
       }
 
       // Use the saved agent id from tabsAtom if available for instant navigation.
-      const savedAgentId = agentIdsByWorkspace.get(workspace.objectId);
+      const savedAgentId = agentIdsByWorkspace.get(workspaceId);
       if (savedAgentId) {
-        navigateToAgent(workspace.objectId, savedAgentId);
+        navigateToAgent(workspaceId, savedAgentId);
         return;
       }
 
       // No saved agent yet — navigate to the workspace URL and let
       // WorkspacePage's validation effect pick a fallback agent.
-      navigateToWorkspace(workspace.objectId);
+      navigateToWorkspace(workspaceId);
     },
     [isHomeRoute, openTab, convertHomeTab, agentIdsByWorkspace, navigateToAgent, navigateToWorkspace],
+  );
+  const handleWorkspaceClick = useCallback(
+    (workspace: RecentWorkspaceResponse): void => {
+      navigateToWorkspaceById(workspace.objectId);
+    },
+    [navigateToWorkspaceById],
   );
 
   const handleOpenInNewTab = useCallback(
@@ -54,5 +64,5 @@ export const useWorkspaceNavigation = (): WorkspaceNavigationResult => {
     [openTab],
   );
 
-  return { handleWorkspaceClick, handleOpenInNewTab };
+  return { navigateToWorkspaceById, handleWorkspaceClick, handleOpenInNewTab };
 };

--- a/sculptor/frontend/src/pages/home/HomePage.module.scss
+++ b/sculptor/frontend/src/pages/home/HomePage.module.scss
@@ -1,16 +1,23 @@
-.container {
+.root {
   background: var(--gray-2);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.switcherBar {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  padding: var(--space-4) var(--space-5) 0 var(--space-5);
+}
+
+// Holds the active home view, which owns its own scrolling and padding.
+.body {
+  display: flex;
   flex: 1;
   min-height: 0;
   overflow: hidden;
-  padding: var(--space-9) var(--space-5) var(--space-6) var(--space-5);
-}
-
-.content {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  max-width: min(850px, 90%);
-  min-height: 0;
-  width: 100%;
 }

--- a/sculptor/frontend/src/pages/home/HomePage.tsx
+++ b/sculptor/frontend/src/pages/home/HomePage.tsx
@@ -1,28 +1,37 @@
-import { Flex } from "@radix-ui/themes";
+import { useAtomValue } from "jotai";
 import type { ReactElement } from "react";
-import { useRef } from "react";
 
-import { useWorkspaceNavigation } from "../../common/state/hooks/useWorkspaceNavigation.ts";
-import { RecentWorkspaces } from "../add-workspace/components/RecentWorkspaces.tsx";
+import { pluginHomeViewsAtom } from "~/plugins/pluginRegistry.ts";
+
 import styles from "./HomePage.module.scss";
+import { BUILTIN_HOME_VIEW_ID, effectiveHomeViewIdAtom, homeViewOptionsAtom } from "./homeViews.ts";
+import { HomeViewSwitcher } from "./HomeViewSwitcher.tsx";
+import { RecentWorkspacesHomeView } from "./RecentWorkspacesHomeView.tsx";
 
 export const HomePage = (): ReactElement => {
-  const { handleWorkspaceClick, handleOpenInNewTab } = useWorkspaceNavigation();
-  const searchInputRef = useRef<HTMLInputElement>(null);
+  const options = useAtomValue(homeViewOptionsAtom);
+  const effectiveId = useAtomValue(effectiveHomeViewIdAtom);
+  const pluginHomeViews = useAtomValue(pluginHomeViewsAtom);
+
+  // Only surface the switcher once there is something to switch to: with no
+  // plugin home views the page is the recent-workspaces list, exactly as before.
+  const shouldShowSwitcher = options.length > 1;
+
+  const SelectedView =
+    effectiveId === BUILTIN_HOME_VIEW_ID
+      ? RecentWorkspacesHomeView
+      : (pluginHomeViews.find((view) => view.id === effectiveId)?.component ?? RecentWorkspacesHomeView);
 
   return (
-    <Flex direction="column" align="center" className={styles.container}>
-      <div className={styles.content}>
-        <RecentWorkspaces
-          searchInputRef={searchInputRef}
-          autoFocusSearch
-          onWorkspaceClick={handleWorkspaceClick}
-          onOpenInNewTab={handleOpenInNewTab}
-          onEscapeToTitle={(): void => {
-            searchInputRef.current?.focus();
-          }}
-        />
+    <div className={styles.root}>
+      {shouldShowSwitcher && (
+        <div className={styles.switcherBar}>
+          <HomeViewSwitcher />
+        </div>
+      )}
+      <div className={styles.body}>
+        <SelectedView />
       </div>
-    </Flex>
+    </div>
   );
 };

--- a/sculptor/frontend/src/pages/home/HomeViewSwitcher.tsx
+++ b/sculptor/frontend/src/pages/home/HomeViewSwitcher.tsx
@@ -1,0 +1,30 @@
+import { Flex, SegmentedControl } from "@radix-ui/themes";
+import { useAtomValue, useSetAtom } from "jotai";
+import type { ReactElement } from "react";
+
+import { effectiveHomeViewIdAtom, homeViewOptionsAtom, selectedHomeViewAtom } from "./homeViews.ts";
+
+/**
+ * Segmented control that switches the homepage body between the built-in
+ * recent-workspaces view and any plugin-contributed home views. Bound to the
+ * persisted selection; the active item reflects the *effective* view, so a
+ * selection whose plugin has gone away shows the built-in view as active.
+ */
+export const HomeViewSwitcher = (): ReactElement => {
+  const options = useAtomValue(homeViewOptionsAtom);
+  const effectiveId = useAtomValue(effectiveHomeViewIdAtom);
+  const setSelected = useSetAtom(selectedHomeViewAtom);
+
+  return (
+    <SegmentedControl.Root value={effectiveId} onValueChange={setSelected} size="2">
+      {options.map(({ id, title, icon: Icon }) => (
+        <SegmentedControl.Item key={id} value={id}>
+          <Flex align="center" gap="2">
+            {Icon ? <Icon /> : null}
+            {title}
+          </Flex>
+        </SegmentedControl.Item>
+      ))}
+    </SegmentedControl.Root>
+  );
+};

--- a/sculptor/frontend/src/pages/home/HomeViewSwitcher.tsx
+++ b/sculptor/frontend/src/pages/home/HomeViewSwitcher.tsx
@@ -20,7 +20,9 @@ export const HomeViewSwitcher = (): ReactElement => {
       {options.map(({ id, title, icon: Icon }) => (
         <SegmentedControl.Item key={id} value={id}>
           <Flex align="center" gap="2">
-            {Icon ? <Icon /> : null}
+            {/* 16px matches the codebase's SegmentedControl icon size; Lucide's
+                24px default sits taller than the item text. */}
+            {Icon ? <Icon size={16} /> : null}
             {title}
           </Flex>
         </SegmentedControl.Item>

--- a/sculptor/frontend/src/pages/home/RecentWorkspacesHomeView.module.scss
+++ b/sculptor/frontend/src/pages/home/RecentWorkspacesHomeView.module.scss
@@ -1,0 +1,16 @@
+.container {
+  background: var(--gray-2);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: var(--space-9) var(--space-5) var(--space-6) var(--space-5);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: min(850px, 90%);
+  min-height: 0;
+  width: 100%;
+}

--- a/sculptor/frontend/src/pages/home/RecentWorkspacesHomeView.tsx
+++ b/sculptor/frontend/src/pages/home/RecentWorkspacesHomeView.tsx
@@ -1,0 +1,33 @@
+import { Flex } from "@radix-ui/themes";
+import type { ReactElement } from "react";
+import { useRef } from "react";
+
+import { useWorkspaceNavigation } from "../../common/state/hooks/useWorkspaceNavigation.ts";
+import { RecentWorkspaces } from "../add-workspace/components/RecentWorkspaces.tsx";
+import styles from "./RecentWorkspacesHomeView.module.scss";
+
+/**
+ * The built-in homepage view: a centered, searchable list of recent workspaces.
+ * Registered under {@link BUILTIN_HOME_VIEW_ID} and always the fallback view, so
+ * the homepage looks unchanged when no plugin contributes an alternative.
+ */
+export const RecentWorkspacesHomeView = (): ReactElement => {
+  const { handleWorkspaceClick, handleOpenInNewTab } = useWorkspaceNavigation();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <Flex direction="column" align="center" className={styles.container}>
+      <div className={styles.content}>
+        <RecentWorkspaces
+          searchInputRef={searchInputRef}
+          autoFocusSearch
+          onWorkspaceClick={handleWorkspaceClick}
+          onOpenInNewTab={handleOpenInNewTab}
+          onEscapeToTitle={(): void => {
+            searchInputRef.current?.focus();
+          }}
+        />
+      </div>
+    </Flex>
+  );
+};

--- a/sculptor/frontend/src/pages/home/homeViews.test.ts
+++ b/sculptor/frontend/src/pages/home/homeViews.test.ts
@@ -63,4 +63,19 @@ describe("home view atoms", () => {
     store.set(pluginHomeViewsAtom, []);
     expect(store.get(effectiveHomeViewIdAtom)).toBe(BUILTIN_HOME_VIEW_ID);
   });
+
+  it("keeps option ids unique when a plugin view claims the reserved built-in id", () => {
+    // registerHomeView rejects this id, but guard the options atom too: a stray
+    // entry must not produce duplicate ids (duplicate React keys / segment values).
+    const store = createStore();
+    store.set(pluginHomeViewsAtom, [
+      { id: BUILTIN_HOME_VIEW_ID, title: "Hijacked", component: TasksView },
+      { id: "tasks", title: "Tasks board", component: TasksView },
+    ]);
+    const ids = store.get(homeViewOptionsAtom).map((option) => option.id);
+    expect(ids).toEqual([BUILTIN_HOME_VIEW_ID, "tasks"]);
+    // The built-in title wins the reserved id, not the plugin's "Hijacked".
+    expect(store.get(homeViewOptionsAtom)[0].title).toBe("Recent workspaces");
+    expect(store.get(effectiveHomeViewIdAtom)).toBe(BUILTIN_HOME_VIEW_ID);
+  });
 });

--- a/sculptor/frontend/src/pages/home/homeViews.test.ts
+++ b/sculptor/frontend/src/pages/home/homeViews.test.ts
@@ -1,0 +1,66 @@
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { pluginHomeViewsAtom } from "~/plugins/pluginRegistry.ts";
+
+import {
+  BUILTIN_HOME_VIEW_ID,
+  effectiveHomeViewIdAtom,
+  homeViewOptionsAtom,
+  resolveEffectiveHomeViewId,
+  selectedHomeViewAtom,
+} from "./homeViews.ts";
+
+describe("resolveEffectiveHomeViewId", () => {
+  it("keeps the selection when it is still available", () => {
+    expect(resolveEffectiveHomeViewId("tasks-board", [BUILTIN_HOME_VIEW_ID, "tasks-board"])).toBe("tasks-board");
+  });
+
+  it("falls back to the built-in view when the selection is gone", () => {
+    // e.g. the plugin that registered "tasks-board" was unloaded
+    expect(resolveEffectiveHomeViewId("tasks-board", [BUILTIN_HOME_VIEW_ID])).toBe(BUILTIN_HOME_VIEW_ID);
+  });
+
+  it("returns the built-in view when it is the only option", () => {
+    expect(resolveEffectiveHomeViewId(BUILTIN_HOME_VIEW_ID, [BUILTIN_HOME_VIEW_ID])).toBe(BUILTIN_HOME_VIEW_ID);
+  });
+});
+
+describe("home view atoms", () => {
+  const TasksView = (): null => null;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("offers only the built-in view, selected, when no plugin contributes one", () => {
+    const store = createStore();
+    expect(store.get(homeViewOptionsAtom).map((option) => option.id)).toEqual([BUILTIN_HOME_VIEW_ID]);
+    expect(store.get(effectiveHomeViewIdAtom)).toBe(BUILTIN_HOME_VIEW_ID);
+  });
+
+  it("appends plugin views to the switcher but keeps the built-in active by default", () => {
+    const store = createStore();
+    store.set(pluginHomeViewsAtom, [{ id: "tasks", title: "Tasks board", component: TasksView }]);
+    expect(store.get(homeViewOptionsAtom).map((option) => option.id)).toEqual([BUILTIN_HOME_VIEW_ID, "tasks"]);
+    expect(store.get(effectiveHomeViewIdAtom)).toBe(BUILTIN_HOME_VIEW_ID);
+  });
+
+  it("honors a stored selection of a registered plugin view", () => {
+    const store = createStore();
+    store.set(pluginHomeViewsAtom, [{ id: "tasks", title: "Tasks board", component: TasksView }]);
+    store.set(selectedHomeViewAtom, "tasks");
+    expect(store.get(effectiveHomeViewIdAtom)).toBe("tasks");
+  });
+
+  it("falls back to the built-in view when the selected plugin view is unregistered", () => {
+    const store = createStore();
+    store.set(pluginHomeViewsAtom, [{ id: "tasks", title: "Tasks board", component: TasksView }]);
+    store.set(selectedHomeViewAtom, "tasks");
+    expect(store.get(effectiveHomeViewIdAtom)).toBe("tasks");
+
+    // The plugin is unloaded; the selection persists but no longer resolves.
+    store.set(pluginHomeViewsAtom, []);
+    expect(store.get(effectiveHomeViewIdAtom)).toBe(BUILTIN_HOME_VIEW_ID);
+  });
+});

--- a/sculptor/frontend/src/pages/home/homeViews.ts
+++ b/sculptor/frontend/src/pages/home/homeViews.ts
@@ -40,7 +40,13 @@ export const homeViewOptionsAtom = atom<ReadonlyArray<HomeViewOption>>((get) => 
   const pluginViews = get(pluginHomeViewsAtom);
   return [
     { id: BUILTIN_HOME_VIEW_ID, title: BUILTIN_HOME_VIEW_TITLE },
-    ...pluginViews.map((view) => ({ id: view.id, title: view.title, icon: view.icon })),
+    // Drop any plugin view that claims the reserved built-in id, so option ids
+    // stay unique — a duplicate would mean duplicate React keys and duplicate
+    // SegmentedControl values, which breaks selection. Registration also rejects
+    // this id (see registerHomeView), so this is a defensive second guard.
+    ...pluginViews
+      .filter((view) => view.id !== BUILTIN_HOME_VIEW_ID)
+      .map((view) => ({ id: view.id, title: view.title, icon: view.icon })),
   ];
 });
 

--- a/sculptor/frontend/src/pages/home/homeViews.ts
+++ b/sculptor/frontend/src/pages/home/homeViews.ts
@@ -1,0 +1,63 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import type { ComponentType } from "react";
+
+import { pluginHomeViewsAtom } from "~/plugins/pluginRegistry.ts";
+
+/**
+ * Reserved id of the built-in homepage view (the recent-workspaces list). It is
+ * always the first option and the fallback whenever the persisted selection
+ * names a view that is not currently registered.
+ */
+export const BUILTIN_HOME_VIEW_ID = "recent-workspaces";
+
+const BUILTIN_HOME_VIEW_TITLE = "Recent workspaces";
+
+/** A switcher entry: the built-in view plus one per registered plugin home view. */
+export type HomeViewOption = {
+  id: string;
+  title: string;
+  icon?: ComponentType;
+};
+
+/**
+ * The user's selected home view, persisted to localStorage. Kept here (per
+ * browser) rather than in backend user config because the set of available
+ * views is itself per-browser: plugin sources live in localStorage
+ * (`pluginSourcesAtom`), so a backend-synced selection would routinely point at
+ * a plugin not installed on another device. `getOnInit: true` mirrors the
+ * plugin-source atoms so the very first read returns the persisted value.
+ */
+export const selectedHomeViewAtom = atomWithStorage<string>(
+  "sculptor-selected-home-view",
+  BUILTIN_HOME_VIEW_ID,
+  undefined,
+  { getOnInit: true },
+);
+
+/** Options shown in the switcher: the built-in view first, then plugin views. */
+export const homeViewOptionsAtom = atom<ReadonlyArray<HomeViewOption>>((get) => {
+  const pluginViews = get(pluginHomeViewsAtom);
+  return [
+    { id: BUILTIN_HOME_VIEW_ID, title: BUILTIN_HOME_VIEW_TITLE },
+    ...pluginViews.map((view) => ({ id: view.id, title: view.title, icon: view.icon })),
+  ];
+});
+
+/**
+ * Resolves the selection against what is actually available, falling back to the
+ * built-in view when the stored id is gone (e.g. its plugin was unloaded). Pure
+ * so the fallback rule is unit-testable without Jotai or the plugin registry.
+ */
+export const resolveEffectiveHomeViewId = (selectedId: string, availableIds: ReadonlyArray<string>): string =>
+  availableIds.includes(selectedId) ? selectedId : BUILTIN_HOME_VIEW_ID;
+
+/** The home view actually rendered, after applying the fallback rule. */
+export const effectiveHomeViewIdAtom = atom<string>((get) => {
+  const selected = get(selectedHomeViewAtom);
+  const options = get(homeViewOptionsAtom);
+  return resolveEffectiveHomeViewId(
+    selected,
+    options.map((option) => option.id),
+  );
+});

--- a/sculptor/frontend/src/pages/home/homeViews.ts
+++ b/sculptor/frontend/src/pages/home/homeViews.ts
@@ -17,7 +17,8 @@ const BUILTIN_HOME_VIEW_TITLE = "Recent workspaces";
 export type HomeViewOption = {
   id: string;
   title: string;
-  icon?: ComponentType;
+  // Accepts `size` so the switcher can render it at the segmented-control's icon size.
+  icon?: ComponentType<{ size?: number | string }>;
 };
 
 /**

--- a/sculptor/frontend/src/plugins/pluginManager.tsx
+++ b/sculptor/frontend/src/plugins/pluginManager.tsx
@@ -13,6 +13,7 @@ import { PluginErrorBoundary } from "./PluginErrorBoundary.tsx";
 import {
   pluginDisabledSourcesAtom,
   pluginEnabledSourcesAtom,
+  pluginHomeViewsAtom,
   pluginOverlaysAtom,
   pluginPanelsAtom,
   pluginSettingsComponentsAtom,
@@ -23,6 +24,7 @@ import {
   pluginWorkspaceWidgetsAtom,
 } from "./pluginRegistry.ts";
 import type {
+  HomeViewDefinition,
   LoadedPlugin,
   OverlayDefinition,
   PluginHostApi,
@@ -858,6 +860,31 @@ export class PluginManager {
         store.set(pluginWorkspaceWidgetsAtom, (prev) => [...prev.filter((w) => w.id !== widget.id), entry]);
         const undo = (): void => {
           store.set(pluginWorkspaceWidgetsAtom, (prev) => prev.filter((w) => w !== entry));
+        };
+        loadDisposers.push(undo);
+        return undo;
+      },
+      registerHomeView: (view: HomeViewDefinition): (() => void) => {
+        // App-global like an overlay: wrap in the error boundary and
+        // PluginContext, but no WorkspacePluginContext — the homepage is not
+        // scoped to a workspace, so the view reads app state through SDK hooks.
+        const PluginComponent = view.component;
+        // Attribute crashes to the owning plugin (manifest), matching the other
+        // register paths — not to the home-view contribution id.
+        const Wrapped = (): ReactElement => (
+          <PluginErrorBoundary pluginId={manifest.id} pluginName={manifest.name}>
+            <PluginContext.Provider value={{ pluginId: manifest.id }}>
+              <PluginComponent />
+            </PluginContext.Provider>
+          </PluginErrorBoundary>
+        );
+        Wrapped.displayName = `PluginHomeView(${view.id})`;
+        const entry = { id: view.id, title: view.title, icon: view.icon, component: Wrapped };
+
+        // Replace-by-id; undo by instance (see the panel undo above).
+        store.set(pluginHomeViewsAtom, (prev) => [...prev.filter((v) => v.id !== view.id), entry]);
+        const undo = (): void => {
+          store.set(pluginHomeViewsAtom, (prev) => prev.filter((v) => v !== entry));
         };
         loadDisposers.push(undo);
         return undo;

--- a/sculptor/frontend/src/plugins/pluginManager.tsx
+++ b/sculptor/frontend/src/plugins/pluginManager.tsx
@@ -6,6 +6,7 @@ import { baseUrl } from "~/apiClient.ts";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { queryClient, SCULPTOR_QUERY_KEY_PREFIX } from "~/common/queryClient.ts";
 import type { PanelDefinition } from "~/components/panels/types.ts";
+import { BUILTIN_HOME_VIEW_ID } from "~/pages/home/homeViews.ts";
 
 import { installHostRuntime } from "./hostRuntime.ts";
 import { PluginContext } from "./PluginContext.tsx";
@@ -865,6 +866,16 @@ export class PluginManager {
         return undo;
       },
       registerHomeView: (view: HomeViewDefinition): (() => void) => {
+        // The recent-workspaces view is the built-in the host always offers; a
+        // plugin can't claim its id, or the switcher would have two options with
+        // the same value. Reject up front (rather than silently dropping it in
+        // the options atom) so the plugin author gets a reason it didn't appear.
+        if (view.id === BUILTIN_HOME_VIEW_ID) {
+          console.warn(
+            `Plugin "${manifest.id}" tried to register a home view with the reserved id "${BUILTIN_HOME_VIEW_ID}"; ignoring it.`,
+          );
+          return () => {};
+        }
         // App-global like an overlay: wrap in the error boundary and
         // PluginContext, but no WorkspacePluginContext — the homepage is not
         // scoped to a workspace, so the view reads app state through SDK hooks.

--- a/sculptor/frontend/src/plugins/pluginRegistry.ts
+++ b/sculptor/frontend/src/plugins/pluginRegistry.ts
@@ -38,6 +38,18 @@ export const pluginWorkspaceWidgetsAtom = atom<
 >([]);
 
 /**
+ * Full-page home views contributed by plugins via `registerHomeView`. The
+ * homepage shows a switcher (built-in recent-workspaces view plus each of
+ * these) whenever this list is non-empty, and renders the selected one in place
+ * of the built-in list. Each entry's component is already wrapped by the loader
+ * in an error boundary and the plugin's PluginContext (no WorkspacePluginContext
+ * — the homepage is not workspace-scoped).
+ */
+export const pluginHomeViewsAtom = atom<
+  ReadonlyArray<{ id: string; title: string; icon?: ComponentType; component: ComponentType }>
+>([]);
+
+/**
  * User-added plugin sources, persisted to localStorage. A source is a URL or
  * directory that contains a `manifest.json` (e.g. `http://localhost:5174/my-plugin`
  * or `/plugins/my-plugin`). Built-in sources are loaded separately and are not

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -3,28 +3,25 @@ import { atomFamily, atomWithStorage, selectAtom } from "jotai/utils";
 import { useContext, useEffect, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
 
-import type { CodingAgentTaskView, Workspace } from "~/api";
+import type { CodingAgentTaskView } from "~/api";
 import { prStatusAtomFamily } from "~/common/state/atoms/prStatus.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { workspaceBranchAtomFamily } from "~/common/state/atoms/workspaceBranch.ts";
 import { workspaceAtomFamily, workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
+import { useWorkspaceNavigation } from "~/common/state/hooks/useWorkspaceNavigation.ts";
 
 import { usePluginContext } from "../PluginContext.tsx";
 import { useWorkspacePluginContext, WorkspacePluginContext } from "../WorkspaceContext.tsx";
 
 /**
- * Every non-deleted workspace known to the host, or `undefined` until the
- * first batch has loaded. App-global: it reads a shared atom and needs no
- * workspace context, so it works in an overlay as well as a panel.
+ * A curated, plugin-facing view of a single workspace: identity, label, live git
+ * branch, and code-host link. Deliberately a subset — not the host's full
+ * `Workspace` model — so the plugin contract doesn't couple to backend
+ * internals. The element type of `useWorkspaces` and the return of
+ * `useCurrentWorkspace`, so a plugin reads the same shape whether it looks at
+ * one workspace or all of them.
  */
-export const useWorkspaces = (): ReadonlyArray<Workspace> | undefined => useAtomValue(workspacesArrayAtom);
-
-/**
- * A curated, plugin-facing view of a single workspace: identity, label, and
- * live git branch. Deliberately a subset — not the host's full `Workspace`
- * model — so the plugin contract doesn't couple to backend internals.
- */
-export type CurrentWorkspace = {
+export type WorkspaceView = {
   id: string;
   description: string;
   /** Live current branch, or `null` until the backend has reported it. */
@@ -40,11 +37,15 @@ export type CurrentWorkspace = {
   pullRequestUrl: string | null;
 };
 
+/** @deprecated Use {@link WorkspaceView}; kept as an alias for the prior name. */
+export type CurrentWorkspace = WorkspaceView;
+
 // One derived view atom per workspace id, composing the workspace model with
-// its live branch (which the host keeps in a separate atom) into the curated
-// CurrentWorkspace shape.
-const currentWorkspaceViewAtomFamily = atomFamily((id: string) =>
-  atom((get): CurrentWorkspace | null => {
+// its live branch and PR status (which the host keeps in separate atoms) into
+// the curated WorkspaceView shape. Shared by the single- and all-workspaces
+// hooks so the curated mapping lives in exactly one place.
+const workspaceViewAtomFamily = atomFamily((id: string) =>
+  atom((get): WorkspaceView | null => {
     const workspace = get(workspaceAtomFamily(id));
     if (!workspace) return null;
     return {
@@ -57,9 +58,28 @@ const currentWorkspaceViewAtomFamily = atomFamily((id: string) =>
   }),
 );
 
+// The curated view of every non-deleted workspace, composed from the same
+// per-id view atom so the all-workspaces list and the current-workspace hook
+// can never report a workspace differently.
+const allWorkspaceViewsAtom = atom((get): ReadonlyArray<WorkspaceView> | undefined => {
+  const workspaces = get(workspacesArrayAtom);
+  if (workspaces === undefined) return undefined;
+  return workspaces
+    .map((workspace) => get(workspaceViewAtomFamily(workspace.objectId)))
+    .filter((view): view is WorkspaceView => view !== null);
+});
+
+/**
+ * Every non-deleted workspace known to the host as a curated {@link
+ * WorkspaceView} (including live branch and PR URL), or `undefined` until the
+ * first batch has loaded. App-global: it needs no workspace context, so it
+ * works in an overlay or home view as well as a panel.
+ */
+export const useWorkspaces = (): ReadonlyArray<WorkspaceView> | undefined => useAtomValue(allWorkspaceViewsAtom);
+
 // Stable fallback for when there is no current workspace, so the hook's
 // memoized selection always has a constant source atom.
-const noCurrentWorkspaceAtom = atom<CurrentWorkspace | null>(null);
+const noCurrentWorkspaceAtom = atom<WorkspaceView | null>(null);
 
 /**
  * The workspace the user is currently in — the panel's workspace when mounted
@@ -76,8 +96,8 @@ const noCurrentWorkspaceAtom = atom<CurrentWorkspace | null>(null);
  * The selector should be pure over the workspace (no external closure state):
  * its identity may change between renders, but its logic must not.
  */
-export function useCurrentWorkspace<T = CurrentWorkspace | null>(
-  selector?: (workspace: CurrentWorkspace | null) => T,
+export function useCurrentWorkspace<T = WorkspaceView | null>(
+  selector?: (workspace: WorkspaceView | null) => T,
   equalityFn?: (a: T, b: T) => boolean,
 ): T {
   // Resolve the active id: the panel's workspace if mounted in one (read
@@ -100,12 +120,12 @@ export function useCurrentWorkspace<T = CurrentWorkspace | null>(
   });
 
   const sourceAtom = useMemo(
-    () => (workspaceId ? currentWorkspaceViewAtomFamily(workspaceId) : noCurrentWorkspaceAtom),
+    () => (workspaceId ? workspaceViewAtomFamily(workspaceId) : noCurrentWorkspaceAtom),
     [workspaceId],
   );
   const selectedAtom = useMemo(
     () =>
-      selectAtom<CurrentWorkspace | null, T>(
+      selectAtom<WorkspaceView | null, T>(
         sourceAtom,
         // eslint-disable-next-line react-hooks/refs -- jotai invokes these wrappers when it evaluates the atom, not during render; the ref indirection is what keeps the wrappers' identity stable so selectAtom subscribes once.
         (workspace) => (selectorRef.current ? selectorRef.current(workspace) : (workspace as unknown as T)),
@@ -117,12 +137,28 @@ export function useCurrentWorkspace<T = CurrentWorkspace | null>(
   return useAtomValue(selectedAtom);
 }
 
+/**
+ * Returns a function that navigates to a workspace by id — the host's own
+ * workspace-open behavior: it opens (or converts the home tab into) the
+ * workspace's tab and jumps to its most-recently-used agent. The blessed seam
+ * for a plugin to send the user into a workspace (e.g. a home view opening the
+ * workspace a ticket is being worked in), so the navigation stays consistent
+ * with clicking a workspace in the host's own lists.
+ */
+export const useNavigateToWorkspace = (): ((workspaceId: string) => void) =>
+  // navigateToWorkspaceById is already a stable callback, so hand it back as-is.
+  useWorkspaceNavigation().navigateToWorkspaceById;
+
 // One persisted atom per (plugin, key). atomFamily caches by the full storage
 // key; getOnInit reads localStorage synchronously so the value is present on
 // first render instead of flashing the default.
 const pluginSettingAtomFamily = atomFamily((storageKey: string) =>
   atomWithStorage<string>(storageKey, "", undefined, { getOnInit: true }),
 );
+
+// The localStorage namespace for one of a plugin's settings. Shared by the
+// single- and multi-key hooks so the key shape can't drift between them.
+const settingStorageKey = (pluginId: string, key: string): string => `sculptor-plugin:${pluginId}:${key}`;
 
 /**
  * A persisted string setting scoped to the calling plugin. Backed by
@@ -131,7 +167,37 @@ const pluginSettingAtomFamily = atomFamily((storageKey: string) =>
  */
 export const usePluginSetting = (key: string): [string, (value: string) => void] => {
   const { pluginId } = usePluginContext();
-  return useAtom(pluginSettingAtomFamily(`sculptor-plugin:${pluginId}:${key}`));
+  return useAtom(pluginSettingAtomFamily(settingStorageKey(pluginId, key)));
+};
+
+/**
+ * Read several of the calling plugin's persisted settings at once, reactively —
+ * the multi-key companion to {@link usePluginSetting} for when the set of keys
+ * is dynamic, so you can't call `usePluginSetting` once per key (e.g. one
+ * per-workspace key, with the workspace list coming from `useWorkspaces`).
+ * Returns a map from each requested key to its current value (the empty string
+ * for an unset key) and re-renders when any of those keys changes — including a
+ * write from another surface of the plugin, since both share the same per-key
+ * atoms.
+ */
+export const usePluginSettings = (keys: ReadonlyArray<string>): ReadonlyMap<string, string> => {
+  const { pluginId } = usePluginContext();
+  // Encode the key set so the derived atom is rebuilt only when the set itself
+  // changes — a fresh `keys` array every render would otherwise rebuild it each
+  // time. Plugin keys are `<name>:<id>`-style and never contain a newline, so it
+  // is a safe separator to split back out inside the atom.
+  const encodedKeys = keys.join("\n");
+  const mapAtom = useMemo(
+    () =>
+      atom((get): ReadonlyMap<string, string> => {
+        const requestedKeys = encodedKeys === "" ? [] : encodedKeys.split("\n");
+        return new Map(
+          requestedKeys.map((key) => [key, get(pluginSettingAtomFamily(settingStorageKey(pluginId, key)))]),
+        );
+      }),
+    [pluginId, encodedKeys],
+  );
+  return useAtomValue(mapAtom);
 };
 
 /**

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -11,5 +11,11 @@ export type { CodingAgentTaskView, Workspace } from "~/api";
 // The contract a plugin's `activate(api)` targets. Re-exported as types so
 // plugins reference the host's real definitions instead of hand-redeclaring
 // the registration shape (types are erased at build, so no runtime stub).
-export type { OverlayDefinition, PluginHostApi, PluginManifest, WorkspaceWidgetDefinition } from "../types.ts";
+export type {
+  HomeViewDefinition,
+  OverlayDefinition,
+  PluginHostApi,
+  PluginManifest,
+  WorkspaceWidgetDefinition,
+} from "../types.ts";
 export type { PanelDefinition } from "~/components/panels/types.ts";

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -5,9 +5,16 @@
  */
 export { openExternal } from "./actions.ts";
 export { Markdown, PanelHeader } from "./components.ts";
-export type { CurrentWorkspace } from "./hooks.ts";
-export { useCurrentWorkspace, usePluginSetting, useWorkspaces, useWorkspaceTasks } from "./hooks.ts";
-export type { CodingAgentTaskView, Workspace } from "~/api";
+export type { CurrentWorkspace, WorkspaceView } from "./hooks.ts";
+export {
+  useCurrentWorkspace,
+  useNavigateToWorkspace,
+  usePluginSetting,
+  usePluginSettings,
+  useWorkspaces,
+  useWorkspaceTasks,
+} from "./hooks.ts";
+export type { CodingAgentTaskView } from "~/api";
 // The contract a plugin's `activate(api)` targets. Re-exported as types so
 // plugins reference the host's real definitions instead of hand-redeclaring
 // the registration shape (types are erased at build, so no runtime stub).

--- a/sculptor/frontend/src/plugins/types.ts
+++ b/sculptor/frontend/src/plugins/types.ts
@@ -36,7 +36,7 @@ export type PluginManifest = {
  * whole app (across every route) for as long as the plugin is loaded. The
  * component draws into a full-viewport, click-through layer, so it must opt
  * its own interactive box back into pointer events. Use the workspace SDK
- * hooks (`useWorkspaces`, `useCurrentWorkspaceId`) to react to app state —
+ * hooks (`useWorkspaces`, `useCurrentWorkspace`) to react to app state —
  * there is no single workspace context, because an overlay outlives any one
  * workspace page.
  */
@@ -85,15 +85,19 @@ export type WorkspaceWidgetDefinition = {
  * Like an app-global overlay (and unlike a panel/workspace widget) it is mounted
  * with no `WorkspacePluginContext`: the homepage is not scoped to a single
  * workspace, so a home view reads app state through the SDK hooks
- * (`useWorkspaces`, `useCurrentWorkspaceId`) instead of a fixed context.
+ * (`useWorkspaces`, `useCurrentWorkspace`) instead of a fixed context.
  */
 export type HomeViewDefinition = {
   /** Stable id; registering twice with the same id replaces the previous one. */
   id: string;
   /** Label shown for this view in the homepage switcher. */
   title: string;
-  /** Optional Lucide icon shown beside the title in the switcher. */
-  icon?: ComponentType;
+  /**
+   * Optional Lucide icon shown beside the title in the switcher. Typed to accept
+   * a `size` prop so the switcher can render it at a consistent size rather than
+   * Lucide's 24px default (which sits taller than the segmented-control text).
+   */
+  icon?: ComponentType<{ size?: number | string }>;
   component: ComponentType;
 };
 

--- a/sculptor/frontend/src/plugins/types.ts
+++ b/sculptor/frontend/src/plugins/types.ts
@@ -74,6 +74,29 @@ export type WorkspaceWidgetDefinition = {
   collapsePriority?: number;
 };
 
+/**
+ * A full-page contribution the host offers as an alternative homepage body. The
+ * homepage shows a view switcher whenever at least one of these is registered;
+ * picking one replaces the built-in recent-workspaces list with the plugin's
+ * component, which owns the entire content area below the switcher. The user's
+ * choice is remembered, and falls back to the built-in view if the selected
+ * plugin is later unloaded.
+ *
+ * Like an app-global overlay (and unlike a panel/workspace widget) it is mounted
+ * with no `WorkspacePluginContext`: the homepage is not scoped to a single
+ * workspace, so a home view reads app state through the SDK hooks
+ * (`useWorkspaces`, `useCurrentWorkspaceId`) instead of a fixed context.
+ */
+export type HomeViewDefinition = {
+  /** Stable id; registering twice with the same id replaces the previous one. */
+  id: string;
+  /** Label shown for this view in the homepage switcher. */
+  title: string;
+  /** Optional Lucide icon shown beside the title in the switcher. */
+  icon?: ComponentType;
+  component: ComponentType;
+};
+
 export type PluginHostApi = {
   registerPanel: (panel: PanelDefinition) => () => void;
   /**
@@ -96,6 +119,14 @@ export type PluginHostApi = {
    * WorkspacePluginContext for the workspace it is shown in. Returns a disposer.
    */
   registerWorkspaceWidget: (widget: WorkspaceWidgetDefinition) => () => void;
+  /**
+   * Registers a full-page home view selectable from the homepage switcher.
+   * Wrapped, like an overlay, in a per-plugin error boundary and the host's
+   * PluginContext (so `usePluginSetting` works), but with no
+   * WorkspacePluginContext — the homepage is not workspace-scoped. Returns a
+   * disposer.
+   */
+  registerHomeView: (view: HomeViewDefinition) => () => void;
 };
 
 export type PluginActivate = (api: PluginHostApi) => void | (() => void) | Promise<void | (() => void)>;


### PR DESCRIPTION
## What

Adds a **homepage plugin slot**: plugins can contribute a full-page "home view" that the homepage offers as an alternative to the built-in recent-workspaces list.

When at least one home view is registered, the homepage shows a switcher between the built-in **Recent workspaces** view and the plugin views. The selected view takes over the homepage body. The choice is remembered, and falls back to the built-in view if the selected plugin is no longer registered. With no plugin home views, the switcher is hidden and the homepage is unchanged.

## How

- **New contribution point.** `HomeViewDefinition` (`id`, `title`, optional `icon`, `component`) + `registerHomeView` on the plugin host API, a `pluginHomeViewsAtom` registry, and the manager wiring. Home views are app-global like overlays — wrapped in the per-plugin error boundary and `PluginContext`, with **no** `WorkspacePluginContext` (the homepage isn't workspace-scoped).
- **Built-in view extracted.** The existing recent-workspaces homepage moves into `RecentWorkspacesHomeView`. `HomePage` now hosts the switcher and renders the selected view.
- **Persistence.** The selection is stored in `localStorage` (consistent with how plugin sources are persisted), behind a pure `resolveEffectiveHomeViewId` fallback resolver with unit tests.
- **Switcher.** A Radix `SegmentedControl`, shown only when there's more than one view to choose between.

The example/demo home-view plugin shown during development is intentionally **not** included here — it will land alongside the Linear plugin work.

## Testing

- Unit tests for the fallback rule and the derived option/effective-view atoms (`homeViews.test.ts`).
- `just check` (typecheck + lint + ratchets + hygiene) and the frontend unit suite pass.
- Manually QA'd end-to-end via the live-browser harness with a throwaway home-view plugin: baseline unchanged with no plugin; switcher appears once a home view registers; selected view renders and switches both ways; selection persists across in-session navigation.

(Sent by Claude)