### PR TITLE
Route sculpt agent send to the PTY for registered terminal agents

### DIFF
--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2322,6 +2322,20 @@ def get_workspace_agent_diagnostics(
     )
 
 
+def _raise_for_terminal_delivery_result(result: TerminalDeliveryResult) -> None:
+    """Raise the HTTP 409 that a non-DELIVERED PTY write maps to, or return for
+    DELIVERED. The frontend's enable/disable logic and the integration tests
+    depend on these exact statuses and details, so every endpoint that drives a
+    terminal agent maps results through here to keep them identical.
+    """
+    if result is TerminalDeliveryResult.NOT_OPT_IN:
+        raise HTTPException(status_code=409, detail="this agent does not accept automated prompts")
+    if result is TerminalDeliveryResult.NOT_AT_PROMPT:
+        raise HTTPException(status_code=409, detail="agent is busy or not at its prompt")
+    if result is TerminalDeliveryResult.NO_PTY:
+        raise HTTPException(status_code=409, detail="terminal not running")
+
+
 @router.post("/api/v1/workspaces/{workspace_id}/agents/{agent_id}/messages")
 def send_workspace_agent_messages(
     workspace_id: str,
@@ -2402,12 +2416,7 @@ def send_workspace_agent_messages(
         submit=True,
         task_service=services.task_service,
     )
-    if result is TerminalDeliveryResult.NOT_OPT_IN:
-        raise HTTPException(status_code=409, detail="this agent does not accept automated prompts")
-    if result is TerminalDeliveryResult.NOT_AT_PROMPT:
-        raise HTTPException(status_code=409, detail="agent is busy or not at its prompt")
-    if result is TerminalDeliveryResult.NO_PTY:
-        raise HTTPException(status_code=409, detail="terminal not running")
+    _raise_for_terminal_delivery_result(result)
 
 
 @router.post("/api/v1/workspaces/{workspace_id}/agents/{agent_id}/answer_question")
@@ -3633,21 +3642,15 @@ def post_agent_terminal_input(
 
     # All three security guards and the bracketed-paste write live in the
     # shared helper so this endpoint and the CI Babysitter stay identically
-    # gated. Map each non-DELIVERED result to the status/detail the endpoint
-    # has always returned — the integration test and the frontend's
-    # enable/disable logic depend on these exact 409s.
+    # gated. _raise_for_terminal_delivery_result maps each non-DELIVERED result
+    # to the 409 the message endpoint returns too.
     result = deliver_prompt_to_terminal_agent(
         task,
         input_request.text,
         submit=input_request.submit,
         task_service=services.task_service,
     )
-    if result is TerminalDeliveryResult.NOT_OPT_IN:
-        raise HTTPException(status_code=409, detail="this agent does not accept automated prompts")
-    if result is TerminalDeliveryResult.NOT_AT_PROMPT:
-        raise HTTPException(status_code=409, detail="agent is busy or not at its prompt")
-    if result is TerminalDeliveryResult.NO_PTY:
-        raise HTTPException(status_code=409, detail="terminal not running")
+    _raise_for_terminal_delivery_result(result)
     return Response(status_code=204)
 
 

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2345,45 +2345,69 @@ def send_workspace_agent_messages(
                 detail=[{"loc": ["body", "message"], "msg": "Message required", "type": "value_error.missing"}],
             )
 
-        saved_messages = services.task_service.get_saved_messages_for_task(task.object_id, transaction)
         assert isinstance(task.input_data, AgentTaskInputsV2), (
             f"Expected AgentTaskInputsV2 for agent message endpoint, got {type(task.input_data).__name__}"
         )
-        harness = get_harness_for_config(task.input_data.agent_config)
-        if message_request.enter_plan_mode and not harness.capabilities().supports_interactive_backchannel:
-            raise HTTPException(
-                status_code=400,
-                detail="plan mode requires a harness that supports the interactive backchannel",
+
+        # A registered terminal agent has no chat message stream to queue into;
+        # its delivery is handled below, outside this transaction. Chat agents
+        # take the original queueing path here, unchanged.
+        if not isinstance(task.input_data.agent_config, RegisteredTerminalAgentConfig):
+            saved_messages = services.task_service.get_saved_messages_for_task(task.object_id, transaction)
+            harness = get_harness_for_config(task.input_data.agent_config)
+            if message_request.enter_plan_mode and not harness.capabilities().supports_interactive_backchannel:
+                raise HTTPException(
+                    status_code=400,
+                    detail="plan mode requires a harness that supports the interactive backchannel",
+                )
+            task_state = convert_agent_messages_to_task_update(
+                saved_messages, task_id=task.object_id, completed_message_by_id={}, harness=harness
             )
-        task_state = convert_agent_messages_to_task_update(
-            saved_messages, task_id=task.object_id, completed_message_by_id={}, harness=harness
-        )
-        if task_state.pending_user_question is not None:
-            raise HTTPException(
-                status_code=409,
-                detail="Cannot send a message while the agent is waiting for a response to AskUserQuestion.",
+            if task_state.pending_user_question is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Cannot send a message while the agent is waiting for a response to AskUserQuestion.",
+                )
+
+            message_id = AgentMessageID()
+            logger.info("Sending message {} to agent {}: {}", message_id, agent_id, message_str[:100])
+
+            message = ChatInputUserMessage(
+                message_id=message_id,
+                text=message_str,
+                model_name=message_request.model,
+                files=message_request.files,
+                enter_plan_mode=message_request.enter_plan_mode,
+                exit_plan_mode=message_request.exit_plan_mode,
+                fast_mode=message_request.fast_mode,
+                effort=message_request.effort,
+                sent_via=message_request.sent_via,
             )
 
-        message_id = AgentMessageID()
-        logger.info("Sending message {} to agent {}: {}", message_id, agent_id, message_str[:100])
+            services.task_service.create_message(
+                message=message,
+                task_id=task.object_id,
+                transaction=transaction,
+            )
+            return
 
-        message = ChatInputUserMessage(
-            message_id=message_id,
-            text=message_str,
-            model_name=message_request.model,
-            files=message_request.files,
-            enter_plan_mode=message_request.enter_plan_mode,
-            exit_plan_mode=message_request.exit_plan_mode,
-            fast_mode=message_request.fast_mode,
-            effort=message_request.effort,
-            sent_via=message_request.sent_via,
-        )
-
-        services.task_service.create_message(
-            message=message,
-            task_id=task.object_id,
-            transaction=transaction,
-        )
+    # Registered terminal agent: type the prompt into the PTY via the shared
+    # helper, exactly as POST /agents/{id}/terminal/input and the CI Babysitter
+    # do, so every feature that drives a terminal agent stays identically gated.
+    # Done outside the transaction above — the helper sleeps briefly before the
+    # submit Enter and must not hold a DB transaction while it does.
+    result = deliver_prompt_to_terminal_agent(
+        task,
+        message_str,
+        submit=True,
+        task_service=services.task_service,
+    )
+    if result is TerminalDeliveryResult.NOT_OPT_IN:
+        raise HTTPException(status_code=409, detail="this agent does not accept automated prompts")
+    if result is TerminalDeliveryResult.NOT_AT_PROMPT:
+        raise HTTPException(status_code=409, detail="agent is busy or not at its prompt")
+    if result is TerminalDeliveryResult.NO_PTY:
+        raise HTTPException(status_code=409, detail="terminal not running")
 
 
 @router.post("/api/v1/workspaces/{workspace_id}/agents/{agent_id}/answer_question")

--- a/sculptor/tests/integration/frontend/test_sculpt_cli.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_cli.py
@@ -23,7 +23,10 @@ from typing import Any
 import playwright.sync_api
 from playwright.sync_api import expect
 
+from sculptor.testing.elements.agent_tab import PlaywrightAgentTabBarElement
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.terminal import get_agent_terminal_panel
+from sculptor.testing.elements.terminal import wait_for_xterm_substring
 from sculptor.testing.pages.home_page import PlaywrightHomePage
 from sculptor.testing.playwright_utils import navigate_to_home_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -1324,3 +1327,94 @@ def test_sculpt_send_shows_sent_via_badge_in_ui(sculptor_instance_: SculptorInst
     assert len(cli_messages) == 4, f"Expected 4 messages, got {len(cli_messages)}"
     _assert_matches(cli_messages[2], _expected_user_message(follow_up, sent_via="sculpt"))
     _assert_matches(cli_messages[0], _expected_user_message(prompt, sent_via=None))
+
+
+# ---------------------------------------------------------------------------
+# sculpt agent send → registered terminal agent: prompt must be typed into the PTY
+# ---------------------------------------------------------------------------
+
+# A fake registered program: idle at its prompt, echo each received line as
+# RECEIVED:<line>, then go busy. The IDLE-DONE marker is assembled via printf so
+# the echoed command line never contains it (mirrors
+# test_terminal_agent_automated_prompts), letting the test gate on the marker.
+_FAKE_PROMPTS_COMMAND = (
+    "echo FAKE-PROMPTS-BANNER; sculpt signal idle; printf %sDONE IDLE-; echo; "
+    + "while read -r _line; do echo RECEIVED:$_line; sculpt signal busy; done"
+)
+
+_NEUTRAL_DOT = re.compile(r"^(read|unread)$")
+
+
+@user_story("to send a prompt to a registered terminal agent with `sculpt agent send`")
+def test_sculpt_agent_send_types_into_registered_terminal_agent_pty(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """`sculpt agent send` to a registered terminal agent must type the prompt
+    into the agent's PTY (as the action buttons and CI Babysitter do), not queue
+    it as a chat message the terminal agent never consumes.
+
+    A fake registered program opts into automated prompts, signals idle, and
+    echoes each stdin line as ``RECEIVED:<line>``. With it at its prompt, running
+    ``sculpt agent send <agent> <msg>`` must surface ``RECEIVED:<msg>`` in the
+    terminal buffer. With the bug present the CLI's message is queued as a
+    ChatInputUserMessage and never reaches the PTY, so the echo never appears and
+    this wait times out.
+    """
+    page = sculptor_instance_.page
+
+    # A workspace with a chat agent gives us somewhere to launch the terminal
+    # agent; the prompt content is irrelevant to this test.
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt='fake_claude:text `{"text": "ready"}`',
+        workspace_name="Sculpt Terminal Send WS",
+    )
+    ws_match = re.search(r"/ws/([a-zA-Z0-9_-]+)/", page.url)
+    assert ws_match, f"Could not extract workspace ID from URL: {page.url}"
+    workspace_id = ws_match.group(1)
+    chat_agent_id = task_page.get_task_id()
+
+    registrations_dir = sculptor_instance_.sculptor_folder / "terminal_agents"
+    registrations_dir.mkdir(parents=True, exist_ok=True)
+    (registrations_dir / "fake-prompts.toml").write_text(
+        f'display_name = "Fake Prompts"\nlaunch_command = "{_FAKE_PROMPTS_COMMAND}"\naccepts_automated_prompts = true\n'
+    )
+    try:
+        # Launch the registered terminal agent and wait until it is at its prompt.
+        agent_tab_bar = PlaywrightAgentTabBarElement(page)
+        agent_tab_bar.open_agent_type_menu()
+        registered_item = agent_tab_bar.get_agent_type_menu_item_registered("fake-prompts")
+        expect(registered_item).to_be_visible()
+        registered_item.click()
+
+        prompts_tab = agent_tab_bar.get_agent_tab_by_name("Fake Prompts 1").first
+        expect(prompts_tab).to_be_visible()
+        expect(get_agent_terminal_panel(page)).to_be_visible()
+        wait_for_xterm_substring(page, "FAKE-PROMPTS-BANNER")
+        # The idle signal landed in the backend: the program is at its prompt.
+        wait_for_xterm_substring(page, "IDLE-DONE")
+        expect(prompts_tab).to_have_attribute("data-dot-status", _NEUTRAL_DOT)
+
+        # Resolve the terminal agent's id from the CLI (it is the only agent in
+        # the workspace that is not the original chat agent).
+        exit_code, output = _run_sculpt(sculptor_instance_, ["agent", "list", "--workspace", workspace_id])
+        assert exit_code == 0, f"agent list failed: {output}"
+        other_agent_ids = [a["id"] for a in json.loads(output) if a["id"] != chat_agent_id]
+        assert len(other_agent_ids) == 1, f"Expected exactly one terminal agent, got {other_agent_ids}"
+        terminal_agent_id = other_agent_ids[0]
+
+        # No spaces: the prompt lands on one xterm line and the echoed RECEIVED
+        # line matches exactly (the program's `echo RECEIVED:$_line` is unquoted).
+        prompt_text = "SCULPT-CLI-TERMINAL-PROMPT"
+        exit_code, output = _run_sculpt(
+            sculptor_instance_,
+            ["agent", "send", terminal_agent_id, prompt_text, "--workspace", workspace_id],
+        )
+        assert exit_code == 0, f"agent send failed: {output}"
+
+        # The prompt was typed into the PTY: the program echoes it back. (The
+        # line-discipline echo of the typed text also appears, but only the
+        # program's output carries the RECEIVED: prefix.)
+        wait_for_xterm_substring(page, f"RECEIVED:{prompt_text}")
+    finally:
+        (registrations_dir / "fake-prompts.toml").unlink(missing_ok=True)


### PR DESCRIPTION
## Original bug

`sculpt agent send <agent> <msg>` always injected a chat message, even when the
target is a registered terminal agent. The action buttons (Commit, Create PR,
custom actions) and the CI Babysitter already type prompts into a terminal
agent's PTY via a shared helper; the CLI's send path did not, so a prompt sent
to a terminal agent went nowhere.

## Root cause

`sculpt agent send` posts to `POST /api/v1/workspaces/{ws}/agents/{id}/messages`
(`send_workspace_agent_messages`), which unconditionally built a
`ChatInputUserMessage` and queued it via `task_service.create_message`. A
registered terminal agent has no chat message stream to consume that message, so
the prompt was silently dropped — it never reached the agent. The endpoint did
not dispatch on the agent's config the way the action buttons (which call
`POST /agents/{id}/terminal/input`) and the CI Babysitter
(`CIBabysitterCoordinator.deliver_prompt_to_agent`) do.

## Fix

`send_workspace_agent_messages` now dispatches on the agent config:

- **Registered terminal agent** → routes the prompt through the shared
  `deliver_prompt_to_terminal_agent` helper — the same guarded, bracketed-paste
  PTY write the terminal-input endpoint and the CI Babysitter use — so every
  feature that drives a terminal agent stays identically gated. The PTY write
  runs outside the DB transaction (the helper sleeps briefly before the submit
  Enter and must not hold a transaction).
- **Chat agent** → the original queueing path, unchanged.

This fixes the CLI and any other caller of that endpoint uniformly.

A second commit extracts the `TerminalDeliveryResult` → 409 mapping that the
message endpoint and the terminal-input endpoint now share into a single
`_raise_for_terminal_delivery_result` helper, so the exact statuses/details
(which the frontend's enable/disable logic and the integration tests depend on)
live in one place and cannot drift. No behavior change in that commit.

A deliberately-scoped decision: I did **not** unify all three delivery sites
(the two endpoints plus the Babysitter) into one helper. The PTY write itself is
already shared; the chat halves differ materially (request-driven vs
config-driven message construction, different transaction ownership, chat-only
pre-checks), so a single helper would add conditional plumbing rather than
clarity.

## Expected vs actual

- Expected: `sculpt agent send` to a registered terminal agent at its prompt
  types the prompt into the PTY, so the agent receives it.
- Actual (before): the prompt was queued as a chat message the terminal agent
  never consumes, so it never arrived.

## Test

- Path: `sculptor/tests/integration/frontend/test_sculpt_cli.py`
- Kind: integration / e2e (Playwright). The test registers a fake terminal agent
  that opts into automated prompts and echoes each received line as
  `RECEIVED:<line>`, launches it through the UI, waits until it is at its prompt,
  runs the real `sculpt agent send` subprocess, and asserts the prompt surfaces
  in the terminal buffer (`RECEIVED:<msg>`).
- Failing-test commit: `c55b927489`
- Fix commit: `5c300e7e24`
- Refactor commit: `fab1bf44d9`

**Before (bug present):** the test fails — it times out waiting for
`RECEIVED:SCULPT-CLI-TERMINAL-PROMPT`; the terminal buffer shows the program at
its prompt with no received line (the prompt was queued, never typed).

**After (fixed):**

```
sculptor/tests/integration/frontend/test_sculpt_cli.py::test_sculpt_agent_send_types_into_registered_terminal_agent_pty
============================== 1 passed in 21.82s ==============================
```

Re-running the new test together with `test_terminal_agent_automated_prompts.py`
(which exercises the terminal-input endpoint's delivery and disabled/409 paths)
after the shared-mapping refactor:

```
============================== 3 passed in 57.39s ==============================
```

`just check` (ratchets, typecheck, lint, file-hygiene) and `just test-unit`
(backend, frontend, foundation, sculpt) both pass.

(Sent by Claude)
