### PR TITLE
Cherry-pick #205 into 0.38.0: fix Python 3.14 pydantic RSS leak (SCU-1628)

### DIFF
--- a/sculptor/sculptor/foundation/pydantic_serialization.py
+++ b/sculptor/sculptor/foundation/pydantic_serialization.py
@@ -4,7 +4,6 @@ from typing import Any
 from typing import TypeVar
 from typing import cast
 
-import pydantic._internal._fields as _pydantic_internal_fields
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Discriminator
@@ -15,6 +14,14 @@ from sculptor.foundation.nested_evolver import _Evolver
 from sculptor.foundation.nested_evolver import chill
 from sculptor.foundation.nested_evolver import evolver
 from sculptor.foundation.serialization_types import Serializable
+
+# Imported defensively: pydantic may relocate its internals on a major version bump. If so, the
+# memoization below is left uninstalled (the regression test fails loudly) rather than the app
+# crashing at import time.
+try:
+    import pydantic._internal._fields as _pydantic_internal_fields
+except ImportError:
+    _pydantic_internal_fields = None  # type: ignore[assignment]
 
 T = TypeVar("T", bound=BaseModel)
 V = TypeVar("V")
@@ -28,24 +35,44 @@ _threading_local = threading.local()
 # ``inspect.signature(factory)`` -- and re-runs it on *every* model instantiation, for each
 # ``PrivateAttr(default_factory=...)``. Under Python 3.14, ``inspect.signature`` on a C/builtin
 # callable (``dict``/``list``/``set``/``threading.Lock``/...) goes through
-# ``inspect._signature_fromstr``, which copies ``sys.modules`` and retains the copy. Models are
-# instantiated thousands of times a second (ShutdownEvent, ConcurrencyGroup, per-stream task views),
-# so this leaks gigabytes of RSS over a session. A given factory's signature never changes, so cache
-# the result per factory object; the factories are module-level singletons, so the cache stays tiny
-# (``functools.cache`` also exposes ``cache_info``/``cache_clear``, which the regression test uses).
+# ``inspect._signature_fromstr``, which copies ``sys.modules`` and builds closures that capture it --
+# reference cycles only the cyclic GC can reclaim. Generated thousands of times a second
+# (ShutdownEvent, ConcurrencyGroup, per-stream task views), that cyclic garbage accumulates into
+# gigabytes of RSS over a session. A given factory's signature never changes, so cache the check per
+# factory object; the factories are module-level singletons, so the cache stays tiny. This assumes
+# pydantic's helper is a pure function of the factory -- re-verify on a pydantic upgrade.
 #
-# Workaround for an upstream pydantic inefficiency. If a future pydantic renames/relocates the helper
-# the cache is simply not installed (``pydantic_serialization_test`` fails loudly in that case)
-# rather than crashing the app on a dependency bump. Factories must be hashable, which every current
-# ``default_factory`` is; an unhashable one (e.g. a ``functools.partial``) would raise here and need
-# wrapping in a ``lambda`` at its definition site.
-_uncached_takes_validated_data_argument = getattr(_pydantic_internal_fields, "takes_validated_data_argument", None)
+# Installed defensively: if pydantic has relocated its internals (the import above) or renamed the
+# helper, the cache is left uninstalled and ``pydantic_serialization_test`` fails loudly, rather than
+# the app crashing on a dependency bump. An unhashable factory (e.g. a ``functools.partial``) can't
+# be a cache key, so it falls back to the uncached check.
+_uncached_takes_validated_data_argument = (
+    getattr(_pydantic_internal_fields, "takes_validated_data_argument", None)
+    if _pydantic_internal_fields is not None
+    else None
+)
+_cached_takes_validated_data_argument = (
+    functools.cache(_uncached_takes_validated_data_argument)
+    if _uncached_takes_validated_data_argument is not None
+    else None
+)
+
+
+def _memoized_takes_validated_data_argument(default_factory: Any) -> Any:
+    try:
+        return _cached_takes_validated_data_argument(default_factory)  # type: ignore[misc]
+    except TypeError:
+        # Unhashable factory (e.g. a functools.partial): skip the cache, run the original check.
+        return _uncached_takes_validated_data_argument(default_factory)  # type: ignore[misc]
+
+
 if _uncached_takes_validated_data_argument is not None and not getattr(
     _uncached_takes_validated_data_argument, "__sculptor_memoized__", False
 ):
-    _memoized_takes_validated_data_argument = functools.cache(_uncached_takes_validated_data_argument)
     _memoized_takes_validated_data_argument.__sculptor_memoized__ = True  # type: ignore[attr-defined]
-    _pydantic_internal_fields.takes_validated_data_argument = _memoized_takes_validated_data_argument
+    _memoized_takes_validated_data_argument.cache_info = _cached_takes_validated_data_argument.cache_info  # type: ignore[attr-defined]
+    _memoized_takes_validated_data_argument.cache_clear = _cached_takes_validated_data_argument.cache_clear  # type: ignore[attr-defined]
+    _pydantic_internal_fields.takes_validated_data_argument = _memoized_takes_validated_data_argument  # type: ignore[missing-attribute]
 
 
 class EvolvableModel:

--- a/sculptor/sculptor/foundation/pydantic_serialization.py
+++ b/sculptor/sculptor/foundation/pydantic_serialization.py
@@ -1,8 +1,10 @@
+import functools
 import threading
 from typing import Any
 from typing import TypeVar
 from typing import cast
 
+import pydantic._internal._fields as _pydantic_internal_fields
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Discriminator
@@ -18,6 +20,32 @@ T = TypeVar("T", bound=BaseModel)
 V = TypeVar("V")
 
 _threading_local = threading.local()
+
+
+# Memoize pydantic's per-instantiation ``default_factory`` signature check.
+#
+# To decide whether a ``default_factory`` accepts the validated data, pydantic calls
+# ``inspect.signature(factory)`` -- and re-runs it on *every* model instantiation, for each
+# ``PrivateAttr(default_factory=...)``. Under Python 3.14, ``inspect.signature`` on a C/builtin
+# callable (``dict``/``list``/``set``/``threading.Lock``/...) goes through
+# ``inspect._signature_fromstr``, which copies ``sys.modules`` and retains the copy. Models are
+# instantiated thousands of times a second (ShutdownEvent, ConcurrencyGroup, per-stream task views),
+# so this leaks gigabytes of RSS over a session. A given factory's signature never changes, so cache
+# the result per factory object; the factories are module-level singletons, so the cache stays tiny
+# (``functools.cache`` also exposes ``cache_info``/``cache_clear``, which the regression test uses).
+#
+# Workaround for an upstream pydantic inefficiency. If a future pydantic renames/relocates the helper
+# the cache is simply not installed (``pydantic_serialization_test`` fails loudly in that case)
+# rather than crashing the app on a dependency bump. Factories must be hashable, which every current
+# ``default_factory`` is; an unhashable one (e.g. a ``functools.partial``) would raise here and need
+# wrapping in a ``lambda`` at its definition site.
+_uncached_takes_validated_data_argument = getattr(_pydantic_internal_fields, "takes_validated_data_argument", None)
+if _uncached_takes_validated_data_argument is not None and not getattr(
+    _uncached_takes_validated_data_argument, "__sculptor_memoized__", False
+):
+    _memoized_takes_validated_data_argument = functools.cache(_uncached_takes_validated_data_argument)
+    _memoized_takes_validated_data_argument.__sculptor_memoized__ = True  # type: ignore[attr-defined]
+    _pydantic_internal_fields.takes_validated_data_argument = _memoized_takes_validated_data_argument
 
 
 class EvolvableModel:

--- a/sculptor/sculptor/foundation/pydantic_serialization_test.py
+++ b/sculptor/sculptor/foundation/pydantic_serialization_test.py
@@ -1,3 +1,4 @@
+import functools
 from threading import Lock
 from typing import Collection
 
@@ -34,6 +35,17 @@ def test_default_factory_signature_check_is_memoized() -> None:
     _Model()
     info = getattr(check, "cache_info")()
     assert info.misses <= 2 and info.hits >= 1, f"default-factory signature check is not being cached: {info}"
+
+
+def test_unhashable_default_factory_does_not_crash() -> None:
+    # The memoization cache keys on the factory object, so an unhashable factory (e.g. a
+    # functools.partial) must fall back to the uncached check rather than raising TypeError on
+    # instantiation -- which stock pydantic (calling inspect.signature directly) does not do.
+    class _Model(BaseModel):
+        _data: dict = PrivateAttr(default_factory=functools.partial(dict))
+
+    _Model()
+    _Model()  # must not raise
 
 
 class TestObject(SerializableModel):

--- a/sculptor/sculptor/foundation/pydantic_serialization_test.py
+++ b/sculptor/sculptor/foundation/pydantic_serialization_test.py
@@ -1,9 +1,39 @@
+from threading import Lock
 from typing import Collection
 
+import pydantic._internal._fields as pydantic_internal_fields
 from inline_snapshot import snapshot
+from pydantic import BaseModel
+from pydantic import PrivateAttr
 
+import sculptor.foundation.pydantic_serialization  # noqa: F401 -- importing installs the cache
 from sculptor.foundation.pydantic_serialization import SerializableModel
 from sculptor.foundation.pydantic_serialization import model_dump
+
+
+def test_default_factory_signature_check_is_memoized() -> None:
+    # Guards the workaround for the Python-3.14 / pydantic default-factory leak: pydantic calls
+    # inspect.signature(default_factory) on EVERY instantiation, and on a C/builtin factory that
+    # copies and retains sys.modules -> gigabytes of RSS. pydantic_serialization installs a cache.
+    # If pydantic renames the helper (so the cache silently isn't installed), this fails loudly.
+    check = pydantic_internal_fields.takes_validated_data_argument
+    assert getattr(check, "__sculptor_memoized__", False), (
+        "pydantic's takes_validated_data_argument is not memoized -- the Python 3.14 default-factory"
+        + " leak workaround in pydantic_serialization is missing or no longer applies to this pydantic version"
+    )
+
+    # ...and the cache is effective: the expensive signature check runs once per factory, not per call.
+    # (cache_info/cache_clear are added by functools.cache at runtime, so reach them via getattr.)
+    getattr(check, "cache_clear")()
+
+    class _Model(BaseModel):
+        _lock: Lock = PrivateAttr(default_factory=Lock)
+
+    _Model()
+    _Model()
+    _Model()
+    info = getattr(check, "cache_info")()
+    assert info.misses <= 2 and info.hits >= 1, f"default-factory signature check is not being cached: {info}"
 
 
 class TestObject(SerializableModel):


### PR DESCRIPTION
Cherry-picks #205 (SCU-1628) into the 0.38.0 release branch to fix the multi-GB RSS growth behind "Sculptor slows down the longer it runs."

## What
Memoizes pydantic's per-instantiation `default_factory` signature check. Under Python 3.14, `inspect.signature` on a builtin callable copies and retains `sys.modules` on every model instantiation; high-frequency models retain millions of dicts → multi-GB RSS, which makes every `fork()` (git/subprocess) progressively more expensive.

## Included (full commit set from #205's merge)
- `e45e56c83a3` Fix Python 3.14 pydantic default-factory leak: memoize the signature check (SCU-1628)
- `4b13c7da196` Address review on SCU-1628: make the pydantic memoization defensive

## Cherry-pick notes
- Clean apply, no conflicts. Touches only `foundation/pydantic_serialization.py` + its test (+97 lines).
- No dependency chain: neither file had any intervening change on main since the 0.38 branch point, so this is self-contained (unlike SCU-1613/#185, which depends on the target-branch + MR-removal + polling stack).
- Pairs with the on-demand tracing already on the RC (rc2) for verifying the RSS flatline.

After this merges, `just fixup` on the release branch will tag rc3 and kick off the build.

(Sent by Claude)