### PR TITLE
Fix zen-mode tab navigation flake on rapid keypresses (SCU-1633)

### DIFF
--- a/sculptor/frontend/src/components/WorkspaceTabs.tsx
+++ b/sculptor/frontend/src/components/WorkspaceTabs.tsx
@@ -52,11 +52,9 @@ import styles from "./WorkspaceTabs.module.scss";
 const ICON_SIZE = 14;
 
 // Derive the active tab id from the live URL hash (e.g. "#/ws/<id>/agent/<id>").
-// The tab-cycle keydown listener must read the current location at the moment a
-// key is pressed: it re-registers only after React flushes effects, so a route
-// value it closes over lags window.location once a navigation has updated the
-// hash synchronously. Without this, a rapid second keypress would cycle from the
-// previously-active tab and land back where it started.
+// cycleTab reads this at keypress time rather than a closed-over route value: the
+// keydown listener re-registers only after React commits, while navigate() updates
+// the hash synchronously, so the closed-over value lags after a rapid first press.
 const getCurrentTabIdFromHash = (hash: string): string | null => {
   const pathname = hash.replace(/^#/, "").split("?")[0] ?? "";
   if (pathname === "/home") return HOME_TAB_ID;

--- a/sculptor/frontend/src/components/WorkspaceTabs.tsx
+++ b/sculptor/frontend/src/components/WorkspaceTabs.tsx
@@ -51,6 +51,24 @@ import styles from "./WorkspaceTabs.module.scss";
 
 const ICON_SIZE = 14;
 
+// Derive the active tab id from the live URL hash (e.g. "#/ws/<id>/agent/<id>").
+// The tab-cycle keydown listener must read the current location at the moment a
+// key is pressed: it re-registers only after React flushes effects, so a route
+// value it closes over lags window.location once a navigation has updated the
+// hash synchronously. Without this, a rapid second keypress would cycle from the
+// previously-active tab and land back where it started.
+const getCurrentTabIdFromHash = (hash: string): string | null => {
+  const pathname = hash.replace(/^#/, "").split("?")[0] ?? "";
+  if (pathname === "/home") return HOME_TAB_ID;
+  if (pathname === "/settings") return SETTINGS_TAB_ID;
+  if (pathname === "/component-gallery") return COMPONENT_GALLERY_TAB_ID;
+  const newWorkspaceDraftId = pathname.match(/^\/ws\/new\/([^/?]+)/)?.[1];
+  if (newWorkspaceDraftId != null) return newWorkspaceTabId(newWorkspaceDraftId);
+  const workspaceId = pathname.match(/^\/ws\/(?!new\b)([^/?]+)/)?.[1];
+  if (workspaceId != null) return workspaceId;
+  return null;
+};
+
 export const WorkspaceTabs = (): ReactElement => {
   const dangerColor = useThemeDangerColor();
   const workspaces = useAtomValue(workspacesArrayAtom);
@@ -183,17 +201,8 @@ export const WorkspaceTabs = (): ReactElement => {
     (direction: 1 | -1): void => {
       if (effectiveOpenTabIds.length === 0) return;
 
-      const currentIndex = activeWorkspaceID
-        ? effectiveOpenTabIds.indexOf(activeWorkspaceID)
-        : isHomeRoute
-          ? effectiveOpenTabIds.indexOf(HOME_TAB_ID)
-          : isSettingsRoute
-            ? effectiveOpenTabIds.indexOf(SETTINGS_TAB_ID)
-            : isComponentGalleryRoute
-              ? effectiveOpenTabIds.indexOf(COMPONENT_GALLERY_TAB_ID)
-              : addWorkspaceDraftId
-                ? effectiveOpenTabIds.indexOf(newWorkspaceTabId(addWorkspaceDraftId))
-                : -1;
+      const currentTabId = getCurrentTabIdFromHash(window.location.hash);
+      const currentIndex = currentTabId !== null ? effectiveOpenTabIds.indexOf(currentTabId) : -1;
 
       const nextIndex = (currentIndex + direction + effectiveOpenTabIds.length) % effectiveOpenTabIds.length;
       const nextTabId = effectiveOpenTabIds[nextIndex];
@@ -214,12 +223,7 @@ export const WorkspaceTabs = (): ReactElement => {
       }
     },
     [
-      activeWorkspaceID,
-      addWorkspaceDraftId,
       effectiveOpenTabIds,
-      isHomeRoute,
-      isSettingsRoute,
-      isComponentGalleryRoute,
       handleWorkspaceClick,
       navigateToAddWorkspace,
       navigateToHome,

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -739,6 +739,42 @@ def navigate_to_workspace_without_agent(page: Page, workspace_id: str) -> None:
     page.evaluate(f"window.location.hash = '/ws/{workspace_id}'")
 
 
+def dispatch_modified_shortcuts_in_one_task(page: Page, shortcuts: Sequence[tuple[str, str]]) -> list[str]:
+    """Fire Cmd/Ctrl-modified keydown shortcuts back-to-back within a single task.
+
+    Each ``(key, code)`` pair is dispatched on ``window`` as a keydown carrying
+    the platform's primary modifier (Cmd on macOS, Ctrl elsewhere), with no yield
+    to the event loop between dispatches.  React therefore cannot re-render or
+    re-register window listeners in between, which deterministically exercises
+    handlers that would otherwise read stale closed-over state only on a rapid
+    second keypress.
+
+    Returns ``window.location.hash`` captured before the first dispatch and after
+    each one, so a navigation test can assert how the shortcuts moved the route
+    before the app had a chance to settle.
+
+    ``page.evaluate`` is unavoidable here: ``page.keyboard.press`` delivers each
+    press as a separate input event, letting the event loop (and React) run in
+    between, which would mask exactly the timing this reproduces.
+    """
+    return page.evaluate(
+        """(shortcuts) => {
+            const isMac = window.sculptor?.platform === "darwin" || navigator.platform.startsWith("Mac");
+            const hashes = [window.location.hash];
+            for (const [key, code] of shortcuts) {
+              window.dispatchEvent(new KeyboardEvent("keydown", {
+                key, code,
+                metaKey: isMac, ctrlKey: !isMac, altKey: false, shiftKey: false,
+                bubbles: true, cancelable: true,
+              }));
+              hashes.push(window.location.hash);
+            }
+            return hashes;
+        }""",
+        [list(shortcut) for shortcut in shortcuts],
+    )
+
+
 def get_electron_app_version(page: Page) -> str:
     """Return the Electron ``app.getVersion()`` string from the running instance.
 

--- a/sculptor/tests/integration/frontend/test_zen_mode.py
+++ b/sculptor/tests/integration/frontend/test_zen_mode.py
@@ -377,6 +377,81 @@ def test_workspace_tab_navigation_works_in_zen_mode(sculptor_instance_: Sculptor
     page.wait_for_url(f"**{second_workspace_url.split('#')[-1]}**")
 
 
+@user_story("to rapidly cycle workspace tabs in zen mode without a stale-route no-op")
+def test_rapid_tab_navigation_reads_live_route_in_zen_mode(sculptor_instance_: SculptorInstance) -> None:
+    """Two tab-cycle keypresses fired back-to-back must each cycle from the
+    *current* route, not a stale one.
+
+    Regression test for SCU-1633. The tab-cycle keydown listener computed the
+    active tab from React route state, which lags ``window.location`` because the
+    listener (a passive effect) only re-registers with a fresh closure after React
+    commits and flushes effects — and react-router defers the route-state update
+    into a transition. ``navigate()`` to a loaderless agent route updates
+    ``window.location.hash`` synchronously, so a second keypress arriving before
+    React catches up cycled from the *previous* active tab and landed back where it
+    started, hanging ``wait_for_url``.
+
+    We reproduce that timing deterministically by dispatching both keydown events
+    synchronously inside a single ``page.evaluate`` — React cannot re-render
+    between them, so the listener's closure is guaranteed stale for the second
+    press. With the bug present, the back-press is a no-op; with the fix (reading
+    the live hash) it returns to the starting workspace.
+
+    Steps:
+    1. Create two workspaces (ending on the second).
+    2. Enter zen mode.
+    3. Synchronously dispatch Cmd+] then Cmd+[ on ``window``.
+    4. The forward press must change the route (proves the events are handled).
+    5. The back press must return to the starting route (the fix).
+    """
+    page = sculptor_instance_.page
+    mod = get_playwright_modifier_key()
+
+    # Step 1: Create two workspaces; we end up on the second.
+    start_task_and_wait_for_ready(sculptor_page=page, prompt="Task A", workspace_name="WS A")
+    start_task_and_wait_for_ready(sculptor_page=page, prompt="Task B", workspace_name="WS B")
+
+    # Step 2: Enter zen mode.
+    blur_active_element(page)
+    page.keyboard.press(f"{mod}+Shift+\\")
+
+    layout = PlaywrightProjectLayoutPage(page)
+    expect(layout.get_top_bar_locator()).not_to_be_visible()
+
+    # Steps 3-5: dispatch both presses synchronously, before React can re-render
+    # and re-register the keydown listener with a fresh closure. Build the event
+    # the way the app's isMac() check does so the platform modifier matches.
+    result = page.evaluate(
+        """
+        () => {
+          document.activeElement?.blur();
+          const isMac = window.sculptor?.platform === "darwin" || navigator.platform.startsWith("Mac");
+          const fire = (key, code) => window.dispatchEvent(new KeyboardEvent("keydown", {
+            key, code, metaKey: isMac, ctrlKey: !isMac, altKey: false, shiftKey: false,
+            bubbles: true, cancelable: true,
+          }));
+          const before = window.location.hash;
+          fire("]", "BracketRight");
+          const afterForward = window.location.hash;
+          fire("[", "BracketLeft");
+          const afterBack = window.location.hash;
+          return { before, afterForward, afterBack };
+        }
+        """
+    )
+
+    # The forward press must have actually navigated; otherwise the synthetic
+    # events were not handled and the back-press assertion would pass vacuously.
+    assert result["afterForward"] != result["before"], (
+        f"Cmd+] did not change the route — the synthetic events were not handled: {result}"
+    )
+    # The back press must return to the starting workspace. With the stale-closure
+    # bug it cycles from the previous active tab and stays on the forward tab.
+    assert result["afterBack"] == result["before"], (
+        f"Cmd+[ did not return to the starting workspace (stale-route cycle): {result}"
+    )
+
+
 @user_story("to verify the exit button is hidden by default when entering zen mode")
 def test_exit_button_hidden_by_default_in_zen_mode(sculptor_instance_: SculptorInstance) -> None:
     """The exit zen mode button should be in the DOM but not visible without hovering.

--- a/sculptor/tests/integration/frontend/test_zen_mode.py
+++ b/sculptor/tests/integration/frontend/test_zen_mode.py
@@ -364,11 +364,9 @@ def test_workspace_tab_navigation_works_in_zen_mode(sculptor_instance_: Sculptor
     layout = PlaywrightProjectLayoutPage(page)
     top_bar = layout.get_top_bar_locator()
 
-    # Step 2: Enter zen mode. Use press_keyboard_shortcut (not raw keyboard.press)
-    # for every chord here: macOS Chromium occasionally drops the modifier keyup
-    # between back-to-back chords, leaving Cmd "held" so the next chord arrives
-    # malformed and is swallowed. press_keyboard_shortcut releases the modifier
-    # after each chord.
+    # Step 2: Enter zen mode. The chords go through press_keyboard_shortcut, which
+    # releases the modifier between presses (macOS Chromium can drop the keyup
+    # between back-to-back chords and swallow the next one).
     blur_active_element(page)
     layout.press_keyboard_shortcut(f"{mod}+Shift+\\")
     expect(top_bar).not_to_be_visible()
@@ -436,9 +434,7 @@ def test_rapid_tab_navigation_reads_live_route_in_zen_mode(sculptor_instance_: S
     assert after_forward != before, (
         f"Cmd+] did not change the route — the synthetic events were not handled: {(before, after_forward, after_back)}"
     )
-    # Step 5: the back press must return to the starting workspace. With the
-    # stale-closure bug it cycles from the previous active tab and stays on the
-    # forward tab.
+    # Step 5: the back press must return to the starting workspace.
     assert after_back == before, (
         f"Cmd+[ did not return to the starting workspace (stale-route cycle): {(before, after_forward, after_back)}"
     )

--- a/sculptor/tests/integration/frontend/test_zen_mode.py
+++ b/sculptor/tests/integration/frontend/test_zen_mode.py
@@ -8,6 +8,7 @@ from sculptor.testing.elements.panels import ensure_right_area_visible
 from sculptor.testing.elements.zen_mode import PlaywrightZenModeElement
 from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 from sculptor.testing.playwright_utils import blur_active_element
+from sculptor.testing.playwright_utils import dispatch_modified_shortcuts_in_one_task
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -360,20 +361,24 @@ def test_workspace_tab_navigation_works_in_zen_mode(sculptor_instance_: Sculptor
     # Sanity: we're on the second workspace and URLs differ
     assert first_workspace_url != second_workspace_url
 
-    # Step 2: Enter zen mode
-    blur_active_element(page)
-    page.keyboard.press(f"{mod}+Shift+\\")
-
     layout = PlaywrightProjectLayoutPage(page)
     top_bar = layout.get_top_bar_locator()
+
+    # Step 2: Enter zen mode. Use press_keyboard_shortcut (not raw keyboard.press)
+    # for every chord here: macOS Chromium occasionally drops the modifier keyup
+    # between back-to-back chords, leaving Cmd "held" so the next chord arrives
+    # malformed and is swallowed. press_keyboard_shortcut releases the modifier
+    # after each chord.
+    blur_active_element(page)
+    layout.press_keyboard_shortcut(f"{mod}+Shift+\\")
     expect(top_bar).not_to_be_visible()
 
     # Step 3: Press Cmd+] to cycle to next tab (wraps to first workspace)
-    page.keyboard.press(f"{mod}+]")
+    layout.press_keyboard_shortcut(f"{mod}+]")
     page.wait_for_url(f"**{first_workspace_url.split('#')[-1]}**")
 
     # Step 5: Press Cmd+[ to cycle back to second workspace
-    page.keyboard.press(f"{mod}+[")
+    layout.press_keyboard_shortcut(f"{mod}+[")
     page.wait_for_url(f"**{second_workspace_url.split('#')[-1]}**")
 
 
@@ -392,10 +397,10 @@ def test_rapid_tab_navigation_reads_live_route_in_zen_mode(sculptor_instance_: S
     started, hanging ``wait_for_url``.
 
     We reproduce that timing deterministically by dispatching both keydown events
-    synchronously inside a single ``page.evaluate`` — React cannot re-render
-    between them, so the listener's closure is guaranteed stale for the second
-    press. With the bug present, the back-press is a no-op; with the fix (reading
-    the live hash) it returns to the starting workspace.
+    synchronously in a single task (via ``dispatch_modified_shortcuts_in_one_task``)
+    — React cannot re-render between them, so the listener's closure is guaranteed
+    stale for the second press. With the bug present, the back-press is a no-op;
+    with the fix (reading the live hash) it returns to the starting workspace.
 
     Steps:
     1. Create two workspaces (ending on the second).
@@ -418,37 +423,24 @@ def test_rapid_tab_navigation_reads_live_route_in_zen_mode(sculptor_instance_: S
     layout = PlaywrightProjectLayoutPage(page)
     expect(layout.get_top_bar_locator()).not_to_be_visible()
 
-    # Steps 3-5: dispatch both presses synchronously, before React can re-render
-    # and re-register the keydown listener with a fresh closure. Build the event
-    # the way the app's isMac() check does so the platform modifier matches.
-    result = page.evaluate(
-        """
-        () => {
-          document.activeElement?.blur();
-          const isMac = window.sculptor?.platform === "darwin" || navigator.platform.startsWith("Mac");
-          const fire = (key, code) => window.dispatchEvent(new KeyboardEvent("keydown", {
-            key, code, metaKey: isMac, ctrlKey: !isMac, altKey: false, shiftKey: false,
-            bubbles: true, cancelable: true,
-          }));
-          const before = window.location.hash;
-          fire("]", "BracketRight");
-          const afterForward = window.location.hash;
-          fire("[", "BracketLeft");
-          const afterBack = window.location.hash;
-          return { before, afterForward, afterBack };
-        }
-        """
+    # Step 3: fire Cmd+] then Cmd+[ back-to-back, before React can re-render and
+    # re-register the keydown listener with a fresh closure.
+    blur_active_element(page)
+    before, after_forward, after_back = dispatch_modified_shortcuts_in_one_task(
+        page, [("]", "BracketRight"), ("[", "BracketLeft")]
     )
 
-    # The forward press must have actually navigated; otherwise the synthetic
-    # events were not handled and the back-press assertion would pass vacuously.
-    assert result["afterForward"] != result["before"], (
-        f"Cmd+] did not change the route — the synthetic events were not handled: {result}"
+    # Step 4: the forward press must have actually navigated; otherwise the
+    # synthetic events were not handled and the back-press assertion below would
+    # pass vacuously.
+    assert after_forward != before, (
+        f"Cmd+] did not change the route — the synthetic events were not handled: {(before, after_forward, after_back)}"
     )
-    # The back press must return to the starting workspace. With the stale-closure
-    # bug it cycles from the previous active tab and stays on the forward tab.
-    assert result["afterBack"] == result["before"], (
-        f"Cmd+[ did not return to the starting workspace (stale-route cycle): {result}"
+    # Step 5: the back press must return to the starting workspace. With the
+    # stale-closure bug it cycles from the previous active tab and stays on the
+    # forward tab.
+    assert after_back == before, (
+        f"Cmd+[ did not return to the starting workspace (stale-route cycle): {(before, after_forward, after_back)}"
     )
 
 


### PR DESCRIPTION
## Original bug

`sculptor/tests/integration/frontend/test_zen_mode.py::test_workspace_tab_navigation_works_in_zen_mode`
flakes on offload (Linux) with:

```
playwright._impl._errors.TimeoutError: Timeout 30000ms exceeded.
  waiting for navigation to "**/ws/<workspace-id>/agent/<agent-id>"
```

Tracked as [SCU-1633](https://linear.app/imbue/issue/SCU-1633). It flaked on 7
distinct offload commits over 2026-06-26 → 2026-06-29 (including the `main`
tips `184b1de6` and `bb595065`). The offload traces show the timeout is
**always on the second navigation** (the `Cmd+[` press cycling back), never
the first — a precise fingerprint of the root cause below.

## Hypotheses considered

1. **Tab switch doesn't push the route in zen mode** — DISCARDED. The first
   `Cmd+]` always reaches the target; only the second press hangs, so the
   handler and route push work.
2. **The cycle handler reads stale route state after a navigation** —
   REPRODUCED. See below.

## For each reproduced bug

### Workspace tab cycling hangs on a rapid second keypress

**Repro steps**
1. Create two workspaces (WS A, then WS B); the app ends on WS B.
2. Enter zen mode (`Cmd+Shift+\`).
3. Press `Cmd+]` to cycle to the next tab; the URL moves to WS A.
4. Immediately press `Cmd+[` to cycle back; expect the URL to return to WS B.

**Expected vs actual**
- Expected: the second press returns the URL to WS B.
- Actual: under a fast second press, the URL stays on WS A — the back-press is
  a no-op — and `wait_for_url` for WS B times out after 30s.

**Root cause**
`WorkspaceTabs.cycleTab` computed the current tab index from React route state
(`activeWorkspaceID` via `useParams`, plus the route booleans). That state lags
`window.location`: the tab-cycle `keydown` listener is registered in a passive
`useEffect`, so it only re-registers with a fresh closure after React commits
and flushes effects, and react-router v7 defers the route-state update into a
transition. `navigate()` to a loaderless agent route
(`/ws/:workspaceID/agent/:id` has no loader) updates `window.location.hash`
**synchronously**, and `page.wait_for_url` returns the instant the hash
changes. So a second keypress arriving in that window runs against the stale
closure: it cycles from the *previous* active tab and navigates right back to
where the first press already landed — a no-op. Zen mode widens the window
because entering it also toggles focus mode, adding extra re-renders.

**Fix**
`cycleTab` now derives the current tab from `window.location.hash` at keypress
time — the same synchronous source the URL (and `wait_for_url`) reflects —
via a small pure `getCurrentTabIdFromHash` helper, instead of the lagging
closed-over route state. Cycling is then correct regardless of when React
re-renders and re-registers the listener. This is "read the authoritative
live route," not a sleep or timeout bump.

**Test**
- Path: `sculptor/tests/integration/frontend/test_zen_mode.py::test_rapid_tab_navigation_reads_live_route_in_zen_mode`
- Kind: e2e (Playwright)
- It pins the race **deterministically**: a new
  `dispatch_modified_shortcuts_in_one_task` helper dispatches both keydowns in
  a single task so React cannot re-render between them, guaranteeing the
  closure is stale for the second press. It asserts the forward press changed
  the route (so the events are genuinely handled — no vacuous pass) and the
  back press returned to the start.
- Failing-test commit: `8224203d`
- Fix commit: `7735d80e`

**Before** (deterministic regression test, without the fix):

```
E   AssertionError: Cmd+[ did not return to the starting workspace (stale-route cycle):
E   {'before': '#/ws/ws_01kw9pq3.../agent/tsk_01kw9pq3...',
E    'afterForward': '#/ws/ws_01kw9pq2.../agent/tsk_01kw9pq2...',
E    'afterBack': '#/ws/ws_01kw9pq2.../agent/tsk_01kw9pq2...'}
sculptor/tests/integration/frontend/test_zen_mode.py: AssertionError
=========================== 1 failed ===========================
```

(`afterBack` stayed on the forward tab instead of returning to `before`.)

**After** (with the fix, both the regression test and the original test):

```
[gw0] PASSED test_zen_mode.py::test_workspace_tab_navigation_works_in_zen_mode
[gw1] PASSED test_zen_mode.py::test_rapid_tab_navigation_reads_live_route_in_zen_mode
============================== 2 passed in 26.41s ==============================
```

This is a timing/flake bug with no meaningful visual surface, so the evidence
is failing-then-passing test output rather than screenshots.

## Additional test hardening

The original `test_workspace_tab_navigation_works_in_zen_mode` also failed
**locally on macOS** for an unrelated reason: macOS Chromium can drop the
modifier keyup between back-to-back `Cmd` chords, leaving the modifier "held"
so the next chord arrives malformed and is swallowed. This masked the offload
flake during local repro. The test now presses its chords via
`press_keyboard_shortcut`, which explicitly releases the modifier between
presses — making it reliable on both local macOS and offload Linux.

## Review notes

- `test_rapid_tab_navigation_reads_live_route_in_zen_mode` uses Python `assert`
  on values captured synchronously inside one `page.evaluate`, rather than the
  usual auto-retrying `expect()`. This is intentional: the race is sub-render
  timing, so the test must observe state synchronously — `expect()`'s retry
  would let React catch up and mask the bug. The values are already
  materialized when asserted, so there is no DOM race in the assertion.
- `getCurrentTabIdFromHash` returns `string | null`. The frontend style guide
  prefers `undefined`, but `null` matches the directly-analogous route-parsing
  helper `useImbueLocation` (`workspaceId: string | null`) in the same domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
