### PR TITLE
Upgrade managed pi pin to 0.80.2 and de-duplicate the pin

### DIFF
--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -218,7 +218,7 @@ packaging Sculptor):
 - **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no
   minimum-version check** (searched; none found). The minimum supported git version is undefined
   (worktree support is the relevant capability). → OPEN-6 (§7).
-- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness (experimental agent) pins **0.78.0**; platforms
+- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness (experimental agent) pins **0.80.2**; platforms
   darwin-arm64, darwin-x64, linux-x64, with per-platform sha256 checksums
   (`sculptor/sculptor/services/managed_tools.py`). A version mismatch fails clearly (REQ-INT-022).
 - **REQ-COMPAT-023 (MUST, conditional).** The PR surface requires **`gh`** (GitHub CLI) present and

--- a/sculptor/frontend/src/common/useManagedDependency.test.tsx
+++ b/sculptor/frontend/src/common/useManagedDependency.test.tsx
@@ -61,7 +61,7 @@ describe("useManagedDependency", () => {
       makeStatus({
         pi: makeInfo({
           installed: true,
-          version: "0.78.0",
+          version: "0.80.2",
           mode: "MANAGED",
           isVersionInRange: true,
           installError: "stale error from an earlier attempt",

--- a/sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx
+++ b/sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx
@@ -12,7 +12,7 @@ const piNotInstalled = {
   version: null,
   isOverride: false,
   mode: null,
-  versionRange: { minVersion: "0.78.0", maxVersion: "0.78.0", recommendedVersion: "0.78.0" },
+  versionRange: { minVersion: "0.80.2", maxVersion: "0.80.2", recommendedVersion: "0.80.2" },
   isVersionInRange: null,
 } as const;
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -1858,7 +1858,7 @@ def _make_start_env(persisted_session_id: str | None = None) -> MagicMock:
     env.get_tool_binary_path.return_value = "/bin/pi"
     version_result = MagicMock()
     version_result.stdout = ""
-    version_result.stderr = "pi 0.78.0\n"
+    version_result.stderr = "pi 0.80.2\n"
     env.run_process_to_completion.return_value = version_result
     env.get_state_path.return_value = Path("/fake/state")
     env.get_system_prompt.return_value = ""
@@ -1985,7 +1985,7 @@ def test_start_raises_pi_version_mismatch_when_out_of_range() -> None:
     agent = _make_agent(env)
     with pytest.raises(PiVersionMismatchError) as exc_info:
         agent.start(secrets={})
-    assert exc_info.value.pinned_version == "0.78.0"
+    assert exc_info.value.pinned_version == "0.80.2"
     assert exc_info.value.detected_version == "0.50.0"
     # The message must point the user at the self-healing fix (managed install).
     assert "Managed" in str(exc_info.value)
@@ -3366,7 +3366,7 @@ def _make_probe_env(probe_process: MagicMock) -> MagicMock:
     env.get_tool_binary_path.return_value = "/bin/pi"
     version_result = MagicMock()
     version_result.stdout = ""
-    version_result.stderr = "pi 0.78.0\n"
+    version_result.stderr = "pi 0.80.2\n"
     env.run_process_to_completion.return_value = version_result
     env.get_state_path.return_value = Path("/fake/state")
     env.run_process_in_background.return_value = probe_process

--- a/sculptor/sculptor/services/dependency_management_service.py
+++ b/sculptor/sculptor/services/dependency_management_service.py
@@ -64,9 +64,6 @@ class DependencyCheckResult(FrozenModel):
     version: str | None = None
 
 
-# ``PI_VERSION_RANGE`` is defined beside ``PI_PIN`` in ``managed_tools`` (imported above)
-# and re-exported here: callers and the justfile import it from this service.
-
 DEPENDENCIES_DIR_NAME = "dependencies"
 _VERSION_DIR_PREFIX = "version-"
 _TEMP_DIR_PREFIX = "tmp-"

--- a/sculptor/sculptor/services/dependency_management_service.py
+++ b/sculptor/sculptor/services/dependency_management_service.py
@@ -33,12 +33,12 @@ from sculptor.foundation.thread_utils import ObservableThread
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
 from sculptor.primitives.service import Service
 from sculptor.services.managed_tools import CLAUDE_VERSION_RANGE
+from sculptor.services.managed_tools import PI_VERSION_RANGE
 from sculptor.services.managed_tools import ManagedTool
 from sculptor.services.managed_tools import ResolvedDistribution
 from sculptor.services.managed_tools import VersionRange
 from sculptor.services.managed_tools import get_managed_tool
 from sculptor.services.managed_tools import get_managed_tools
-from sculptor.services.pi_version import PI_PINNED_VERSION
 from sculptor.services.user_config.user_config import get_user_config_instance
 from sculptor.utils.build import get_internal_folder
 from sculptor.web.data_types import AuthResult
@@ -64,15 +64,8 @@ class DependencyCheckResult(FrozenModel):
     version: str | None = None
 
 
-# Pinned-single-version range — Sculptor refuses to talk to a pi outside this pin
-# so the RPC schema stays known. The version string is sourced from the
-# dependency-free ``pi_version`` module so ``fake_pi`` can report it without
-# importing this heavy module.
-PI_VERSION_RANGE = VersionRange(
-    min_version=PI_PINNED_VERSION,
-    max_version=PI_PINNED_VERSION,
-    recommended_version=PI_PINNED_VERSION,
-)
+# ``PI_VERSION_RANGE`` is defined beside ``PI_PIN`` in ``managed_tools`` (imported above)
+# and re-exported here: callers and the justfile import it from this service.
 
 DEPENDENCIES_DIR_NAME = "dependencies"
 _VERSION_DIR_PREFIX = "version-"

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -63,10 +63,6 @@ class PiPin(FrozenModel):
     plugin_set_revision: str = "bundled"
 
 
-# ``version`` is imported from the dependency-free ``PI_PINNED_VERSION`` so the pinned
-# string lives in exactly one place; ``pi_version`` imports nothing, so this can't cycle.
-# (The service's ``PI_VERSION_RANGE`` can't be imported here — the service imports this
-# module — so it is the pin string that is shared, not the range.)
 PI_PIN = PiPin(
     version=PI_PINNED_VERSION,
     platforms={
@@ -168,11 +164,9 @@ _PI_PLATFORM_MAP: dict[tuple[str, str], str] = {
 
 _PI_RELEASE_BASE_URL = "https://github.com/earendil-works/pi/releases/download"
 
-# Pinned single-version range, derived from ``PI_PINNED_VERSION`` — Sculptor refuses to
-# talk to a pi outside this pin so the RPC schema stays known. It lives in the seam
-# (beside ``PI_PIN``) rather than the dependency service so ``PiManagedTool`` can use it
-# without importing the service — which imports this module and would cycle. The service
-# re-exports it for its own callers.
+# Defined here, not in the dependency service, so ``PiManagedTool`` can reference it
+# without importing the service (which imports this module — a cycle). The service
+# re-exports it.
 PI_VERSION_RANGE = VersionRange(
     min_version=PI_PINNED_VERSION,
     max_version=PI_PINNED_VERSION,

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -24,6 +24,7 @@ import httpx
 
 from sculptor.foundation.pydantic_serialization import FrozenModel
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
+from sculptor.services.pi_version import PI_PINNED_VERSION
 
 
 class BlockedVersionRange(FrozenModel):
@@ -62,23 +63,24 @@ class PiPin(FrozenModel):
     plugin_set_revision: str = "bundled"
 
 
-# ``version`` is a literal, not an import of ``PI_VERSION_RANGE``: the dependency
-# service imports this module, so importing it back would be a cycle. A unit test
-# asserts the two stay equal.
+# ``version`` is imported from the dependency-free ``PI_PINNED_VERSION`` so the pinned
+# string lives in exactly one place; ``pi_version`` imports nothing, so this can't cycle.
+# (The service's ``PI_VERSION_RANGE`` can't be imported here — the service imports this
+# module — so it is the pin string that is shared, not the range.)
 PI_PIN = PiPin(
-    version="0.78.0",
+    version=PI_PINNED_VERSION,
     platforms={
         "darwin-arm64": PlatformPin(
             asset="pi-darwin-arm64.tar.gz",
-            sha256="68ebbe4f56a136a1c7bace3393eca4ad0aa1fd9f253b797fd370058bd39fe070",
+            sha256="c7d125bbdebd863fa76d92274458ba0eb405e5cde39db34db1f49f767ed9f1dd",
         ),
         "darwin-x64": PlatformPin(
             asset="pi-darwin-x64.tar.gz",
-            sha256="66074b271260068199f47738a172397f1e0b5a3334697dd2acea35bbd3470b1c",
+            sha256="d4b6b62a0c34c0f2e4cb16ee6fd4f0086b86ad70e0488fd3daa9231216d84e2b",
         ),
         "linux-x64": PlatformPin(
             asset="pi-linux-x64.tar.gz",
-            sha256="8ac03343d1e1228106e8172157f32d6b882829e46b34feaf577f171a5f1387cc",
+            sha256="2e68772bbeaacd73488751098193875389636b80589100609a29921ded71c984",
         ),
     },
 )
@@ -166,12 +168,15 @@ _PI_PLATFORM_MAP: dict[tuple[str, str], str] = {
 
 _PI_RELEASE_BASE_URL = "https://github.com/earendil-works/pi/releases/download"
 
-# Built from the pin rather than imported from the service's ``PI_VERSION_RANGE`` (that
-# reverse import would cycle); a unit test asserts the two stay equal.
-_PI_VERSION_RANGE = VersionRange(
-    min_version=PI_PIN.version,
-    max_version=PI_PIN.version,
-    recommended_version=PI_PIN.version,
+# Pinned single-version range, derived from ``PI_PINNED_VERSION`` — Sculptor refuses to
+# talk to a pi outside this pin so the RPC schema stays known. It lives in the seam
+# (beside ``PI_PIN``) rather than the dependency service so ``PiManagedTool`` can use it
+# without importing the service — which imports this module and would cycle. The service
+# re-exports it for its own callers.
+PI_VERSION_RANGE = VersionRange(
+    min_version=PI_PINNED_VERSION,
+    max_version=PI_PINNED_VERSION,
+    recommended_version=PI_PINNED_VERSION,
 )
 
 
@@ -189,7 +194,7 @@ class PiManagedTool(ManagedTool):
     """
 
     tool = Dependency.PI
-    version_range = _PI_VERSION_RANGE
+    version_range = PI_VERSION_RANGE
     platform_keys = frozenset({"darwin-arm64", "darwin-x64", "linux-x64"})
     retention_keep = 1
     # pi keeps its whole extracted tree and runs from ``pi/pi``.

--- a/sculptor/sculptor/services/managed_tools_test.py
+++ b/sculptor/sculptor/services/managed_tools_test.py
@@ -10,7 +10,6 @@ import pytest
 from pydantic import ValidationError
 
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
-from sculptor.services.dependency_management_service import PI_VERSION_RANGE
 from sculptor.services.managed_tools import CLAUDE_VERSION_RANGE
 from sculptor.services.managed_tools import ClaudeManagedTool
 from sculptor.services.managed_tools import GCP_BUCKET_BASE_URL
@@ -26,8 +25,8 @@ from sculptor.services.managed_tools import _PI_PLATFORM_MAP
 from sculptor.services.managed_tools import get_managed_tool
 from sculptor.services.managed_tools import get_managed_tools
 
-# Verified darwin-arm64 sha256 for pi 0.78.0; regenerate with ``just compute-pi-pin 0.78.0``.
-_PI_DARWIN_ARM64_SHA256_0_78_0 = "68ebbe4f56a136a1c7bace3393eca4ad0aa1fd9f253b797fd370058bd39fe070"
+# Verified darwin-arm64 sha256 for pi 0.80.2; regenerate with ``just compute-pi-pin 0.80.2``.
+_PI_DARWIN_ARM64_SHA256_0_80_2 = "c7d125bbdebd863fa76d92274458ba0eb405e5cde39db34db1f49f767ed9f1dd"
 
 
 def _instantiate_with_no_arguments(candidate: Callable[[], object]) -> object:
@@ -91,10 +90,6 @@ def test_get_managed_tool_returns_none_for_unmanaged_git() -> None:
     assert get_managed_tool(Dependency.GIT) is None
 
 
-def test_pi_pin_version_equals_recommended_version_of_pi_version_range() -> None:
-    assert PI_PIN.version == PI_VERSION_RANGE.recommended_version
-
-
 def test_pi_pin_covers_exactly_the_three_supported_platform_keys() -> None:
     assert set(PI_PIN.platforms) == {"darwin-arm64", "darwin-x64", "linux-x64"}
 
@@ -105,7 +100,7 @@ def test_pi_pin_asset_names_follow_the_pi_release_naming_for_each_platform() -> 
 
 
 def test_pi_pin_darwin_arm64_sha256_matches_the_verified_value() -> None:
-    assert PI_PIN.platforms["darwin-arm64"].sha256 == _PI_DARWIN_ARM64_SHA256_0_78_0
+    assert PI_PIN.platforms["darwin-arm64"].sha256 == _PI_DARWIN_ARM64_SHA256_0_80_2
 
 
 def test_pi_pin_platform_sha256s_are_distinct_lowercase_hex_digests() -> None:
@@ -210,12 +205,6 @@ class TestPiManagedToolRegistration:
         assert tool.tool == Dependency.PI
         assert tool.retention_keep == 1
         assert tool.platform_keys == frozenset({"darwin-arm64", "darwin-x64", "linux-x64"})
-
-
-def test_pi_managed_tool_version_range_equals_the_service_pi_version_range() -> None:
-    # version_range is built from the pin (importing the service's PI_VERSION_RANGE
-    # would cycle); this test keeps the two from drifting apart.
-    assert PiManagedTool().version_range == PI_VERSION_RANGE
 
 
 def test_pi_platform_map_values_match_the_advertised_platform_keys() -> None:

--- a/sculptor/sculptor/services/pi_version.py
+++ b/sculptor/sculptor/services/pi_version.py
@@ -1,10 +1,10 @@
 """The single pinned pi version, in a dependency-free module.
 
-Sculptor pins pi to one exact version so the RPC schema stays known.
-``dependency_management_service`` builds ``PI_VERSION_RANGE`` from this constant,
-but the string itself lives here — apart from that heavy module — so the test
-harness's ``fake_pi`` stub can answer ``pi --version`` without importing the
-database / web / httpx service layer it pulls in. Keep this module import-free.
+Sculptor pins pi to one exact version so the RPC schema stays known. ``managed_tools``
+builds ``PI_PIN`` and ``PI_VERSION_RANGE`` from this constant, but the string itself lives
+here — in its own import-free module — so the test harness's ``fake_pi`` stub can answer
+``pi --version`` without pulling in that module's heavier dependency stack. Keep this
+module import-free.
 """
 
 PI_PINNED_VERSION = "0.80.2"

--- a/sculptor/sculptor/services/pi_version.py
+++ b/sculptor/sculptor/services/pi_version.py
@@ -7,4 +7,4 @@ harness's ``fake_pi`` stub can answer ``pi --version`` without importing the
 database / web / httpx service layer it pulls in. Keep this module import-free.
 """
 
-PI_PINNED_VERSION = "0.78.0"
+PI_PINNED_VERSION = "0.80.2"


### PR DESCRIPTION
## Summary

Upgrades the Sculptor-managed `pi` agent pin from **0.78.0** to **0.80.2** (latest stable release), and removes avoidable duplication of the pin so a future bump touches a single source-of-truth variable.

## Changes

**Pin bump**
- `PI_PINNED_VERSION` → `0.80.2`.
- Per-platform sha256 checksums regenerated via `scripts/compute_pi_pin.py` and cross-checked against the release's published `SHA256SUMS` (exact match on darwin-arm64, darwin-x64, linux-x64).
- `docs/specs/requirements.md` (REQ-COMPAT-022) updated to the new pin.

**De-duplicate the pin (DRY)**
- `PI_PIN.version` now derives from `PI_PINNED_VERSION` instead of re-typing the literal. The import is cycle-free because the `pi_version` module imports nothing; the previous comment justified the literal with an import cycle that only applies to the service's range, not to the pin string.
- `PI_VERSION_RANGE` now has a single canonical definition beside `PI_PIN` in `managed_tools`, re-exported by `dependency_management_service` for its existing callers (and the justfile). This removes the duplicate `VersionRange` construction and the two tautological consistency tests that only existed to police the duplication.
- Net result: the pinned version string lives in exactly one place; the per-version checksums remain the only other version-specific data.

**Frontend**
- Refreshed the two dependency fixtures (a unit test and a Storybook story) to the current pinned version. The frontend has no compile-time pinned-version constant — the value is delivered at runtime via the dependencies-status API — so these stay concrete fixtures built on the real generated types.

## Testing

- Backend unit suite green: **1998 passed, 4 skipped**.
- `ruff check` + `ruff format --check` clean; an import smoke test confirms one canonical `PI_VERSION_RANGE`, re-exported as the same object, with no import cycle.
- Frontend: the two edits are value-only swaps in non-asserted fixtures (type unchanged), so they are inert to tsc/eslint/vitest; the frontend suite was not run in this environment.

## Note for reviewers

This bump skips the 0.79.x line. The Sculptor↔pi RPC wire protocol and the captured model catalog were implemented against 0.78.0, and the unit tests exercise a `fake_pi` stub — so they do not exercise any real RPC/behavior drift in 0.80.2. The `real_pi` integration suite is what validates the live protocol against the actual binary.

(Sent by Claude)
