### PR TITLE
Add `sculpt debug heap`: an opt-in backend memory-profiling endpoint (SCU-1625)

### DIFF
--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -4589,6 +4589,13 @@ def get_debug_heap(
     not atomic ``str``/``bytes``; their payload bytes show up in RSS and via
     tracemalloc, not the shallow-size column. Requires the session token.
     Development only."""
+    # Clamp to non-negative: a negative `top` would slice almost the whole list
+    # (Python's [:n] semantics) and dump a runaway report, and a negative `limit`
+    # would quietly disable the census cap.
+    top = max(0, top)
+    limit = max(0, limit)
+    start_trace = max(0, start_trace)
+
     process = psutil.Process()
     started_at = time.monotonic()
 
@@ -4625,7 +4632,9 @@ def get_debug_heap(
         counts[name] = counts.get(name, 0) + 1
         try:
             sizes[name] = sizes.get(name, 0) + getsizeof(obj)
-        except Exception:
+        except TypeError:
+            # getsizeof raises TypeError when an object's __sizeof__ returns a
+            # non-int; skip that one object rather than aborting the census.
             pass
     # Drop our strong reference to the full object list before formatting.
     del objects

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import contextlib
 import datetime
+import gc
 import json
 import logging
 import mimetypes
@@ -14,6 +15,7 @@ import sys
 import threading
 import time
 import traceback
+import tracemalloc
 import urllib.parse
 from asyncio import CancelledError
 from importlib import resources
@@ -4553,6 +4555,132 @@ def get_debug_threads() -> PlainTextResponse:
         # join them with "" — using "\n".join here would double every newline.
         chunks.extend(traceback.format_stack(frame))
         chunks.append("\n")
+    return PlainTextResponse("".join(chunks))
+
+
+@router.get("/api/v1/debug/heap", response_class=PlainTextResponse, include_in_schema=False)
+def get_debug_heap(
+    collect: bool = False,
+    limit: int = 5_000_000,
+    top: int = 30,
+    start_trace: int = 0,
+    stop_trace: bool = False,
+) -> PlainTextResponse:
+    """Heap census for diagnosing backend RSS growth, as plain text.
+
+    Inert until called — there is no always-on tracking. On demand it runs a
+    one-shot ``gc``-based object census (top types by count and aggregate shallow
+    size) plus GC stats, and with ``?collect=true`` forces a full
+    ``gc.collect()`` and reports RSS before vs after. That delta is the decisive
+    probe: a large drop means cyclic garbage was accumulating (a GC-cadence
+    issue, e.g. the incremental collector), while little change means the bytes
+    are live retention, not garbage.
+
+    Allocation-site attribution (the only way to see where ``str``/``bytes``
+    payloads come from) needs tracemalloc. Because the packaged backend is a
+    PyInstaller bundle that ignores ``PYTHONTRACEMALLOC``, start it at runtime
+    instead: ``?start_trace=N`` calls ``tracemalloc.start(N)`` (capturing
+    allocations from that point on); reproduce the growth, then a plain call
+    appends the top allocation sites; ``?stop_trace=true`` turns it back off.
+
+    The census walks ``gc.get_objects()`` in Python and briefly holds the GIL, so
+    ``limit`` caps how many objects are sized to bound that pause (``limit=0`` =
+    full but slower). Note ``gc`` tracks containers (lists/dicts/model instances),
+    not atomic ``str``/``bytes``; their payload bytes show up in RSS and via
+    tracemalloc, not the shallow-size column. Requires the session token.
+    Development only."""
+    process = psutil.Process()
+    started_at = time.monotonic()
+
+    chunks: list[str] = [
+        f"Heap report at {datetime.datetime.now().isoformat()}\n",
+        "=" * 72 + "\n",
+        f"RSS: {process.memory_info().rss / 1024 / 1024:.1f} MiB\n",
+        f"gc.enabled={gc.isenabled()}  gc.get_count()={gc.get_count()}  gc.get_threshold()={gc.get_threshold()}\n",
+    ]
+
+    if collect:
+        rss_before = process.memory_info().rss / 1024 / 1024
+        unreachable = gc.collect()
+        rss_after = process.memory_info().rss / 1024 / 1024
+        chunks.append(
+            f"\ngc.collect(): {unreachable} unreachable objects collected; "
+            + f"RSS {rss_before:.1f} -> {rss_after:.1f} MiB (delta {rss_after - rss_before:+.1f} MiB)\n"
+            + "  Big drop => cyclic garbage was accumulating (GC cadence). "
+            + "Little change => live retention, not collectable garbage.\n"
+        )
+
+    objects = gc.get_objects()
+    total_objects = len(objects)
+    counts: dict[str, int] = {}
+    sizes: dict[str, int] = {}
+    getsizeof = sys.getsizeof
+    scanned = 0
+    for obj in objects:
+        if limit > 0 and scanned >= limit:
+            break
+        scanned += 1
+        obj_type = type(obj)
+        name = f"{obj_type.__module__}.{obj_type.__qualname__}"
+        counts[name] = counts.get(name, 0) + 1
+        try:
+            sizes[name] = sizes.get(name, 0) + getsizeof(obj)
+        except Exception:
+            pass
+    # Drop our strong reference to the full object list before formatting.
+    del objects
+
+    truncated = 0 < limit < total_objects
+    chunks.append(
+        f"\nTracked objects: {total_objects:,} (sized {scanned:,}"
+        + ("; TRUNCATED — pass ?limit=0 for a full, slower census" if truncated else "")
+        + f"). Census took {time.monotonic() - started_at:.1f}s.\n"
+    )
+
+    chunks.append(f"\nTop {top} types by aggregate shallow size:\n")
+    for name, size in sorted(sizes.items(), key=lambda kv: kv[1], reverse=True)[:top]:
+        chunks.append(f"  {size / 1024 / 1024:10.1f} MiB  n={counts[name]:>12,}  {name}\n")
+
+    chunks.append(f"\nTop {top} types by object count:\n")
+    for name, count in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:top]:
+        chunks.append(f"  {count:>12,}  {sizes.get(name, 0) / 1024 / 1024:8.1f} MiB  {name}\n")
+
+    if stop_trace and tracemalloc.is_tracing():
+        tracemalloc.stop()
+        chunks.append("\ntracemalloc: stopped.\n")
+    elif start_trace > 0 and not tracemalloc.is_tracing():
+        tracemalloc.start(start_trace)
+        chunks.append(
+            f"\ntracemalloc: STARTED (nframe={start_trace}) — capturing allocations from now on.\n"
+            + "Reproduce the growth, then re-run `sculpt debug heap` to see the top allocation sites.\n"
+        )
+    elif tracemalloc.is_tracing():
+        snapshot = tracemalloc.take_snapshot()
+        traced, peak = tracemalloc.get_traced_memory()
+        chunks.append(
+            f"\ntracemalloc tracing (traced={traced / 1024 / 1024:.1f} MiB, peak={peak / 1024 / 1024:.1f} MiB)."
+            + f" Top {top} allocation sites (file:line):\n"
+        )
+        for stat in snapshot.statistics("lineno")[:top]:
+            chunks.append(f"  {stat.size / 1024 / 1024:10.1f} MiB  count={stat.count:>12,}  {stat.traceback}\n")
+        # Group by full traceback so the leaf line's CALLER chain is visible —
+        # the only way to attribute, e.g., a sys.modules.copy() inside
+        # inspect._signature_fromstr to the code that actually calls
+        # inspect.signature() and retains the result. Capped (and full stacks
+        # are multi-line) so the report stays readable; start_trace's nframe
+        # bounds the depth.
+        traceback_top = min(top, 8)
+        chunks.append(f"\ntracemalloc top {traceback_top} by full traceback (caller chains):\n")
+        for i, stat in enumerate(snapshot.statistics("traceback")[:traceback_top], 1):
+            chunks.append(f"\n#{i}  {stat.size / 1024 / 1024:.1f} MiB  count={stat.count:,}\n")
+            for line in stat.traceback.format():
+                chunks.append(f"    {line}\n")
+    else:
+        chunks.append(
+            "\ntracemalloc: not tracing — pass ?start_trace=N (sculpt debug heap --start-trace) "
+            + "to capture allocation sites at runtime.\n"
+        )
+
     return PlainTextResponse("".join(chunks))
 
 

--- a/sculptor/sculptor/web/debug_heap_endpoint_test.py
+++ b/sculptor/sculptor/web/debug_heap_endpoint_test.py
@@ -1,0 +1,73 @@
+"""Integration tests for the /api/v1/debug/heap census endpoint.
+
+Goes through the HTTP layer to cover route registration and the plain-text
+report shape. The endpoint is a development-only diagnostic for backend RSS
+growth (gc census + optional forced collect); these tests just assert it runs
+and reports the expected sections rather than pinning exact numbers.
+"""
+
+import tracemalloc
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _tracemalloc_off() -> Generator[None, None, None]:
+    # pytest enables tracemalloc (for ResourceWarning tracebacks), which would
+    # make the endpoint report "tracing" instead of "not tracing". Force it off
+    # around each test so the not-tracing / start / stop assertions are
+    # deterministic regardless of run order.
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    yield
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+
+
+def test_debug_heap_returns_census(client: TestClient) -> None:
+    response = client.get("/api/v1/debug/heap")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    body = response.text
+    assert "Heap report at" in body
+    assert "Tracked objects:" in body
+    assert "Top 30 types by aggregate shallow size:" in body
+    assert "Top 30 types by object count:" in body
+    # tracemalloc is off by default in tests, so the opt-in note is shown.
+    assert "tracemalloc: not tracing" in body
+
+
+def test_debug_heap_collect_reports_rss_delta(client: TestClient) -> None:
+    response = client.get("/api/v1/debug/heap", params={"collect": "true"})
+    assert response.status_code == 200
+    assert "gc.collect():" in response.text
+
+
+def test_debug_heap_start_and_stop_tracemalloc(client: TestClient) -> None:
+    was_tracing = tracemalloc.is_tracing()
+    try:
+        started = client.get("/api/v1/debug/heap", params={"start_trace": 5})
+        assert started.status_code == 200
+        # Freshly started here, or already tracing from another test -> either way it's on now.
+        assert "tracemalloc: STARTED" in started.text or "tracemalloc tracing" in started.text
+
+        sites = client.get("/api/v1/debug/heap")
+        assert "tracemalloc tracing" in sites.text
+        assert "by full traceback (caller chains)" in sites.text
+
+        stopped = client.get("/api/v1/debug/heap", params={"stop_trace": "true"})
+        assert "tracemalloc: stopped" in stopped.text
+    finally:
+        if not was_tracing and tracemalloc.is_tracing():
+            tracemalloc.stop()
+
+
+def test_debug_heap_top_and_limit_are_honored(client: TestClient) -> None:
+    response = client.get("/api/v1/debug/heap", params={"top": 5, "limit": 1000})
+    assert response.status_code == 200
+    body = response.text
+    assert "Top 5 types by object count:" in body
+    # A small limit smaller than the live object count must mark the census truncated.
+    assert "TRUNCATED" in body

--- a/sculptor/sculptor/web/debug_heap_endpoint_test.py
+++ b/sculptor/sculptor/web/debug_heap_endpoint_test.py
@@ -71,3 +71,14 @@ def test_debug_heap_top_and_limit_are_honored(client: TestClient) -> None:
     assert "Top 5 types by object count:" in body
     # A small limit smaller than the live object count must mark the census truncated.
     assert "TRUNCATED" in body
+
+
+def test_debug_heap_clamps_negative_params(client: TestClient) -> None:
+    # A negative `top` must not slice almost the whole type list (Python's [:n]
+    # semantics) into a runaway report; it is clamped to 0.
+    response = client.get("/api/v1/debug/heap", params={"top": -1, "limit": -1})
+    assert response.status_code == 200
+    body = response.text
+    assert "Top 0 types by object count:" in body
+    # A clamped (0) limit means a full, untruncated census.
+    assert "TRUNCATED" not in body

--- a/tools/sculpt/sculpt/commands/debug.py
+++ b/tools/sculpt/sculpt/commands/debug.py
@@ -5,12 +5,15 @@ exist to debug and profile the Sculptor backend itself; they are not part of
 the product surface and may change or disappear without notice.
 
     sculpt debug threads              # print a Python traceback for every thread
+    sculpt debug heap                 # census the heap to diagnose RSS growth
     sculpt debug trace start|stop|status   # profile the backend (viztracer)
 
 ``threads`` is the lightweight alternative to a full trace when the backend
 looks wedged: it returns an instant snapshot of every thread's Python stack via
-``sys._current_frames()`` (greenlet-safe — no signals, no C-stack walk). All
-commands require the session token, which ``get_authenticated_client`` resolves.
+``sys._current_frames()`` (greenlet-safe — no signals, no C-stack walk).
+``heap`` censuses live objects (and, with ``--collect``, forces a GC to tell
+accumulating garbage apart from live retention). All commands require the
+session token, which ``get_authenticated_client`` resolves.
 """
 
 import httpx
@@ -44,5 +47,53 @@ def threads(output: str | None = _OUTPUT_OPTION) -> None:
         with open(output, "w") as f:
             f.write(response.text)
         typer.echo(f"Thread dump written to {output}")
+    else:
+        typer.echo(response.text)
+
+
+@debug_app.command("heap")
+def heap(
+    collect: bool = typer.Option(
+        False,
+        "--collect",
+        help="Force gc.collect() and report RSS before/after — distinguishes accumulating garbage from live retention.",
+    ),
+    start_trace: bool = typer.Option(
+        False,
+        "--start-trace",
+        help="Start tracemalloc in the backend (captures allocation sites from now on). Reproduce growth, then re-run plain.",
+    ),
+    stop_trace: bool = typer.Option(False, "--stop-trace", help="Stop tracemalloc in the backend."),
+    trace_frames: int = typer.Option(10, "--trace-frames", help="Frames per allocation captured when starting tracemalloc."),
+    top: int = typer.Option(30, "--top", help="How many types / allocation sites to show."),
+    limit: int = typer.Option(
+        5_000_000,
+        "--limit",
+        help="Cap objects sized (0 = full census; larger = longer GIL pause on the backend).",
+    ),
+    output: str | None = _OUTPUT_OPTION,
+) -> None:
+    """Census the backend heap to diagnose RSS growth (Sculptor development only).
+
+    The census briefly pauses the backend (it walks every tracked object), so it
+    can take several seconds on a multi-GB heap; the request timeout is raised
+    accordingly. For allocation-site attribution, run once with --start-trace,
+    reproduce the growth, then run plain to see the top sites."""
+    client = get_authenticated_client(get_default_base_url())
+    params: dict[str, object] = {"collect": str(collect).lower(), "top": top, "limit": limit}
+    if start_trace:
+        params["start_trace"] = trace_frames
+    if stop_trace:
+        params["stop_trace"] = "true"
+    try:
+        response = client.get_httpx_client().get("/api/v1/debug/heap", params=params, timeout=300.0)
+    except (httpx.ConnectError, httpx.ConnectTimeout):
+        handle_connection_error()
+    if response.status_code >= 400:
+        cli_error(f"Request failed with status {response.status_code}", detail=response.text)
+    if output is not None:
+        with open(output, "w") as f:
+            f.write(response.text)
+        typer.echo(f"Heap report written to {output}")
     else:
         typer.echo(response.text)

--- a/tools/sculpt/sculpt/commands/debug.py
+++ b/tools/sculpt/sculpt/commands/debug.py
@@ -79,6 +79,10 @@ def heap(
     can take several seconds on a multi-GB heap; the request timeout is raised
     accordingly. For allocation-site attribution, run once with --start-trace,
     reproduce the growth, then run plain to see the top sites."""
+    if start_trace and trace_frames < 1:
+        # tracemalloc.start() needs nframe >= 1; a smaller value would reach the
+        # backend as start_trace=0 and silently fail to start tracing.
+        cli_error("--trace-frames must be at least 1 when --start-trace is set.")
     client = get_authenticated_client(get_default_base_url())
     params: dict[str, object] = {"collect": str(collect).lower(), "top": top, "limit": limit}
     if start_trace:


### PR DESCRIPTION
## What

Adds a development-only heap-introspection endpoint and `sculpt` subcommand for diagnosing `sculptor_backend` RSS growth, alongside the existing `/api/v1/debug/threads` and `/api/v1/trace/*` tooling.

- **`GET /api/v1/debug/heap`** (auth-gated; `include_in_schema=False` so it does not churn generated frontend types):
  - One-shot **gc-based object census** — top types by live count and aggregate shallow size, plus `gc` stats. `limit` bounds how many objects are sized so the GIL pause stays small on a multi-GB heap.
  - **`?collect=true`** forces a full `gc.collect()` and reports RSS before vs. after, which distinguishes accumulating cyclic garbage from genuine live retention.
  - **`?start_trace=N` / `?stop_trace=true`** toggle `tracemalloc` at runtime. The packaged backend is a PyInstaller bundle that ignores `PYTHONTRACEMALLOC`, so launch-time enabling isn't an option — this lets you turn allocation tracking on, reproduce the growth, then read back the top allocation sites both **by line** and **by full caller traceback**.
- **`sculpt debug heap [--collect] [--start-trace [--trace-frames N]] [--stop-trace] [--top N] [--limit N] [-o FILE]`** — thin CLI over the endpoint with a raised request timeout for the census pause.

## Why

This is the tooling used to find and confirm the recent backend RSS-growth regression. It is being split out as a standalone, mergeable change so the memory profiler can land independently of the fix it helped find.

## Safety

Inert until invoked: the census runs only on request and `tracemalloc` stays off unless explicitly started, so there is no always-on cost. Auth-gated and hidden from the public API schema. Development-only diagnostic.

## Test

`sculptor/sculptor/web/debug_heap_endpoint_test.py` — census returns, `collect` reports an RSS delta, `top`/`limit` are honored, and runtime tracemalloc start/stop produces the "by full traceback" section. 4 passed locally; `just check` / pre-commit green.

(Sent by Claude)