### PR TITLE
[SCU-1635] Bump shipped Claude CLI version to 2.1.195

### DIFF
--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -208,8 +208,8 @@ packaging Sculptor):
 
 ### 3.3 Required external binaries
 
-- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.170,
-  minimum 2.1.170, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
+- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.195,
+  minimum 2.1.195, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
   **linux-x64** (`sculptor/sculptor/services/managed_tools.py`). Sculptor can install/manage it and can use a
   user-supplied binary (`SPEC.md` §7.1, §7.10).
 - **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -233,9 +233,9 @@ _CLAUDE_MANIFEST_FETCH_TIMEOUT_SECONDS = 30.0
 # the existing service -> managed_tools edge, which would be an import cycle. The
 # service re-imports this constant for its status / version-range logic.
 CLAUDE_VERSION_RANGE = VersionRange(
-    min_version="2.1.170",
+    min_version="2.1.195",
     max_version="2.99.99",
-    recommended_version="2.1.170",
+    recommended_version="2.1.195",
     # Blocked versions create background tool invocations that are missing events
     # describing them.
     blocked_versions=(BlockedVersionRange(min_version="2.1.101", max_version="2.1.101"),),

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -5783,6 +5783,88 @@ class TestChatMessageIdCollisionContract:
             expected_tool_ids=("toolu_agent", "toolu_sub", "toolu_b"),
         )
 
+    def test_two_level_nested_subagent_turns_keep_parent_attribution(self) -> None:
+        """Two-level nesting (a subagent that spawns its own subagent) must preserve each
+        level's parent_tool_use_id so the frontend can rebuild the depth-2 tree.
+
+        Claude 2.1.172 lets a sub-agent spawn its own sub-agents.  A foreground grandchild's
+        messages carry their *immediate* parent's tool_use id (the level-1 Agent tool_use),
+        which itself lives in a message whose parent is the top-level Agent tool_use.  The
+        converter must keep all three parent contexts distinct as control descends
+        None -> toolu_l1 -> toolu_l2 and returns back to None: collapsing any adjacent pair
+        merges turns and loses an Agent tool_use or a subagent reply (the SCU-1421/1422
+        collapse class, one level deeper than
+        ``test_interleaved_subagent_and_main_turns_keep_distinct_ids``).  buildSubagentTree
+        reconstructs the nesting purely from these ids, so a flattened/dropped parent here
+        silently breaks the rendered tree.
+        """
+        request_id = AgentMessageID()
+        assistant = AssistantMessageID("assistant-1")
+        main_a, main_b = AgentMessageID(), AgentMessageID()
+        child, grandchild = AgentMessageID(), AgentMessageID()
+
+        stream = self._user_and_start(request_id) + [
+            # Main agent spawns the level-1 subagent (parent None).
+            PartialResponseBlockAgentMessage(
+                assistant_message_id=assistant,
+                message_id=AgentMessageID(),
+                first_response_message_id=main_a,
+                content=(TextBlock(text="MAIN_BEFORE"), ToolUseBlock(id=ToolUseID("toolu_l1"), name="Task", input={})),
+            ),
+            # Level-1 subagent runs and itself spawns the level-2 subagent
+            # (parent = the main agent's Agent tool_use).
+            ResponseBlockAgentMessage(
+                role="assistant",
+                assistant_message_id=AssistantMessageID("subagent-l1"),
+                message_id=child,
+                content=(TextBlock(text="L1_TEXT"), ToolUseBlock(id=ToolUseID("toolu_l2"), name="Task", input={})),
+                parent_tool_use_id="toolu_l1",
+            ),
+            # Level-2 grandchild runs a leaf tool (parent = the level-1 Agent tool_use).
+            ResponseBlockAgentMessage(
+                role="assistant",
+                assistant_message_id=AssistantMessageID("subagent-l2"),
+                message_id=grandchild,
+                content=(
+                    TextBlock(text="L2_TEXT"),
+                    ToolUseBlock(id=ToolUseID("toolu_l2_bash"), name="Bash", input={}),
+                ),
+                parent_tool_use_id="toolu_l2",
+            ),
+            # Control returns to the main agent (parent None again).
+            PartialResponseBlockAgentMessage(
+                assistant_message_id=assistant,
+                message_id=AgentMessageID(),
+                first_response_message_id=main_b,
+                content=(TextBlock(text="MAIN_AFTER"),),
+            ),
+            RequestSuccessAgentMessage(request_id=request_id),
+        ]
+
+        update = convert_agent_messages_to_task_update(
+            stream, task_id=TaskID(), harness=CLAUDE_CODE_HARNESS, completed_message_by_id={}
+        )
+        _assert_turns_survive(
+            update,
+            expected_text_markers=("MAIN_BEFORE", "L1_TEXT", "L2_TEXT", "MAIN_AFTER"),
+            expected_tool_ids=("toolu_l1", "toolu_l2", "toolu_l2_bash"),
+        )
+
+        # Every turn keeps its own nesting context: the grandchild points at the level-1
+        # Agent tool_use, the child at the top-level Agent tool_use, and the main turns at
+        # nothing.  A regression that flattened deep nesting would surface here as a wrong
+        # (or None) parent on L2_TEXT even while the survival assertion above still passes.
+        parent_by_marker = {
+            block.text: message.parent_tool_use_id
+            for message in _rendered_chat_messages(update)
+            for block in message.content
+            if isinstance(block, TextBlock)
+        }
+        assert parent_by_marker.get("MAIN_BEFORE") is None
+        assert parent_by_marker.get("L1_TEXT") == "toolu_l1"
+        assert parent_by_marker.get("L2_TEXT") == "toolu_l2"
+        assert parent_by_marker.get("MAIN_AFTER") is None
+
     def test_multi_step_turn_reusing_id_preserves_every_step(self) -> None:
         """A multi-step turn legitimately reuses one first_response_message_id across segments
         (text -> tool -> more text), separated by StreamingMessageComplete.  Reusing the id must


### PR DESCRIPTION
## What

Bumps the shipped Claude CLI version **2.1.170 → 2.1.195**. The single source of truth is `CLAUDE_VERSION_RANGE` in `sculptor/sculptor/services/managed_tools.py` — `min_version` and `recommended_version` move to `2.1.195`, `max_version` stays at `2.99.99`. 2.1.195 is the current npm `latest`; its release manifest is present in the distribution bucket for every platform Sculptor ships (darwin-arm64, linux-x64).

## Why

Going past `stable` (2.1.181) to `latest` (2.1.195) is deliberate, not churn — it picks up fixes that matter for how Sculptor drives `claude` headlessly:

- `--resume` no longer fails with "No conversation found" when the original `-p` run produced no model turns (Sculptor uses `-p` + resume).
- Background/subagent event-completeness fixes (stuck "working", `agent({schema})` looping) — the same class of bug the existing `blocked_versions` guard exists for.

## Validation

The biggest event-shape change in the `2.1.170…2.1.195` range is **2.1.172's nested subagents** (a sub-agent spawning its own sub-agents), so that was the focus.

- **Manual `claude -p` (2.1.195) inspection.** Ran a 3-level nested-subagent prompt and confirmed each level's messages carry their *immediate* parent's `parent_tool_use_id` (main → L1 → L2 Bash) — exactly what Sculptor's `output_processor` and the recursive `buildSubagentTree` expect; no flattening or orphaning. Also confirmed 2.1.195's new top-level event fields (`subagent_type`, `task_description`) are safely ignored by the parser (explicit field extraction + base-model `extra="allow"`).
- **New deterministic test** (`message_conversion_test.py::…test_two_level_nested_subagent_turns_keep_parent_attribution`). Drives a hand-built two-level stream (`None → toolu_l1 → toolu_l2 → None`) through the converter and asserts every turn survives with its exact `parent_tool_use_id` intact, so `buildSubagentTree` can rebuild the depth-2 tree. Extends the existing single-level SCU-1421/1422 collapse guard one level deeper — model-independent, ~0.2s.
- **Why not a real_claude foreground-nested test:** in 2.1.195 the Agent tool preferentially runs subagents in the **background** even when asked for foreground, so a foreground-nested scenario can't be deterministically forced through prompting (the deep output also only renders in a hover popover, never a top-level message). The runtime subagent path is already covered by the existing `real_claude` `test_background_subagent_pill_completes`, which passes on 2.1.195.
- `just format` / `just check` (typecheck, lint, ratchets, hygiene), backend version-range unit tests (143), and the full frontend unit suite (2527, incl. `subagentTree`'s 3-level case) all pass.

## Note

The `2.1.101` entry in `blocked_versions` is now redundant (anything below the new `2.1.195` min is already rejected), so `test_blocked_version.py` now exercises the min-version path rather than the blocked path. The entry is left in place — harmless, and it documents the known-bad version.

(Sent by Claude)