### PR TITLE
[SCU-1609] Enable frontend plugins by default with Linear bundled

### DIFF
--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -780,9 +780,9 @@ compact **workspace widgets** that sit in the workspace banner's action row (col
 order as space tightens, like the built-in segments) — built against a small versioned Sculptor SDK
 that reuses the host's React, Radix theming, icons, and shared data client so they look and behave
 like native UI. The plugin system is **on by default**. A
-master switch at the top of the **Plugins** settings section is the kill switch for the whole system:
+toggle at the top of the **Plugins** settings section globally enables or disables all plugins:
 turning it off hides the plugin-management controls and, after an app reload, stops loading plugins
-(already-loaded plugins aren't torn down live), while the section and its switch stay in place so the
+(already-loaded plugins aren't torn down live), while the section and its toggle stay in place so the
 system can be turned back on.
 
 The **Plugins** settings section manages plugin **sources**: you add a plugin by dropping its folder

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -792,10 +792,12 @@ has an enable/disable switch (mute a plugin without removing it) and, while enab
 Reload controls; user-added URL sources can also be removed, while bundled and disk-discovered plugins
 can't. Sculptor ships a bundled **Linear** plugin, enabled by default, alongside two no-build example
 plugins — **Sculpty** and **Pomodoro** — that ship disabled and can be switched on per plugin. The
-Linear plugin shows two surfaces: a banner **widget** displaying the workspace's primary issue as a
-`# TICKET-ID` badge with a state dot (clicking it opens the issue in Linear), and a side **panel** of
-ticket details with collapsible **sub-issues** (the open state is remembered per workspace) and badges
-marking where each ticket came from (branch, PR, or a pinned search). It resolves the workspace's
+Linear plugin shows two surfaces: a banner **widget**, shown by default, displaying the workspace's
+primary issue as a `# TICKET-ID` badge with a state dot (clicking it opens the issue in Linear), and a
+side **panel** of ticket details with collapsible **sub-issues** (the open state is remembered per
+workspace) and badges marking where each ticket came from (branch, PR, or a pinned search). The panel
+ships **off by default** and is enabled from Settings → Panels (like the built-in Browser panel), so an
+on-by-default plugin doesn't claim a slot in the panel layout uninvited. It resolves the workspace's
 **primary issue** from the branch name first, falling back to the issues linked from the workspace's
 pull request.
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -746,9 +746,6 @@ product makes no finer distinction than that: a feature is either generally avai
   viewer, toggled by the eye icon in the diff toolbar.
 - **Pi agent** — offer the experimental **Pi** agent as a choice when creating an agent (→ §7.4); an
   already-running Pi agent keeps going regardless of the toggle.
-- **Frontend plugins** — enable the experimental plugin system that lets third-party plugins extend
-  Sculptor's own UI (the plugin system below). Off by default; turning it off only fully takes effect
-  after an app reload, since already-loaded plugins aren't torn down live.
 - **Custom backend command** — the entry point for the container / remote backend described below.
 
 The **CI babysitter** (→ §7.6, §7.10) is likewise experimental and off by default.
@@ -766,27 +763,6 @@ notably the in-app **Browser** panel (desktop-only), which embeds a browser besi
 address bar and back/forward/reload/screenshot controls; outside the desktop app it shows a
 placeholder.
 
-**Frontend plugin system.** With **Frontend plugins** enabled, Sculptor can load third-party
-**plugins** that extend the app's own UI from inside the renderer — contributing new **panels** (which
-show up in the Panels list with a "plugin" badge), full-screen **overlays**, and compact **workspace
-widgets** that sit in the workspace banner's action row (collapsing in priority order as space
-tightens, like the built-in segments), built against a small versioned Sculptor SDK that reuses the
-host's React, Radix theming, icons, and shared data client so they look and behave like native UI. A new **Plugins** section appears in Settings to manage plugin
-**sources**: you add a plugin by dropping its folder into the Sculptor folder's `plugins/` directory
-(picked up on the next launch or via a **Refresh** button) or by adding the **URL** of a plugin
-server (saved and re-fetched on every launch). Each row has an enable/disable switch (mute a plugin
-without removing it) and, while enabled, Settings and Reload controls; user-added URL sources can also
-be removed, while bundled and disk-discovered plugins can't. Sculptor ships a bundled **Linear** example
-plugin and two no-build example plugins (**Sculpty** and **Pomodoro**). The Linear plugin shows two
-surfaces: a banner **widget** displaying the workspace's primary issue as a `# TICKET-ID` badge with a
-state dot (clicking it opens the issue in Linear), and a side **panel** of ticket details with
-collapsible **sub-issues** (the open state is remembered per workspace) and badges marking where each
-ticket came from (branch, PR, or a pinned search). It resolves the workspace's **primary issue** from
-the branch name first, falling back to the issues linked from the workspace's pull request. Because a plugin runs with the
-**same privileges as Sculptor's own UI** — and a URL source serves whatever code it holds at load time
-— adding a plugin means running that code, so you should only add sources you trust (the plugin trust
-model is documented in `SECURITY.md`; outbound links a plugin opens are restricted to `http(s)`).
-
 **Container / remote execution backend.** Pointing the **custom backend command** at a launcher lets
 Sculptor run agents somewhere other than your host machine — inside a Docker container, on a remote
 server over SSH, or in a VM. The launcher starts the backend and prints a URL the app connects to;
@@ -795,6 +771,38 @@ the GUI, workspace management, and agent orchestration are otherwise unchanged. 
 automatically restarts the custom backend (with backoff) if it crashes. The command can be set either
 in Settings or through an environment variable, and setting or clearing it requires restarting the app
 (→ §9.1 for the isolation and trust implications).
+
+### 7.13 Frontend plugins
+
+Sculptor loads **plugins** that extend the app's own UI from inside the renderer — contributing new
+**panels** (which show up in the Panels list with a "plugin" badge), full-screen **overlays**, and
+compact **workspace widgets** that sit in the workspace banner's action row (collapsing in priority
+order as space tightens, like the built-in segments) — built against a small versioned Sculptor SDK
+that reuses the host's React, Radix theming, icons, and shared data client so they look and behave
+like native UI. The plugin system is **on by default**. A
+master switch at the top of the **Plugins** settings section is the kill switch for the whole system:
+turning it off hides the plugin-management controls and, after an app reload, stops loading plugins
+(already-loaded plugins aren't torn down live), while the section and its switch stay in place so the
+system can be turned back on.
+
+The **Plugins** settings section manages plugin **sources**: you add a plugin by dropping its folder
+into the Sculptor folder's `plugins/` directory (picked up on the next launch or via a **Refresh**
+button) or by adding the **URL** of a plugin server (saved and re-fetched on every launch). Each row
+has an enable/disable switch (mute a plugin without removing it) and, while enabled, Settings and
+Reload controls; user-added URL sources can also be removed, while bundled and disk-discovered plugins
+can't. Sculptor ships a bundled **Linear** plugin, enabled by default, alongside two no-build example
+plugins — **Sculpty** and **Pomodoro** — that ship disabled and can be switched on per plugin. The
+Linear plugin shows two surfaces: a banner **widget** displaying the workspace's primary issue as a
+`# TICKET-ID` badge with a state dot (clicking it opens the issue in Linear), and a side **panel** of
+ticket details with collapsible **sub-issues** (the open state is remembered per workspace) and badges
+marking where each ticket came from (branch, PR, or a pinned search). It resolves the workspace's
+**primary issue** from the branch name first, falling back to the issues linked from the workspace's
+pull request.
+
+Because a plugin runs with the **same privileges as Sculptor's own UI** — and a URL source serves
+whatever code it holds at load time — adding a plugin means running that code, so you should only add
+sources you trust (the plugin trust model is documented in `SECURITY.md`; outbound links a plugin
+opens are restricted to `http(s)`).
 
 ## 8. The `sculpt` CLI  _(core product surface)_
 

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -62,7 +62,8 @@ pointers to their spec/scenario home.
 | REQ-FUNC-011 | Command palette & navigation: tabs, Cmd+K / Cmd+P, bottom bar, focus/zen mode, version popover | §7.9 | `SHELL`, `CMDP`, `HELP` | Core |
 | REQ-FUNC-012 | Settings (all sections) | §7.10 | `SET` | Core |
 | REQ-FUNC-013 | Actions & notes; mentions & path autocomplete | §7.11 | `ACT`, `MENT` | Optional |
-| REQ-FUNC-014 | Experimental surface (toggles, experimental skills/panels, frontend plugin system, container backend) | §7.12 | `SET`, `PANEL` | Experimental |
+| REQ-FUNC-014 | Experimental surface (toggles, experimental skills/panels, container backend) | §7.12 | `SET`, `PANEL` | Experimental |
+| REQ-FUNC-016 | Frontend plugins: on-by-default plugin system, Plugins settings section with a master kill switch, bundled Linear plugin enabled by default | §7.13 | `PANEL`, `SET` | Standard |
 | REQ-FUNC-015 | `sculpt` CLI: full command surface, `--json`, env-var defaults, cross-surface visibility | §8 | (CLI-level, see §5.4) | Standard |
 
 - **REQ-FUNC-100 (MUST).** Every behavior enumerated in `scenarios.md` is a product requirement; that
@@ -401,17 +402,18 @@ rules behind them.
 - **REQ-SEC-003 (MUST).** Build & distribution security: the macOS artifact is **signed and notarized**
   (`.dmg`); releases are **tag-driven** with the version checked against build context so a tag build
   cannot publish an inconsistent version (`SPEC.md` §11.2–§11.3).
-- **REQ-SEC-004 (Experimental).** **Frontend-plugin trust model.** The experimental frontend plugin
-  system (off by default, gated on the `enableFrontendPlugins` flag — atom
-  `isFrontendPluginsEnabledAtom`, default `false`) runs plugin code **in the renderer with the same
-  privileges as Sculptor's own UI**; a URL plugin source is re-fetched on every load, so the user
-  trusts whatever it serves at load time. Adding a plugin source is therefore equivalent to running
-  that code, documented in `SECURITY.md`. The SDK's `openExternal` is restricted to **`http(s)`**
-  URLs (`sculptor/frontend/src/plugins/sdk/actions.ts`). In the packaged app the renderer and its
-  plugins are served from a single secure custom origin (`sculptor://app`) rather than `file://`
-  (`sculptor/frontend/src/electron/appProtocol.ts`). Plugins load from the Sculptor folder's
-  `plugins/` directory or user-added URL sources; precedence is local-disk > URL > bundled for the
-  same plugin id (`SPEC.md` §7.12).
+- **REQ-SEC-004.** **Frontend-plugin trust model.** The frontend plugin system (on by default, gated
+  on the `enableFrontendPlugins` flag — atom `isFrontendPluginsEnabledAtom`, default `true`; the
+  flag's master switch lives at the top of the Plugins settings section) runs plugin code **in the
+  renderer with the same privileges as Sculptor's own UI**; a URL plugin source is re-fetched on every
+  load, so the user trusts whatever it serves at load time. Adding a plugin source is therefore
+  equivalent to running that code, documented in `SECURITY.md`. Of the bundled plugins only **Linear**
+  is enabled by default; the others (**Sculpty**, **Pomodoro**) ship disabled. The SDK's
+  `openExternal` is restricted to **`http(s)`** URLs (`sculptor/frontend/src/plugins/sdk/actions.ts`).
+  In the packaged app the renderer and its plugins are served from a single secure custom origin
+  (`sculptor://app`) rather than `file://` (`sculptor/frontend/src/electron/appProtocol.ts`). Plugins
+  load from the Sculptor folder's `plugins/` directory or user-added URL sources; precedence is
+  local-disk > URL > bundled for the same plugin id (`SPEC.md` §7.13).
 - **REQ-SEC-010 (MUST).** **Telemetry is consent-gated.** Error reporting (Sentry, frontend-only) and
   product analytics (PostHog) are each gated on explicit consent flags
   (`is_error_reporting_enabled`, `is_product_analytics_enabled`, `is_session_recording_enabled`,

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -63,7 +63,7 @@ pointers to their spec/scenario home.
 | REQ-FUNC-012 | Settings (all sections) | §7.10 | `SET` | Core |
 | REQ-FUNC-013 | Actions & notes; mentions & path autocomplete | §7.11 | `ACT`, `MENT` | Optional |
 | REQ-FUNC-014 | Experimental surface (toggles, experimental skills/panels, container backend) | §7.12 | `SET`, `PANEL` | Experimental |
-| REQ-FUNC-016 | Frontend plugins: on-by-default plugin system, Plugins settings section with a master kill switch, bundled Linear plugin enabled by default | §7.13 | `PANEL`, `SET` | Standard |
+| REQ-FUNC-016 | Frontend plugins: on-by-default plugin system, Plugins settings section with a global enable/disable toggle, bundled Linear plugin enabled by default | §7.13 | `PANEL`, `SET` | Standard |
 | REQ-FUNC-015 | `sculpt` CLI: full command surface, `--json`, env-var defaults, cross-surface visibility | §8 | (CLI-level, see §5.4) | Standard |
 
 - **REQ-FUNC-100 (MUST).** Every behavior enumerated in `scenarios.md` is a product requirement; that
@@ -404,7 +404,7 @@ rules behind them.
   cannot publish an inconsistent version (`SPEC.md` §11.2–§11.3).
 - **REQ-SEC-004.** **Frontend-plugin trust model.** The frontend plugin system (on by default, gated
   on the `enableFrontendPlugins` flag — atom `isFrontendPluginsEnabledAtom`, default `true`; the
-  flag's master switch lives at the top of the Plugins settings section) runs plugin code **in the
+  flag is toggled at the top of the Plugins settings section) runs plugin code **in the
   renderer with the same privileges as Sculptor's own UI**; a URL plugin source is re-fetched on every
   load, so the user trusts whatever it serves at load time. Adding a plugin source is therefore
   equivalent to running that code, documented in `SECURITY.md`. Of the bundled plugins only **Linear**

--- a/docs/specs/scenario_coverage.md
+++ b/docs/specs/scenario_coverage.md
@@ -43,12 +43,12 @@ Integration tests considered:
 | MSG | 15 | 12 | 10 | 37 |
 | PANEL | 23 | 20 | 14 | 57 |
 | CMDP | 4 | 9 | 18 | 31 |
-| SET | 12 | 18 | 10 | 40 |
+| SET | 13 | 18 | 10 | 41 |
 | DEV | 3 | 1 | 0 | 4 |
 | MENT | 5 | 2 | 3 | 10 |
 | SKILL | 2 | 1 | 0 | 3 |
 | ACT | 2 | 3 | 1 | 6 |
-| **Total** | **180** | **150** | **136** | **466** |
+| **Total** | **181** | **150** | **136** | **467** |
 
 **Under the integration-only standard, 39% of scenarios are completely covered, 32% partially, and
 29% not at all.** (Counts are derived directly from the two sections below.)
@@ -391,6 +391,7 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | SET-038 | Partial | test_plugin_loader.py::test_valid_plugin_loads_and_can_be_removed; ::test_plugin_source_can_be_disabled_and_re_enabled | Cover the Refresh rescan of the plugins directory and the displayed directory path. |
 | SET-039 | Partial | test_ci_babysitter.py::test_settings_selector_lists_only_driveable_harnesses | Assert the selector saves with a toast and is disabled when the babysitter is off. |
 | SET-040 | Complete | test_plugins_settings_visibility.py::test_plugins_section_always_present; ::test_master_switch_reveals_management_ui_live | — |
+| SET-041 | Complete | test_plugin_loader.py::test_failed_plugin_can_be_retried | — |
 | DEV-001 | Partial | test_tanstack_devtools_panel.py::test_tanstack_devtools_panel_mounts_with_content (panel mounts only) | Cover header Dock/Float/Close controls, floating drag + resize within viewport, docked resize-from-top-edge + pushes content up, and closing hides it. |
 
 ---

--- a/docs/specs/scenario_coverage.md
+++ b/docs/specs/scenario_coverage.md
@@ -43,14 +43,14 @@ Integration tests considered:
 | MSG | 15 | 12 | 10 | 37 |
 | PANEL | 23 | 20 | 14 | 57 |
 | CMDP | 4 | 9 | 18 | 31 |
-| SET | 11 | 18 | 10 | 39 |
+| SET | 12 | 18 | 10 | 40 |
 | DEV | 3 | 1 | 0 | 4 |
 | MENT | 5 | 2 | 3 | 10 |
 | SKILL | 2 | 1 | 0 | 3 |
 | ACT | 2 | 3 | 1 | 6 |
-| **Total** | **179** | **150** | **136** | **465** |
+| **Total** | **180** | **150** | **136** | **466** |
 
-**Under the integration-only standard, 38% of scenarios are completely covered, 32% partially, and
+**Under the integration-only standard, 39% of scenarios are completely covered, 32% partially, and
 29% not at all.** (Counts are derived directly from the two sections below.)
 
 The per-scenario detail is split into two sections: **Coverage gaps — Partial & Missing** (every
@@ -388,8 +388,9 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | SET-034 | Partial | test_theme_builder.py::test_theme_builder_navigation; ::test_theme_builder_change_accent_color | Exercise changing appearance mode, primary font, code font, and code theme and verify the UI updates. |
 | SET-035 | Partial | test_theme_builder.py::test_theme_builder_change_accent_color; ::test_theme_builder_reset_to_defaults | Cover custom hex entry, the light/dark hex override toggle, invalid-hex-shown-red, and the Gray/Success/Warning/Info swatches. |
 | SET-036 | Missing | — | Click a radius / scaling / panel-background option and assert the live UI updates. |
-| SET-038 | Partial | test_plugins_settings_visibility.py::test_plugins_section_visible_and_toggles_with_switch; test_plugin_loader.py::test_valid_plugin_loads_and_can_be_removed; ::test_plugin_source_can_be_disabled_and_re_enabled | Cover adding a source by URL, the Refresh rescan of the plugins directory, removing a user-added URL source, and the displayed directory path. |
+| SET-038 | Partial | test_plugin_loader.py::test_valid_plugin_loads_and_can_be_removed; ::test_plugin_source_can_be_disabled_and_re_enabled | Cover the Refresh rescan of the plugins directory and the displayed directory path. |
 | SET-039 | Partial | test_ci_babysitter.py::test_settings_selector_lists_only_driveable_harnesses | Assert the selector saves with a toast and is disabled when the babysitter is off. |
+| SET-040 | Complete | test_plugins_settings_visibility.py::test_plugins_section_always_present; ::test_master_switch_reveals_management_ui_live | — |
 | DEV-001 | Partial | test_tanstack_devtools_panel.py::test_tanstack_devtools_panel_mounts_with_content (panel mounts only) | Cover header Dock/Float/Close controls, floating drag + resize within viewport, docked resize-from-top-edge + pushes content up, and closing hides it. |
 
 ---

--- a/docs/specs/scenario_coverage.md
+++ b/docs/specs/scenario_coverage.md
@@ -390,7 +390,7 @@ Every scenario that is **not** Complete, grouped by area. **Missing** = no integ
 | SET-036 | Missing | — | Click a radius / scaling / panel-background option and assert the live UI updates. |
 | SET-038 | Partial | test_plugin_loader.py::test_valid_plugin_loads_and_can_be_removed; ::test_plugin_source_can_be_disabled_and_re_enabled | Cover the Refresh rescan of the plugins directory and the displayed directory path. |
 | SET-039 | Partial | test_ci_babysitter.py::test_settings_selector_lists_only_driveable_harnesses | Assert the selector saves with a toast and is disabled when the babysitter is off. |
-| SET-040 | Complete | test_plugins_settings_visibility.py::test_plugins_section_always_present; ::test_master_switch_reveals_management_ui_live | — |
+| SET-040 | Complete | test_plugins_settings_visibility.py::test_plugins_section_present_and_on_by_default; ::test_global_toggle_hides_management_ui_live | — |
 | SET-041 | Complete | test_plugin_loader.py::test_failed_plugin_can_be_retried | — |
 | DEV-001 | Partial | test_tanstack_devtools_panel.py::test_tanstack_devtools_panel_mounts_with_content (panel mounts only) | Cover header Dock/Float/Close controls, floating drag + resize within viewport, docked resize-from-top-edge + pushes content up, and closing hides it. |
 

--- a/docs/specs/scenarios.md
+++ b/docs/specs/scenarios.md
@@ -2415,10 +2415,15 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: the user adds a plugin source by URL, toggles a plugin's enable/disable switch, clicks Refresh to rescan the plugins directory, or removes a user-added URL source.
   - Then: an added source appears in the list; the switch mutes/unmutes the plugin without removing it; Refresh re-scans drop-in plugins; a user-added URL source can be removed while bundled/disk-discovered ones cannot; the plugins directory path is shown.
 
-- **SET-040 — Plugin system master switch**
-  - Given: the Plugins settings section (always present, since it hosts the master switch).
-  - When: the user toggles the master switch at the top of the section off, then on.
+- **SET-040 — Global plugin enable/disable toggle**
+  - Given: the Plugins settings section (always present, since it hosts the global plugin toggle).
+  - When: the user toggles the global plugin switch at the top of the section off, then on.
   - Then: turning it off hides the plugin-management UI (add-source input and list) while the section and switch remain; turning it on reveals the management UI again.
+
+- **SET-041 — Retry a failed plugin load**
+  - Given: a plugin source whose row is in the error state (its load failed).
+  - When: the user clicks the retry control on that row.
+  - Then: the row re-attempts the load — settling back to error if it fails again, or showing the loaded plugin's name and version if it now succeeds.
 
 ## Actions
 

--- a/docs/specs/scenarios.md
+++ b/docs/specs/scenarios.md
@@ -2047,10 +2047,10 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: switching tabs/files and returning.
   - Then: each of these states is restored.
 
-## Plugin panels (experimental)
+## Plugin panels
 
 - **PANEL-057 — Plugin-contributed panel appears with a badge**
-  - Given: Frontend plugins is enabled and a plugin contributing a panel is loaded (e.g. the bundled Linear plugin).
+  - Given: the bundled Linear plugin (enabled by default) is loaded and contributes a panel.
   - When: the user views the Panels list and opens the plugin's panel.
   - Then: the panel is listed with a "plugin" badge and renders its content when opened.
 
@@ -2400,7 +2400,7 @@ The home page and the Add Workspace page share the recent-workspaces list and it
 
 - **SET-029 — Experimental toggles**
   - Given: the Experimental section.
-  - When: the user toggles any feature (Always interrupt and send, Smooth streaming, Per-workspace panel layout, In-place workspaces, Clone workspaces, Review all, Entity mentions, Rich markdown rendering, Pi agent, Frontend plugins).
+  - When: the user toggles any feature (Always interrupt and send, Smooth streaming, Per-workspace panel layout, In-place workspaces, Clone workspaces, Review all, Entity mentions, Rich markdown rendering, Pi agent).
   - Then: each shows "Setting updated".
 
 - **SET-030 — Custom backend command & timeout**
@@ -2408,12 +2408,17 @@ The home page and the Add Workspace page share the recent-workspaces list and it
   - When: the user sets a custom backend command or readiness timeout.
   - Then: each saves with a "restart required" toast.
 
-## Plugins (experimental)
+## Plugins
 
 - **SET-038 — Manage plugin sources**
-  - Given: Frontend plugins is enabled, so a Plugins section appears in Settings.
+  - Given: the Plugins settings section with the plugin system enabled.
   - When: the user adds a plugin source by URL, toggles a plugin's enable/disable switch, clicks Refresh to rescan the plugins directory, or removes a user-added URL source.
   - Then: an added source appears in the list; the switch mutes/unmutes the plugin without removing it; Refresh re-scans drop-in plugins; a user-added URL source can be removed while bundled/disk-discovered ones cannot; the plugins directory path is shown.
+
+- **SET-040 — Plugin system master switch**
+  - Given: the Plugins settings section (always present, since it hosts the master switch).
+  - When: the user toggles the master switch at the top of the section off, then on.
+  - Then: turning it off hides the plugin-management UI (add-source input and list) while the section and switch remain; turning it on reveals the management UI again.
 
 ## Actions
 

--- a/sculptor/frontend/plugins/linear-issue/src/index.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/index.tsx
@@ -16,6 +16,11 @@ export default function activate(api: PluginHostApi): () => void {
     icon: Hash,
     defaultZone: "top-right",
     defaultShortcut: "",
+    // Registered but off by default: a bundled, on-by-default plugin shouldn't
+    // claim a slot in everyone's panel layout uninvited. The workspace banner
+    // widget below is the always-on surface; users opt the panel in from
+    // Settings → Panels (like the built-in Browser panel).
+    defaultEnabled: false,
     component: LinearPanel,
   });
   const disposeSettings = api.registerSettings(LinearSettings);

--- a/sculptor/frontend/src/components/CommandPalette/__tests__/settingsSectionDrift.test.ts
+++ b/sculptor/frontend/src/components/CommandPalette/__tests__/settingsSectionDrift.test.ts
@@ -1,11 +1,9 @@
 import { getDefaultStore } from "jotai";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import type { UserConfig } from "~/api";
-import { SETTINGS_SECTIONS, SettingsSection } from "~/pages/settings/sections.ts";
+import { SETTINGS_SECTIONS } from "~/pages/settings/sections.ts";
 
 import { DEFAULT_THEME_BUILDER_SETTINGS, themeBuilderSettingsAtom } from "../../../common/state/atoms/themeBuilder.ts";
-import { userConfigAtom } from "../../../common/state/atoms/userConfig.ts";
 import { buildSettingsCommands } from "../builtinCommands/settings.ts";
 import type { CommandRuntime } from "../runtime.ts";
 
@@ -45,12 +43,6 @@ const makeRuntime = (): CommandRuntime =>
   }) as unknown as CommandRuntime;
 
 describe("Settings section drift", () => {
-  // The Plugins section is gated on the experimental frontend-plugins flag
-  // at both consumers; turn it on so the parity checks cover every section.
-  beforeEach(() => {
-    getDefaultStore().set(userConfigAtom, { enableFrontendPlugins: true } as unknown as UserConfig);
-  });
-
   it("every section in SETTINGS_SECTIONS has a corresponding palette command", () => {
     getDefaultStore().set(themeBuilderSettingsAtom, { ...DEFAULT_THEME_BUILDER_SETTINGS });
     const cmds = buildSettingsCommands(makeRuntime());
@@ -75,12 +67,6 @@ describe("Settings section drift", () => {
       const cmd = cmds.find((c) => c.id === `settings.page.${section.id.toLowerCase()}`);
       expect(cmd?.title).toBe(section.displayName);
     }
-  });
-
-  it("excludes the Plugins section when the frontend-plugins flag is off", () => {
-    getDefaultStore().set(userConfigAtom, null);
-    const cmds = buildSettingsCommands(makeRuntime());
-    expect(cmds.some((c) => c.id === `settings.page.${SettingsSection.PLUGINS.toLowerCase()}`)).toBe(false);
   });
 
   it("palette command performs runtime.navigate.toSettings with the section id", () => {

--- a/sculptor/frontend/src/components/CommandPalette/builtinCommands/settings.ts
+++ b/sculptor/frontend/src/components/CommandPalette/builtinCommands/settings.ts
@@ -1,7 +1,6 @@
 import { PaletteIcon } from "lucide-react";
 
-import { isFrontendPluginsEnabledAtom } from "~/common/state/atoms/userConfig.ts";
-import { SETTINGS_SECTIONS, SettingsSection } from "~/pages/settings/sections.ts";
+import { SETTINGS_SECTIONS } from "~/pages/settings/sections.ts";
 
 import type { CommandRuntime } from "../runtime.ts";
 import type { Command } from "../types.ts";
@@ -59,11 +58,6 @@ export const buildSettingsCommands = (runtime: CommandRuntime): Array<Command> =
   ];
 
   for (const entry of SETTINGS_SECTIONS) {
-    // The Plugins section only surfaces once the experimental
-    // frontend-plugins flag is on — mirrors the Settings sidebar gating.
-    if (entry.id === SettingsSection.PLUGINS && !runtime.store.get(isFrontendPluginsEnabledAtom)) {
-      continue;
-    }
     // Page-scoped variant under the "settings.section" sub-page. Section
     // names are kept off the root palette to avoid flooding it; they
     // surface either by opening the sub-page, or via fuzzy search at the

--- a/sculptor/frontend/src/components/panels/PanelRegistryProvider.test.tsx
+++ b/sculptor/frontend/src/components/panels/PanelRegistryProvider.test.tsx
@@ -133,7 +133,7 @@ describe("PanelRegistryProvider — bootstrap", () => {
     expect(store.get(zoneOrderAtom)).toEqual({});
   });
 
-  it("does not re-apply defaultLayout when zoneAssignments is already populated", () => {
+  it("does not overwrite a populated zoneAssignments with the default", () => {
     const store = createStore();
     // Seed with an existing user-configured assignment that differs from the
     // defaultLayout (info is placed in "bottom" instead of "top-left").
@@ -141,13 +141,30 @@ describe("PanelRegistryProvider — bootstrap", () => {
 
     renderProvider({ store, panels: TEST_PANELS, defaultLayout: TEST_DEFAULT_LAYOUT });
 
-    // The bootstrap effect must not overwrite the existing assignments with
+    // The bootstrap must not overwrite the existing assignments with
     // defaultLayout.zoneAssignments. The user-configured zone for "info" stays.
     expect(store.get(zoneAssignmentsAtom).info).toBe("bottom");
-    // activePanelPerZone and zoneVisibility are bootstrap-only atoms — they
-    // must remain untouched when zoneAssignments is already populated.
-    expect(store.get(activePanelPerZoneAtom)).toEqual({});
-    expect(store.get(zoneVisibilityAtom)).toEqual({});
+  });
+
+  it("seeds the other layout pieces even when zoneAssignments was populated first", () => {
+    // Regression: a plugin's panel registers asynchronously, and the
+    // reconciliation effect writes zoneAssignments to give it a zone. If that
+    // write lands before the bootstrap and the seed is gated on zoneAssignments
+    // being empty, zoneVisibility never gets seeded — and a missing zoneVisibility
+    // entry gates the zone hidden, collapsing the whole docked layout to the
+    // center panel. The bootstrap must seed each still-empty piece regardless.
+    const store = createStore();
+    store.set(zoneAssignmentsAtom, { info: "bottom", terminal: "bottom", changes: "top-right" });
+
+    renderProvider({ store, panels: TEST_PANELS, defaultLayout: TEST_DEFAULT_LAYOUT });
+
+    // The populated zoneAssignments is preserved...
+    expect(store.get(zoneAssignmentsAtom).info).toBe("bottom");
+    // ...but the still-empty pieces are seeded from the default, so the zones are
+    // visible rather than all-hidden.
+    expect(store.get(zoneVisibilityAtom)).toEqual(TEST_DEFAULT_LAYOUT.zoneVisibility);
+    expect(store.get(activePanelPerZoneAtom)).toEqual(TEST_DEFAULT_LAYOUT.activePanelPerZone);
+    expect(store.get(zoneOrderAtom)).toEqual(TEST_DEFAULT_LAYOUT.zoneOrder);
   });
 });
 

--- a/sculptor/frontend/src/components/panels/PanelRegistryProvider.tsx
+++ b/sculptor/frontend/src/components/panels/PanelRegistryProvider.tsx
@@ -32,6 +32,8 @@ export const PanelRegistryProvider = ({
   useHydrateAtoms([[panelRegistryAtom, panels]]);
 
   const zoneAssignments = useAtomValue(zoneAssignmentsAtom);
+  const activePanelPerZone = useAtomValue(activePanelPerZoneAtom);
+  const zoneVisibility = useAtomValue(zoneVisibilityAtom);
   const zoneOrder = useAtomValue(zoneOrderAtom);
   const panelEnabled = useAtomValue(panelEnabledAtom);
   const setZoneAssignments = useSetAtom(zoneAssignmentsAtom);
@@ -47,20 +49,39 @@ export const PanelRegistryProvider = ({
     setPanelRegistry(panels);
   }, [panels, setPanelRegistry]);
 
-  // One-time bootstrap: apply the full defaultLayout when no persisted layout
-  // exists. Only runs on first render; later changes are handled by the
+  // One-time bootstrap: seed defaults for any layout piece that has no persisted
+  // value. Only runs on first render; later changes are handled by the
   // reconciliation effect below so dynamic panel toggling works.
+  //
+  // Each piece is seeded independently rather than all-or-nothing on
+  // `zoneAssignments` being empty: a plugin's panel registers asynchronously,
+  // and the reconciliation effect below writes `zoneAssignments` to give that
+  // panel a zone. If that write lands before this bootstrap and the seed were
+  // gated on `zoneAssignments` being empty, `zoneVisibility` would never get
+  // seeded — and `isZoneVisibleAtom` treats a missing entry as hidden, so every
+  // docked zone (file browser, terminal, …) would collapse, leaving only the
+  // center panel. Seeding per-piece keeps the visibility default independent of
+  // when the plugin's zone assignment lands. A returning user has all pieces
+  // persisted, so nothing here overwrites their layout.
   useEffect(() => {
     if (!defaultLayout || hasInitialized.current) return;
     hasInitialized.current = true;
 
-    if (Object.keys(zoneAssignments).length === 0) {
-      setZoneAssignments(defaultLayout.zoneAssignments);
-      setActivePanelPerZone(defaultLayout.activePanelPerZone);
-      setZoneVisibility(defaultLayout.zoneVisibility);
-      setZoneOrder(defaultLayout.zoneOrder);
-    }
-  }, [defaultLayout, zoneAssignments, setZoneAssignments, setActivePanelPerZone, setZoneVisibility, setZoneOrder]);
+    if (Object.keys(zoneAssignments).length === 0) setZoneAssignments(defaultLayout.zoneAssignments);
+    if (Object.keys(activePanelPerZone).length === 0) setActivePanelPerZone(defaultLayout.activePanelPerZone);
+    if (Object.keys(zoneVisibility).length === 0) setZoneVisibility(defaultLayout.zoneVisibility);
+    if (Object.keys(zoneOrder).length === 0) setZoneOrder(defaultLayout.zoneOrder);
+  }, [
+    defaultLayout,
+    zoneAssignments,
+    activePanelPerZone,
+    zoneVisibility,
+    zoneOrder,
+    setZoneAssignments,
+    setActivePanelPerZone,
+    setZoneVisibility,
+    setZoneOrder,
+  ]);
 
   // Reconcile the persisted layout against the currently-registered panels.
   // Runs whenever the panels prop changes (e.g. an experimental panel toggle),

--- a/sculptor/frontend/src/pages/settings/SettingsPage.tsx
+++ b/sculptor/frontend/src/pages/settings/SettingsPage.tsx
@@ -21,7 +21,6 @@ import {
   isCloneWorkspacesEnabledAtom,
   isDefaultFastModeAtom,
   isEntityMentionsEnabledAtom,
-  isFrontendPluginsEnabledAtom,
   isInPlaceWorkspacesEnabledAtom,
   isPanelLayoutPerWorkspaceAtom,
   isPiAgentEnabledAtom,
@@ -90,14 +89,6 @@ export const SettingsPage = (): ReactElement => {
   const isCloneWorkspacesEnabled = useAtomValue(isCloneWorkspacesEnabledAtom);
   const isReviewAllEnabled = useAtomValue(isReviewAllEnabledAtom);
   const isPiAgentEnabled = useAtomValue(isPiAgentEnabledAtom);
-  const isFrontendPluginsEnabled = useAtomValue(isFrontendPluginsEnabledAtom);
-  // The Plugins section only shows once the experimental flag is on; the
-  // page itself stays reachable via ?section=PLUGINS for plugin development.
-  const visibleSections = SETTINGS_SECTIONS.filter((s) => s.id !== SettingsSection.PLUGINS || isFrontendPluginsEnabled);
-  // The mobile Select binds value={activeSection}, so its options must always
-  // include the active section — even one normally hidden (e.g. deep-linked to
-  // ?section=PLUGINS with the flag off) — or the trigger renders blank.
-  const mobileSections = SETTINGS_SECTIONS.filter((s) => visibleSections.includes(s) || s.id === activeSection);
   const isEntityMentionsEnabled = useAtomValue(isEntityMentionsEnabledAtom);
   const isRichMarkdownRenderingEnabled = useAtomValue(isRichMarkdownRenderingEnabledAtom);
   const isSmoothStreamingEnabled = useAtomValue(isSmoothStreamingUserPreferenceAtom);
@@ -164,7 +155,7 @@ export const SettingsPage = (): ReactElement => {
         <Flex position="relative" flexGrow="1" data-testid={ElementIds.SETTINGS_PAGE} minHeight="0" overflow="hidden">
           <Flex direction="column" px="6" pt="8" pb="4" className={styles.sidebar}>
             <Flex direction="column" gap="2">
-              {visibleSections.map(({ id }) => (
+              {SETTINGS_SECTIONS.map(({ id }) => (
                 <Box key={id}>
                   {id === SettingsSection.EXPERIMENTAL && <Separator size="4" my="2" className={styles.navSeparator} />}
                   <Box
@@ -185,7 +176,7 @@ export const SettingsPage = (): ReactElement => {
               <Select.Root value={activeSection} onValueChange={(value) => setActiveSection(value as SettingsSection)}>
                 <Select.Trigger variant="soft" />
                 <Select.Content>
-                  {mobileSections.map(({ id }) => (
+                  {SETTINGS_SECTIONS.map(({ id }) => (
                     <Select.Item key={id} value={id} data-testid={SECTION_TEST_IDS[id] ?? ""}>
                       {getDisplayName(id)}
                     </Select.Item>
@@ -371,7 +362,9 @@ export const SettingsPage = (): ReactElement => {
               {activeSection === SettingsSection.PANELS && (
                 <PanelsSettingsSection onSettingChange={handleSettingChange} />
               )}
-              {activeSection === SettingsSection.PLUGINS && <PluginsSettingsSection />}
+              {activeSection === SettingsSection.PLUGINS && (
+                <PluginsSettingsSection onSettingChange={handleSettingChange} />
+              )}
               {activeSection === SettingsSection.PRIVACY && (
                 <SettingsSectionLayout description="Your email and telemetry preferences.">
                   <AccountFieldRow
@@ -507,18 +500,6 @@ export const SettingsPage = (): ReactElement => {
                       checked={isPiAgentEnabled}
                       onCheckedChange={(checked) => handleSettingChange(UserConfigField.ENABLE_PI_AGENT, checked)}
                       data-testid={ElementIds.SETTINGS_ENABLE_PI_AGENT_TOGGLE}
-                    />
-                  </SettingRow>
-                  <SettingRow
-                    title="Frontend plugins"
-                    description="Load runtime frontend plugins and show the Plugins settings section. Enabling applies immediately; disabling takes effect after an app reload."
-                  >
-                    <Switch
-                      checked={isFrontendPluginsEnabled}
-                      onCheckedChange={(checked) =>
-                        handleSettingChange(UserConfigField.ENABLE_FRONTEND_PLUGINS, checked)
-                      }
-                      data-testid={ElementIds.SETTINGS_ENABLE_FRONTEND_PLUGINS_TOGGLE}
                     />
                   </SettingRow>
                   <CustomBackendSection setToast={setToast} />

--- a/sculptor/frontend/src/pages/settings/components/PluginsSettingsSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PluginsSettingsSection.tsx
@@ -158,7 +158,7 @@ export const PluginsSettingsSection = ({ onSettingChange }: PluginsSettingsSecti
     >
       <SettingRow
         title="Frontend plugins"
-        description="Master switch for the plugin system. Turning it on applies immediately; turning it off takes effect after an app reload (already-loaded plugins keep running for the rest of the session). Use the per-plugin switches below to disable individual plugins."
+        description="Enable or disable all plugins globally. Unloading plugins may require a page refresh."
       >
         <Switch
           checked={isFrontendPluginsEnabled}
@@ -264,6 +264,7 @@ const SourceRow = ({
   // dead-trace row, with no live plugin to toggle, settings, or reload — only a
   // Remove to forget it.
   const isMissing = state?.status === "missing";
+  const isError = state?.status === "error";
   // Loaded and shadowed rows both carry a manifest (the shadowed one fetched
   // fine, it just isn't the active version) so both can show name + version.
   const manifest = state?.status === "loaded" || state?.status === "shadowed" ? state.manifest : undefined;
@@ -394,10 +395,12 @@ const SourceRow = ({
           )}
         </Flex>
         <Flex align="center" gap="2">
-          {/* Settings and reload only show while the source is enabled (loaded).
-              They sit to the LEFT of the switch so toggling the source — which
-              shows/hides them — never shifts the switch horizontally; only the
-              always-present Remove stays to its right. */}
+          {/* Settings shows only while the source is loaded; Reload also shows on
+              an errored row so a failed load (e.g. a bundle that wasn't ready yet
+              on a cold start) can be retried in place. Both sit to the LEFT of the
+              switch so toggling the source — which shows/hides them — never shifts
+              the switch horizontally; only the always-present Remove stays to its
+              right. */}
           {isLoaded && SettingsComponent && (
             <Tooltip content="Settings">
               <IconButton
@@ -412,13 +415,13 @@ const SourceRow = ({
               </IconButton>
             </Tooltip>
           )}
-          {isLoaded && (
-            <Tooltip content="Reload">
+          {(isLoaded || isError) && (
+            <Tooltip content={isError ? "Retry" : "Reload"}>
               <IconButton
                 variant="ghost"
                 size="1"
                 color="gray"
-                aria-label={`Reload ${source}`}
+                aria-label={`${isError ? "Retry" : "Reload"} ${source}`}
                 onClick={() => void handleReload()}
                 data-testid={ElementIds.SETTINGS_PLUGINS_SOURCE_RELOAD}
               >

--- a/sculptor/frontend/src/pages/settings/components/PluginsSettingsSection.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PluginsSettingsSection.tsx
@@ -3,8 +3,9 @@ import { useAtomValue, useStore } from "jotai";
 import { Plus, RefreshCw, RotateCw, Settings2, Trash2 } from "lucide-react";
 import { type ComponentType, type ReactElement, useEffect, useState } from "react";
 
-import { ElementIds, getLocalPluginsDirectory } from "~/api";
+import { ElementIds, getLocalPluginsDirectory, UserConfigField } from "~/api";
 import { healthCheckDataAtom } from "~/common/state/atoms/backend.ts";
+import { isFrontendPluginsEnabledAtom } from "~/common/state/atoms/userConfig.ts";
 import { Code } from "~/components/Code.tsx";
 import { PluginContext } from "~/plugins/PluginContext.tsx";
 import { PluginErrorBoundary } from "~/plugins/PluginErrorBoundary.tsx";
@@ -16,6 +17,7 @@ import {
   pluginSourceStatesAtom,
 } from "~/plugins/pluginRegistry.ts";
 
+import { SettingRow } from "./SettingRow.tsx";
 import { SettingsSectionLayout } from "./SettingsSection.tsx";
 import { inlineCodeStyle } from "./settingsStyles.ts";
 
@@ -36,13 +38,24 @@ const pluginsDirFromDataDirectory = (dataDirectory: string | null | undefined): 
   return `${dataDirectory.replace(/[/\\]+$/, "")}${separator}plugins`;
 };
 
+type PluginsSettingsSectionProps = {
+  onSettingChange: (field: UserConfigField, value: unknown) => Promise<void>;
+};
+
 /**
- * Lists installed plugins and lets the user point Sculptor at additional plugin
- * sources (a URL serving a `manifest.json`). User sources are persisted to
- * localStorage and re-loaded on every boot.
+ * Hosts the frontend-plugins master switch (the kill switch for the whole
+ * system), then — while that switch is on — lists installed plugins and lets
+ * the user point Sculptor at additional plugin sources (a URL serving a
+ * `manifest.json`). User sources are persisted to localStorage and re-loaded on
+ * every boot.
+ *
+ * The kill switch lives here rather than in Experimental so the section can't
+ * gate its own visibility: it stays reachable to flip the system back on after
+ * it's been turned off.
  */
-export const PluginsSettingsSection = (): ReactElement => {
+export const PluginsSettingsSection = ({ onSettingChange }: PluginsSettingsSectionProps): ReactElement => {
   const store = useStore();
+  const isFrontendPluginsEnabled = useAtomValue(isFrontendPluginsEnabledAtom);
   const userSources = useAtomValue(pluginSourcesAtom);
   const states = useAtomValue(pluginSourceStatesAtom);
   const healthCheckData = useAtomValue(healthCheckDataAtom);
@@ -143,61 +156,79 @@ export const PluginsSettingsSection = (): ReactElement => {
         </>
       }
     >
-      <Flex gap="2" align="center" mb="4">
-        <TextField.Root
-          style={{ flexGrow: 1 }}
-          placeholder="http://localhost:5174/my-plugin"
-          value={draft}
-          disabled={isBusy}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") void handleAdd();
-          }}
-          data-testid={ElementIds.SETTINGS_PLUGINS_SOURCE_INPUT}
+      <SettingRow
+        title="Frontend plugins"
+        description="Master switch for the plugin system. Turning it on applies immediately; turning it off takes effect after an app reload (already-loaded plugins keep running for the rest of the session). Use the per-plugin switches below to disable individual plugins."
+      >
+        <Switch
+          checked={isFrontendPluginsEnabled}
+          onCheckedChange={(checked) => void onSettingChange(UserConfigField.ENABLE_FRONTEND_PLUGINS, checked)}
+          data-testid={ElementIds.SETTINGS_ENABLE_FRONTEND_PLUGINS_TOGGLE}
         />
-        <Button
-          onClick={() => void handleAdd()}
-          disabled={!draft.trim() || isBusy}
-          data-testid={ElementIds.SETTINGS_PLUGINS_ADD_BUTTON}
-        >
-          <Plus size={14} />
-          Add
-        </Button>
-        <Tooltip content={`Re-scan ${pluginsDir} for added or removed plugins`}>
-          <IconButton
-            variant="soft"
-            color="gray"
-            disabled={isBusy}
-            onClick={() => void handleRefresh()}
-            aria-label="Refresh local plugins"
-            data-testid={ElementIds.SETTINGS_PLUGINS_REFRESH_BUTTON}
-          >
-            <RefreshCw size={14} />
-          </IconButton>
-        </Tooltip>
-      </Flex>
+      </SettingRow>
 
-      {orderedSources.length === 0 ? (
-        <Flex direction="column" align="center" py="6" data-testid={ElementIds.SETTINGS_PLUGINS_EMPTY}>
-          <Text size="2" color="gray">
-            No plugins installed.
-          </Text>
-        </Flex>
-      ) : (
-        <Flex direction="column" data-testid={ElementIds.SETTINGS_PLUGINS_LIST}>
-          {orderedSources.map((source) => (
-            <SourceRow
-              key={source}
-              source={source}
-              state={states[source]}
-              activeSourceByPluginId={activeSourceByPluginId}
-              activeOrLoadingSources={activeOrLoadingSources}
-              pluginsDir={pluginsDir}
-              store={store}
-              setIsBusy={setIsBusy}
+      {/* The plugin list and add-source controls only matter while the system
+          is on — with it off nothing is loaded, so we hide them and leave just
+          the master switch above. */}
+      {isFrontendPluginsEnabled && (
+        <>
+          <Flex gap="2" align="center" mb="4" mt="4">
+            <TextField.Root
+              style={{ flexGrow: 1 }}
+              placeholder="http://localhost:5174/my-plugin"
+              value={draft}
+              disabled={isBusy}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleAdd();
+              }}
+              data-testid={ElementIds.SETTINGS_PLUGINS_SOURCE_INPUT}
             />
-          ))}
-        </Flex>
+            <Button
+              onClick={() => void handleAdd()}
+              disabled={!draft.trim() || isBusy}
+              data-testid={ElementIds.SETTINGS_PLUGINS_ADD_BUTTON}
+            >
+              <Plus size={14} />
+              Add
+            </Button>
+            <Tooltip content={`Re-scan ${pluginsDir} for added or removed plugins`}>
+              <IconButton
+                variant="soft"
+                color="gray"
+                disabled={isBusy}
+                onClick={() => void handleRefresh()}
+                aria-label="Refresh local plugins"
+                data-testid={ElementIds.SETTINGS_PLUGINS_REFRESH_BUTTON}
+              >
+                <RefreshCw size={14} />
+              </IconButton>
+            </Tooltip>
+          </Flex>
+
+          {orderedSources.length === 0 ? (
+            <Flex direction="column" align="center" py="6" data-testid={ElementIds.SETTINGS_PLUGINS_EMPTY}>
+              <Text size="2" color="gray">
+                No plugins installed.
+              </Text>
+            </Flex>
+          ) : (
+            <Flex direction="column" data-testid={ElementIds.SETTINGS_PLUGINS_LIST}>
+              {orderedSources.map((source) => (
+                <SourceRow
+                  key={source}
+                  source={source}
+                  state={states[source]}
+                  activeSourceByPluginId={activeSourceByPluginId}
+                  activeOrLoadingSources={activeOrLoadingSources}
+                  pluginsDir={pluginsDir}
+                  store={store}
+                  setIsBusy={setIsBusy}
+                />
+              ))}
+            </Flex>
+          )}
+        </>
       )}
     </SettingsSectionLayout>
   );

--- a/sculptor/frontend/src/pages/settings/sections.ts
+++ b/sculptor/frontend/src/pages/settings/sections.ts
@@ -100,10 +100,9 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSectionDescriptor> = [
     icon: LayoutGridIcon,
     testId: ElementIds.SETTINGS_NAV_PANELS,
   },
-  // Visibility of the Plugins section is gated on the experimental
-  // frontend-plugins flag at both consumers of this array (the Settings
-  // sidebar in SettingsPage and the Cmd+K palette builder) — with the flag
-  // off it appears in neither.
+  // The Plugins section is always visible: it hosts the frontend-plugins
+  // master switch, so it must stay reachable even when the system is off (to
+  // flip it back on).
   {
     id: SettingsSection.PLUGINS,
     displayName: "Plugins",

--- a/sculptor/frontend/src/plugins/pluginManager.tsx
+++ b/sculptor/frontend/src/plugins/pluginManager.tsx
@@ -96,8 +96,8 @@ type BuiltinSource = { path: string; disabledByDefault?: boolean };
  * UI. They serve from `public/plugins/<id>/`.
  */
 const BUILTIN_SOURCES: ReadonlyArray<BuiltinSource> = [
-  { path: "/plugins/sculpty" },
-  { path: "/plugins/pomodoro" },
+  { path: "/plugins/sculpty", disabledByDefault: true },
+  { path: "/plugins/pomodoro", disabledByDefault: true },
   { path: "/plugins/linear-issue" },
 ];
 

--- a/sculptor/sculptor/config/user_config.py
+++ b/sculptor/sculptor/config/user_config.py
@@ -311,7 +311,7 @@ class UserConfig(SerializableModel):
     )
     enable_frontend_plugins: bool = Field(
         default=True,
-        description="When enabled, the frontend plugin system loads runtime plugins and shows the Plugins settings section. On by default. Enabling applies immediately; disabling takes effect after an app reload (already-loaded plugins are not unloaded mid-session).",
+        description="When enabled, the frontend plugin system loads runtime plugins and shows the plugin-management UI in the Plugins settings section. On by default. The Plugins settings section itself is always present (it hosts the toggle for this flag); this flag gates loading plugins and the management UI, not the section's visibility. Enabling applies immediately; disabling takes effect after an app reload (already-loaded plugins are not unloaded mid-session).",
     )
     default_fast_mode: bool = Field(
         default=False,

--- a/sculptor/sculptor/config/user_config.py
+++ b/sculptor/sculptor/config/user_config.py
@@ -310,8 +310,8 @@ class UserConfig(SerializableModel):
         description="When enabled, the agent-type menus offer the experimental pi agent. Off by default. Gates only the creation entry point — an existing pi agent keeps running regardless.",
     )
     enable_frontend_plugins: bool = Field(
-        default=False,
-        description="When enabled, the frontend plugin system loads runtime plugins and shows the Plugins settings section. Off by default. Enabling applies immediately; disabling takes effect after an app reload (already-loaded plugins are not unloaded mid-session).",
+        default=True,
+        description="When enabled, the frontend plugin system loads runtime plugins and shows the Plugins settings section. On by default. Enabling applies immediately; disabling takes effect after an app reload (already-loaded plugins are not unloaded mid-session).",
     )
     default_fast_mode: bool = Field(
         default=False,

--- a/sculptor/sculptor/testing/elements/settings_experimental.py
+++ b/sculptor/sculptor/testing/elements/settings_experimental.py
@@ -58,16 +58,3 @@ class PlaywrightExperimentalSettingsElement(PlaywrightIntegrationTestElement):
         if toggle.get_attribute("data-state") != target_state:
             toggle.click()
         expect(toggle).to_have_attribute("data-state", target_state)
-
-    def get_frontend_plugins_toggle(self) -> Locator:
-        """Return the 'Frontend plugins' toggle locator."""
-        return self._page.get_by_test_id(ElementIDs.SETTINGS_ENABLE_FRONTEND_PLUGINS_TOGGLE)
-
-    def set_frontend_plugins(self, *, enabled: bool) -> None:
-        """Set the 'Frontend plugins' toggle to the desired state (idempotent)."""
-        toggle = self.get_frontend_plugins_toggle()
-        expect(toggle).to_be_visible()
-        target_state = "checked" if enabled else "unchecked"
-        if toggle.get_attribute("data-state") != target_state:
-            toggle.click()
-        expect(toggle).to_have_attribute("data-state", target_state)

--- a/sculptor/sculptor/testing/elements/settings_plugins.py
+++ b/sculptor/sculptor/testing/elements/settings_plugins.py
@@ -92,6 +92,11 @@ class PlaywrightPluginsSettingsElement(PlaywrightIntegrationTestElement):
         was located by kind/status rather than by source)."""
         return row.get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_TOGGLE)
 
+    def get_reload_in(self, row: Locator) -> Locator:
+        """The reload/retry control within a source row. Present on a loaded row
+        and on an errored row, where it re-attempts the failed load in place."""
+        return row.get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_RELOAD)
+
     def add_source(self, source: str) -> None:
         """Type a source into the input, click Add, and wait for its row to appear.
 
@@ -109,6 +114,10 @@ class PlaywrightPluginsSettingsElement(PlaywrightIntegrationTestElement):
     def remove_source(self, source: str) -> None:
         """Click the remove (trash) button on a source's row."""
         self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_REMOVE).click()
+
+    def retry(self, source: str) -> None:
+        """Click the reload/retry control on a source's row to re-attempt its load."""
+        self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_RELOAD).click()
 
     def open_source_settings(self, source: str) -> None:
         """Reveal a source's plugin-rendered settings component (clicks the gear).

--- a/sculptor/sculptor/testing/elements/settings_plugins.py
+++ b/sculptor/sculptor/testing/elements/settings_plugins.py
@@ -15,6 +15,21 @@ class PlaywrightPluginsSettingsElement(PlaywrightIntegrationTestElement):
     ``import``/``activate``/``load``).
     """
 
+    def get_frontend_plugins_toggle(self) -> Locator:
+        """Return the frontend-plugins master switch (the kill switch for the
+        whole plugin system). It lives at the top of this section rather than in
+        Experimental so the section stays reachable to flip the system back on."""
+        return self._page.get_by_test_id(ElementIDs.SETTINGS_ENABLE_FRONTEND_PLUGINS_TOGGLE)
+
+    def set_frontend_plugins(self, *, enabled: bool) -> None:
+        """Set the frontend-plugins master switch to the desired state (idempotent)."""
+        toggle = self.get_frontend_plugins_toggle()
+        expect(toggle).to_be_visible()
+        target_state = "checked" if enabled else "unchecked"
+        if toggle.get_attribute("data-state") != target_state:
+            toggle.click()
+        expect(toggle).to_have_attribute("data-state", target_state)
+
     def get_source_input(self) -> Locator:
         return self._page.get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_INPUT)
 

--- a/sculptor/sculptor/testing/pages/settings_page.py
+++ b/sculptor/sculptor/testing/pages/settings_page.py
@@ -65,8 +65,8 @@ class PlaywrightSettingsPage(PlaywrightProjectLayoutPage):
     def click_on_plugins(self) -> PlaywrightPluginsSettingsElement:
         """Navigate to Plugins settings and return the section element.
 
-        The Plugins nav item is gated on the experimental frontend-plugins flag,
-        so this only works on an instance with that flag enabled.
+        The Plugins nav item is always present (it hosts the frontend-plugins
+        master switch), so this works regardless of whether the system is on.
         """
         self.get_plugins_nav().click()
         return PlaywrightPluginsSettingsElement(locator=self._get_settings_content(), page=self._page)
@@ -134,8 +134,8 @@ class PlaywrightSettingsPage(PlaywrightProjectLayoutPage):
     def get_plugins_nav(self) -> Locator:
         """Get the Plugins navigation item.
 
-        The Plugins section is gated on the experimental frontend-plugins
-        flag, so this locator is expected to be absent unless that flag is on.
+        The Plugins section is always present — it hosts the frontend-plugins
+        master switch, so it stays reachable even when the system is off.
         """
         return self.get_by_test_id(ElementIDs.SETTINGS_NAV_PLUGINS)
 

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -721,14 +721,6 @@ def _make_test_user_config(claude_path: str = "claude") -> UserConfig:
         is_session_recording_enabled=True,
         is_privacy_policy_consented=True,
         is_telemetry_level_set=True,
-        # The plugin system ships on by default, which loads the bundled Linear
-        # plugin and contributes its panel to the top-right zone. The broad UI
-        # suite (e.g. panel-layout tests) asserts on the core panel set and must
-        # not depend on which plugins ship enabled, so pin the system off here.
-        # The dedicated plugin tests opt back in — most via their own folder
-        # populators, the shared-instance (Electron) ones by toggling the switch
-        # in the Plugins settings section at runtime.
-        enable_frontend_plugins=False,
         # Managed pi has no fake-on-PATH path, so integration tests pin pi=CUSTOM (bare "pi") to resolve the FakePi stub on PATH.
         dependency_paths=DependencyPaths(claude=claude_path, pi="pi"),
     )

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -725,7 +725,9 @@ def _make_test_user_config(claude_path: str = "claude") -> UserConfig:
         # plugin and contributes its panel to the top-right zone. The broad UI
         # suite (e.g. panel-layout tests) asserts on the core panel set and must
         # not depend on which plugins ship enabled, so pin the system off here.
-        # The dedicated plugin tests opt back in via their own populators.
+        # The dedicated plugin tests opt back in — most via their own folder
+        # populators, the shared-instance (Electron) ones by toggling the switch
+        # in the Plugins settings section at runtime.
         enable_frontend_plugins=False,
         # Managed pi has no fake-on-PATH path, so integration tests pin pi=CUSTOM (bare "pi") to resolve the FakePi stub on PATH.
         dependency_paths=DependencyPaths(claude=claude_path, pi="pi"),

--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -721,6 +721,12 @@ def _make_test_user_config(claude_path: str = "claude") -> UserConfig:
         is_session_recording_enabled=True,
         is_privacy_policy_consented=True,
         is_telemetry_level_set=True,
+        # The plugin system ships on by default, which loads the bundled Linear
+        # plugin and contributes its panel to the top-right zone. The broad UI
+        # suite (e.g. panel-layout tests) asserts on the core panel set and must
+        # not depend on which plugins ship enabled, so pin the system off here.
+        # The dedicated plugin tests opt back in via their own populators.
+        enable_frontend_plugins=False,
         # Managed pi has no fake-on-PATH path, so integration tests pin pi=CUSTOM (bare "pi") to resolve the FakePi stub on PATH.
         dependency_paths=DependencyPaths(claude=claude_path, pi="pi"),
     )

--- a/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
+++ b/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
@@ -156,10 +156,10 @@ def test_bundled_linear_plugin_loads_and_renders_in_electron(
 ) -> None:
     """In Electron, the bundled Linear plugin loads and renders its UI."""
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
-    settings_page.click_on_experimental().set_frontend_plugins(enabled=True)
+    plugins = settings_page.click_on_plugins()
+    plugins.set_frontend_plugins(enabled=True)
     try:
-        plugins = settings_page.click_on_plugins()
         _assert_linear_plugin_loads_and_renders(plugins)
     finally:
         # Leave the shared instance's flag as we found it for the next test.
-        settings_page.click_on_experimental().set_frontend_plugins(enabled=False)
+        plugins.set_frontend_plugins(enabled=False)

--- a/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
+++ b/sculptor/tests/integration/frontend/test_bundled_linear_plugin.py
@@ -18,19 +18,13 @@ Runs in both browser and electron launch modes, since the plugin ships bundled
 into the served build for every mode.
 """
 
-from pathlib import Path
-
 import pytest
 from playwright.sync_api import Route
 from playwright.sync_api import expect
 
-from sculptor.services.user_config.user_config import load_config
-from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.elements.settings_plugins import PlaywrightPluginsSettingsElement
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
-from sculptor.testing.resources import _default_sculptor_folder_populator
-from sculptor.testing.resources import custom_sculptor_folder_populator
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 
@@ -59,14 +53,6 @@ _MOCK_PRIMARY_ISSUE = {
     "assignee": None,
     "attachments": {"nodes": []},
 }
-
-
-def _enable_frontend_plugins_populator(folder_path: Path) -> None:
-    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
-    _default_sculptor_folder_populator(folder_path)
-    config_path = folder_path / "internal" / "config.toml"
-    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
-    save_config(config, config_path)
 
 
 def _mock_linear_graphql(instance: SculptorInstance) -> None:
@@ -107,7 +93,6 @@ def _assert_linear_plugin_loads_and_renders(plugins: PlaywrightPluginsSettingsEl
     expect(plugins.get_source_row(LINEAR_SOURCE)).to_contain_text(LINEAR_SETTINGS_TEXT)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_bundled_linear_plugin_loads_and_renders(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
@@ -118,7 +103,6 @@ def test_bundled_linear_plugin_loads_and_renders(
         _assert_linear_plugin_loads_and_renders(plugins)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_bundled_linear_plugin_workspace_widget_shows_branch_ticket(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
@@ -157,9 +141,4 @@ def test_bundled_linear_plugin_loads_and_renders_in_electron(
     """In Electron, the bundled Linear plugin loads and renders its UI."""
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     plugins = settings_page.click_on_plugins()
-    plugins.set_frontend_plugins(enabled=True)
-    try:
-        _assert_linear_plugin_loads_and_renders(plugins)
-    finally:
-        # Leave the shared instance's flag as we found it for the next test.
-        plugins.set_frontend_plugins(enabled=False)
+    _assert_linear_plugin_loads_and_renders(plugins)

--- a/sculptor/tests/integration/frontend/test_linear_plugin_runtime.py
+++ b/sculptor/tests/integration/frontend/test_linear_plugin_runtime.py
@@ -15,33 +15,20 @@ covers cross-mode loading.
 """
 
 import json
-from pathlib import Path
 
 from playwright.sync_api import Page
 from playwright.sync_api import Route
 from playwright.sync_api import expect
 
-from sculptor.services.user_config.user_config import load_config
-from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
 from sculptor.testing.elements.panels import ensure_right_area_visible
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
-from sculptor.testing.resources import _default_sculptor_folder_populator
-from sculptor.testing.resources import custom_sculptor_folder_populator
 from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 
 LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
 LINEAR_SOURCE = "/plugins/linear-issue"
 API_KEY = "lin_api_test_key_1234"
-
-
-def _enable_frontend_plugins_populator(folder_path: Path) -> None:
-    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
-    _default_sculptor_folder_populator(folder_path)
-    config_path = folder_path / "internal" / "config.toml"
-    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
-    save_config(config, config_path)
 
 
 def _make_linear_route(captured_auth: list[str]):
@@ -83,7 +70,6 @@ def _activate_linear_panel(page: Page, zones: PlaywrightPanelZonesElement) -> No
     zones.activate_plugin_panel("linear-issue")
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_linear_panel_follows_workspace_branch_and_sends_key(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
@@ -102,6 +88,10 @@ def test_linear_panel_follows_workspace_branch_and_sends_key(
         plugins = settings_page.click_on_plugins()
         plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
         plugins.set_source_text_setting(LINEAR_SOURCE, API_KEY)
+
+        # The Linear panel ships disabled (opt-in, like the built-in Browser
+        # panel), so enable it before driving it from the panel zones.
+        settings_page.click_on_panels().set_panel_enabled("linear-issue", True)
 
         zones = PlaywrightPanelZonesElement(page)
 

--- a/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
+++ b/sculptor/tests/integration/frontend/test_panel_open_state_after_plugin_unload.py
@@ -5,41 +5,27 @@ zone, turning the plugin off — or turning it off then on again — must never
 leave a panel the user has disabled (e.g. the Browser panel) rendered in that
 zone.
 
-The reproducer mirrors a real user setup: the bundled Linear plugin docks its
-panel in the top-right zone (alongside the built-in, disabled-by-default
-Browser panel). With the disabled Browser panel ordered ahead of the remaining
+The reproducer mirrors a real user setup: the bundled Linear plugin's panel is
+enabled and docked in the top-right zone (alongside the built-in,
+disabled-by-default Browser panel). With the disabled Browser panel ordered ahead of the remaining
 enabled panel, unloading the active Linear panel used to select Browser as the
 fallback and actually render it. These tests drive that arrangement through the
 UI and assert the zone falls back to an enabled panel instead — both for a
 plain disable and for a disable-then-re-enable cycle.
 """
 
-from pathlib import Path
-
 from playwright.sync_api import Page
 from playwright.sync_api import expect
 
-from sculptor.services.user_config.user_config import load_config
-from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.elements.panel_zones import PlaywrightPanelZonesElement
 from sculptor.testing.elements.panels import ensure_right_area_visible
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
-from sculptor.testing.resources import _default_sculptor_folder_populator
-from sculptor.testing.resources import custom_sculptor_folder_populator
 from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 from sculptor.testing.user_stories import user_story
 
 LINEAR_SOURCE = "/plugins/linear-issue"
-
-
-def _enable_frontend_plugins_populator(folder_path: Path) -> None:
-    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
-    _default_sculptor_folder_populator(folder_path)
-    config_path = folder_path / "internal" / "config.toml"
-    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
-    save_config(config, config_path)
 
 
 def _open_linear_with_disabled_browser_ahead(
@@ -48,16 +34,21 @@ def _open_linear_with_disabled_browser_ahead(
     """Order the disabled Browser panel ahead of an enabled panel in top-right,
     then open the Linear plugin panel as the active one in that zone.
 
-    The default top-right order is [actions, skills, browser]; moving the two
-    enabled built-ins out and one back (each move appends to the target zone's
-    order) leaves [browser (disabled), linear-issue, skills (enabled)] — so the
-    disabled Browser panel is the first sibling after Linear is removed.
+    The Linear panel ships disabled (opt-in, like the built-in Browser panel), so
+    it is enabled here first; it then sits in its default top-right zone. Moving
+    the two enabled built-ins out and one back (each move appends to the target
+    zone's order) leaves the disabled Browser panel ordered ahead of the enabled
+    Skills panel — so once the active Linear panel is removed, the zone must fall
+    back to Skills rather than render the disabled Browser panel.
     """
     settings_page = navigate_to_settings_page(page=page)
     plugins = settings_page.click_on_plugins()
     plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
 
     panels = settings_page.click_on_panels()
+    # The Linear panel is opt-in (defaultEnabled: false); enable it so it docks
+    # in the top-right zone and can be activated below.
+    panels.set_panel_enabled("linear-issue", True)
     panels.set_panel_zone("skills", "bottom-right")
     panels.set_panel_zone("actions", "bottom-right")
     panels.set_panel_zone("skills", "top-right")
@@ -70,7 +61,6 @@ def _open_linear_with_disabled_browser_ahead(
     expect(task_page.get_browser_panel_root()).not_to_be_visible()
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 @user_story("to keep a disabled panel hidden when I turn off a plugin whose panel was open")
 def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
     sculptor_instance_factory_: SculptorInstanceFactory,
@@ -97,7 +87,6 @@ def test_unloading_active_plugin_panel_falls_back_to_an_enabled_panel(
         expect(task_page.get_skills_panel()).to_be_visible()
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 @user_story("to keep a disabled panel hidden after I toggle a plugin off and back on")
 def test_toggling_plugin_off_then_on_does_not_open_a_disabled_panel(
     sculptor_instance_factory_: SculptorInstanceFactory,

--- a/sculptor/tests/integration/frontend/test_plugin_loader.py
+++ b/sculptor/tests/integration/frontend/test_plugin_loader.py
@@ -412,18 +412,19 @@ def test_plugin_loader_in_electron(sculptor_instance_: SculptorInstance) -> None
     differ). That packaged ``file://`` case remains a separate, unsolved scenario.
 
     The factory fixture can't launch a non-packaged Electron, so Electron
-    coverage rides the shared instance. That instance ships with the flag off, so
-    we flip it on through the Experimental settings (live, no reload) before
-    driving the Plugins section, and flip it back off afterward so later
-    Electron tests start from a clean flag. (The error rows the run leaves behind
-    are renderer-local and harmless -- no other Electron test reads plugin
-    sources -- so we don't bother removing them.)
+    coverage rides the shared instance. The broad UI suite pins the plugin
+    system off (see ``_make_test_user_config``), so we flip it on through the
+    Plugins section's master switch (live, no reload) before driving the section,
+    and flip it back off afterward so later Electron tests start from a clean
+    flag. (The error rows the run leaves behind are renderer-local and harmless
+    -- no other Electron test reads plugin sources -- so we don't bother removing
+    them.)
     """
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
-    settings_page.click_on_experimental().set_frontend_plugins(enabled=True)
+    plugins = settings_page.click_on_plugins()
+    plugins.set_frontend_plugins(enabled=True)
     try:
         with spawn_plugin_fixture_server() as server:
-            plugins = settings_page.click_on_plugins()
             _exercise_error_modes(plugins, server)
             _exercise_valid_load_and_remove(plugins, server)
     finally:
@@ -431,4 +432,4 @@ def test_plugin_loader_in_electron(sculptor_instance_: SculptorInstance) -> None
         # raise on failure rather than swallowing it: a silent cleanup failure
         # would leave the instance in a bad state for the next test, so it's
         # better to surface it (worst case, a double exception with the body).
-        settings_page.click_on_experimental().set_frontend_plugins(enabled=False)
+        plugins.set_frontend_plugins(enabled=False)

--- a/sculptor/tests/integration/frontend/test_plugin_loader.py
+++ b/sculptor/tests/integration/frontend/test_plugin_loader.py
@@ -6,12 +6,11 @@ fetches the manifest, validates it, dynamic-imports the entry module, and runs
 its ``activate``. Each source renders a row whose ``data-status`` reflects the
 outcome and, on failure, a ``data-phase`` naming the stage that failed.
 
-The flow lives behind the experimental ``enable_frontend_plugins`` flag. The
-browser tests use a fresh factory instance seeded with the flag on; the Electron
-variant rides the shared instance (the only path that launches a real,
-non-packaged Electron today -- the factory is browser-only) and flips the flag on
-at runtime via the Experimental toggle. The same loader assertions back all of
-them, shared through ``_exercise_*`` helpers.
+The frontend plugin system is on by default, so the browser tests run on a plain
+factory instance and the Electron variant rides the shared instance (the only
+path that launches a real, non-packaged Electron today -- the factory is
+browser-only). The same loader assertions back all of them, shared through
+``_exercise_*`` helpers.
 
 Plugin sources are served from a local cross-origin fixture HTTP server (the
 shape a plugin dev server takes), which lets each failure mode be reproduced
@@ -28,8 +27,6 @@ from pathlib import Path
 import pytest
 from playwright.sync_api import expect
 
-from sculptor.services.user_config.user_config import load_config
-from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.elements.settings_plugins import PlaywrightPluginsSettingsElement
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.plugin_fixture_server import PluginFixtureServer
@@ -53,16 +50,8 @@ _NO_DEFAULT_JS = "export const notActivate = 1;\n"
 _THROWS_ON_ACTIVATE_JS = "export default function activate() { throw new Error('boom'); }\n"
 
 
-def _enable_frontend_plugins_populator(folder_path: Path) -> None:
-    """Seed the per-test sculptor folder with ``enable_frontend_plugins=True``."""
-    _default_sculptor_folder_populator(folder_path)
-    config_path = folder_path / "internal" / "config.toml"
-    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
-    save_config(config, config_path)
-
-
 def _local_plugin_populator(folder_path: Path) -> None:
-    """Seed the per-test sculptor folder with the flag on AND a drop-in plugin.
+    """Seed the per-test sculptor folder with a drop-in plugin.
 
     Writes a complete plugin under ``<folder>/plugins/local-hello/`` — exactly
     the "drop a folder into ``~/.sculptor/plugins/``" flow — so the backend
@@ -70,7 +59,7 @@ def _local_plugin_populator(folder_path: Path) -> None:
     with no user action and no cross-origin dev server. This proves the host can
     run *arbitrary* local plugin code end-to-end.
     """
-    _enable_frontend_plugins_populator(folder_path)
+    _default_sculptor_folder_populator(folder_path)
     plugin_dir = folder_path / "plugins" / "local-hello"
     plugin_dir.mkdir(parents=True, exist_ok=True)
     (plugin_dir / "manifest.json").write_text(
@@ -86,7 +75,7 @@ def _competing_local_plugins_populator(folder_path: Path) -> None:
     enable toggle locked. The two are equal priority (both local), so the
     discovery order (sorted by directory name) breaks the tie — ``dupe-a`` wins.
     """
-    _enable_frontend_plugins_populator(folder_path)
+    _default_sculptor_folder_populator(folder_path)
     for dir_name in ("dupe-a", "dupe-b"):
         plugin_dir = folder_path / "plugins" / dir_name
         plugin_dir.mkdir(parents=True, exist_ok=True)
@@ -101,7 +90,7 @@ def _broken_local_plugin_populator(folder_path: Path) -> None:
     fields). The loader's error handling is shared with the URL path, but this
     proves an error row renders for a discovered *local* source too.
     """
-    _enable_frontend_plugins_populator(folder_path)
+    _default_sculptor_folder_populator(folder_path)
     plugin_dir = folder_path / "plugins" / "broken-local"
     plugin_dir.mkdir(parents=True, exist_ok=True)
     # No `entry` / `sdkVersion`: validateManifest rejects it (validate phase).
@@ -223,7 +212,6 @@ def _exercise_disable_and_enable(plugins: PlaywrightPluginsSettingsElement, serv
     expect(plugins.get_source_row(source)).to_have_count(0)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_plugin_source_can_be_disabled_and_re_enabled(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """A loaded source can be disabled without removal and later re-enabled."""
     with (
@@ -235,7 +223,6 @@ def test_plugin_source_can_be_disabled_and_re_enabled(sculptor_instance_factory_
         _exercise_disable_and_enable(plugins, server)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_plugin_source_error_modes(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """Every malformed-source mode settles the row into an error at its phase.
 
@@ -252,7 +239,6 @@ def test_plugin_source_error_modes(sculptor_instance_factory_: SculptorInstanceF
         _exercise_error_modes(plugins, server)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_failed_plugin_can_be_retried(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """An errored row offers a retry control that re-attempts the load in place.
 
@@ -281,7 +267,6 @@ def test_failed_plugin_can_be_retried(sculptor_instance_factory_: SculptorInstan
         plugins.expect_loaded(source, name="Retry Me", version="0.1.0")
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_valid_plugin_loads_and_can_be_removed(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """A well-formed cross-origin source loads (name/version shown) and removes cleanly."""
     with (
@@ -353,7 +338,6 @@ def test_local_plugin_with_invalid_manifest_shows_error(sculptor_instance_factor
         expect(errored).to_have_attribute("data-phase", "validate")
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_refresh_discovers_added_plugin_and_dead_traces_a_removed_one(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
@@ -402,7 +386,6 @@ def test_refresh_discovers_added_plugin_and_dead_traces_a_removed_one(
         expect(plugins.get_source_row(source)).to_have_count(0)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_plugins_directory_shows_real_backend_path(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """The directory chip shows this instance's real data folder, not a placeholder.
 
@@ -441,24 +424,13 @@ def test_plugin_loader_in_electron(sculptor_instance_: SculptorInstance) -> None
     differ). That packaged ``file://`` case remains a separate, unsolved scenario.
 
     The factory fixture can't launch a non-packaged Electron, so Electron
-    coverage rides the shared instance. The broad UI suite pins the plugin
-    system off (see ``_make_test_user_config``), so we flip it on through the
-    Plugins section's master switch (live, no reload) before driving the section,
-    and flip it back off afterward so later Electron tests start from a clean
-    flag. (The error rows the run leaves behind are renderer-local and harmless
-    -- no other Electron test reads plugin sources -- so we don't bother removing
-    them.)
+    coverage rides the shared instance. The plugin system is on by default, so we
+    drive the Plugins section directly. (The error rows the run leaves behind are
+    renderer-local and harmless -- no other Electron test reads plugin sources --
+    so we don't bother removing them.)
     """
     settings_page = navigate_to_settings_page(page=sculptor_instance_.page)
     plugins = settings_page.click_on_plugins()
-    plugins.set_frontend_plugins(enabled=True)
-    try:
-        with spawn_plugin_fixture_server() as server:
-            _exercise_error_modes(plugins, server)
-            _exercise_valid_load_and_remove(plugins, server)
-    finally:
-        # Restore the shared instance's flag for later Electron tests. Let this
-        # raise on failure rather than swallowing it: a silent cleanup failure
-        # would leave the instance in a bad state for the next test, so it's
-        # better to surface it (worst case, a double exception with the body).
-        plugins.set_frontend_plugins(enabled=False)
+    with spawn_plugin_fixture_server() as server:
+        _exercise_error_modes(plugins, server)
+        _exercise_valid_load_and_remove(plugins, server)

--- a/sculptor/tests/integration/frontend/test_plugin_loader.py
+++ b/sculptor/tests/integration/frontend/test_plugin_loader.py
@@ -253,6 +253,35 @@ def test_plugin_source_error_modes(sculptor_instance_factory_: SculptorInstanceF
 
 
 @custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
+def test_failed_plugin_can_be_retried(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
+    """An errored row offers a retry control that re-attempts the load in place.
+
+    Mirrors the cold-start race a bundled plugin can hit: the manifest is
+    reachable but the entry bundle 404s on the first load (an import-phase
+    failure). The row must let the user retry rather than sit failed until a full
+    app reload; once the bundle is available, retrying loads the plugin.
+    """
+    with (
+        sculptor_instance_factory_.spawn_instance() as instance,
+        spawn_plugin_fixture_server() as server,
+    ):
+        settings_page = navigate_to_settings_page(page=instance.page)
+        plugins = settings_page.click_on_plugins()
+
+        # Manifest OK, but the entry bundle isn't served yet -> import-phase error.
+        source = server.add_plugin("retry-me", manifest=_valid_manifest("retry-me", name="Retry Me"), entry_js=None)
+        plugins.add_source(source)
+        plugins.expect_failed(source, phase="import")
+        # The error row exposes a retry control (it doesn't just sit failed).
+        expect(plugins.get_reload_in(plugins.get_source_row(source))).to_be_visible()
+
+        # The bundle becomes available; retrying re-fetches and loads the plugin.
+        server.add_route("/retry-me/main.js", body=_VALID_PLUGIN_JS, content_type="text/javascript")
+        plugins.retry(source)
+        plugins.expect_loaded(source, name="Retry Me", version="0.1.0")
+
+
+@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
 def test_valid_plugin_loads_and_can_be_removed(sculptor_instance_factory_: SculptorInstanceFactory) -> None:
     """A well-formed cross-origin source loads (name/version shown) and removes cleanly."""
     with (

--- a/sculptor/tests/integration/frontend/test_plugins_settings_visibility.py
+++ b/sculptor/tests/integration/frontend/test_plugins_settings_visibility.py
@@ -1,21 +1,16 @@
-"""Integration tests for the Plugins settings section and its master switch.
+"""Integration tests for the Plugins settings section and its global toggle.
 
 The Plugins settings section is always present in the sidebar — it hosts the
-master switch (the kill switch for the whole plugin system), so it must stay
-reachable even when the system is off, to flip it back on. Turning the switch on
-reveals the plugin-management UI (the add-source input and the list); turning it
-off hides that UI but leaves the section and switch in place, live, with no
-reload.
-
-The plugin system ships on by default, but the broad UI integration suite pins
-it off (see ``_make_test_user_config``) so panel-layout assertions don't depend
-on which plugins ship enabled. These tests therefore exercise the off baseline
-and the switch that flips it on.
+toggle that globally enables or disables the whole plugin system, so it must
+stay reachable even when the system is off, to turn it back on. The system is on
+by default: the section shows the plugin-management UI (the add-source input and
+the list). Turning the toggle off hides that UI but leaves the section and toggle
+in place, live, with no reload; turning it on reveals the management UI again.
 
 Two instances are used deliberately:
-  - the shared ``sculptor_instance_`` asserts the always-present section without
+  - the shared ``sculptor_instance_`` asserts the default-on state without
     mutating any config, so it leaves no state behind;
-  - a fresh factory instance owns the switch mutation and is torn down (process
+  - a fresh factory instance owns the toggle mutation and is torn down (process
     + temp folder) when its ``spawn_instance()`` context exits.
 """
 
@@ -26,8 +21,8 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 
 
-def test_plugins_section_always_present(sculptor_instance_: SculptorInstance) -> None:
-    """The Plugins section is in the sidebar and hosts the (off) master switch.
+def test_plugins_section_present_and_on_by_default(sculptor_instance_: SculptorInstance) -> None:
+    """The Plugins section is in the sidebar with the system on by default.
 
     Uses the shared instance and mutates nothing, so there is nothing to clean
     up — the assertion is purely read-only.
@@ -35,20 +30,19 @@ def test_plugins_section_always_present(sculptor_instance_: SculptorInstance) ->
     page = sculptor_instance_.page
     settings_page = navigate_to_settings_page(page=page)
 
-    # The section is always present — it stays reachable to flip the system on.
+    # The section is always present (it stays reachable to turn the system on).
     expect(settings_page.get_plugins_nav()).to_be_visible()
 
     plugins = settings_page.click_on_plugins()
-    # The suite pins the system off, so the switch is off and the management UI
-    # (add-source input) is hidden, leaving just the switch.
-    expect(plugins.get_frontend_plugins_toggle()).to_have_attribute("data-state", "unchecked")
-    expect(plugins.get_source_input()).to_have_count(0)
+    # On by default: the toggle is on and the management UI (add-source input) shows.
+    expect(plugins.get_frontend_plugins_toggle()).to_have_attribute("data-state", "checked")
+    expect(plugins.get_source_input()).to_be_visible()
 
 
-def test_master_switch_reveals_management_ui_live(
+def test_global_toggle_hides_management_ui_live(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
-    """Toggling the master switch shows/hides the management UI without a reload.
+    """Toggling the global switch hides/shows the management UI without a reload.
 
     A fresh factory instance keeps this mutation isolated; it is fully torn down
     when the ``spawn_instance()`` context exits.
@@ -58,12 +52,12 @@ def test_master_switch_reveals_management_ui_live(
         settings_page = navigate_to_settings_page(page=page)
         plugins = settings_page.click_on_plugins()
 
-        # Turning the switch on reveals the add-source input and the list.
-        plugins.set_frontend_plugins(enabled=True)
-        expect(plugins.get_source_input()).to_be_visible()
-
-        # Turning it back off hides the management UI, but the section and switch
-        # stay put so the system can be turned on again.
+        # Turning the toggle off hides the add-source input and the list, but the
+        # section and toggle stay put so the system can be turned back on.
         plugins.set_frontend_plugins(enabled=False)
         expect(settings_page.get_plugins_nav()).to_be_visible()
         expect(plugins.get_source_input()).to_have_count(0)
+
+        # Turning it back on reveals the management UI again.
+        plugins.set_frontend_plugins(enabled=True)
+        expect(plugins.get_source_input()).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_plugins_settings_visibility.py
+++ b/sculptor/tests/integration/frontend/test_plugins_settings_visibility.py
@@ -1,33 +1,33 @@
-"""Integration tests for the experimental frontend-plugins gating.
+"""Integration tests for the Plugins settings section and its master switch.
 
-The plugin system ships behind the experimental `enable_frontend_plugins`
-UserConfig flag. With the flag off (the default) the Plugins settings section
-must be absent from the sidebar; with it on, the section appears, and toggling
-the switch flips that visibility live (no reload needed for the section itself).
+The Plugins settings section is always present in the sidebar — it hosts the
+master switch (the kill switch for the whole plugin system), so it must stay
+reachable even when the system is off, to flip it back on. Turning the switch on
+reveals the plugin-management UI (the add-source input and the list); turning it
+off hides that UI but leaves the section and switch in place, live, with no
+reload.
+
+The plugin system ships on by default, but the broad UI integration suite pins
+it off (see ``_make_test_user_config``) so panel-layout assertions don't depend
+on which plugins ship enabled. These tests therefore exercise the off baseline
+and the switch that flips it on.
 
 Two instances are used deliberately:
-  - the shared `sculptor_instance_` asserts the default-off behavior without
+  - the shared ``sculptor_instance_`` asserts the always-present section without
     mutating any config, so it leaves no state behind;
-  - a fresh factory instance, seeded with the flag on via a folder populator,
-    owns all the mutation and is torn down (process + temp folder) when its
-    `spawn_instance()` context exits.
+  - a fresh factory instance owns the switch mutation and is torn down (process
+    + temp folder) when its ``spawn_instance()`` context exits.
 """
-
-from pathlib import Path
 
 from playwright.sync_api import expect
 
-from sculptor.services.user_config.user_config import load_config
-from sculptor.services.user_config.user_config import save_config
 from sculptor.testing.playwright_utils import navigate_to_settings_page
-from sculptor.testing.resources import _default_sculptor_folder_populator
-from sculptor.testing.resources import custom_sculptor_folder_populator
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 
 
-def test_plugins_section_hidden_by_default(sculptor_instance_: SculptorInstance) -> None:
-    """With the default config (flag off), the Plugins nav item is absent.
+def test_plugins_section_always_present(sculptor_instance_: SculptorInstance) -> None:
+    """The Plugins section is in the sidebar and hosts the (off) master switch.
 
     Uses the shared instance and mutates nothing, so there is nothing to clean
     up — the assertion is purely read-only.
@@ -35,44 +35,35 @@ def test_plugins_section_hidden_by_default(sculptor_instance_: SculptorInstance)
     page = sculptor_instance_.page
     settings_page = navigate_to_settings_page(page=page)
 
-    # The section is gated off by default, so the nav item should not render.
-    expect(settings_page.get_plugins_nav()).to_have_count(0)
+    # The section is always present — it stays reachable to flip the system on.
+    expect(settings_page.get_plugins_nav()).to_be_visible()
 
-    # Sanity: the Experimental section is reachable and the flag toggle exists
-    # but is off — confirming the gating wiring (not just a missing test id).
-    experimental = settings_page.click_on_experimental()
-    expect(experimental.get_frontend_plugins_toggle()).to_have_attribute("data-state", "unchecked")
-
-
-def _enable_frontend_plugins_populator(folder_path: Path) -> None:
-    """Seed the per-test sculptor folder with `enable_frontend_plugins=True`."""
-    _default_sculptor_folder_populator(folder_path)
-    config_path = folder_path / "internal" / "config.toml"
-    config = load_config(config_path).model_copy(update={"enable_frontend_plugins": True})
-    save_config(config, config_path)
+    plugins = settings_page.click_on_plugins()
+    # The suite pins the system off, so the switch is off and the management UI
+    # (add-source input) is hidden, leaving just the switch.
+    expect(plugins.get_frontend_plugins_toggle()).to_have_attribute("data-state", "unchecked")
+    expect(plugins.get_source_input()).to_have_count(0)
 
 
-@custom_sculptor_folder_populator.with_args(_enable_frontend_plugins_populator)
-def test_plugins_section_visible_and_toggles_with_switch(
+def test_master_switch_reveals_management_ui_live(
     sculptor_instance_factory_: SculptorInstanceFactory,
 ) -> None:
-    """Seeded on, the Plugins section shows; the switch hides/shows it live.
+    """Toggling the master switch shows/hides the management UI without a reload.
 
-    A fresh factory instance keeps this mutation isolated; it is fully torn
-    down when the `spawn_instance()` context exits.
+    A fresh factory instance keeps this mutation isolated; it is fully torn down
+    when the ``spawn_instance()`` context exits.
     """
     with sculptor_instance_factory_.spawn_instance() as instance:
         page = instance.page
         settings_page = navigate_to_settings_page(page=page)
+        plugins = settings_page.click_on_plugins()
 
-        # Seeded with the flag on -> the section is present.
+        # Turning the switch on reveals the add-source input and the list.
+        plugins.set_frontend_plugins(enabled=True)
+        expect(plugins.get_source_input()).to_be_visible()
+
+        # Turning it back off hides the management UI, but the section and switch
+        # stay put so the system can be turned on again.
+        plugins.set_frontend_plugins(enabled=False)
         expect(settings_page.get_plugins_nav()).to_be_visible()
-
-        # Turning the switch off removes the section without a reload.
-        experimental = settings_page.click_on_experimental()
-        experimental.set_frontend_plugins(enabled=False)
-        expect(settings_page.get_plugins_nav()).to_have_count(0)
-
-        # Turning it back on brings the section back.
-        experimental.set_frontend_plugins(enabled=True)
-        expect(settings_page.get_plugins_nav()).to_be_visible()
+        expect(plugins.get_source_input()).to_have_count(0)


### PR DESCRIPTION
## What

Enable the frontend plugin system by default, with only the bundled Linear plugin enabled out of the box.

- Flip the `enable_frontend_plugins` user-config default `false` → `true`, so the plugin system loads on a fresh install.
- Only the bundled **Linear** plugin is enabled by default; the `sculpty` and `pomodoro` example plugins ship `disabledByDefault` and can be turned on per plugin.
- Move the **global enable/disable toggle** for the plugin system out of **Experimental** into the **Plugins** settings section. The Plugins section is now always visible (it hosts the toggle, so it must stay reachable to turn the system back on); turning the toggle off hides the plugin-management UI while the section and toggle stay in place.
- The bundled Linear **panel** ships **opt-in** (`defaultEnabled: false`) — registered but enabled from Settings → Panels (like the built-in Browser panel), while its always-on **banner widget** is the default surface. An on-by-default plugin shouldn't claim a slot in everyone's panel layout uninvited.
- A failed plugin load now exposes a **Retry** control on its row (a one-shot manual reload, not a retry loop), so a plugin that fails to load (e.g. on a cold dev-server start) can be recovered in place without an app reload.
- Fix a latent layout race the plugins-on default exposed: a plugin registering its panel during the layout bootstrap could leave every docked zone hidden (collapsing the file browser / terminal / etc. to just the center panel). The bootstrap now seeds each layout piece independently. Includes a regression unit test.

## Why

The plugin system is ready to ship on by default, with Linear as the flagship bundled plugin. A global on/off toggle co-located with the rest of the plugin controls keeps a clean kill switch without an Experimental opt-in, and shipping the Linear panel opt-in keeps the default layout uncluttered.

## Testing

The integration suite now runs plugins-on, matching production. Because the Linear panel is opt-in it no longer perturbs panel-layout tests; the tests that drive the panel enable it explicitly. Verified locally: the plugin loader/retry, bundled-Linear, panel-zones, panel-open-state, plugin-runtime, and Plugins-visibility integration tests pass; `format` / `check` / unit-tests green. (One unrelated offload-runner flake — `test_file_browser`, "Repo Path Not Found" — passes locally and is being investigated separately.)

## Docs

`docs/specs` updated: a new `SPEC.md` §7.13 describes the plugin system as generally available, with the global toggle in the Plugins section and the Linear panel as opt-in; `REQ-FUNC-016` / `REQ-SEC-004` record the default-on flag; scenarios `SET-040` (global toggle) and `SET-041` (retry a failed plugin load) were added.

Linear: SCU-1609

(Sent by Claude)