### PR TITLE
Quarantine browser-panel webview flakes to a higher-retry offload group (SCU-1607)

### DIFF
--- a/offload-electron.toml
+++ b/offload-electron.toml
@@ -44,11 +44,29 @@ command = "uv run --project sculptor pytest"
 paths = ["sculptor/tests/integration/"]
 run_args = "-p no:xdist --sculptor-launch-mode=electron"
 
-# The @electron subset. real_claude/real_pi are excluded as in the browser lane;
-# the conftest launch-mode gate additionally skips any non-electron test.
+# The @electron subset, minus the Browser-panel webview tests (those get their
+# own higher-retry group below). real_claude/real_pi are excluded as in the
+# browser lane; the conftest launch-mode gate additionally skips any
+# non-electron test.
 [groups.electron]
 retry_count = 1
-filters = "-m 'electron and not real_claude and not real_pi'"
+filters = "-m 'electron and not real_claude and not real_pi and not browser_panel_webview_flaky'"
+
+# Browser-panel webview tests whose residual nondeterminism is a
+# chromium-in-chromium environment limit, not a product-logic bug. The Browser
+# panel renders a real Electron <webview> guest; under xvfb software rendering
+# at high parallelism, guest compositing (which capturePage needs before it
+# returns a non-empty frame), the X11 clipboard image round-trip, and <webview>
+# attach latency are all environment-timed, and no in-product readiness gate can
+# make them deterministic — the dom-ready gate and the capturePage retry helper
+# already shipped and the flake still recurs. The feature itself works (every
+# failure recovers on retry; preserved in-page state proves the guest survives),
+# so rather than another source band-aid these run in their own group with a
+# more generous retry budget that keeps the lane reliably green. The environment
+# limit is tracked in SCU-1607.
+[groups.browser_panel_webview_flaky]
+retry_count = 4
+filters = "-m 'electron and browser_panel_webview_flaky and not real_claude and not real_pi'"
 
 [checkpoint]
 build_inputs = [

--- a/sculptor/pytest.ini
+++ b/sculptor/pytest.ini
@@ -22,6 +22,7 @@ markers =
     custom_sculptor_folder: provide a populator callable for the per-test sculptor folder (read by _extract_marker_arg in sculptor/testing/resources.py)
     real_pi: tests that hit a real pi binary + real upstream model (excluded from CI)
     allow_dependency_downloads: opt out of the unit-test guard that blocks managed binary downloads (the test mocks the network itself and exercises the real install path)
+    browser_panel_webview_flaky: Browser-panel webview test whose residual nondeterminism is a chromium-in-chromium environment limit (xvfb software rendering: <webview> guest compositing for capturePage, the X11 clipboard image round-trip, and guest attach latency under heavy parallelism). Runs in a dedicated higher-retry offload group rather than the default electron group; see offload-electron.toml and SCU-1607.
 
 
 python_files = *_test.py *_tests.py test_*.py *_benchmarks.py

--- a/sculptor/tests/integration/frontend/test_browser_panel.py
+++ b/sculptor/tests/integration/frontend/test_browser_panel.py
@@ -13,6 +13,15 @@ panel's user-visible contract:
 - Cross-workspace isolation: independent URLs, cookies, history (R8).
 - In-page state preservation across workspace switches and route
   detours (R8 strongest form).
+
+The ``@electron`` tests that drive a real ``<webview>`` guest are marked
+``@pytest.mark.browser_panel_webview_flaky``.  The feature works, but under
+CI's chromium-in-chromium xvfb software rendering their readiness is
+environment-timed (guest compositing for ``capturePage``, the X11 clipboard
+image round-trip, and ``<webview>`` attach latency under heavy parallelism),
+which no product-side gate can make deterministic.  They run in a dedicated
+higher-retry offload group rather than the default electron group; see
+``offload-electron.toml`` and SCU-1607.
 """
 
 from __future__ import annotations
@@ -219,6 +228,7 @@ def test_browser_panel_navigation_tour(
 
 
 @pytest.mark.electron
+@pytest.mark.browser_panel_webview_flaky
 @user_story("to land in the URL field with its contents selected, see errors on bad URLs, and load file paths")
 def test_browser_panel_url_input_polish(
     sculptor_instance_: SculptorInstance,
@@ -301,6 +311,7 @@ def test_browser_panel_url_input_polish(
 
 
 @pytest.mark.electron
+@pytest.mark.browser_panel_webview_flaky
 @user_story("to copy a screenshot of the Browser panel to the clipboard, blank or live")
 def test_browser_panel_screenshot(
     sculptor_instance_: SculptorInstance,
@@ -331,6 +342,7 @@ def test_browser_panel_screenshot(
 
 
 @pytest.mark.electron
+@pytest.mark.browser_panel_webview_flaky
 @user_story("to keep the Browser panel's URL when I collapse and reopen the panel")
 def test_browser_panel_url_persists_across_collapse(
     sculptor_instance_: SculptorInstance,
@@ -360,6 +372,7 @@ def test_browser_panel_url_persists_across_collapse(
 
 
 @pytest.mark.electron
+@pytest.mark.browser_panel_webview_flaky
 @user_story("to keep each workspace's Browser panel state — URL, cookies, history — fully isolated")
 def test_browser_panel_cross_workspace_isolation(
     sculptor_instance_: SculptorInstance,
@@ -409,6 +422,7 @@ def test_browser_panel_cross_workspace_isolation(
 
 
 @pytest.mark.electron
+@pytest.mark.browser_panel_webview_flaky
 @user_story("to keep my Browser panel's in-page state alive when I switch workspaces")
 def test_browser_panel_in_page_state_preserved_across_workspace_switch(
     sculptor_instance_: SculptorInstance,
@@ -448,6 +462,7 @@ def test_browser_panel_in_page_state_preserved_across_workspace_switch(
 
 
 @pytest.mark.electron
+@pytest.mark.browser_panel_webview_flaky
 @user_story("to keep my Browser panel's in-page state alive when I detour through a non-workspace route")
 def test_browser_panel_in_page_state_preserved_across_route_detour(
     sculptor_instance_: SculptorInstance,


### PR DESCRIPTION
## Original bug

[SCU-1607](https://linear.app/imbue/issue/SCU-1607) — the `@electron`
Browser-panel **webview** integration tests still flake in CI after PR #172
("Browser panel webview flakes: dom-ready gate + screenshot retry", merged to
`main` 2026-06-25). Across the offload runs of 2026-06-26 → 2026-06-29 (all
post-#172), three signatures recur on the `offload electron integration tests`
lane:

- `No PNG on clipboard after 30.0s (last=None)` — `test_browser_panel_screenshot`
  (the single most frequent flake in the suite).
- `Timed out waiting for webview did-attach` — `url_persists_across_collapse`,
  `route_detour`, `url_input_polish`.
- `Webview location did not reach <url>; last value was 'about:blank'` —
  `in_page_state_preserved_across_workspace_switch`, `cross_workspace_isolation`.

## Decision: CI-environment limit → retry-policy quarantine (not a source fix)

This is the **second** attempt. PR #172 already tried to remove the
nondeterminism at the source (a `dom-ready` readiness gate in `useBrowserWebview`
plus the `captureNonEmptyPage` retry helper). That code is on `main` and the
flake persists, which is the key evidence that the residue is **environmental,
not product logic**. Rather than layer on another source band-aid or bump a
timeout (both explicitly out of scope), this change makes the disposition
explicit and durable via a retry-policy/quarantine.

## Root-cause analysis (fixable-in-product vs CI-environment-limit)

The Browser panel renders one real Electron `<webview>` guest per workspace. The
three signatures bottom out in **chromium-in-chromium under xvfb software
rendering at 200-way parallelism**, where three things are environment-timed and
not observable by any product-side gate:

1. **Screenshot (`last=None`)** — `BROWSER_PANEL_CAPTURE_TO_CLIPBOARD` →
   `captureNonEmptyPage(contents)` → `clipboard.writeImage` → the test reads back
   via `clipboard.readImage()`. `last=None` means the clipboard never received a
   readable PNG. Two irreducibly-environmental dependencies: `webContents.capturePage()`
   only resolves a non-empty frame once the guest GPU-composites (software
   rendering can lag past the 15s retry budget), and the **X11 clipboard image
   round-trip** under xvfb (no clipboard manager) is itself timing-sensitive. The
   feature *is* the OS clipboard, so it cannot be taken out of the loop.
   PR #172's `captureNonEmptyPage` retry already targeted the compositing half
   and the flake survived → **CI-environment limit.**

2. **`Timed out waiting for webview did-attach` (`last value was ''`)** — the test
   bridge waits for the focused `<webview>`'s `did-attach` to publish a
   `webContentsId`. The tests that hit this all toggle the slot between
   `display:none` and visible (collapse/reopen, route detour, workspace switch);
   under heavy load the guest's (re)attach can exceed the 30s budget. Guest-process
   attach latency → **CI-environment limit.**

3. **`last value was 'about:blank'`** — the guest *is* attached (its
   `document.location` is readable) but the typed URL's `loadURL` was lost in the
   narrow window where the guest is mid-`about:blank`-commit. This is the closest
   to "fixable", but PR #172 already moved the gate to `dom-ready` and it recurs;
   the remaining slice is compositor/commit timing the renderer can't
   deterministically observe, so any further change is another timing heuristic,
   not a deterministic signal. **Predominantly CI-environment limit.**

The feature itself works: every failure recovers on retry (the lane stays
neutral/green), and the preserved in-page counter in
`in_page_state_preserved_*` proves the guest survives. So the honest, durable
decision is an explicit retry policy, not a forced code change.

### Real offload evidence (post-#172 `main` commits)

```
bb595065 (Jun 29)  test_browser_panel_screenshot  attempt 4/4  No PNG on clipboard after 30.0s (last=None)   [flaked 1, passed 3]
f6b0d1da           test_browser_panel_screenshot  attempt 2/3 & 3/3  No PNG on clipboard after 30.0s (last=None)
cc3b624e           test_browser_panel_screenshot  No PNG on clipboard after 30.0s (last=None)
2aa4e4ee           test_browser_panel_screenshot  No PNG on clipboard after 30.0s (last=None)
4b13c7da  url_persists_across_collapse  Webview location did not reach .../next.html; last value was '' (Timed out waiting for webview did-attach)
e45e56c8  in_page_state_preserved_across_route_detour  last value was '' (Timed out waiting for webview did-attach)
4b33a122  in_page_state_preserved_across_workspace_switch  last value was 'about:blank'
3abb36f4  in_page_state_preserved_across_workspace_switch  last value was 'about:blank' (+ one "Script failed to execute")
```

## The change

Non-UI; the proof is the failing-then-recovering offload runs above plus the
config/collection verification below.

- **Register a `browser_panel_webview_flaky` pytest marker** (`sculptor/pytest.ini`)
  carrying the rationale.
- **Apply it to the six affected tests** (`test_browser_panel.py`), with a
  module-docstring note so the decision is discoverable from the test file.
- **Split `offload-electron.toml`**: the default `electron` group excludes the
  marker (`and not browser_panel_webview_flaky`), and a new
  `[groups.browser_panel_webview_flaky]` runs them with `retry_count = 4` (vs the
  main-branch worst case of 4 attempts observed in CI) so the lane stays reliably
  green. The group comment carries the full rationale and the SCU-1607 reference.

Not touched: `useBrowserWebview.ts`, `captureNonEmptyPage.ts`, `main.ts`, or any
other product code. No timeout was bumped.

### Why a marker + retry group, not `@pytest.mark.flaky` or `quarantine/`

`@pytest.mark.flaky` is effectively dead in this repo: it is not a registered
marker, and the `_write_flaky_manifest` hook the junit summary references no
longer exists, so the "Tests marked `@pytest.mark.flaky`" count is always 0.
Moving the tests to the `quarantine/` directory would delete all coverage of a
working feature. A dedicated offload retry group (the option the ticket itself
suggests) isolates the known-environment-limited tests, keeps their coverage,
and documents the decision in the place the retry policy actually lives.

## Verification

- `offload validate -c offload-electron.toml` — valid; shows both groups
  (`browser_panel_webview_flaky: retry_count = 4`, `electron: retry_count = 1`).
- `pytest --collect-only -m browser_panel_webview_flaky test_browser_panel.py` —
  selects **exactly the 6** tests (6/11, 5 deselected).
- The `electron` group's new filter collects the **2** remaining `@electron`
  browser_panel tests (`electron_mode_hides_web_placeholder`, `navigation_tour`) —
  union = all 8, no overlap, no drop.
- Global integration collection: 1046 tests collected cleanly, no
  unknown-marker warnings.
- `just format` — clean. `just check` — ratchets / typecheck / lint /
  file-hygiene all OK.

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
