### PR TITLE
[SCU-1634] Stabilize load/zsh-sensitive backend unit tests

### DIFF
--- a/docs/development/review/integration_tests.md
+++ b/docs/development/review/integration_tests.md
@@ -250,23 +250,24 @@ create_disabled_dependency_stub(fake_bin_dir, "claude", DependencyState.INSTALLE
 
 ---
 
-### `isolate_spawned_shell_config`
+### `no_user_config_coupled_assertions`
 
-**Question:** Does this test spawn a real interactive/login shell (or other host process) and then assert on output read back through it — coupling a config-independent assertion to the developer's terminal configuration?
+**Question:** Does this test invoke a user-configurable tool or environment (a shell, `git`, an editor, locale, `$TERM`, any rc-driven CLI) and then assert on output or behaviour that the user's configuration can perturb — coupling a config-independent assertion to per-developer settings?
 
-A test that launches the developer's `$SHELL` — especially as a login shell (`-l`) — inherits their whole rc chain: prompt themes, plugins, syntax highlighting, bracketed-paste, autosuggestions. That output is uncontrolled input: a bare `/bin/bash` on CI behaves nothing like a heavily-themed zsh on a laptop, so the test passes in CI and flakes (or fails outright) locally. The deeper smell is the coupling itself — the property under test (e.g. that an env var is propagated or scrubbed) is usually produced by a pure function and has nothing to do with the shell's theme, yet it is being observed through a noisy, config-dependent channel.
+Many tools read configuration the test does not control: a login shell sources the user's rc chain (themes, plugins, syntax highlighting, bracketed-paste); `git` reads `~/.gitconfig` (aliases, `init.defaultBranch`, signing, hooks); CLIs read dotfiles; output formatting and parsing depend on `$LANG`/`$LC_*` and `$TERM`. When a test invokes such a tool and asserts on what comes back, that configuration becomes uncontrolled input — a clean CI runner behaves nothing like a heavily-customised laptop, so the test passes in one place and flakes or fails in the other. The deeper smell is the coupling itself: the property under test (an env var is propagated, a path is built, a commit is created) is usually produced by code whose behaviour does not depend on those settings at all, yet it is being observed through a config-dependent channel. (This is the assertion-coupling counterpart to `isolate_from_host_filesystem`: that rule is about not depending on host *state*; this one is about not coupling an *assertion* to host *configuration*.)
 
 **What to look for:**
 - A process built from `$SHELL` / `os.environ["SHELL"]`, or a shell run with `-l`, without pinning the shell's environment
-- Reading command output back through an interactive shell and matching on it, especially with ANSI/escape-stripping or `errors="replace"` decoding added to cope with prompt noise
-- Fixed sleeps or generous timeouts added so a slow, heavily-configured shell has "enough" time to initialize before the test writes to it
-- An assertion about logic (env handling, argument building, path construction) verified *only* end-to-end through a spawned shell, with no direct test of the function that implements it
+- Invoking `git`, an editor, a package manager, or any rc-driven CLI without neutralising the user's global config (`HOME`, `ZDOTDIR`, `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_NOSYSTEM`, `EDITOR`, `LANG`/`LC_ALL`, `TERM`)
+- Matching on a tool's output with ANSI/escape-stripping, locale-tolerant parsing, or `errors="replace"` decoding added to cope with config-driven noise
+- Fixed sleeps or generous timeouts added so a slow, heavily-configured tool (e.g. a themed shell with an async prompt) has "enough" time before the test interacts with it
+- An assertion about logic (env handling, argument building, path construction) verified *only* end-to-end through such a tool, with no direct test of the function that implements it
 
 **Fix:**
-- Isolate the shell so every run gets a vanilla, fast-starting config: an autouse fixture that points `HOME` and `ZDOTDIR` at an empty directory removes the user's rc files (and lets you delete the escape-stripping band-aids). Pin the shell explicitly rather than inheriting `$SHELL` when the test does not specifically need the user's shell.
-- Push the real assertion down a layer: unit-test the pure function that produces the behaviour (env scrub/merge, arg building) directly with controlled inputs, and keep at most a thin end-to-end test that a value reaches a real spawned process. Don't paper over a config-independent assertion with filtering or longer timeouts — remove the dependency on the channel.
+- Neutralise the configuration so every run gets a vanilla, deterministic tool: point `HOME`/`ZDOTDIR` at an empty directory for shells, set `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_NOSYSTEM` for git, pin `LANG`/`LC_ALL` and `TERM`, and pass an explicit tool rather than inheriting `$SHELL`/`$EDITOR` when the test does not specifically need the user's. An autouse fixture is a good home for this. Removing the variability usually lets you delete the escape-stripping / timeout band-aids too.
+- Push the real assertion down a layer: unit-test the pure function that produces the behaviour (env scrub/merge, arg building, path construction) directly with controlled inputs, and keep at most a thin end-to-end test that the value reaches the real tool.
 
-**Exceptions:** Tests that genuinely exercise the interactive-shell integration itself (e.g. that a login shell honours SIGHUP and exits, or that a specific rc-sourcing behaviour works) legitimately need a real shell — but should still pin its configuration so the behaviour under test is the only variable.
+**Exceptions:** Tests that genuinely exercise the tool integration itself — that a login shell honours SIGHUP and exits, that a git hook fires — legitimately invoke the real tool, but should still pin its configuration so the behaviour under test is the only variable.
 
 ---
 

--- a/docs/development/review/integration_tests.md
+++ b/docs/development/review/integration_tests.md
@@ -250,6 +250,26 @@ create_disabled_dependency_stub(fake_bin_dir, "claude", DependencyState.INSTALLE
 
 ---
 
+### `isolate_spawned_shell_config`
+
+**Question:** Does this test spawn a real interactive/login shell (or other host process) and then assert on output read back through it — coupling a config-independent assertion to the developer's terminal configuration?
+
+A test that launches the developer's `$SHELL` — especially as a login shell (`-l`) — inherits their whole rc chain: prompt themes, plugins, syntax highlighting, bracketed-paste, autosuggestions. That output is uncontrolled input: a bare `/bin/bash` on CI behaves nothing like a heavily-themed zsh on a laptop, so the test passes in CI and flakes (or fails outright) locally. The deeper smell is the coupling itself — the property under test (e.g. that an env var is propagated or scrubbed) is usually produced by a pure function and has nothing to do with the shell's theme, yet it is being observed through a noisy, config-dependent channel.
+
+**What to look for:**
+- A process built from `$SHELL` / `os.environ["SHELL"]`, or a shell run with `-l`, without pinning the shell's environment
+- Reading command output back through an interactive shell and matching on it, especially with ANSI/escape-stripping or `errors="replace"` decoding added to cope with prompt noise
+- Fixed sleeps or generous timeouts added so a slow, heavily-configured shell has "enough" time to initialize before the test writes to it
+- An assertion about logic (env handling, argument building, path construction) verified *only* end-to-end through a spawned shell, with no direct test of the function that implements it
+
+**Fix:**
+- Isolate the shell so every run gets a vanilla, fast-starting config: an autouse fixture that points `HOME` and `ZDOTDIR` at an empty directory removes the user's rc files (and lets you delete the escape-stripping band-aids). Pin the shell explicitly rather than inheriting `$SHELL` when the test does not specifically need the user's shell.
+- Push the real assertion down a layer: unit-test the pure function that produces the behaviour (env scrub/merge, arg building) directly with controlled inputs, and keep at most a thin end-to-end test that a value reaches a real spawned process. Don't paper over a config-independent assertion with filtering or longer timeouts — remove the dependency on the channel.
+
+**Exceptions:** Tests that genuinely exercise the interactive-shell integration itself (e.g. that a login shell honours SIGHUP and exits, or that a specific rc-sourcing behaviour works) legitimately need a real shell — but should still pin its configuration so the behaviour under test is the only variable.
+
+---
+
 ## Test Placement
 
 ### `correct_launch_mode_markers`

--- a/sculptor/sculptor/primitives/threads_test.py
+++ b/sculptor/sculptor/primitives/threads_test.py
@@ -1,6 +1,7 @@
 """Unit tests for :mod:`sculptor.primitives.threads`."""
 
 import time
+from queue import Empty
 from queue import Queue
 
 from sculptor.foundation.concurrency_group import ConcurrencyGroup
@@ -32,14 +33,30 @@ def test_source_polls_and_emits_values(test_root_concurrency_group: ConcurrencyG
         concurrency_group=test_root_concurrency_group,
     )
     source.start()
-    time.sleep(0.2)
+
+    # Drain until the distinct values arrive rather than sleeping for a fixed
+    # window: the source emits at most one value per ``check_interval`` tick, so
+    # a fixed window encodes an assumption about how many ticks the polling
+    # thread gets to run — and under heavy parallel-test load that thread can be
+    # starved enough to fire far fewer ticks than the window nominally allows.
+    # Waiting on the eventual queue contents (with a generous timeout) keeps the
+    # assertion exact — duplicates de-duplicated — without baking in a
+    # scheduling assumption.
+    expected = [1, 2, 3]
+    drained: list[int] = []
+    deadline = time.monotonic() + 5.0
+    while len(drained) < len(expected) and time.monotonic() < deadline:
+        try:
+            drained.append(queue.get(timeout=0.1))
+        except Empty:
+            continue
     source.stop()
 
-    drained = []
-    while not queue.empty():
-        drained.append(queue.get())
     # Duplicate consecutive values are de-duplicated by the source.
-    assert drained == [1, 2, 3]
+    assert drained == expected
+    # The callback yields None forever once exhausted, so nothing further is
+    # emitted: a spurious extra value would mean a de-dup or stop-after-None bug.
+    assert queue.empty()
 
 
 def test_source_stops_itself_when_callback_raises_stop_polling(

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
@@ -38,6 +38,23 @@ from sculptor.services.workspace_service.environment_manager.environments.spawne
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_shell_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Point the spawned login shell at an empty HOME/ZDOTDIR so it sources no
+    user rc files.
+
+    These tests start a real terminal (``$SHELL -l``), and the self-exit test
+    drives that shell to exit. A heavily-configured login shell is slow to
+    initialize and drops typed-ahead input while it does, which is what made the
+    self-exit teardown flaky on a developer's machine but not on CI's bare bash.
+    An empty HOME/ZDOTDIR gives every run a vanilla, fast-starting shell, so the
+    behavior under test depends on Sculptor, not on who runs the suite.
+    """
+    empty_home = tmp_path_factory.mktemp("empty_shell_home")
+    monkeypatch.setenv("HOME", str(empty_home))
+    monkeypatch.setenv("ZDOTDIR", str(empty_home))
+
+
 def _wait_for_dead(pid: int, timeout: float = 1.0) -> bool:
     """Return True once ``os.kill(pid, 0)`` raises ProcessLookupError.
 

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
@@ -45,10 +45,11 @@ def _isolate_shell_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pyt
 
     These tests start a real terminal (``$SHELL -l``), and the self-exit test
     drives that shell to exit. A heavily-configured login shell is slow to
-    initialize and drops typed-ahead input while it does, which is what made the
-    self-exit teardown flaky on a developer's machine but not on CI's bare bash.
-    An empty HOME/ZDOTDIR gives every run a vanilla, fast-starting shell, so the
-    behavior under test depends on Sculptor, not on who runs the suite.
+    initialize and drops typed-ahead input while it does, so a write issued
+    right after start() can be lost — and how long that takes varies per
+    developer. An empty HOME/ZDOTDIR gives every run a vanilla, fast-starting
+    shell, so the behavior under test depends on Sculptor, not on who runs the
+    suite.
     """
     empty_home = tmp_path_factory.mktemp("empty_shell_home")
     monkeypatch.setenv("HOME", str(empty_home))

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
@@ -132,13 +132,22 @@ def test_read_loop_closes_primary_fd_and_unregisters_on_shell_self_exit(tmp_path
             os.fstat(primary_fd)
 
             # Tell the login shell to exit on its own. The reader thread should
-            # then observe EOF/EIO and run the self-exit cleanup path.
-            manager.write(b"exit\n")
-
-            # The reader clears _pty_process once it has closed the fd + terminated
-            # the shell. Poll for that (manager.stop() was never called).
-            deadline = time.monotonic() + 5.0
+            # then observe EOF/EIO and run the self-exit cleanup path, which
+            # clears _pty_process once it has closed the fd + terminated the
+            # shell (manager.stop() is never called here).
+            #
+            # ``exit`` is resent periodically rather than written once: a login
+            # shell with a heavy rc can still be initializing — and discarding
+            # typed-ahead input — right after start(), so a single early write
+            # can be dropped and the shell would never exit. Resending until the
+            # reader tears the terminal down makes this robust under load.
+            deadline = time.monotonic() + 15.0
+            next_write = 0.0
             while time.monotonic() < deadline and manager._pty_process is not None:
+                now = time.monotonic()
+                if now >= next_write:
+                    manager.write(b"exit\n")
+                    next_write = now + 0.5
                 time.sleep(0.02)
 
             assert manager._pty_process is None, "reader did not tear down the pty after the shell self-exited"

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/local_terminal_manager_test.py
@@ -141,12 +141,24 @@ def test_read_loop_closes_primary_fd_and_unregisters_on_shell_self_exit(tmp_path
             # typed-ahead input — right after start(), so a single early write
             # can be dropped and the shell would never exit. Resending until the
             # reader tears the terminal down makes this robust under load.
+            #
+            # Write straight to the captured pty fd rather than via
+            # ``manager.write()``: the reader thread is concurrently nulling
+            # ``manager._pty_process`` as it tears down, and ``write()`` reads
+            # that attribute twice, so a resend racing the teardown could hit an
+            # AttributeError. ``pty_process`` is a stable reference and its
+            # ``primary_fd`` property reads cleanly (returning None once closed).
             deadline = time.monotonic() + 15.0
             next_write = 0.0
             while time.monotonic() < deadline and manager._pty_process is not None:
                 now = time.monotonic()
                 if now >= next_write:
-                    manager.write(b"exit\n")
+                    exit_fd = pty_process.primary_fd
+                    if exit_fd is not None:
+                        try:
+                            os.write(exit_fd, b"exit\n")
+                        except OSError:
+                            pass  # fd closed mid-teardown; the shell is already exiting
                     next_write = now + 0.5
                 time.sleep(0.02)
 

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
@@ -34,12 +34,11 @@ def _isolate_shell_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pyt
     These tests spawn a real ``$SHELL -l`` — a login shell, which sources the
     user's full rc chain. Left alone, that turns the developer's personal
     terminal configuration (prompt themes, plugins, syntax highlighting,
-    bracketed-paste) into uncontrolled test input: a bare ``/bin/bash`` on CI
-    behaves nothing like a heavily-themed zsh on a laptop, which is what made
-    these reads flaky. Pointing HOME (bash, ``~/.profile`` etc.) and ZDOTDIR
-    (zsh, ``.zshrc`` etc.) at an empty directory gives every run a vanilla
-    prompt, so what the tests observe depends only on Sculptor's own env
-    handling, not on who runs the suite.
+    bracketed-paste) into uncontrolled test input — a bare ``/bin/bash`` on CI
+    behaves nothing like a heavily-themed zsh on a laptop. Pointing HOME (bash,
+    ``~/.profile`` etc.) and ZDOTDIR (zsh, ``.zshrc`` etc.) at an empty
+    directory gives every run a vanilla prompt, so what the tests observe
+    depends only on Sculptor's own env handling, not on who runs the suite.
     """
     empty_home = tmp_path_factory.mktemp("empty_shell_home")
     monkeypatch.setenv("HOME", str(empty_home))

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
@@ -49,8 +49,9 @@ _TERMINAL_NOISE_RE = re.compile(
 # OUTPUT: the shell's echo of the *typed* command still has the literal
 # ``${VAR}`` between the sentinels, so it can never match — not even for an
 # empty (scrubbed) value, whose output is ``<SCT||SCT>``. That is what lets the
-# scrub assertions actually prove a variable is empty in the child, rather than
-# merely that some shared ``CHECK:`` substring appeared somewhere on the line.
+# scrub assertions prove a variable is genuinely empty in the child, instead of
+# passing on any substring that merely happens to appear on the line (such as
+# the shell's own echo of the typed command).
 _SENTINEL_OPEN = "<SCT|"
 _SENTINEL_CLOSE = "|SCT>"
 
@@ -101,6 +102,15 @@ def _assert_pty_echo(fd: int, env_var: str, expected: str, timeout: float = 15.0
     marker = f"{_SENTINEL_OPEN}{expected}{_SENTINEL_CLOSE}".encode()
     command = f'echo "{_SENTINEL_OPEN}${{{env_var}}}{_SENTINEL_CLOSE}"\n'.encode()
 
+    # Wait for readability with poll(2), not select(2): select cannot wait on a
+    # file descriptor whose number is >= FD_SETSIZE (1024) and raises
+    # "filedescriptor out of range in select()". An fd-heavy test run (xdist, a
+    # long-lived process) can hand a freshly opened pty a high fd number, so a
+    # select() here would reintroduce exactly the high-fd flakiness the
+    # production reader uses poll(2) to avoid.
+    poller = select.poll()
+    poller.register(fd, select.POLLIN)
+
     output = b""
     deadline = time.monotonic() + timeout
     next_send = 0.0
@@ -112,15 +122,17 @@ def _assert_pty_echo(fd: int, env_var: str, expected: str, timeout: float = 15.0
             except OSError:
                 pass
             next_send = now + 0.75
-        # ``select`` so we never block past the resend cadence; the pty primary
-        # fd is non-blocking, so a bare ``os.read`` would spin on BlockingIOError.
-        readable, _, _ = select.select([fd], [], [], 0.2)
-        if not readable:
+        # poll so we never block past the resend cadence; the pty primary fd is
+        # non-blocking, so a bare os.read would spin on BlockingIOError. A 200ms
+        # timeout (in milliseconds for poll) paces the loop when there is no data.
+        if not poller.poll(200):
             continue
         try:
             chunk = os.read(fd, 4096)
-        except (BlockingIOError, OSError):
+        except BlockingIOError:
             continue
+        except OSError:
+            break  # EIO/EBADF: the shell is gone; stop and report what we have.
         if not chunk:
             break  # EOF: the shell exited.
         output += chunk

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
@@ -6,6 +6,8 @@ backend -> posix_spawn -> pty_helper -> pty.fork -> shell path.
 """
 
 import os
+import re
+import select
 import signal
 import socket
 import sys
@@ -25,30 +27,51 @@ from sculptor.services.workspace_service.environment_manager.environments.spawne
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only")
 
 
-def _read_pty_until(fd: int, marker: str, timeout: float = 5.0) -> str:
-    """Read from pty fd until marker appears or timeout expires."""
-    output = b""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            chunk = os.read(fd, 4096)
-            if chunk:
-                output += chunk
-                if marker.encode() in output:
-                    return output.decode(errors="replace")
-        except OSError:
-            pass
-        time.sleep(0.05)
-    return output.decode(errors="replace")
+# Matches ANSI/OSC escape sequences and stray C0 control bytes so a sentinel can
+# be found even when a developer's heavily-themed interactive login shell wraps
+# its prompt and output in color, bracketed-paste, or window-title codes. CI
+# typically runs a bare ``/bin/bash`` with none of these; local machines often
+# run zsh with prompt plugins. Tabs and newlines are preserved so captured
+# output stays readable in assertion messages.
+_TERMINAL_NOISE_RE = re.compile(
+    b"|".join(
+        (
+            rb"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)",  # OSC ... terminated by BEL or ST
+            rb"\x1b[@-Z\\-_]",  # two-byte ESC sequences
+            rb"\x1b\[[0-9;?]*[ -/]*[@-~]",  # CSI sequences (colors, cursor moves, ?2004h, ...)
+            rb"[\x00-\x08\x0b-\x1f\x7f]",  # stray C0 controls, keeping \t (0x09) and \n (0x0a)
+        )
+    )
+)
+
+# Sentinels bracketing the echoed value. We search for the fully-expanded form
+# (e.g. ``<SCT|local_port_5050|SCT>``), which can appear ONLY in the command's
+# OUTPUT: the shell's echo of the *typed* command still has the literal
+# ``${VAR}`` between the sentinels, so it can never match — not even for an
+# empty (scrubbed) value, whose output is ``<SCT||SCT>``. That is what lets the
+# scrub assertions actually prove a variable is empty in the child, rather than
+# merely that some shared ``CHECK:`` substring appeared somewhere on the line.
+_SENTINEL_OPEN = "<SCT|"
+_SENTINEL_CLOSE = "|SCT>"
+
+
+def _strip_terminal_noise(data: bytes) -> bytes:
+    return _TERMINAL_NOISE_RE.sub(b"", data)
 
 
 @contextmanager
 def _running_pty(proc: SpawnedPtyProcess) -> Generator[int, None, None]:
-    """Start a SpawnedPtyProcess, yield its primary fd, and ensure cleanup."""
+    """Start a SpawnedPtyProcess, yield its primary fd, and ensure cleanup.
+
+    There is deliberately no fixed "wait for the prompt" sleep here:
+    ``_assert_pty_echo`` resends its probe until the shell is actually ready,
+    which is robust to a slow login-shell init under load. A fixed pre-write
+    delay is unreliable — a heavily-configured shell (plugins, async/instant
+    prompt) can still be initializing, and dropping typed-ahead input, well past
+    any hardcoded delay.
+    """
     proc.start()
     try:
-        # Give the shell a moment to print its prompt before we write commands.
-        time.sleep(0.5)
         fd = proc.primary_fd
         assert fd is not None
         yield fd
@@ -60,12 +83,51 @@ def _running_pty(proc: SpawnedPtyProcess) -> Generator[int, None, None]:
         proc.close_primary_fd()
 
 
-def _assert_pty_echo(fd: int, env_var: str, expected: str) -> None:
-    """Write an echo command to the pty and assert the output contains the marker."""
-    marker = f"CHECK:{expected}"
-    os.write(fd, f'echo "CHECK:${{{env_var}}}"\n'.encode())
-    output = _read_pty_until(fd, marker)
-    assert marker in output
+def _assert_pty_echo(fd: int, env_var: str, expected: str, timeout: float = 15.0) -> None:
+    """Echo ``$env_var`` through the pty and assert its value equals ``expected``.
+
+    The probe command is *resent* periodically rather than written once after a
+    fixed delay: an interactive login shell with a heavy rc (prompt plugins,
+    async/instant prompt, syntax highlighting) can still be initializing — and
+    discarding typed-ahead input — for a second or more after it first draws a
+    prompt, especially when several shells start at once under parallel-test
+    load. Resending guarantees at least one probe lands once the shell is ready,
+    instead of betting that init finished within a hardcoded window.
+
+    Matching is done against noise-stripped output and uses sentinels that can
+    only appear in the command's output (never in the shell's echo of the typed
+    command), so the assertion stays meaningful even for an empty value.
+    """
+    marker = f"{_SENTINEL_OPEN}{expected}{_SENTINEL_CLOSE}".encode()
+    command = f'echo "{_SENTINEL_OPEN}${{{env_var}}}{_SENTINEL_CLOSE}"\n'.encode()
+
+    output = b""
+    deadline = time.monotonic() + timeout
+    next_send = 0.0
+    while time.monotonic() < deadline:
+        now = time.monotonic()
+        if now >= next_send:
+            try:
+                os.write(fd, command)
+            except OSError:
+                pass
+            next_send = now + 0.75
+        # ``select`` so we never block past the resend cadence; the pty primary
+        # fd is non-blocking, so a bare ``os.read`` would spin on BlockingIOError.
+        readable, _, _ = select.select([fd], [], [], 0.2)
+        if not readable:
+            continue
+        try:
+            chunk = os.read(fd, 4096)
+        except (BlockingIOError, OSError):
+            continue
+        if not chunk:
+            break  # EOF: the shell exited.
+        output += chunk
+        if marker in _strip_terminal_noise(output):
+            return
+    cleaned = _strip_terminal_noise(output)
+    raise AssertionError(f"marker {marker!r} for ${env_var} not seen within {timeout:.0f}s; output: {cleaned!r}")
 
 
 def test_extra_env_available_in_child(tmp_path: Path) -> None:

--- a/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
+++ b/sculptor/sculptor/services/workspace_service/environment_manager/environments/spawned_pty_process_test.py
@@ -6,7 +6,6 @@ backend -> posix_spawn -> pty_helper -> pty.fork -> shell path.
 """
 
 import os
-import re
 import select
 import signal
 import socket
@@ -27,22 +26,25 @@ from sculptor.services.workspace_service.environment_manager.environments.spawne
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only")
 
 
-# Matches ANSI/OSC escape sequences and stray C0 control bytes so a sentinel can
-# be found even when a developer's heavily-themed interactive login shell wraps
-# its prompt and output in color, bracketed-paste, or window-title codes. CI
-# typically runs a bare ``/bin/bash`` with none of these; local machines often
-# run zsh with prompt plugins. Tabs and newlines are preserved so captured
-# output stays readable in assertion messages.
-_TERMINAL_NOISE_RE = re.compile(
-    b"|".join(
-        (
-            rb"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)",  # OSC ... terminated by BEL or ST
-            rb"\x1b[@-Z\\-_]",  # two-byte ESC sequences
-            rb"\x1b\[[0-9;?]*[ -/]*[@-~]",  # CSI sequences (colors, cursor moves, ?2004h, ...)
-            rb"[\x00-\x08\x0b-\x1f\x7f]",  # stray C0 controls, keeping \t (0x09) and \n (0x0a)
-        )
-    )
-)
+@pytest.fixture(autouse=True)
+def _isolate_shell_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Point the spawned login shell at an empty HOME/ZDOTDIR so it sources no
+    user rc files.
+
+    These tests spawn a real ``$SHELL -l`` — a login shell, which sources the
+    user's full rc chain. Left alone, that turns the developer's personal
+    terminal configuration (prompt themes, plugins, syntax highlighting,
+    bracketed-paste) into uncontrolled test input: a bare ``/bin/bash`` on CI
+    behaves nothing like a heavily-themed zsh on a laptop, which is what made
+    these reads flaky. Pointing HOME (bash, ``~/.profile`` etc.) and ZDOTDIR
+    (zsh, ``.zshrc`` etc.) at an empty directory gives every run a vanilla
+    prompt, so what the tests observe depends only on Sculptor's own env
+    handling, not on who runs the suite.
+    """
+    empty_home = tmp_path_factory.mktemp("empty_shell_home")
+    monkeypatch.setenv("HOME", str(empty_home))
+    monkeypatch.setenv("ZDOTDIR", str(empty_home))
+
 
 # Sentinels bracketing the echoed value. We search for the fully-expanded form
 # (e.g. ``<SCT|local_port_5050|SCT>``), which can appear ONLY in the command's
@@ -54,10 +56,6 @@ _TERMINAL_NOISE_RE = re.compile(
 # the shell's own echo of the typed command).
 _SENTINEL_OPEN = "<SCT|"
 _SENTINEL_CLOSE = "|SCT>"
-
-
-def _strip_terminal_noise(data: bytes) -> bytes:
-    return _TERMINAL_NOISE_RE.sub(b"", data)
 
 
 @contextmanager
@@ -95,9 +93,12 @@ def _assert_pty_echo(fd: int, env_var: str, expected: str, timeout: float = 15.0
     load. Resending guarantees at least one probe lands once the shell is ready,
     instead of betting that init finished within a hardcoded window.
 
-    Matching is done against noise-stripped output and uses sentinels that can
-    only appear in the command's output (never in the shell's echo of the typed
-    command), so the assertion stays meaningful even for an empty value.
+    The sentinels bracket the value so a match can come only from the command's
+    output (never the shell's echo of the typed command), which keeps the
+    assertion meaningful even for an empty value. The expanded sentinel string
+    lands contiguously on echo's output line, so a plain substring search over
+    the raw bytes suffices — no escape-stripping needed once the shell is
+    isolated to a vanilla config (see ``_isolate_shell_config``).
     """
     marker = f"{_SENTINEL_OPEN}{expected}{_SENTINEL_CLOSE}".encode()
     command = f'echo "{_SENTINEL_OPEN}${{{env_var}}}{_SENTINEL_CLOSE}"\n'.encode()
@@ -136,10 +137,11 @@ def _assert_pty_echo(fd: int, env_var: str, expected: str, timeout: float = 15.0
         if not chunk:
             break  # EOF: the shell exited.
         output += chunk
-        if marker in _strip_terminal_noise(output):
+        if marker in output:
             return
-    cleaned = _strip_terminal_noise(output)
-    raise AssertionError(f"marker {marker!r} for ${env_var} not seen within {timeout:.0f}s; output: {cleaned!r}")
+    raise AssertionError(
+        f"marker {marker!r} for ${env_var} not seen within {timeout:.0f}s; output: {output.decode(errors='replace')!r}"
+    )
 
 
 def test_extra_env_available_in_child(tmp_path: Path) -> None:
@@ -196,6 +198,70 @@ def test_inherited_sculpt_env_is_scrubbed_so_extra_env_takes_effect(
         _assert_pty_echo(fd, "SCULPT_API_PORT", "local_port_5050")
         _assert_pty_echo(fd, "SCULPT_AGENT_ID", "")
         _assert_pty_echo(fd, "SCULPT_LEAKED_VAR", "")
+
+
+# ``_scrub_shell_env`` is the pure function that actually decides what the shell
+# sees; the pty echo tests above prove a value survives an end-to-end spawn,
+# while these pin down every branch of the rule deterministically — no pty, no
+# shell, no dependence on the developer's terminal at all.
+
+
+def test_scrub_shell_env_removes_sculptor_internal_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCULPT_API_PORT", "5050")
+    monkeypatch.setenv("SCULPTOR_INTERNAL", "x")
+    monkeypatch.setenv("_PYI_BOOTSTRAP", "x")
+    monkeypatch.setenv("SESSION_TOKEN", "secret")
+    monkeypatch.setenv("SCTEST_UNRELATED", "keep")
+
+    env = spawned_pty_process._scrub_shell_env(extra_env={}, env_var_override=False)
+
+    assert "SCULPT_API_PORT" not in env
+    assert "SCULPTOR_INTERNAL" not in env
+    assert "_PYI_BOOTSTRAP" not in env
+    assert "SESSION_TOKEN" not in env
+    # Vars outside the excluded names/prefixes are left untouched.
+    assert env["SCTEST_UNRELATED"] == "keep"
+    # The pty advertises xterm-256color, so TERM is always forced to match.
+    assert env["TERM"] == spawned_pty_process.TERMINAL_TYPE
+
+
+def test_scrub_shell_env_injects_extra_env_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCTEST_NEW_VAR", raising=False)
+    env = spawned_pty_process._scrub_shell_env(extra_env={"SCTEST_NEW_VAR": "new"}, env_var_override=False)
+    assert env["SCTEST_NEW_VAR"] == "new"
+
+
+def test_scrub_shell_env_keeps_inherited_value_when_override_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCTEST_EXISTING", "original")
+    env = spawned_pty_process._scrub_shell_env(extra_env={"SCTEST_EXISTING": "replacement"}, env_var_override=False)
+    assert env["SCTEST_EXISTING"] == "original"
+
+
+def test_scrub_shell_env_replaces_inherited_value_when_override_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCTEST_EXISTING", "original")
+    env = spawned_pty_process._scrub_shell_env(extra_env={"SCTEST_EXISTING": "replacement"}, env_var_override=True)
+    assert env["SCTEST_EXISTING"] == "replacement"
+
+
+def test_scrub_shell_env_prepends_path_even_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PATH", "/usr/bin")
+    # PATH is special-cased: a terminal's extra PATH is *prepended* (so its tools
+    # win) rather than replacing the inherited PATH — and this happens even with
+    # override disabled, unlike every other key.
+    env = spawned_pty_process._scrub_shell_env(extra_env={"PATH": "/custom/bin"}, env_var_override=False)
+    assert env["PATH"] == "/custom/bin" + os.pathsep + "/usr/bin"
+
+
+def test_scrub_shell_env_reinjects_scrubbed_sculpt_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The Sculptor-on-Sculptor case (see test_inherited_sculpt_env_... above),
+    # isolated to the pure function: the inherited SCULPT_* value is scrubbed, so
+    # extra_env's fresh value is injected and wins even with override disabled —
+    # precisely because scrubbing removed the inherited one first.
+    monkeypatch.setenv("SCULPT_API_PORT", "outer_port_12345")
+    env = spawned_pty_process._scrub_shell_env(
+        extra_env={"SCULPT_API_PORT": "local_port_5050"}, env_var_override=False
+    )
+    assert env["SCULPT_API_PORT"] == "local_port_5050"
 
 
 def test_shell_exit_via_close_primary_fd_is_detected(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Stabilize four backend unit tests that fail reproducibly under heavy parallel-test load (`pytest -n 8`) on local dev machines running an interactive zsh login, but pass on CI. These are fragile timing/environment assumptions in the tests, not product bugs.

- `sculptor/sculptor/primitives/threads_test.py::test_source_polls_and_emits_values`
- `…/environments/spawned_pty_process_test.py::test_extra_env_overrides_when_enabled`
- `…/environments/spawned_pty_process_test.py::test_inherited_sculpt_env_is_scrubbed_so_extra_env_takes_effect`
- `…/environments/local_terminal_manager_test.py::test_read_loop_closes_primary_fd_and_unregisters_on_shell_self_exit`

## Why they were flaky

- **Timing test**: asserted how many values landed inside a fixed `time.sleep` window. The polling source emits one value per `check_interval` tick, so a fixed window assumes a number of scheduler slices the thread may not get under load.
- **PTY tests**: spawn a real `$SHELL -l` (a **login** shell) and read an echoed marker back. A login shell sources the developer's full rc chain, so prompt themes, plugins, syntax-highlighting and bracketed-paste become uncontrolled test input — bare bash on CI behaves nothing like a heavy zsh locally. On top of that, a heavy shell keeps initializing (and drops typed-ahead input) past any fixed pre-write sleep, so the probe is dropped and its marker never lands.

## Fix

**Tactical stabilization:**
- Replace fixed `time.sleep` windows with condition-based waits that assert eventual state with a generous timeout.
- Resend the probe / `exit` until the shell is ready instead of a fixed pre-write delay.
- Wait on readability with `poll(2)` (not `select(2)`, which breaks for fds ≥ 1024), and bracket the echoed value in sentinels so a match can come only from the command's output (never the typed-command echo) — which also makes the empty/scrubbed-variable assertions genuinely meaningful.

**Fix the coupling at the source** (after review feedback that the escape-stripping "read odd"):
- **Isolate the shell config.** An autouse fixture points `HOME`/`ZDOTDIR` at an empty dir so every run gets a vanilla, fast-starting shell regardless of who runs the suite. With the shell de-themed, the sentinel lands contiguously on echo's output line and a plain substring search suffices — the ANSI/control-code stripping is removed entirely.
- **Test the logic at the right layer.** The env propagation/scrub behavior these tests care about is produced by the pure `_scrub_shell_env()` function, which had no direct coverage. Added focused, deterministic unit tests for it (scrub of `SCULPT_*`/`SCULPTOR_*`/`_PYI_*`/`SESSION_TOKEN`, extra-env inject, override on/off, PATH prepend, and the scrub-then-reinject Sculptor-on-Sculptor case). The remaining pty tests stay as a thin end-to-end check that a value really reaches a spawned shell.

**Codify the lesson.** Adds a review rule (`no_user_config_coupled_assertions`, under Test Isolation in `docs/development/review/integration_tests.md`): don't couple a config-independent assertion to a user-configurable tool's output (shell, git, editor, locale, `$TERM`) — neutralise the config and test the pure function directly, rather than band-aiding with escape-stripping or longer timeouts.

## Verification

- Each formerly-failing test: green many times in isolation; the pty file 10/10 with vanilla-shell isolation + raw matching.
- Real `just test-unit-backend` (random order, `-n 8`): repeatedly green — 2056 passed, 4 skipped, 0 failed.
- `just format` and `just check` clean.

Cut from `main`; changes are test files plus one review-rule doc, independent of the SCU-1609 plugin work.

(Sent by Claude)
