### PR TITLE
Un-fork git diff generation and de-dupe redundant regenerations (SCU-1627)

### DIFF
--- a/sculptor/sculptor/services/git_repo_service/git_commands.py
+++ b/sculptor/sculptor/services/git_repo_service/git_commands.py
@@ -57,41 +57,41 @@ def run_git_command_local(
     new_env = os.environ.copy()
     new_env["GIT_SSH_COMMAND"] = str(get_internal_folder() / "ssh" / "ssh")
 
-    # Spawn git via posix_spawn (cost independent of backend RSS, SCU-1624) rather
-    # than fork()+exec(). That requires an absolute executable and cwd=None, so we
-    # resolve git's path and fold any working directory into `git -C <dir>` (which
-    # is equivalent for git's purposes). Only applies when the command really is
-    # git; anything else keeps the original Popen behavior.
+    # Always spawn git via posix_spawn (cost independent of backend RSS, SCU-1624)
+    # rather than fork()+exec(). posix_spawn needs an absolute executable and cannot
+    # set the child's cwd, so we resolve git's path and fold any working directory
+    # into `git -C <dir>` (equivalent for git's purposes). This is git-only by
+    # contract; non-git commands belong in the generic process helpers.
     argv = list(command)
-    spawn_via_git = bool(argv) and argv[0] == "git"
-    if spawn_via_git:
-        argv[0] = _git_executable()
-        if cwd is not None:
-            # `git -C <dir>` only fails once git runs, which our retry path would
-            # treat as a transient error and retry 3x with backoff. subprocess.Popen
-            # (the cwd path) instead fails immediately at spawn with a non-retriable
-            # ProcessSetupError -> GitCommandFailure. Preserve that contract: a
-            # missing/moved repo directory is an immediate, non-retriable failure
-            # (retrying a vanished repo just wastes ~tens of seconds of backoff).
-            if not Path(cwd).is_dir():
-                raise GitCommandFailure(
-                    f"Failed to start git command: {command}\nworking directory does not exist: {cwd}",
-                    command=command,
-                    returncode=None,
-                    stdout="",
-                    stderr="",
-                )
-            argv = [argv[0], "-C", str(cwd), *argv[1:]]
+    if not argv or argv[0] != "git":
+        raise ValueError(f"run_git_command_local expects a command beginning with 'git', got: {command!r}")
+    argv[0] = _git_executable()
+    if cwd is not None:
+        # `git -C <dir>` only fails once git runs, which our retry path would treat
+        # as a transient error and retry 3x with backoff. subprocess.Popen(cwd=...)
+        # instead failed immediately at spawn with a non-retriable
+        # ProcessSetupError -> GitCommandFailure. Preserve that contract: a
+        # missing/moved repo directory is an immediate, non-retriable failure
+        # (retrying a vanished repo just wastes ~tens of seconds of backoff).
+        if not Path(cwd).is_dir():
+            raise GitCommandFailure(
+                f"Failed to start git command: {command}\nworking directory does not exist: {cwd}",
+                command=command,
+                returncode=None,
+                stdout="",
+                stderr="",
+            )
+        argv = [argv[0], "-C", str(cwd), *argv[1:]]
 
     try:
         result = concurrency_group.run_process_to_completion(
             command=argv,
-            cwd=None if spawn_via_git else (Path(cwd) if cwd else None),
+            cwd=None,
             timeout=timeout,
             is_checked_after=True,
             env=new_env,
             log_command=log_command,
-            prefer_posix_spawn=spawn_via_git,
+            prefer_posix_spawn=True,
         )
         assert result.returncode is not None, "returncode should never be None for completed process"
         return result.returncode, result.stdout, result.stderr

--- a/sculptor/sculptor/services/git_repo_service/git_commands_test.py
+++ b/sculptor/sculptor/services/git_repo_service/git_commands_test.py
@@ -86,17 +86,18 @@ def test_git_command_without_cwd_still_uses_posix_spawn(
     assert captured["prefer_posix_spawn"] is True
 
 
-def test_non_git_command_keeps_popen_path(
+def test_non_git_command_is_rejected(
     monkeypatch: pytest.MonkeyPatch, test_root_concurrency_group: ConcurrencyGroup, tmp_path: Path
 ) -> None:
-    # Defensive: a command that is not git keeps the original cwd + Popen behavior.
+    # run_git_command_local is git-only by contract (it always routes through
+    # posix_spawn + `git -C`); a non-git command is caller misuse and must raise
+    # rather than silently spawn.
     captured = _captured_call(monkeypatch)
 
-    run_git_command_local(test_root_concurrency_group, ["not-git", "status"], cwd=tmp_path)
+    with pytest.raises(ValueError):
+        run_git_command_local(test_root_concurrency_group, ["not-git", "status"], cwd=tmp_path)
 
-    assert list(captured["command"]) == ["not-git", "status"]
-    assert captured["cwd"] == tmp_path
-    assert captured["prefer_posix_spawn"] is False
+    assert captured == {}, "must reject before spawning"
 
 
 def test_missing_cwd_fails_fast_and_non_retriable(

--- a/sculptor/sculptor/services/workspace_service/default_implementation.py
+++ b/sculptor/sculptor/services/workspace_service/default_implementation.py
@@ -1,6 +1,9 @@
 import base64
+import hashlib
 import json
+import os
 import re
+import stat
 import threading
 import uuid
 from collections.abc import Callable
@@ -23,6 +26,7 @@ from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.foundation.event_utils import ReadOnlyEvent
 from sculptor.foundation.progress_tracking.progress_tracking import RootProgressHandle
 from sculptor.foundation.progress_tracking.progress_tracking import start_finish_context
+from sculptor.foundation.subprocess_utils import ProcessError
 from sculptor.foundation.time_utils import get_current_time
 from sculptor.interfaces.agents.agent import EnvironmentTypes
 
@@ -89,15 +93,6 @@ _GIT_COMMAND_TIMEOUT = 30.0
 # the maximum a caller is allowed to request.
 _DEFAULT_DIFF_CONTEXT_LINES = 3
 _MAX_DIFF_CONTEXT_LINES = 50
-
-# Shell snippet that produces a unified diff for every untracked file.
-# Used by both the uncommitted diff and the target-branch diff so that new
-# (un-added) files appear in both views.
-_UNTRACKED_FILES_DIFF_CMD = (
-    "git ls-files --others --exclude-standard -z"
-    + " | xargs -0 -I {} find {} -maxdepth 0 -type f -print0"
-    + " | xargs -0 -I {} git --no-pager diff --no-index /dev/null {}"
-)
 
 
 class DefaultWorkspaceService(WorkspaceService):
@@ -882,44 +877,98 @@ class DefaultWorkspaceService(WorkspaceService):
             raise WorkspaceNotFoundError(workspace.object_id)
         return working_dir
 
-    def _run_diff_command(
-        self,
-        command: list[str],
-        cwd: Path,
-        diff_kind: str,
-    ) -> str:
-        """Run a git diff command and return its output.
+    def _run_git_diff(self, working_dir: Path, diff_args: list[str], diff_kind: str) -> str:
+        """Run ``git --no-pager diff <diff_args>`` in *working_dir*, returning stdout.
 
-        Args:
-            command: The git command to run.
-            cwd: Working directory for the command.
-            diff_kind: Human-readable label for the diff type (e.g. "committed", "uncommitted").
-
-        Returns:
-            The diff output, or empty string on failure.
+        Returns "" on a setup failure (e.g. the repo moved). ``git diff`` exits 0
+        normally and 1 under ``--exit-code``/``--no-index``; a higher code is a real
+        error, logged but still returning whatever was captured.
         """
         try:
             returncode, stdout, stderr = run_git_command_local(
                 self.concurrency_group,
-                command,
-                cwd=cwd,
+                ["git", "--no-pager", "diff", *diff_args],
+                cwd=working_dir,
                 check_output=False,
                 timeout=_GIT_COMMAND_TIMEOUT,
                 is_retry_safe=True,
             )
-            # returncode 0 = empty diff, 1 = non-empty diff, >1 = error
-            # 123 = xargs found items (which is fine for our use case)
-            if returncode > 1 and returncode != 123:
-                logger.warning(
-                    "Unexpected returncode for {} diff: returncode={}, stderr={}",
-                    diff_kind,
-                    returncode,
-                    stderr[:500],
-                )
-            return stdout.strip()
         except GitCommandFailure as e:
             logger.warning("Failed to generate {} diff: {}", diff_kind, e)
             return ""
+        if returncode > 1:
+            logger.warning(
+                "Unexpected returncode for {} diff: returncode={}, stderr={}",
+                diff_kind,
+                returncode,
+                stderr[:500],
+            )
+        return stdout
+
+    def _untracked_files_diff(self, working_dir: Path) -> str:
+        """Unified diff for every untracked regular file, each rendered as fully added.
+
+        Reproduces the former shell pipeline::
+
+            git ls-files --others --exclude-standard -z
+              | xargs -0 -I {} find {} -maxdepth 0 -type f -print0
+              | xargs -0 -I {} git --no-pager diff --no-index /dev/null {}
+
+        with bare-``git`` invocations and no shell, so every spawn goes through
+        ``os.posix_spawn`` (SCU-1627). Output is the per-file diffs concatenated in
+        ``git ls-files`` order — byte-for-byte what the pipeline produced.
+        """
+        try:
+            returncode, stdout, _stderr = run_git_command_local(
+                self.concurrency_group,
+                ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+                cwd=working_dir,
+                check_output=False,
+                timeout=_GIT_COMMAND_TIMEOUT,
+                is_retry_safe=True,
+            )
+        except GitCommandFailure as e:
+            logger.debug("Failed to list untracked files for diff: {}", e)
+            return ""
+        if returncode != 0 or not stdout:
+            return ""
+        parts: list[str] = []
+        for rel_path in stdout.split("\x00"):
+            if not rel_path:
+                continue
+            # `find <path> -maxdepth 0 -type f` keeps only regular files, excluding
+            # directories and symlinks; match it with a non-following lstat.
+            try:
+                entry_stat = os.lstat(working_dir / rel_path)
+            except OSError:
+                continue
+            if not stat.S_ISREG(entry_stat.st_mode):
+                continue
+            # `git diff --no-index /dev/null <file>` renders the whole file as added.
+            # It exits 1 because the files differ, which is expected here, not an error.
+            try:
+                _returncode, file_diff, _err = run_git_command_local(
+                    self.concurrency_group,
+                    ["git", "--no-pager", "diff", "--no-index", "/dev/null", rel_path],
+                    cwd=working_dir,
+                    check_output=False,
+                    timeout=_GIT_COMMAND_TIMEOUT,
+                    is_retry_safe=True,
+                )
+            except GitCommandFailure as e:
+                logger.debug("Failed to diff untracked file {}: {}", rel_path, e)
+                continue
+            parts.append(file_diff)
+        return "".join(parts)
+
+    def _compute_diff_with_untracked(self, working_dir: Path, base: str, context_flag: str, diff_kind: str) -> str:
+        """``git diff -M <context> <base>`` against the working tree, plus untracked files.
+
+        Concatenates the tracked diff with each untracked file's add-diff and strips
+        the result, matching the former ``bash -c "git diff …; <untracked>"`` output.
+        """
+        tracked_diff = self._run_git_diff(working_dir, ["-M", context_flag, base], diff_kind)
+        return (tracked_diff + self._untracked_files_diff(working_dir)).strip()
 
     def _create_diff_artifact_local(
         self,
@@ -940,15 +989,8 @@ class DefaultWorkspaceService(WorkspaceService):
             raise ValueError(f"context_lines must be a non-negative integer, got {context_lines!r}")
         context_flag = f"-U{context_lines}"
 
-        # Commands to generate each diff type.
         # -M enables rename detection so renames show as a single entry instead of delete+add.
-        untracked = _UNTRACKED_FILES_DIFF_CMD
-        uncommitted_diff_command = [
-            "bash",
-            "-c",
-            f"git --no-pager diff -M {context_flag} HEAD; {untracked}",
-        ]
-        uncommitted_diff = self._run_diff_command(uncommitted_diff_command, working_dir, "uncommitted")
+        uncommitted_diff = self._compute_diff_with_untracked(working_dir, "HEAD", context_flag, "uncommitted")
 
         # Compute target-branch diff if requested.  Resolve the merge-base once
         # and reuse it both to compute the diff and to expose it on the artifact,
@@ -1006,13 +1048,7 @@ class DefaultWorkspaceService(WorkspaceService):
         # Diff merge-base against the working tree (not HEAD) so uncommitted
         # changes are included.  Also append untracked files, matching the
         # approach used for the uncommitted diff.
-        untracked = _UNTRACKED_FILES_DIFF_CMD
-        diff_command = [
-            "bash",
-            "-c",
-            f"git --no-pager diff -M {context_flag} {merge_base}; {untracked}",
-        ]
-        return self._run_diff_command(diff_command, working_dir, "target-branch")
+        return self._compute_diff_with_untracked(working_dir, merge_base, context_flag, "target-branch")
 
     def _detect_file_errors(self, working_dir: Path) -> dict[str, str]:
         """Detect files that cannot be diffed (e.g., inside nested git repos)."""
@@ -1101,7 +1137,12 @@ class DefaultWorkspaceService(WorkspaceService):
             artifact_path = artifact_dir / ArtifactType.DIFF
             artifact_path.write_text(diff_artifact.model_dump_json(indent=2))
 
-            metadata = {"generated_at": generated_at.isoformat()}
+            # Record the fingerprint of the inputs this diff was generated from, so
+            # maybe_refresh_workspace_diff can skip regenerating while they're unchanged.
+            fingerprint = self._compute_diff_fingerprint(
+                working_dir, target_branch, effective_context_lines, include_target_branch_diff
+            )
+            metadata = {"generated_at": generated_at.isoformat(), "fingerprint": fingerprint}
             metadata_path = artifact_dir / _DIFF_METADATA_FILENAME
             metadata_path.write_text(json.dumps(metadata))
 
@@ -1132,14 +1173,120 @@ class DefaultWorkspaceService(WorkspaceService):
         finally:
             lock.release()
 
+    def _compute_diff_fingerprint(
+        self,
+        working_dir: Path,
+        target_branch: str | None,
+        context_lines: int,
+        include_target_branch_diff: bool,
+    ) -> str | None:
+        """A cheap, content-aware fingerprint of everything the diff depends on.
+
+        Covers HEAD, the merge-base (when a target-branch diff is included), the
+        requested context width and target flag, and the path + size + mtime of
+        every changed and untracked file. Using size+mtime (rather than just
+        ``git status``) is what catches re-editing an already-modified file, so a
+        matching fingerprint genuinely means an identical diff. Returns None when it
+        can't be computed (e.g. no commits yet, or the repo moved), signalling the
+        caller to regenerate rather than risk serving a stale diff.
+        """
+        try:
+            head_rc, head_stdout, _head_err = run_git_command_local(
+                self.concurrency_group,
+                ["git", "rev-parse", "HEAD"],
+                cwd=working_dir,
+                check_output=False,
+                is_retry_safe=False,
+                timeout=_GIT_COMMAND_TIMEOUT,
+            )
+            if head_rc != 0:
+                return None
+            merge_base = ""
+            if include_target_branch_diff and target_branch is not None:
+                merge_base = self._get_merge_base(working_dir, target_branch) or ""
+            changed_rc, changed_stdout, _changed_err = run_git_command_local(
+                self.concurrency_group,
+                ["git", "diff", "--name-only", "-M", "-z", "HEAD"],
+                cwd=working_dir,
+                check_output=False,
+                is_retry_safe=False,
+                timeout=_GIT_COMMAND_TIMEOUT,
+            )
+            untracked_rc, untracked_stdout, _untracked_err = run_git_command_local(
+                self.concurrency_group,
+                ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+                cwd=working_dir,
+                check_output=False,
+                is_retry_safe=False,
+                timeout=_GIT_COMMAND_TIMEOUT,
+            )
+        except (OSError, ProcessError, GitCommandFailure):
+            return None
+        if changed_rc != 0 or untracked_rc != 0:
+            return None
+
+        paths = sorted({p for p in (changed_stdout.split("\x00") + untracked_stdout.split("\x00")) if p})
+        hasher = hashlib.sha256()
+        hasher.update(
+            f"head={head_stdout.strip()}\x00mb={merge_base}\x00ctx={context_lines}\x00tgt={include_target_branch_diff}\x00".encode()
+        )
+        for rel_path in paths:
+            try:
+                entry_stat = os.lstat(working_dir / rel_path)
+                stat_token = f"{entry_stat.st_size}:{entry_stat.st_mtime_ns}"
+            except OSError:
+                stat_token = "absent"
+            hasher.update(f"{rel_path}\x00{stat_token}\x00".encode())
+        return hasher.hexdigest()
+
+    def _read_stored_diff_fingerprint(self, workspace_id: WorkspaceID) -> str | None:
+        """The fingerprint stored alongside the last generated diff artifact, if any."""
+        metadata_path = self._get_workspace_artifact_dir(workspace_id) / _DIFF_METADATA_FILENAME
+        try:
+            metadata = json.loads(metadata_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        fingerprint = metadata.get("fingerprint")
+        return fingerprint if isinstance(fingerprint, str) else None
+
+    def _diff_artifact_exists(self, workspace_id: WorkspaceID) -> bool:
+        return (self._get_workspace_artifact_dir(workspace_id) / ArtifactType.DIFF).exists()
+
     def maybe_refresh_workspace_diff(
         self,
         workspace_id: WorkspaceID,
     ) -> None:
-        """Regenerate workspace diff if needed. For now, always refreshes."""
-        # Future: could check if files actually changed before regenerating
-        # For now, always refresh.  Always include the target-branch diff so the
-        # frontend "All changes" view stays up-to-date without extra requests.
+        """Regenerate the workspace diff only when its inputs have changed.
+
+        Computes a cheap content-aware fingerprint (see ``_compute_diff_fingerprint``)
+        and skips the fork-heavy regeneration when it matches the fingerprint stored
+        with the last artifact. Falls back to regenerating whenever the fingerprint
+        can't be computed or no artifact exists, so a stale or missing diff is never
+        served. Always includes the target-branch diff so the frontend "All changes"
+        view stays current without extra requests.
+        """
+        try:
+            with self.data_model_service.open_transaction(request_id=RequestID()) as transaction:
+                workspace = transaction.get_workspace(workspace_id)
+                working_dir = (
+                    self.get_workspace_working_directory(workspace, transaction) if workspace is not None else None
+                )
+                target_branch = workspace.target_branch if workspace is not None else None
+            if working_dir is not None:
+                fingerprint = self._compute_diff_fingerprint(
+                    working_dir, target_branch, _DEFAULT_DIFF_CONTEXT_LINES, include_target_branch_diff=True
+                )
+                if (
+                    fingerprint is not None
+                    and fingerprint == self._read_stored_diff_fingerprint(workspace_id)
+                    and self._diff_artifact_exists(workspace_id)
+                ):
+                    logger.debug("Workspace {} diff inputs unchanged; skipping regeneration", workspace_id)
+                    return
+        except Exception:
+            # The fingerprint check is a best-effort optimization; never let it block
+            # a refresh. On any error, fall through and regenerate unconditionally.
+            logger.debug("Diff fingerprint check failed for {}; regenerating", workspace_id, exc_info=True)
         self.refresh_workspace_diff(workspace_id, include_target_branch_diff=True)
 
     def mark_workspace_diff_stale(

--- a/sculptor/sculptor/services/workspace_service/diff_generation_test.py
+++ b/sculptor/sculptor/services/workspace_service/diff_generation_test.py
@@ -1,0 +1,127 @@
+"""Tests for local diff generation (SCU-1627).
+
+Cover the de-shelled diff path — the bare-``git`` + Python untracked-file
+orchestration that replaced the former ``bash -c "git diff …; <pipeline>"`` — and
+the content-aware fingerprint that lets ``maybe_refresh_workspace_diff`` skip
+redundant regenerations without going stale.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+from sculptor.service_collections.service_collection import CompleteServiceCollection
+from sculptor.services.workspace_service.default_implementation import DefaultWorkspaceService
+
+# The exact shell pipeline this code path replaced. Kept here only as the
+# reference oracle for the byte-identical regression test below.
+_FORMER_UNTRACKED_PIPELINE = (
+    "git ls-files --others --exclude-standard -z"
+    + " | xargs -0 -I {} find {} -maxdepth 0 -type f -print0"
+    + " | xargs -0 -I {} git --no-pager diff --no-index /dev/null {}"
+)
+
+
+def _service(services: CompleteServiceCollection) -> DefaultWorkspaceService:
+    workspace_service = services.workspace_service
+    assert isinstance(workspace_service, DefaultWorkspaceService)
+    return workspace_service
+
+
+def _former_shell_diff(repo: Path, base: str, context_flag: str) -> str:
+    """Reproduce the former ``bash -c "git diff …; <untracked>"`` output, stripped."""
+    result = subprocess.run(
+        ["bash", "-c", f"git --no-pager diff -M {context_flag} {base}; {_FORMER_UNTRACKED_PIPELINE}"],
+        cwd=repo,
+        capture_output=True,
+    )
+    return result.stdout.decode("utf-8", errors="replace").strip()
+
+
+def test_uncommitted_diff_is_byte_identical_to_former_shell_pipeline(
+    initial_commit_repo: tuple[Path, str], test_service_collection: CompleteServiceCollection
+) -> None:
+    repo, _ = initial_commit_repo
+    # A mix that exercises tracked + untracked, plus a path with a space.
+    (repo / "file1.txt").write_text("Content 1 modified\nsecond line\n")  # tracked, unstaged
+    (repo / "brand new.txt").write_text("hello\nworld\n")  # untracked, space in name
+    (repo / "sub").mkdir()
+    (repo / "sub" / "nested.txt").write_text("nested\n")  # untracked, nested
+
+    new_output = _service(test_service_collection)._compute_diff_with_untracked(repo, "HEAD", "-U3", "uncommitted")
+
+    assert new_output == _former_shell_diff(repo, "HEAD", "-U3")
+    # Sanity: the untracked files really are present (not a vacuously-equal empty diff).
+    assert "brand new.txt" in new_output
+    assert "sub/nested.txt" in new_output
+
+
+def test_untracked_diff_excludes_symlinks_and_directories(
+    initial_commit_repo: tuple[Path, str], test_service_collection: CompleteServiceCollection
+) -> None:
+    repo, _ = initial_commit_repo
+    (repo / "real.txt").write_text("real\n")
+    os.symlink(repo / "real.txt", repo / "link.txt")  # symlink: `find -type f` excludes it
+
+    untracked_diff = _service(test_service_collection)._untracked_files_diff(repo)
+
+    assert "real.txt" in untracked_diff
+    # The symlink must not appear as an added file (matches the former `find -type f`).
+    assert "link.txt" not in untracked_diff
+
+
+def test_untracked_diff_empty_when_nothing_untracked(
+    initial_commit_repo: tuple[Path, str], test_service_collection: CompleteServiceCollection
+) -> None:
+    repo, _ = initial_commit_repo
+    assert _service(test_service_collection)._untracked_files_diff(repo) == ""
+
+
+def test_fingerprint_changes_when_modified_file_edited_again(
+    initial_commit_repo: tuple[Path, str], test_service_collection: CompleteServiceCollection
+) -> None:
+    # The key staleness guarantee: a second edit of an already-modified file keeps
+    # `git status` output identical (" M file1.txt"), so a status-only fingerprint
+    # would miss it. Ours includes size+mtime, so it must change.
+    repo, _ = initial_commit_repo
+    service = _service(test_service_collection)
+    tracked = repo / "file1.txt"
+
+    tracked.write_text("AAAA")
+    first = service._compute_diff_fingerprint(repo, None, 3, include_target_branch_diff=False)
+
+    tracked.write_text("BBBB")  # same length, still " M" in git status
+    os.utime(tracked, ns=(2_000_000_000, 2_000_000_000))  # deterministic, distinct mtime
+    second = service._compute_diff_fingerprint(repo, None, 3, include_target_branch_diff=False)
+
+    assert first is not None and second is not None
+    assert first != second
+
+
+def test_fingerprint_changes_on_head_move_and_context_lines(
+    initial_commit_repo: tuple[Path, str], test_service_collection: CompleteServiceCollection
+) -> None:
+    repo, _ = initial_commit_repo
+    service = _service(test_service_collection)
+
+    base = service._compute_diff_fingerprint(repo, None, 3, include_target_branch_diff=False)
+    wider_context = service._compute_diff_fingerprint(repo, None, 10, include_target_branch_diff=False)
+    assert base is not None and wider_context is not None
+    assert base != wider_context, "context width is part of the diff and must change the fingerprint"
+
+    subprocess.run(["git", "-C", str(repo), "commit", "--allow-empty", "-m", "advance HEAD"], check=True)
+    after_commit = service._compute_diff_fingerprint(repo, None, 3, include_target_branch_diff=False)
+    assert after_commit is not None and after_commit != base, "HEAD movement must change the fingerprint"
+
+
+def test_fingerprint_stable_when_nothing_changes(
+    initial_commit_repo: tuple[Path, str], test_service_collection: CompleteServiceCollection
+) -> None:
+    repo, _ = initial_commit_repo
+    service = _service(test_service_collection)
+    (repo / "untracked.txt").write_text("u\n")
+
+    first = service._compute_diff_fingerprint(repo, None, 3, include_target_branch_diff=False)
+    second = service._compute_diff_fingerprint(repo, None, 3, include_target_branch_diff=False)
+
+    assert first is not None and first == second

--- a/sculptor/sculptor/services/workspace_service/workspace_service_test.py
+++ b/sculptor/sculptor/services/workspace_service/workspace_service_test.py
@@ -429,11 +429,15 @@ def test_get_workspace_diff_with_force_refresh(
     assert diff is not None
 
 
-def test_maybe_refresh_workspace_diff_always_refreshes(
+def test_maybe_refresh_workspace_diff_generates_when_missing(
     test_service_collection: CompleteServiceCollection,
     test_project: Project,
 ) -> None:
-    """Test that maybe_refresh_workspace_diff refreshes the diff (always refreshes for now)."""
+    """maybe_refresh_workspace_diff generates a diff when none exists yet.
+
+    Its fingerprint guard only skips when a prior artifact is present and the inputs
+    are unchanged; a fresh workspace has no artifact, so it must regenerate here.
+    """
     with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
         workspace = test_service_collection.workspace_service.create_workspace(
             project=test_project,

--- a/sculptor/sculptor/tasks/handlers/run_terminal_agent/diff_refresh.py
+++ b/sculptor/sculptor/tasks/handlers/run_terminal_agent/diff_refresh.py
@@ -15,8 +15,10 @@ from typing import Callable
 
 from loguru import logger
 
-from sculptor.foundation.processes.local_process import run_blocking
+from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.foundation.subprocess_utils import ProcessError
+from sculptor.services.git_repo_service.git_commands import run_git_command_local
+from sculptor.services.git_repo_service.git_errors import GitCommandFailure
 
 _GIT_TIMEOUT_SECONDS = 5.0
 
@@ -34,10 +36,12 @@ class PeriodicDiffRefresher:
         self,
         working_directory: Path,
         on_change: Callable[[], None],
+        concurrency_group: ConcurrencyGroup,
         interval_seconds: float = 3.0,
     ) -> None:
         self._working_directory = working_directory
         self._on_change = on_change
+        self._concurrency_group = concurrency_group
         self._interval_seconds = interval_seconds
         self._last_check_at: float | None = None
         self._last_fingerprint: str | None = None
@@ -61,31 +65,40 @@ class PeriodicDiffRefresher:
     def _compute_fingerprint(self) -> str | None:
         """Hash of `git status --porcelain` + HEAD, or None on git failure.
 
-        A transient git failure (index lock, repo mid-rewrite) must not kill
-        the agent loop — swallow and retry on the next interval.
+        Runs git through ``run_git_command_local`` so each spawn goes via
+        ``os.posix_spawn`` (cost independent of backend RSS, SCU-1624/SCU-1627) with
+        the working directory folded into ``git -C``. ``check_output=False`` returns
+        the exit code instead of raising on non-zero (e.g. a repo with no commits),
+        and ``is_retry_safe=False`` keeps this 3s poll from retrying. A transient git
+        failure (index lock, repo mid-rewrite, moved working dir) must not kill the
+        agent loop — swallow and retry on the next interval.
         """
         try:
-            status = run_blocking(
-                command=["git", "status", "--porcelain"],
+            status_rc, status_stdout, _status_stderr = run_git_command_local(
+                self._concurrency_group,
+                ["git", "status", "--porcelain"],
                 cwd=self._working_directory,
+                check_output=False,
+                is_retry_safe=False,
                 timeout=_GIT_TIMEOUT_SECONDS,
-                is_checked=False,
             )
-            head = run_blocking(
-                command=["git", "rev-parse", "HEAD"],
+            head_rc, head_stdout, _head_stderr = run_git_command_local(
+                self._concurrency_group,
+                ["git", "rev-parse", "HEAD"],
                 cwd=self._working_directory,
+                check_output=False,
+                is_retry_safe=False,
                 timeout=_GIT_TIMEOUT_SECONDS,
-                is_checked=False,
             )
-        except (OSError, ProcessError) as e:
+        except (OSError, ProcessError, GitCommandFailure) as e:
             logger.debug("Diff-refresh fingerprint failed in {}: {}", self._working_directory, e)
             return None
-        if status.returncode != 0 or head.returncode != 0 or status.is_timed_out or head.is_timed_out:
+        if status_rc != 0 or head_rc != 0:
             logger.debug(
                 "Diff-refresh git commands failed in {} (status rc={}, rev-parse rc={})",
                 self._working_directory,
-                status.returncode,
-                head.returncode,
+                status_rc,
+                head_rc,
             )
             return None
-        return hashlib.sha256((status.stdout + "\x00" + head.stdout).encode()).hexdigest()
+        return hashlib.sha256((status_stdout + "\x00" + head_stdout).encode()).hexdigest()

--- a/sculptor/sculptor/tasks/handlers/run_terminal_agent/diff_refresh_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_terminal_agent/diff_refresh_test.py
@@ -2,31 +2,42 @@
 
 from pathlib import Path
 
+from sculptor.foundation.concurrency_group import ConcurrencyGroup
 from sculptor.tasks.handlers.run_terminal_agent.diff_refresh import PeriodicDiffRefresher
 
 
-def _make_refresher(repo: Path, fired: list[int], interval_seconds: float = 0.0) -> PeriodicDiffRefresher:
+def _make_refresher(
+    repo: Path,
+    fired: list[int],
+    concurrency_group: ConcurrencyGroup,
+    interval_seconds: float = 0.0,
+) -> PeriodicDiffRefresher:
     return PeriodicDiffRefresher(
         working_directory=repo,
         on_change=lambda: fired.append(1),
+        concurrency_group=concurrency_group,
         interval_seconds=interval_seconds,
     )
 
 
-def test_first_tick_establishes_baseline_without_firing(initial_commit_repo: tuple[Path, str]) -> None:
+def test_first_tick_establishes_baseline_without_firing(
+    initial_commit_repo: tuple[Path, str], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
     repo, _ = initial_commit_repo
     fired: list[int] = []
-    refresher = _make_refresher(repo, fired)
+    refresher = _make_refresher(repo, fired, test_root_concurrency_group)
 
     refresher.tick()
 
     assert fired == []
 
 
-def test_tick_fires_once_per_change(initial_commit_repo: tuple[Path, str]) -> None:
+def test_tick_fires_once_per_change(
+    initial_commit_repo: tuple[Path, str], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
     repo, _ = initial_commit_repo
     fired: list[int] = []
-    refresher = _make_refresher(repo, fired)
+    refresher = _make_refresher(repo, fired, test_root_concurrency_group)
     refresher.tick()  # baseline
 
     (repo / "new_file.txt").write_text("hello")
@@ -38,10 +49,12 @@ def test_tick_fires_once_per_change(initial_commit_repo: tuple[Path, str]) -> No
     assert len(fired) == 1
 
 
-def test_tick_rate_limits_by_interval(initial_commit_repo: tuple[Path, str]) -> None:
+def test_tick_rate_limits_by_interval(
+    initial_commit_repo: tuple[Path, str], test_root_concurrency_group: ConcurrencyGroup
+) -> None:
     repo, _ = initial_commit_repo
     fired: list[int] = []
-    refresher = _make_refresher(repo, fired, interval_seconds=3600.0)
+    refresher = _make_refresher(repo, fired, test_root_concurrency_group, interval_seconds=3600.0)
     refresher.tick()  # baseline
 
     (repo / "new_file.txt").write_text("hello")
@@ -50,9 +63,9 @@ def test_tick_rate_limits_by_interval(initial_commit_repo: tuple[Path, str]) -> 
     assert fired == []
 
 
-def test_tick_swallows_git_failure(tmp_path: Path) -> None:
+def test_tick_swallows_git_failure(tmp_path: Path, test_root_concurrency_group: ConcurrencyGroup) -> None:
     fired: list[int] = []
-    refresher = _make_refresher(tmp_path / "does-not-exist", fired)
+    refresher = _make_refresher(tmp_path / "does-not-exist", fired, test_root_concurrency_group)
 
     refresher.tick()
     refresher.tick()

--- a/sculptor/sculptor/tasks/handlers/run_terminal_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_terminal_agent/v1.py
@@ -266,6 +266,7 @@ def _run_terminal_agent_in_environment(
         refresher = PeriodicDiffRefresher(
             working_directory=underlying_env.get_working_directory(),
             on_change=lambda: services.workspace_service.maybe_refresh_workspace_diff(task_state.workspace_id),
+            concurrency_group=environment_concurrency_group,
             interval_seconds=_DIFF_REFRESH_INTERVAL_SECONDS,
         )
         # Idle until shutdown. A dead shell does NOT exit the loop — the


### PR DESCRIPTION
> **Stacked on #204** (SCU-1624). Base is `maciek/scu-1624-posix-spawn-git`, so this PR shows only the SCU-1627 diff. Once #204 merges, I'll retarget this to `main`.

## What & why

After SCU-1624 moved bare-`git` commands onto `os.posix_spawn`, two diff-related gaps remained — both keeping `sculptor_backend` doing fork-based, RSS-scaling work on a hot path shared by terminal and non-terminal agents (diff generation lives once in `workspace_service` and is triggered by both).

### 1. Un-fork diff generation

The uncommitted and target-branch diffs still ran as `["bash", "-c", "git --no-pager diff -M …; <untracked pipeline>"]`, so they forked **bash**, and bash forked **git** (plus `find`/`xargs` per untracked file) — the worst case for spawn cost that scales with backend RSS. The shell was only needed for the untracked-files pipeline (`git ls-files -z | xargs find | xargs git diff --no-index`).

- De-shelled into bare-`git` invocations: `git --no-pager diff` as a plain argv, and the untracked step reimplemented in Python (`git ls-files --others --exclude-standard -z` → `lstat` regular-file filter, matching `find -type f` → `git --no-pager diff --no-index /dev/null <file>` per file, concatenated in `ls-files` order). Output is **byte-identical** to the former shell pipeline (regression-tested against it directly), so the frontend's unified-diff parsing is unaffected.
- With no non-git callers left, `run_git_command_local` is now git-only by contract: it rejects non-git argv and **always** routes through posix_spawn + `git -C`.
- The terminal agent's ~3s fingerprint poll (`git status --porcelain` + `git rev-parse HEAD`, previously via `run_blocking` → `fork`) now goes through the same posix_spawn path, with no retries (`is_retry_safe=False`).

### 2. De-dupe redundant regenerations

`maybe_refresh_workspace_diff` previously regenerated unconditionally on every trigger (its docstring even said so), running several git invocations and rewriting artifacts even when the result was identical.

- It now computes a cheap, **content-aware fingerprint** — HEAD, the merge-base (when a target-branch diff is included), the context width + target flag, and the path + size + mtime of every changed and untracked file — and skips regeneration when it matches the fingerprint stored alongside the last artifact.
- size+mtime (rather than just `git status`, which is identical when you re-edit an already-modified file) is what makes a fingerprint match genuinely mean an identical diff. Any failure to fingerprint, or a missing artifact, falls back to regenerating, so a stale or missing diff is never served.
- Explicit/force refresh paths (`refresh_workspace_diff` direct, on-demand `get_workspace_diff`) stay unconditional.

## Tests

- `diff_generation_test.py`: byte-identical-to-former-shell-pipeline regression, untracked symlink/directory exclusion, empty-untracked case, and fingerprint behavior (changes on same-status content re-edit, HEAD movement, and context-width change; stable when nothing changes).
- Updated `git_commands_test.py` (non-git argv now rejected) and `diff_refresh_test.py` (threads a concurrency group, runs real git via posix_spawn).

`just format` / `just check` / full `just test-unit` (backend, frontend, foundation, sculpt) all pass locally.

(Sent by Claude)