### PR TITLE
[SCU-1629] Redact credentials from remote-repo clone/list error responses

### DIFF
--- a/sculptor/sculptor/web/remote_repos.py
+++ b/sculptor/sculptor/web/remote_repos.py
@@ -172,7 +172,9 @@ def _fetch_repos(
             timeout=_REMOTE_REPO_LIST_TIMEOUT_SECONDS,
         )
     except ProcessError as e:
-        detail = e.stderr.strip() or f"gh api failed with exit code {e.returncode}"
+        # Redact any user:token@ userinfo: gh echoes the failing URL in stderr,
+        # and this detail is returned to the client, not just logged.
+        detail = _redact_url_credentials(e.stderr.strip()) or f"gh api failed with exit code {e.returncode}"
         raise HTTPException(status_code=502, detail=detail) from e
     try:
         payload = json.loads(result.stdout)
@@ -442,7 +444,9 @@ def clone_remote_repo(
                 e,
             )
         except ProcessError as e:
-            detail = e.stderr.strip() or f"clone failed with exit code {e.returncode}"
+            # Redact any user:token@ userinfo: git echoes the failing clone URL
+            # in stderr, and this detail is returned to the client, not just logged.
+            detail = _redact_url_credentials(e.stderr.strip()) or f"clone failed with exit code {e.returncode}"
             status_code = 409 if _looks_like_already_exists(detail) else 400
             clone_error = (status_code, detail, e)
 

--- a/sculptor/sculptor/web/remote_repos_test.py
+++ b/sculptor/sculptor/web/remote_repos_test.py
@@ -952,7 +952,8 @@ def test_clone_error_detail_redacts_credentials_in_stderr(
     ``https://oauth2:<token>@`` URL) must be stripped so the token never lands
     in the HTTP response body."""
     target_dir = tmp_path / "clones"
-    token = "ghp_supersecrettoken"
+    # Deliberately not a real token prefix (e.g. ghp_) so secret scanners don't flag it.
+    token = "fake-not-a-real-token"
     payload = _clone_payload(target_dir, url=f"https://oauth2:{token}@github.com/owner/my-repo.git")
     stderr = f"fatal: unable to access 'https://oauth2:{token}@github.com/owner/my-repo.git/': The requested URL returned error: 403"
     fake_clone_error = ProcessError(
@@ -996,7 +997,8 @@ def test_list_error_detail_redacts_credentials_in_stderr(
 ) -> None:
     """The 502 detail from a failing ``gh api`` call must likewise strip any
     user:token@ userinfo before reaching the client."""
-    token = "ghp_supersecrettoken"
+    # Deliberately not a real token prefix (e.g. ghp_) so secret scanners don't flag it.
+    token = "fake-not-a-real-token"
     stderr = f"fatal: unable to access 'https://oauth2:{token}@github.com/owner/repo.git/'"
     fake_error = ProcessError(
         command=("/fake/bin/gh", "api"),
@@ -1028,7 +1030,11 @@ def test_list_error_detail_redacts_credentials_in_stderr(
         response = client.get("/api/v1/remotes/github/repos")
 
     assert response.status_code == 502, response.text
-    assert token not in response.json()["detail"]
+    detail = response.json()["detail"]
+    assert token not in detail
+    # The redacted stderr is still surfaced (not swallowed into the fallback message),
+    # so the user gets an actionable error.
+    assert "https://github.com/owner/repo.git" in detail
 
 
 def test_clone_returns_504_on_subprocess_timeout(

--- a/sculptor/sculptor/web/remote_repos_test.py
+++ b/sculptor/sculptor/web/remote_repos_test.py
@@ -942,6 +942,95 @@ def test_clone_maps_unrelated_process_error_to_400(
     assert "Permission denied" in response.json()["detail"]
 
 
+def test_clone_error_detail_redacts_credentials_in_stderr(
+    client: TestClient,
+    test_services: CompleteServiceCollection,
+    tmp_path: Path,
+) -> None:
+    """git echoes the failing clone URL in its stderr, and that stderr becomes
+    the client-facing error detail. A user:token@ userinfo (e.g. from a pasted
+    ``https://oauth2:<token>@`` URL) must be stripped so the token never lands
+    in the HTTP response body."""
+    target_dir = tmp_path / "clones"
+    token = "ghp_supersecrettoken"
+    payload = _clone_payload(target_dir, url=f"https://oauth2:{token}@github.com/owner/my-repo.git")
+    stderr = f"fatal: unable to access 'https://oauth2:{token}@github.com/owner/my-repo.git/': The requested URL returned error: 403"
+    fake_clone_error = ProcessError(
+        command=("/fake/bin/git", "clone"),
+        stdout="",
+        stderr=stderr,
+        returncode=128,
+    )
+
+    with (
+        patch.object(
+            DependencyManagementService,
+            "resolve_binary_path",
+            autospec=True,
+            side_effect=_resolve_for_self(_mock_binary_lookup()),
+        ),
+        patch.object(
+            DependencyManagementService,
+            "check_authenticated",
+            autospec=True,
+            side_effect=_resolve_for_self(_mock_auth_lookup()),
+        ),
+        patch.object(
+            ConcurrencyGroup,
+            "run_process_to_completion",
+            autospec=True,
+            side_effect=_make_fake_run(raises=fake_clone_error),
+        ),
+    ):
+        response = client.post("/api/v1/remotes/clone", json=payload)
+
+    assert response.status_code == 400, response.text
+    detail = response.json()["detail"]
+    assert token not in detail
+    assert "https://github.com/owner/my-repo.git" in detail
+
+
+def test_list_error_detail_redacts_credentials_in_stderr(
+    client: TestClient,
+    test_services: CompleteServiceCollection,
+) -> None:
+    """The 502 detail from a failing ``gh api`` call must likewise strip any
+    user:token@ userinfo before reaching the client."""
+    token = "ghp_supersecrettoken"
+    stderr = f"fatal: unable to access 'https://oauth2:{token}@github.com/owner/repo.git/'"
+    fake_error = ProcessError(
+        command=("/fake/bin/gh", "api"),
+        stdout="",
+        stderr=stderr,
+        returncode=1,
+    )
+
+    with (
+        patch.object(
+            DependencyManagementService,
+            "resolve_binary_path",
+            autospec=True,
+            side_effect=_resolve_for_self(_mock_binary_lookup()),
+        ),
+        patch.object(
+            DependencyManagementService,
+            "check_authenticated",
+            autospec=True,
+            side_effect=_resolve_for_self(_mock_auth_lookup()),
+        ),
+        patch.object(
+            ConcurrencyGroup,
+            "run_process_to_completion",
+            autospec=True,
+            side_effect=_make_fake_run(raises=fake_error),
+        ),
+    ):
+        response = client.get("/api/v1/remotes/github/repos")
+
+    assert response.status_code == 502, response.text
+    assert token not in response.json()["detail"]
+
+
 def test_clone_returns_504_on_subprocess_timeout(
     client: TestClient,
     test_services: CompleteServiceCollection,


### PR DESCRIPTION
## Summary

The remote-repo **clone** and **list** routes (`sculptor/sculptor/web/remote_repos.py`) returned raw subprocess `stderr` to the client as an `HTTPException(detail=...)`. `git`/`gh` echo the failing URL in their stderr, so a credential-bearing clone URL — e.g. `https://oauth2:<token>@github.com/owner/repo.git` — would surface the token in the **HTTP response body** when the operation failed.

The redaction helper `_redact_url_credentials` already existed and was applied to the matching **log** lines, but not to these **client-facing** `detail` strings.

## Change

- Apply `_redact_url_credentials` to both error paths (`_fetch_repos` → 502, `clone_remote_repo` → 400/409) so the response detail matches the already-redacted log output.
- Add two regression tests asserting a tokened URL in stderr never appears in the error `detail`.

## Testing

- `just format`, `just check`, `just test-unit` — all green.
- `remote_repos_test.py`: 61 passed (59 existing + 2 new).

(Sent by Claude)