### PR TITLE
[SCU-1631] Make Linear plugin banner chip consistent with the PR button

### DIFF
--- a/sculptor/frontend/plugins/linear-issue/src/components/StateIcon.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/StateIcon.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from "react";
+
+/**
+ * A workflow-state glyph mirroring Linear's own state iconography, tinted with
+ * the state's color. Linear ships no embeddable icon set, but the shape language
+ * (dashed ring → hollow ring → half-pie → check → ✕) is a generic convention we
+ * can draw ourselves — and, unlike Linear's logo, ours takes any color.
+ *
+ * `type` is Linear's `state.type`: backlog | unstarted | started | completed |
+ * cancelled | triage. Unknown/`null` falls back to a neutral hollow ring so the
+ * chip always has a leading glyph. Drawn in a 24-unit viewBox at lucide's stroke
+ * weight (2) so it sits beside lucide icons at the same visual size.
+ */
+export const StateIcon = ({
+  type,
+  color,
+  size = 12,
+}: {
+  type: string | null;
+  color: string;
+  size?: number;
+}): ReactElement => {
+  // Incomplete states (backlog/unstarted) are low-emphasis in Linear, and the
+  // colors it returns for them are near-white greys tuned for Linear's own
+  // surfaces — they wash out on a light chip here. Their meaning is carried by
+  // the shape (dashed vs hollow ring), so draw them in a theme-aware grey that
+  // always contrasts, and reserve the issue's own color for the saturated
+  // started/completed/cancelled glyphs.
+  const outline = "var(--gray-9)";
+  const c = color || outline;
+  const common = { width: size, height: size, viewBox: "0 0 24 24", fill: "none", "aria-hidden": true } as const;
+
+  switch (type) {
+    case "backlog":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" stroke={outline} strokeWidth="2" strokeDasharray="2.5 2.7" />
+        </svg>
+      );
+    case "started":
+      // Color ring with a right-half pie inside — Linear's "in progress".
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" stroke={c} strokeWidth="2" />
+          <path d="M12 12V6.5A5.5 5.5 0 0 1 12 17.5Z" fill={c} />
+        </svg>
+      );
+    case "completed":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" fill={c} />
+          <path d="M8 12.5l2.5 2.5 5.5-6" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    case "cancelled":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" fill={c} />
+          <path d="M9 9l6 6M15 9l-6 6" stroke="#fff" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      );
+    case "unstarted":
+    default:
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" stroke={outline} strokeWidth="2" />
+        </svg>
+      );
+  }
+};

--- a/sculptor/frontend/plugins/linear-issue/src/components/StateIcon.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/StateIcon.tsx
@@ -1,5 +1,10 @@
 import type { ReactElement } from "react";
 
+// Glyph color for the mark drawn on a filled circle (check, ✕, exclamation).
+// A near-white that reads on the saturated state colors of completed/cancelled/
+// triage in both themes.
+const CONTRAST = "#fff";
+
 /**
  * A workflow-state glyph mirroring Linear's own state iconography, tinted with
  * the state's color. Linear ships no embeddable icon set, but the shape language
@@ -7,9 +12,10 @@ import type { ReactElement } from "react";
  * can draw ourselves — and, unlike Linear's logo, ours takes any color.
  *
  * `type` is Linear's `state.type`: backlog | unstarted | started | completed |
- * cancelled | triage. Unknown/`null` falls back to a neutral hollow ring so the
- * chip always has a leading glyph. Drawn in a 24-unit viewBox at lucide's stroke
- * weight (2) so it sits beside lucide icons at the same visual size.
+ * cancelled | triage. Any other value (or `null`) falls back to a neutral
+ * hollow ring so the chip always has a leading glyph. Drawn in a 24-unit
+ * viewBox at lucide's stroke weight (2) so it sits beside lucide icons at the
+ * same visual size.
  */
 export const StateIcon = ({
   type,
@@ -25,7 +31,7 @@ export const StateIcon = ({
   // surfaces — they wash out on a light chip here. Their meaning is carried by
   // the shape (dashed vs hollow ring), so draw them in a theme-aware grey that
   // always contrasts, and reserve the issue's own color for the saturated
-  // started/completed/cancelled glyphs.
+  // started/completed/cancelled/triage glyphs.
   const outline = "var(--gray-9)";
   const c = color || outline;
   const common = { width: size, height: size, viewBox: "0 0 24 24", fill: "none", "aria-hidden": true } as const;
@@ -49,14 +55,29 @@ export const StateIcon = ({
       return (
         <svg {...common}>
           <circle cx="12" cy="12" r="9" fill={c} />
-          <path d="M8 12.5l2.5 2.5 5.5-6" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M8 12.5l2.5 2.5 5.5-6"
+            stroke={CONTRAST}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       );
     case "cancelled":
       return (
         <svg {...common}>
           <circle cx="12" cy="12" r="9" fill={c} />
-          <path d="M9 9l6 6M15 9l-6 6" stroke="#fff" strokeWidth="2" strokeLinecap="round" />
+          <path d="M9 9l6 6M15 9l-6 6" stroke={CONTRAST} strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      );
+    case "triage":
+      // Filled disc with an exclamation — Linear's "needs triage".
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="9" fill={c} />
+          <path d="M12 7.5v5" stroke={CONTRAST} strokeWidth="2" strokeLinecap="round" />
+          <circle cx="12" cy="16.2" r="1.15" fill={CONTRAST} />
         </svg>
       );
     case "unstarted":

--- a/sculptor/frontend/plugins/linear-issue/src/components/WorkspaceShortcutWidget.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/WorkspaceShortcutWidget.tsx
@@ -71,13 +71,10 @@ export const WorkspaceShortcutWidget = (): ReactElement | null => {
         onClick={() => openExternal(issue.url)}
         data-testid="linear-workspace-shortcut"
       >
-        {/* Workflow-state glyph, tinted by the state color (replaces a generic
-            leading icon + separate dot — the icon now carries the state). */}
-        <StateIcon
-          type={issue.state?.type ?? null}
-          color={issue.state?.color ?? "var(--gray-8)"}
-          size={12}
-        />
+        {/* Leading glyph: the ticket's workflow state, tinted by the state
+            color. StateIcon supplies a neutral fallback when the color is
+            absent. */}
+        <StateIcon type={issue.state?.type ?? null} color={issue.state?.color ?? ""} size={12} />
         {/* Same monospace token as the PR button's "PR #123" beside it. */}
         <span
           style={{

--- a/sculptor/frontend/plugins/linear-issue/src/components/WorkspaceShortcutWidget.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/WorkspaceShortcutWidget.tsx
@@ -1,11 +1,31 @@
-import { Button, Tooltip } from "@radix-ui/themes";
+import { Tooltip } from "@radix-ui/themes";
 import { openExternal, useCurrentWorkspace, usePluginSetting } from "@sculptor/plugin-sdk";
-import { Hash } from "lucide-react";
-import type { ReactElement } from "react";
+import type { CSSProperties, ReactElement } from "react";
+import { useState } from "react";
 
 import { useShortcut } from "../linear/useShortcut.ts";
 import { useShortcutTicket } from "../linear/useShortcutTicket.ts";
-import { StateDot } from "./StateDot.tsx";
+import { StateIcon } from "./StateIcon.tsx";
+
+// Mirrors the host PR button's chip (PrButton.module.scss): a filled gray-a3
+// chip, 2px/space-2 padding, radius-2, font-size-1, with a gray-a4 hover. The
+// plugin compiles to a lone main.js with no CSS asset the host would load, so
+// the chip is styled inline rather than with a CSS module — hence the hover is
+// driven by state instead of a `:hover` rule.
+const CHIP_BASE: CSSProperties = {
+  alignItems: "center",
+  border: "none",
+  borderRadius: "var(--radius-2)",
+  color: "var(--gray-12)",
+  cursor: "pointer",
+  display: "inline-flex",
+  fontFamily: "var(--default-font-family)",
+  fontSize: "var(--font-size-1)",
+  gap: "var(--space-1)",
+  lineHeight: "var(--line-height-1)",
+  padding: "2px var(--space-2)",
+  whiteSpace: "nowrap",
+};
 
 /**
  * The compact Linear shortcut the host places in the workspace banner, beside
@@ -25,27 +45,50 @@ export const WorkspaceShortcutWidget = (): ReactElement | null => {
   const [apiKey] = usePluginSetting("apiKey");
   const { shortcutId } = useShortcut(workspaceId);
   const { issue, isDefault } = useShortcutTicket({ apiKey, branch, pullRequestUrl, shortcutId });
+  const [isHovered, setIsHovered] = useState(false);
 
   if (!apiKey || !issue) return null;
 
-  const tooltip = `${issue.title}${isDefault ? "" : " · assigned shortcut"} — open in Linear`;
+  // A cancelled ticket is terminal and likely stale, so mute it the way the PR
+  // button mutes a merged/closed PR (gray-a2 + struck identifier) — a glance is
+  // enough to spot a still-open PR pointing at an abandoned ticket.
+  const isCancelled = issue.state?.type === "cancelled";
+  const stateLabel = issue.state ? ` · ${issue.state.name}` : "";
+  const tooltip = `${issue.title}${stateLabel}${isDefault ? "" : " · assigned shortcut"} — open in Linear`;
+
+  // Cancelled tickets sit one step more muted than active ones, mirroring the
+  // merged/closed PR button (gray-a2 vs gray-a3).
+  const idleBackground = isCancelled ? "var(--gray-a2)" : "var(--gray-a3)";
+  const hoverBackground = isCancelled ? "var(--gray-a3)" : "var(--gray-a4)";
 
   return (
     <Tooltip content={tooltip}>
-      <Button
-        size="1"
-        // Ghost (not soft) so the chip is content-height, matching the diff
-        // summary and PR button beside it — Radix's soft/solid variants force a
-        // taller fixed control height that would stand proud of the banner row.
-        variant="ghost"
-        color="gray"
+      <button
+        type="button"
+        style={{ ...CHIP_BASE, background: isHovered ? hoverBackground : idleBackground }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
         onClick={() => openExternal(issue.url)}
         data-testid="linear-workspace-shortcut"
       >
-        <Hash size={12} />
-        {issue.identifier}
-        {issue.state && <StateDot color={issue.state.color} />}
-      </Button>
+        {/* Workflow-state glyph, tinted by the state color (replaces a generic
+            leading icon + separate dot — the icon now carries the state). */}
+        <StateIcon
+          type={issue.state?.type ?? null}
+          color={issue.state?.color ?? "var(--gray-8)"}
+          size={12}
+        />
+        {/* Same monospace token as the PR button's "PR #123" beside it. */}
+        <span
+          style={{
+            fontFamily: "var(--mono-font-family)",
+            color: isCancelled ? "var(--gray-11)" : undefined,
+            textDecoration: isCancelled ? "line-through" : undefined,
+          }}
+        >
+          {issue.identifier}
+        </span>
+      </button>
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Summary

Makes the **Linear plugin's workspace banner chip** — the ticket shortcut next to the built-in PR button — visually and behaviorally consistent with that PR button, and adds at-a-glance workflow-state rendering.

Resolves SCU-1631.

The chip was a backgroundless Radix `ghost` button beside the PR button's filled chip, so it read as floating text rather than a sibling control — and it measured **24px tall against the PR button's 20px** (it stood 4px proud, despite a code comment claiming ghost matched content height). It led with a decorative `#` icon and conveyed workflow state only through a small color dot (hard to read at a glance and for colorblind users).

## Visual verification

**Chip vs. PR button — before (ghost) / after (chip), exact 20px height match:**

| Light | Dark |
| --- | --- |
| ![chip parity light](https://raw.githubusercontent.com/imbue-ai/sculptor/scu-1631-pr-assets/screenshots/chip_parity_light.png) | ![chip parity dark](https://raw.githubusercontent.com/imbue-ai/sculptor/scu-1631-pr-assets/screenshots/chip_parity_dark.png) |

**Workflow-state rendering across states (chip beside an Open PR):**

| Light | Dark |
| --- | --- |
| ![states light](https://raw.githubusercontent.com/imbue-ai/sculptor/scu-1631-pr-assets/screenshots/states_light.png) | ![states dark](https://raw.githubusercontent.com/imbue-ai/sculptor/scu-1631-pr-assets/screenshots/states_dark.png) |

**State glyphs (backlog · unstarted · started · completed · cancelled · triage · none):**

![state glyphs](https://raw.githubusercontent.com/imbue-ai/sculptor/scu-1631-pr-assets/screenshots/glyphs.png)

> Screenshots are captured from a Storybook harness (light + dark) and hosted on the throwaway `scu-1631-pr-assets` branch — GitHub has no CLI path to its image CDN. That branch is not for merge and can be deleted after review.

## Changes

- **Match the PR button chip:** filled `gray-a3` background, `radius-2`, `2px / space-2` padding, `gray-a4` hover, and a monospace identifier using the same `--mono-font-family` token as the PR button's "PR #123" → exact **20px** height match. Styled inline because the compiled plugin ships a lone `main.js` with no CSS asset the host would load.
- **New `StateIcon` component:** renders Linear's workflow-state glyphs as our own SVGs — backlog (dashed ring), unstarted (hollow ring), started (half-pie), completed (check), cancelled (✕), triage (exclamation) — tinted by `state.color`. Linear ships no embeddable icon set and restricts its logo to a fixed black-and-white mark, so drawing our own keeps them colorable and license-clean. Replaces both the `#` icon and the separate color dot.
- **Contrast safety:** Linear returns near-white greys for backlog/unstarted that wash out on a light chip; those low-emphasis states are clamped to a theme-aware grey (meaning is carried by shape), reserving `state.color` for the saturated glyphs.
- **Terminal-state treatment:** a cancelled ticket is muted (`gray-a2`) with a struck-through identifier, mirroring how the PR button mutes a merged/closed PR — making a still-open PR pointing at an abandoned ticket spottable at a glance.

## Verification

- Rendered the chip across every workflow state beside the PR button's states in a Storybook harness (light + dark); measured exact box models with Playwright to confirm the 20px match.
- `just format`, `just check`, and `just test-unit-frontend` all pass.

## Follow-up

The panel (`TicketSection` / `TicketBadge` / `IssueDetails`) still uses the old color-dot `StateDot`; adopting `StateIcon` there too would make the plugin internally consistent. Left out of this PR to keep it focused.

(Sent by Claude)
