### PR TITLE
Fix Browser panel webview test flakes at the source (SCU-1607)

### DIFF
--- a/sculptor/frontend/src/electron/captureNonEmptyPage.test.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.test.ts
@@ -23,13 +23,17 @@ describe("captureNonEmptyPage", () => {
     expect(capturePage).toHaveBeenCalledTimes(3);
   });
 
-  it("returns immediately when the first capture is already painted", async () => {
+  it("returns immediately when the first capture is already painted, capturing with stayHidden", async () => {
     const capturePage = vi.fn(() => Promise.resolve(paintedImage));
 
     const result = await captureNonEmptyPage({ capturePage });
 
     expect(result).toBe(paintedImage);
     expect(capturePage).toHaveBeenCalledTimes(1);
+    // stayHidden forces the guest to composite a frame even when its window is
+    // occluded (the xvfb steady state), which is what stops capturePage from
+    // returning an empty image forever; assert we always pass it.
+    expect(capturePage).toHaveBeenCalledWith(undefined, { stayHidden: true, stayAwake: true });
   });
 
   it("captures exactly once when retries is 0", async () => {

--- a/sculptor/frontend/src/electron/captureNonEmptyPage.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.ts
@@ -19,12 +19,10 @@ export type CapturablePage<T extends CapturedImage> = {
 };
 
 // A guest <webview> whose window the OS compositor treats as hidden or occluded
-// — which is the steady state under a headless/xvfb display — never paints on
-// its own, so capturePage() returns an empty image indefinitely no matter how
-// long we retry. `stayHidden` puts the guest into the "being captured" state
-// that keeps it producing frames while hidden, the supported replacement for
-// the removed incrementCapturerCount(). This is what makes the capture resolve
-// to a real frame instead of an empty image in CI.
+// — the steady state under a headless/xvfb display — never paints on its own, so
+// capturePage() returns an empty image no matter how long we retry. `stayHidden`
+// keeps the guest compositing frames while hidden, so the capture resolves to a
+// real frame instead of an empty image.
 const CAPTURE_OPTS: CapturePageOpts = { stayHidden: true, stayAwake: true };
 
 export type CaptureNonEmptyPageOptions = {

--- a/sculptor/frontend/src/electron/captureNonEmptyPage.ts
+++ b/sculptor/frontend/src/electron/captureNonEmptyPage.ts
@@ -6,9 +6,26 @@ export type CapturedImage = {
   isEmpty(): boolean;
 };
 
-export type CapturablePage<T extends CapturedImage> = {
-  capturePage(): Promise<T>;
+// Electron's capturePage opts. `stayHidden` makes the page "considered visible"
+// for the capture even when its window is occluded, forcing the compositor to
+// produce a frame; `stayAwake` keeps the system from sleeping mid-capture.
+export type CapturePageOpts = {
+  stayHidden?: boolean;
+  stayAwake?: boolean;
 };
+
+export type CapturablePage<T extends CapturedImage> = {
+  capturePage(rect?: undefined, opts?: CapturePageOpts): Promise<T>;
+};
+
+// A guest <webview> whose window the OS compositor treats as hidden or occluded
+// — which is the steady state under a headless/xvfb display — never paints on
+// its own, so capturePage() returns an empty image indefinitely no matter how
+// long we retry. `stayHidden` puts the guest into the "being captured" state
+// that keeps it producing frames while hidden, the supported replacement for
+// the removed incrementCapturerCount(). This is what makes the capture resolve
+// to a real frame instead of an empty image in CI.
+const CAPTURE_OPTS: CapturePageOpts = { stayHidden: true, stayAwake: true };
 
 export type CaptureNonEmptyPageOptions = {
   /**
@@ -31,10 +48,11 @@ const DEFAULT_DELAY_MS = 250;
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-// capturePage() resolves with an empty NativeImage until the guest has
-// composited a frame. Capture once, then keep retrying while the image is
-// blank (up to the retry budget) so the screenshot -> clipboard path doesn't
-// write an empty image.
+// Capture the guest with `stayHidden` so the compositor produces a frame even
+// when the window is occluded, then retry while the image is still blank (up to
+// the retry budget) to absorb the beat between the first forced frame request
+// and the compositor delivering it, so the screenshot -> clipboard path never
+// writes an empty image.
 export const captureNonEmptyPage = async <T extends CapturedImage>(
   contents: CapturablePage<T>,
   options: CaptureNonEmptyPageOptions = {},
@@ -43,10 +61,10 @@ export const captureNonEmptyPage = async <T extends CapturedImage>(
   const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
   const sleep = options.sleep ?? defaultSleep;
 
-  let image = await contents.capturePage();
+  let image = await contents.capturePage(undefined, CAPTURE_OPTS);
   for (let retry = 0; retry < retries && image.isEmpty(); retry++) {
     await sleep(delayMs);
-    image = await contents.capturePage();
+    image = await contents.capturePage(undefined, CAPTURE_OPTS);
   }
   return image;
 };

--- a/sculptor/frontend/src/globals.d.ts
+++ b/sculptor/frontend/src/globals.d.ts
@@ -16,8 +16,6 @@ declare global {
     sculptor?: SculptorElectronAPI;
     /** Exposed by the active TerminalInstance for integration tests. */
     __xterm?: XTerm;
-    /** Populated by the Browser panel after webview did-attach, for integration tests. */
-    __BROWSER_PANEL_TEST__?: { webContentsId: number };
     /** Inlined by the backend's static-HTML serve path when --trace-to is set.
      * The renderer reads this synchronously at boot in common/tracing.ts. */
     __SCULPTOR_TRACING__?: { enabled: boolean };

--- a/sculptor/frontend/src/pages/workspace/panels/BrowserPanel.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/BrowserPanel.test.tsx
@@ -1,21 +1,50 @@
 import { Theme } from "@radix-ui/themes";
 import { cleanup, render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactElement, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ElementIds } from "~/api";
 
+import { type BrowserViewStatus, browserViewStatusAtomFamily } from "./browser/browserViewRegistry";
 import { BrowserPanel } from "./BrowserPanel";
 
 vi.mock("~/electron/utils", () => ({
   isElectron: vi.fn(),
 }));
 
-const renderBrowserPanel = (): void => {
-  render(
-    <Theme>
-      <BrowserPanel />
-    </Theme>,
+// The Electron panel reads the active workspace's id from the router; pin it.
+vi.mock("~/common/NavigateUtils", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useWorkspacePageParams: (): { workspaceID: string } => ({ workspaceID: WORKSPACE_ID }),
+}));
+
+// The placement hook drives the <webview> bounds via refs/ResizeObserver, which
+// is irrelevant to the toolbar's rendered output; stub it so the panel renders
+// without a layout environment.
+vi.mock("./browser/useBrowserPanelPlacement", () => ({
+  useBrowserPanelPlacement: (): void => {},
+}));
+
+const WORKSPACE_ID = "ws-browser-test";
+
+const STATUS_DEFAULT: BrowserViewStatus = {
+  currentUrl: "",
+  canGoBack: false,
+  canGoForward: false,
+  isLoading: false,
+  webContentsId: null,
+};
+
+const renderBrowserPanel = (status: Partial<BrowserViewStatus> = {}): void => {
+  const store = createStore();
+  store.set(browserViewStatusAtomFamily(WORKSPACE_ID), { ...STATUS_DEFAULT, ...status });
+  const Wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+    <Provider store={store}>
+      <Theme>{children}</Theme>
+    </Provider>
   );
+  render(<BrowserPanel />, { wrapper: Wrapper });
 };
 
 afterEach(() => {
@@ -32,5 +61,27 @@ describe("BrowserPanel", () => {
 
     expect(screen.getByTestId(ElementIds.BROWSER_WEB_MODE_PLACEHOLDER)).toBeInTheDocument();
     expect(screen.getByText(/desktop app/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the committed webview status on the panel for integration tests", async () => {
+    // The page object gates on these production-truth attributes instead of a
+    // focus-coupled global bridge or a guest document.location round-trip.
+    const { isElectron } = await import("~/electron/utils");
+    (isElectron as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    renderBrowserPanel({ webContentsId: 7, currentUrl: "http://example.test/page.html" });
+
+    const panel = screen.getByTestId(ElementIds.BROWSER_PANEL);
+    expect(panel).toHaveAttribute("data-webview-content-id", "7");
+    expect(panel).toHaveAttribute("data-webview-current-url", "http://example.test/page.html");
+  });
+
+  it("omits the content id until the guest has attached", async () => {
+    const { isElectron } = await import("~/electron/utils");
+    (isElectron as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    renderBrowserPanel({ webContentsId: null });
+
+    expect(screen.getByTestId(ElementIds.BROWSER_PANEL)).not.toHaveAttribute("data-webview-content-id");
   });
 });

--- a/sculptor/frontend/src/pages/workspace/panels/BrowserPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/BrowserPanel.tsx
@@ -145,8 +145,20 @@ const BrowserPanelElectron = (): ReactElement => {
     void window.sculptor?.captureBrowserPanelToClipboard(status.webContentsId);
   }, [status.webContentsId]);
 
+  // Surface the active workspace's webview status (from the per-workspace status
+  // atom, fed by the guest's did-attach / did-navigate events) onto the panel so
+  // integration tests gate on committed production state rather than
+  // focus-coupled or guest-evaluated proxies: data-webview-content-id is present
+  // only once the guest has attached, data-webview-current-url is the committed
+  // URL.
   return (
-    <div className={styles.panel} data-testid={ElementIds.BROWSER_PANEL} data-workspace-id={workspaceID}>
+    <div
+      className={styles.panel}
+      data-testid={ElementIds.BROWSER_PANEL}
+      data-workspace-id={workspaceID}
+      data-webview-content-id={status.webContentsId ?? undefined}
+      data-webview-current-url={status.currentUrl}
+    >
       <Flex align="center" gap="2" className={styles.toolbar}>
         <Tooltip content="Back">
           <IconButton

--- a/sculptor/frontend/src/pages/workspace/panels/browser/BrowserViewSlot.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/BrowserViewSlot.tsx
@@ -77,17 +77,12 @@ export const BrowserViewSlot = ({ workspaceId }: { workspaceId: string }): React
     }
   }, [agentWebviewState, workspaceId, webContentsId, navigate, reload, setPanelState, store]);
 
-  // Mirror the active workspace's webContentsId onto the global test
-  // bridge so the existing Playwright fixture keeps working unchanged.
+  // Only the focused (active-route) workspace's slot carries the
+  // BROWSER_WEBVIEW test id, marking it apart from the hidden background slots.
+  // Integration tests read the active workspace's committed webview status from
+  // the BrowserPanel toolbar's data-webview-* attributes, not from this slot.
   const focusedWorkspaceId = useAtomValue(focusedBrowserWorkspaceIdAtom);
   const isFocused = focusedWorkspaceId === workspaceId;
-  useEffect(() => {
-    if (!isFocused || webContentsId === null) return;
-    window.__BROWSER_PANEL_TEST__ = { webContentsId };
-    return (): void => {
-      delete window.__BROWSER_PANEL_TEST__;
-    };
-  }, [isFocused, webContentsId]);
 
   const placement = useAtomValue(browserViewPlacementAtomFamily(workspaceId));
   const partition = `persist:sculptor-browser-${workspaceId}`;
@@ -114,7 +109,6 @@ export const BrowserViewSlot = ({ workspaceId }: { workspaceId: string }): React
       : { display: "none" }),
   };
 
-  // Only the focused workspace's slot carries the BROWSER_WEBVIEW test id.
   const testId = isFocused ? ElementIds.BROWSER_WEBVIEW : undefined;
 
   return (

--- a/sculptor/frontend/src/pages/workspace/panels/browser/browserViewRegistry.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/browserViewRegistry.ts
@@ -54,8 +54,8 @@ export const browserViewStatusAtomFamily = atomFamily((_workspaceId: string) =>
 );
 
 // Identifies which workspace's panel placeholder is currently mounted (if any).
-// The slot for this workspace mirrors its webContentsId onto window.__BROWSER_PANEL_TEST__
-// so the existing test bridge keeps working without changes to the test harness.
+// The slot for this workspace carries the BROWSER_WEBVIEW test id, marking the
+// active guest apart from the hidden background slots.
 export const focusedBrowserWorkspaceIdAtom = atom<string | null>(null);
 
 // Imperative controllers — refs to webview instance methods. Not Jotai

--- a/sculptor/sculptor/testing/elements/browser_panel.py
+++ b/sculptor/sculptor/testing/elements/browser_panel.py
@@ -7,6 +7,7 @@ panel integration tests.
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any
 
@@ -16,37 +17,38 @@ from playwright.sync_api import expect
 from sculptor.constants import ElementIDs
 from sculptor.testing.elements.base import PlaywrightIntegrationTestElement
 
-# Waits that depend on the <webview> guest attaching and committing a
-# navigation (vs. the address bar, which mirrors the typed URL instantly). The
-# guest can take well over 10s to attach and load under heavy CI parallelism
-# (xvfb + software rendering), so give these a generous budget.
+# The Browser panel surfaces the active workspace's committed webview status on
+# the panel root via data-webview-content-id (the attached guest's
+# webContentsId, present once did-attach fires) and data-webview-current-url
+# (the committed URL, updated on did-navigate). These are the production-truth
+# readiness signals the page object gates on, keyed to the active workspace
+# rather than a focus-coupled global or a guest round-trip.
+_WEBVIEW_CONTENT_ID_ATTR: str = "data-webview-content-id"
+_WEBVIEW_CURRENT_URL_ATTR: str = "data-webview-current-url"
+
+# The guest can take well over 10s to attach under heavy CI parallelism (xvfb +
+# software rendering), so give the attach wait a generous budget.
 _WEBVIEW_ATTACH_TIMEOUT_SECONDS: float = 30.0
-_WEBVIEW_LOAD_TIMEOUT_SECONDS: float = 30.0
 _URL_POLL_INTERVAL_SECONDS: float = 0.1
 _DEFAULT_ADDRESS_BAR_TIMEOUT_SECONDS: float = 10.0
 _PNG_MAGIC: bytes = b"\x89PNG\r\n\x1a\n"
 # The screenshot -> clipboard round-trip goes through Electron's main process
-# and the OS clipboard, which under xvfb + software rendering can take well
-# over the snappy budget a local run sees. Match the webview load budget so a
-# slow-but-healthy CI host isn't mistaken for a missing screenshot.
+# and the OS clipboard, which under xvfb can take longer than a local run. Match
+# the attach budget so a slow-but-healthy CI host isn't mistaken for a missing
+# screenshot.
 _CLIPBOARD_TIMEOUT_SECONDS: float = 30.0
 
-# How long ``webview_evaluate`` retries a *transient* bridge error before giving
-# up. A workspace switch or panel reopen re-creates the guest webContents, and
-# for a short window the test bridge can point at a guest that is mid-load or
-# just re-attached. Executing into it then rejects; retrying (and re-reading the
-# current webContentsId each attempt) lets the guest settle. The injected script
-# itself can also throw transiently -- e.g. ``getElementById(...)`` is null for a
-# beat right after re-focus -- which Electron surfaces as "Script failed to
-# execute". A genuine error still surfaces once the budget is exhausted.
+# How long ``webview_evaluate`` retries a transient execute error before giving
+# up. The injected script can throw for a beat -- e.g. ``getElementById(...)`` is
+# null right after a re-focus -- which Electron surfaces as "Script failed to
+# execute"; retrying rides through that window. A genuine error still surfaces
+# once the budget is exhausted.
 _WEBVIEW_EXECUTE_RETRY_SECONDS: float = 15.0
 
-# Budget for navigate() to land a typed URL, across re-resolutions of the URL
-# input. A workspace switch remounts the panel, so a one-shot fill can land in
-# the old, detaching input while the new one still shows the persisted
-# about:blank. We re-issue fill+Enter on a freshly-resolved input within this
-# window; each attempt's address-bar check is short so the budget supplies the
-# overall wait (the retry pattern, not a lowered single timeout).
+# Budget for navigate() to land a typed URL and have the webview commit it. A
+# workspace switch can remount the panel mid-fill, so we re-issue fill+Enter on a
+# freshly-resolved input until the committed URL moves; each attempt's wait is
+# short so the budget supplies the overall wait.
 _NAVIGATE_RETRY_SECONDS: float = 30.0
 _NAVIGATE_ATTEMPT_SECONDS: float = 3.0
 
@@ -57,10 +59,8 @@ _TRANSIENT_WEBVIEW_EXECUTE_MARKERS: tuple[str, ...] = (
     # Electron's executeJavaScript rejects with this when the guest's page threw
     # (e.g. a null element during a load) or the target webContents is gone.
     "Script failed to execute",
-    # The bridge is briefly absent while focus moves between workspace slots.
+    # The bridge is briefly absent while window.sculptor is still initializing.
     "browser panel test bridge not available",
-    # loadURL/eval before the <webview> has fired did-attach.
-    "WebView must be attached",
 )
 
 
@@ -94,21 +94,22 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
     def navigate(self, url: str, *, wait_for_webview_load: bool = True) -> None:
         """Type ``url`` into the address bar, press Enter, and wait for navigation.
 
-        The address bar mirrors whatever the user typed the moment Enter is
-        pressed, but the webview's ``did-navigate`` event (which feeds the
-        per-workspace persisted-URL atom) is async. By default we additionally
-        wait for the webview's live ``document.location`` to reach ``url``,
-        so callers that immediately collapse the panel see the persisted URL
-        on reopen instead of a stale ``about:blank``.
+        By default we wait for the webview to *commit* the navigation, read from
+        the panel's ``data-webview-current-url`` attribute (the committed URL
+        published on the guest's ``did-navigate``). That is the production-truth
+        signal that the guest actually loaded ``url`` -- deterministic, and free
+        of the focus-coupled global bridge and the guest ``document.location``
+        round-trip the old gate used.
 
         Set ``wait_for_webview_load=False`` for negative-path tests where the
-        URL is intentionally invalid and the webview will never reach it.
+        URL is intentionally invalid and the webview will never commit it; those
+        only confirm the address bar took the typed text.
 
-        The fill is retried on a freshly-resolved URL input each attempt: a
-        workspace switch remounts the panel, so a one-shot fill can land in the
-        old, detaching input while the address bar then reads the new input
-        (still showing the persisted ``about:blank``). Re-issuing fill+Enter on
-        the live input lands the value.
+        The fill is re-issued on a freshly-resolved URL input each attempt: a
+        workspace switch can remount the panel so a one-shot fill lands in the
+        old, detaching input and the committed URL never moves. Re-issuing
+        fill+Enter on the live input until the committed URL reaches ``url``
+        lands the value.
         """
         bare_url = url.split("#", 1)[0]
         deadline = time.monotonic() + _NAVIGATE_RETRY_SECONDS
@@ -118,14 +119,16 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
             input_locator.click(click_count=3)
             input_locator.fill(url)
             input_locator.press("Enter")
-            try:
+            if not wait_for_webview_load:
                 self.wait_for_address_bar_contains(bare_url, timeout_seconds=_NAVIGATE_ATTEMPT_SECONDS)
-                break
-            except AssertionError:
-                if time.monotonic() >= deadline:
-                    raise
-        if wait_for_webview_load:
-            self._wait_for_webview_location_contains(bare_url)
+                return
+            if self._committed_url_contains(bare_url, timeout_seconds=_NAVIGATE_ATTEMPT_SECONDS):
+                return
+            if time.monotonic() >= deadline:
+                last = self._committed_url()
+                raise AssertionError(
+                    f"Webview did not commit navigation to {bare_url!r}; last committed URL was {last!r}"
+                )
 
     def click_back(self) -> None:
         self.get_back_button().click()
@@ -140,35 +143,29 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
         self.get_screenshot_button().click()
 
     def webview_evaluate(self, code: str) -> Any:
-        """Run ``code`` inside the panel's webview guest page via the test-only IPC.
+        """Run ``code`` inside the active panel's webview guest via the test-only IPC.
 
-        Retries transient "guest not ready" failures (see
-        ``_TRANSIENT_WEBVIEW_EXECUTE_MARKERS``) for up to
-        ``_WEBVIEW_EXECUTE_RETRY_SECONDS``, re-reading the current
-        ``webContentsId`` each attempt so a guest re-created by a workspace
-        switch or panel reopen is picked up rather than executed into while it
-        is still attaching. A non-transient execute error is re-raised immediately; a transient one
-        is re-raised only once the budget is spent. If the webview never attaches,
-        ``_wait_for_webview_attached`` will time out.
+        The guest is targeted by the webContentsId read from the panel's
+        ``data-webview-content-id`` attribute (re-read each attempt so a guest
+        re-created by a workspace switch is picked up rather than executed into
+        while it is still attaching). Transient execute failures (see
+        ``_TRANSIENT_WEBVIEW_EXECUTE_MARKERS``) are retried for up to
+        ``_WEBVIEW_EXECUTE_RETRY_SECONDS``; a non-transient error is re-raised
+        immediately, a transient one once the budget is spent.
         """
         deadline = time.monotonic() + _WEBVIEW_EXECUTE_RETRY_SECONDS
         while True:
-            # Re-resolve the bridge each attempt: the webContentsId mirrored onto
-            # window.__BROWSER_PANEL_TEST__ changes when the focused workspace's
-            # guest is re-created, so a value cached across the retry loop could
-            # point at a torn-down webContents.
-            self._wait_for_webview_attached()
+            content_id = self._attached_content_id()
             try:
                 return self._page.evaluate(
-                    """async (code) => {
+                    """async ([id, code]) => {
                       const api = window.sculptor;
-                      const test = window.__BROWSER_PANEL_TEST__;
-                      if (!api || !api.__testBrowserWebviewExecute || !test) {
+                      if (!api || !api.__testBrowserWebviewExecute) {
                         throw new Error('browser panel test bridge not available');
                       }
-                      return api.__testBrowserWebviewExecute(test.webContentsId, code);
+                      return api.__testBrowserWebviewExecute(id, code);
                     }""",
-                    code,
+                    [content_id, code],
                 )
             except Exception as exc:  # noqa: BLE001 — re-raised below unless transient
                 message = str(exc)
@@ -222,42 +219,35 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
             self._page.wait_for_timeout(int(_URL_POLL_INTERVAL_SECONDS * 1000))
         raise AssertionError(f"Address bar did not contain {needle!r}; last value was {last_value!r}")
 
-    def _wait_for_webview_location_contains(
-        self, needle: str, *, timeout_seconds: float = _WEBVIEW_LOAD_TIMEOUT_SECONDS
-    ) -> None:
-        """Wait until the webview's live ``document.location`` reflects ``needle``.
+    def _committed_url(self) -> str:
+        """The webview's committed URL, from the panel's data-webview-current-url."""
+        return self.get_attribute(_WEBVIEW_CURRENT_URL_ATTR) or ""
 
-        Used to gate on the webview's ``did-navigate`` event having fired —
-        the address bar in the toolbar reflects the *typed* URL, but the
-        per-workspace persisted-URL atom is only updated when the webview
-        actually emits ``did-navigate``.
-        """
-        deadline = time.monotonic() + timeout_seconds
-        last_value = ""
-        last_error: Exception | None = None
-        while time.monotonic() < deadline:
-            try:
-                last_value = str(self.webview_evaluate("document.location.href"))
-                last_error = None
-            except Exception as exc:  # noqa: BLE001 — bridge may briefly raise mid-navigation
-                last_value = ""
-                last_error = exc
-            if needle in last_value:
-                return
-            self._page.wait_for_timeout(int(_URL_POLL_INTERVAL_SECONDS * 1000))
-        # Surface the last bridge error if we never got a readable location: a
-        # bare "last value was ''" hides a persistently-stale webContentsId,
-        # which is the failure mode worth diagnosing when this does trip.
-        suffix = f" (last webview-execute error: {last_error})" if last_error is not None else ""
-        raise AssertionError(f"Webview location did not reach {needle!r}; last value was {last_value!r}{suffix}")
-
-    def _wait_for_webview_attached(self) -> None:
-        deadline = time.monotonic() + _WEBVIEW_ATTACH_TIMEOUT_SECONDS
-        while time.monotonic() < deadline:
-            is_ready = self._page.evaluate(
-                "() => Boolean(window.__BROWSER_PANEL_TEST__ && window.__BROWSER_PANEL_TEST__.webContentsId)"
+    def _committed_url_contains(self, needle: str, *, timeout_seconds: float) -> bool:
+        """Whether the committed URL reaches ``needle`` within ``timeout_seconds``."""
+        try:
+            expect(self._locator).to_have_attribute(
+                _WEBVIEW_CURRENT_URL_ATTR,
+                re.compile(re.escape(needle)),
+                timeout=int(timeout_seconds * 1000),
             )
-            if is_ready:
-                return
-            time.sleep(_URL_POLL_INTERVAL_SECONDS)
-        raise TimeoutError("Timed out waiting for webview did-attach")
+            return True
+        except AssertionError:
+            return False
+
+    def _attached_content_id(self) -> int:
+        """Return the attached guest's webContentsId, waiting until it attaches.
+
+        Reads the panel's ``data-webview-content-id`` attribute, which is absent
+        until the active workspace's guest fires ``did-attach`` and then holds
+        its webContentsId. Times out via Playwright's ``to_have_attribute`` if
+        the guest never attaches.
+        """
+        expect(self._locator).to_have_attribute(
+            _WEBVIEW_CONTENT_ID_ATTR,
+            re.compile(r"\d+"),
+            timeout=int(_WEBVIEW_ATTACH_TIMEOUT_SECONDS * 1000),
+        )
+        value = self.get_attribute(_WEBVIEW_CONTENT_ID_ATTR)
+        assert value is not None  # to_have_attribute above guarantees presence
+        return int(value)

--- a/sculptor/sculptor/testing/elements/browser_panel.py
+++ b/sculptor/sculptor/testing/elements/browser_panel.py
@@ -97,9 +97,9 @@ class PlaywrightBrowserPanelElement(PlaywrightIntegrationTestElement):
         By default we wait for the webview to *commit* the navigation, read from
         the panel's ``data-webview-current-url`` attribute (the committed URL
         published on the guest's ``did-navigate``). That is the production-truth
-        signal that the guest actually loaded ``url`` -- deterministic, and free
-        of the focus-coupled global bridge and the guest ``document.location``
-        round-trip the old gate used.
+        signal that the guest actually loaded ``url``: a per-workspace DOM read,
+        so it needs no focus-coupled global and no guest ``document.location``
+        round-trip.
 
         Set ``wait_for_webview_load=False`` for negative-path tests where the
         URL is intentionally invalid and the webview will never commit it; those

--- a/sculptor/sculptor/testing/elements/tests/test_browser_panel_element.py
+++ b/sculptor/sculptor/testing/elements/tests/test_browser_panel_element.py
@@ -20,10 +20,10 @@ from sculptor.testing.elements.browser_panel import PlaywrightBrowserPanelElemen
 class _FakePage:
     """Minimal stand-in for a Playwright ``Page``.
 
-    ``evaluate`` answers the attach probe truthily and delegates the
-    webview-execute call to ``execute_side_effect``, which a test supplies to
-    raise transient/fatal errors before (optionally) returning a value.
-    ``wait_for_timeout`` is a no-op so the retry loop spins at full speed.
+    ``evaluate`` delegates the webview-execute call to ``execute_side_effect``,
+    which a test supplies to raise transient/fatal errors before (optionally)
+    returning a value. ``wait_for_timeout`` is a no-op so the retry loop spins
+    at full speed.
     """
 
     def __init__(self, execute_side_effect: list[Any]) -> None:
@@ -31,9 +31,6 @@ class _FakePage:
         self.execute_calls = 0
 
     def evaluate(self, js: str, *args: Any) -> Any:
-        if "__testBrowserWebviewExecute" not in js:
-            # The attach probe: pretend the bridge is always attached.
-            return True
         self.execute_calls += 1
         # Consume outcomes in order, but repeat the final one indefinitely so a
         # test can model a transient that never clears without sizing a list to
@@ -50,9 +47,13 @@ class _FakePage:
 
 
 def _make_panel(page: _FakePage) -> PlaywrightBrowserPanelElement:
-    # The element only touches ``self._page`` for these calls; the locator is
-    # never exercised, so ``None`` is a safe stand-in.
-    return PlaywrightBrowserPanelElement(locator=None, page=page)  # type: ignore[arg-type]
+    # These tests exercise only webview_evaluate's execute-retry loop. Attach
+    # resolution (which reads the panel's data-webview-content-id off a real
+    # locator) is stubbed to a fixed webContentsId so the locator is never
+    # touched and the execute outcomes drive the test.
+    panel = PlaywrightBrowserPanelElement(locator=None, page=page)  # type: ignore[arg-type]
+    panel._attached_content_id = lambda: 42  # type: ignore[method-assign]
+    return panel
 
 
 def test_webview_evaluate_returns_value_on_first_success() -> None:


### PR DESCRIPTION
## Original bug

[SCU-1607](https://linear.app/imbue/issue/SCU-1607) — the Browser-panel `<webview>` integration tests flake in the `offload electron integration tests` lane on ~half of all runs, in three signatures:

1. `No PNG on clipboard after 30.0s (last=None)` — `test_browser_panel_screenshot` (the dominant flake).
2. `Timed out waiting for webview did-attach` — `url_persists_across_collapse`, `route_detour`, `url_input_polish`.
3. `Webview location did not reach <url>; last value was 'about:blank'` — `in_page_state_preserved_across_workspace_switch`, `cross_workspace_isolation`.

PR #172 (dom-ready gate + capturePage retry) shipped to `main` and did **not** remove the flake. This is the second attempt; it fixes the nondeterminism at the source rather than quarantining.

## Hypotheses considered

1. **Screenshot capture of an occluded guest never composites a frame (signature 1)** — REPRODUCED. `capturePage()` on the guest webContents returns an empty image until the guest paints; under xvfb the guest's window is treated as occluded, so it never paints and the retry loop returns empty forever.
2. **The test observes webview readiness through warring proxies (signatures 2 & 3)** — REPRODUCED. The page object gated on the typed-URL address bar and the guest's `document.location` via a focus-coupled global, none of which is the per-workspace committed truth, so a workspace switch races them.
3. **The readiness is a genuine chromium-in-chromium environment limit that can only be quarantined** — DISCARDED. Electron's `capturePage(rect, { stayHidden: true })` forces an occluded guest to composite, and production already computes the committed per-workspace status; both are addressable at the source.

## Root-cause analysis

The Browser panel renders one Electron `<webview>` guest per workspace, mounted at the React root and kept alive across route changes. Two independent root causes produced the three signatures.

**Screenshot (signature 1).** `captureBrowserPanelToClipboard` captured the guest webContents with `capturePage()`. Per Electron's own docs, a page "is considered visible when its browser window is hidden and the capturer count is non-zero" — under xvfb the guest's window is effectively hidden/occluded, so without a capturer it never composites and `capturePage()` resolves to an empty `NativeImage` indefinitely. The empty image was written to the clipboard (a no-op), so the test polled 30s for a PNG that never arrived. The traceback points at the *blank* `about:blank` capture, which has nothing to paint at all — PR #172's retry can only re-observe the same empty frame.

**Readiness (signatures 2 & 3).** The page object approximated "the webview is ready / has navigated" three ways: the toolbar address bar (which mirrors the *typed* URL the instant Enter is pressed, before the guest commits), and the guest's live `document.location` read through `window.__BROWSER_PANEL_TEST__` — a single global that only the *focused* slot publishes. During a workspace switch the focused-slot bookkeeping and the toolbar's navigate target disagree for a render tick, so the global points at a background guest still on `about:blank` (signature 3) or isn't published at all (signature 2, did-attach timeout). These are three proxies for a value production already maintains deterministically per workspace — `browserViewStatusAtomFamily(workspaceId)` (`webContentsId` from `did-attach`, `currentUrl` from `did-navigate`) — but never exposed where a test could read it.

## For each reproduced bug

### Browser panel screenshot writes no PNG when the guest is occluded (signature 1)

**Repro:** open the Browser panel under the Electron lane; click the screenshot button while the guest's window is occluded (the xvfb steady state). Expected: a PNG on the clipboard. Actual: `capturePage()` returns empty for the whole retry budget, an empty image is written, and `wait_for_clipboard_png` fails after 30s with `last=None`.

**Root cause:** `capturePage()` needs the guest to composite a frame; an occluded guest never does without a capturer.

**Fix:** capture with `capturePage(undefined, { stayHidden: true, stayAwake: true })` in `captureNonEmptyPage`. `stayHidden` puts the guest into the "being captured" state that keeps it producing frames while hidden — the supported replacement for the removed `incrementCapturerCount()` — so the capture resolves to a real frame. The existing retry is kept only to absorb the beat between the forced-frame request and its delivery.

**Test:** `sculptor/frontend/src/electron/captureNonEmptyPage.test.ts` (vitest) — asserts every capture passes `{ stayHidden: true, stayAwake: true }`.

### Webview readiness observed through warring proxies (signatures 2 & 3)

**Repro:** navigate the panel and/or switch workspaces under the Electron lane. Expected: the page object waits on the committed navigation. Actual: the address-bar gate passes on the typed URL before the guest commits, and the focus-coupled `document.location` gate reads a background guest still on `about:blank` (or never sees a published webContentsId → did-attach timeout).

**Root cause:** the readiness model used focus-coupled / typed-URL / guest-round-trip proxies instead of the per-workspace committed status production already maintains.

**Fix:** expose that status on the active panel's DOM — `data-webview-content-id` (attached guest's webContentsId) and `data-webview-current-url` (committed URL from `did-navigate`) — and gate the page object on it: `navigate()` waits for the committed URL, `webview_evaluate()` targets the guest by the content-id attribute, and the attach wait reads the content-id attribute. This deletes the `window.__BROWSER_PANEL_TEST__` global bridge, the typed-URL address-bar nav gate, and the guest `document.location` round-trip — collapsing three warring proxies into one per-workspace production-truth signal.

**Tests:** `BrowserPanel.test.tsx` (vitest) asserts the panel surfaces the committed status; `test_browser_panel_element.py` (the page-object retry unit test) and the full `test_browser_panel.py` integration suite gate on the new signal.

## Proof

- Frontend unit: `captureNonEmptyPage`, `BrowserPanel`, `useBrowserWebview` — 10/10 pass.
- Backend unit: `test_browser_panel_element.py` — 4/4 pass.
- Offload `electron integration tests` lane (`max_parallel=200`, the lane where the flake lives), run on this branch:
  - 4 full-lane runs: 3 fully clean; 1 had a single flaky-recovered test (1 of 32). Run 1's eight `test_browser_panel_*` webview tests all passed on first attempt (confirmed via `offload logs`).
  - 16 runs narrowed to only the browser_panel webview tests: 15 fully clean, 1 flaky-recovered, **zero hard failures**.
  - Net: across 20 runs, **zero hard failures** for the browser_panel webview tests. On `main` they flake on ~half of runs, with `test_browser_panel_screenshot` failing 2 of 3 attempts (e.g. SHA `f6b0d1da`).
- **Residual:** one isolated run showed a single flaky-recovered test (passed on retry); it did not recur across 10 targeted re-runs. This is consistent with the rare chromium-in-chromium / xvfb timing tail (the guest occasionally exceeding an already-generous budget to attach/load/composite), which the lane's existing single retry absorbs as neutral (non-blocking). No quarantine, `@pytest.mark.flaky`, or special retry group is added — the source fix removes the deterministic logic causes and all hard failures.

## Review notes

The `/code-review-checklist` self-review found no merge blockers. Acted on / declined:

- **Acted on (comment hygiene):** trimmed backward-looking narration per `docs/development/style_guide.md` — the reference to Electron's removed `incrementCapturerCount()` in `captureNonEmptyPage`, and "the old gate used" in the `navigate()` docstring (commit `b8ba9012`).
- **Declined (LOW, correctness):** `_committed_url_contains` uses an unanchored substring (`contains`) match on `data-webview-current-url`. Left as-is: it mirrors the page object's existing `wait_for_address_bar_contains` (`needle in value`) convention, it is **not a regression** (the replaced `document.location` gate was also a substring check), and no current `navigate()` caller re-navigates to an already-committed or prefix URL, so the theoretical false-pass is not reachable today.
- **Confirmed:** `tsc` is green for the `capturePage(rect?: undefined, opts?)` signature (`just typecheck` passes locally).

(Sent by Claude)
