### PR TITLE
Add post-pr-to-slack skill for announcing PRs in Slack

### DIFF
--- a/.claude/skills/post-pr-to-slack/SKILL.md
+++ b/.claude/skills/post-pr-to-slack/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: post-pr-to-slack
+description: |
+  Post a one-line PR announcement to a Slack channel, and mark it :done: when
+  the PR merges. Use whenever you open or meaningfully adjust a Sculptor PR.
+compatibility: |
+  Requires latchkey with a working Slack credential, plus `jq` and `gh`. Run
+  `scripts/slack_pr.sh check` to verify; see the latchkey skill to set it up.
+argument-hint: [pr-number | pr-url] [#channel]
+---
+
+# Post PR to Slack
+
+Announce Sculptor pull requests in the team's merges channel with a single
+standalone line, then mark each announcement `:done:` once its PR merges. This
+file covers *when* to post and *what* the message should say; the Slack
+mechanics (channel lookup, posting, reacting) live in
+[`scripts/slack_pr.sh`](scripts/slack_pr.sh).
+
+The skill is agent-agnostic — it depends only on `latchkey`, `jq`, `gh`, and
+`bash`, not on any agent-specific tooling.
+
+## When to run
+
+- **When you open a PR for Sculptor.** After `gh pr create --base main`
+  succeeds, post to `#project-sculptor-merges`. This is a standing instruction —
+  just post; see [Authorization](#authorization).
+- **When you meaningfully adjust an open PR** — a force-push that changes the
+  approach, a scope change, or a retitle. Reply in the existing thread; don't
+  start a new top-level post. Skip trivial edits (typo fixes, rebases, minor doc
+  tweaks). If unsure, ask the user.
+- **When a PR merges** (you observe it, or the user says so). Add a `:done:`
+  reaction to the original post. Do *not* post a separate "merged" message — the
+  reaction is the convention.
+
+## Inputs
+
+- **Channel** — `#project-sculptor-merges` for Sculptor PRs unless the user says
+  otherwise.
+- **PR URL** — infer from git when not given:
+  - current branch: `gh pr view --json url -q .url`
+  - a specific PR: `gh pr view <number> --json url -q .url`
+- **One-line description** — draft from the PR title/body (see
+  [Drafting](#drafting-the-one-liner)). If the PR already has a crisp one-liner
+  (its title, or a `## Summary` bullet), reuse it verbatim so Slack and the PR
+  stay in lockstep.
+
+> The only PR-host-specific step is fetching the URL with `gh`. On a GitLab repo,
+> swap in `glab mr view --output json | jq -r .web_url`; everything else is the
+> same.
+
+## Setup
+
+Point a variable at the helper script and confirm Slack is reachable, once per
+session:
+
+```bash
+SLACK=.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
+"$SLACK" check          # prints "slack ok: team '…' as '…'", or says how to fix auth
+```
+
+If the check fails, run `latchkey services info slack` and follow its setup (a
+browser login if supported, otherwise `latchkey auth set`). The script puts an
+nvm-installed `latchkey` back on `PATH` itself; if `check` still reports it
+missing, install it with `npm install -g latchkey`.
+
+## Steps — initial post
+
+1. **Read recent channel history** to match the house style (terse vs.
+   emoji-led, where the URL goes, capitalization), then **draft the line** per
+   [Drafting](#drafting-the-one-liner):
+
+   ```bash
+   "$SLACK" history '#project-sculptor-merges'
+   ```
+
+2. **Post it** and capture the message timestamp (`ts`). The text is sent
+   verbatim, so include the PR URL — Slack unfurls it into a preview:
+
+   ```bash
+   TEXT="Fix login crash when the token contains a colon  $PR_URL"
+   TS=$("$SLACK" post '#project-sculptor-merges' "$TEXT")
+   echo "posted ts=$TS"
+   ```
+
+   `slack_pr.sh` builds the JSON with `jq`, so backticks, quotes, or `&` in the
+   text are safe.
+
+3. **Report** the channel and `ts` back to the user, and remember the `ts` — the
+   merge-time `:done:` step needs it.
+
+## Steps — adjusting an open PR
+
+If a post for this PR already exists (use the `ts` you remembered, or find it),
+reply in its thread — don't post a new top-level message for the same PR, which
+splits the discussion:
+
+```bash
+TS=$("$SLACK" find-ts '#project-sculptor-merges' "$PR_URL")
+"$SLACK" reply '#project-sculptor-merges' "$TS" "Revised approach: now …"
+```
+
+## Steps — PR merged
+
+```bash
+TS=$("$SLACK" find-ts '#project-sculptor-merges' "$PR_URL")
+"$SLACK" done '#project-sculptor-merges' "$TS"
+```
+
+`find-ts` matches the bare URL even when Slack has wrapped it in `<…>`. `done` is
+idempotent — an already-present `:done:` counts as success. Don't post anything
+else; the reaction *is* the "merged" signal.
+
+## Drafting the one-liner
+
+The audience is teammates and future reviewers skimming the channel. The line
+must convey the PR's **one key outcome** and **read standalone** — no thread,
+repo, or commit-history context required. Lead with a verb in the channel's
+imperative style ("Fix X", "Migrate Y", "Speed up Z"). Draft it directly; if
+your harness lets you delegate prose to a smaller/faster model, you may, but
+it's not required.
+
+Check the draft against these guardrails:
+
+- **Outcome, not process.** Describe what the PR achieves in the codebase as it
+  now exists — not the bootstrap, onboarding, or workflow that produced it.
+- **Timeless.** No "follow-up commit does Y", "next we'll…", or "still to come".
+  Frame it as if every commit on the branch has already landed and is the new
+  normal. A channel post is a record, not a roadmap or a per-commit changelog.
+- **One sentence, one outcome.** No parenthetical hedging in a secondary change.
+  If a second change is genuinely co-equal, that's a sign it should be its own PR.
+- **Plain, not hype.** "Improve performance" — not "Massive perf win!" — unless
+  the channel actually talks that way.
+- Ends with the PR URL; no ticket IDs unless the channel uses them.
+
+## Authorization
+
+The `#project-sculptor-merges` post-and-`:done:` flow is **pre-authorized** for
+Sculptor PRs — this skill living in the repo *is* the standing instruction.
+Don't pause to ask "should I post this?" after `gh pr create` succeeds; just
+post. Posting and reacting are still visible to others, so **do** ask before any
+scope expansion: a different channel, @-mentioning people, a reaction other than
+`:done:`, or cross-posting to a non-Sculptor PR.
+
+## Notes
+
+- **Re-resolve the channel ID each invocation.** Looking up by name tolerates
+  renames; a cached ID can go stale across sessions.
+- **Track the `ts` of your initial post** in conversation memory so the
+  merge-time reaction doesn't have to scan history.
+- **Raw API / fallback.** Every call routes through `latchkey curl` against the
+  Slack Web API; the exact endpoints and payloads are in
+  [`scripts/slack_pr.sh`](scripts/slack_pr.sh) if you ever need to run them by
+  hand.

--- a/.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
+++ b/.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# slack_pr.sh — Slack helpers for the post-pr-to-slack skill.
+#
+# Every request goes through `latchkey curl`, which injects the Slack
+# credential automatically (see the latchkey skill). JSON bodies are built with
+# jq so message text containing backticks, quotes, or & is escaped correctly.
+#
+# Commands:
+#   check                                verify latchkey + jq + a working Slack credential
+#   channel-id <name>                    print a channel's ID (paginates conversations.list)
+#   history <#name|ID> [limit]           print the text of recent messages (default 10)
+#   post <#name|ID> <text>               post a message; print its ts
+#   reply <#name|ID> <thread_ts> <text>  post a threaded reply; print its ts
+#   find-ts <#name|ID> <substring>       print ts of the latest message containing <substring>
+#   done <#name|ID> <ts>                 add the :done: reaction (idempotent)
+#
+set -euo pipefail
+
+API="https://slack.com/api"
+
+die() { echo "slack_pr.sh: $*" >&2; exit 1; }
+
+# latchkey is usually an nvm-managed node binary. Non-login shells often don't
+# source nvm, so latchkey (and its node runtime) may be missing from PATH even
+# when installed. Add the install dir back if needed; a no-op when already found.
+if ! command -v latchkey >/dev/null 2>&1; then
+  for d in "$HOME"/.nvm/versions/node/*/bin "$HOME/.local/bin" /usr/local/bin /opt/homebrew/bin; do
+    [ -x "$d/latchkey" ] && { PATH="$d:$PATH"; break; }
+  done
+fi
+command -v latchkey >/dev/null 2>&1 || die "missing dependency: latchkey (npm install -g latchkey; see the latchkey skill)"
+command -v jq       >/dev/null 2>&1 || die "missing dependency: jq"
+
+# Fail loudly unless the JSON on stdin has ok:true; pass it through otherwise.
+check_ok() {
+  local json; json="$(cat)"
+  [ -n "$json" ] || die "empty response from Slack"
+  if [ "$(printf '%s' "$json" | jq -r '.ok')" != "true" ]; then
+    die "Slack API error: $(printf '%s' "$json" | jq -r '.error // "unknown"')"
+  fi
+  printf '%s' "$json"
+}
+
+slack_get()  { latchkey curl -s "$API/$1?${2:-}"; }
+slack_post() {
+  latchkey curl -s -X POST "$API/$1" \
+    -H 'Content-Type: application/json; charset=utf-8' \
+    -d "$2"
+}
+
+# Confirm the Slack credential actually works (read-only identity check).
+cmd_check() {
+  local resp; resp="$(latchkey curl -s -X POST "$API/auth.test")"
+  [ -n "$resp" ] || die "no response from Slack — is latchkey configured? (latchkey services info slack)"
+  if [ "$(printf '%s' "$resp" | jq -r '.ok')" = "true" ]; then
+    echo "slack ok: team '$(printf '%s' "$resp" | jq -r '.team')' as '$(printf '%s' "$resp" | jq -r '.user')'"
+  else
+    die "slack auth failed: $(printf '%s' "$resp" | jq -r '.error // "unknown"') — run: latchkey services info slack"
+  fi
+}
+
+# Resolve a #name (or bare name) to a channel ID, paginating the full list so
+# this tolerates renames and large workspaces (>1000 channels).
+channel_id() {
+  local want="${1#\#}" cursor="" page id
+  [ -n "$want" ] || die "usage: channel-id <name>"
+  while :; do
+    page="$(slack_get conversations.list \
+      "types=public_channel,private_channel&limit=1000&cursor=$cursor" | check_ok)"
+    id="$(printf '%s' "$page" | jq -r --arg n "$want" \
+      '[.channels[] | select(.name == $n) | .id][0] // ""')"
+    [ -n "$id" ] && { printf '%s\n' "$id"; return 0; }
+    cursor="$(printf '%s' "$page" | jq -r '.response_metadata.next_cursor // ""')"
+    [ -n "$cursor" ] || break
+  done
+  die "channel '#$want' not found (wrong name, or you are not a member)"
+}
+
+# A C…/G… argument is already a channel ID; anything else is a name to resolve.
+resolve() { case "$1" in C* | G*) printf '%s\n' "$1" ;; *) channel_id "$1" ;; esac; }
+
+cmd_history() {
+  [ $# -ge 1 ] || die "usage: history <#name|ID> [limit]"
+  local ch; ch="$(resolve "$1")"
+  slack_get conversations.history "channel=$ch&limit=${2:-10}" | check_ok | jq -r '.messages[].text'
+}
+
+cmd_post() {
+  [ $# -eq 2 ] || die "usage: post <#name|ID> <text>"
+  local ch; ch="$(resolve "$1")"
+  slack_post chat.postMessage \
+    "$(jq -n --arg c "$ch" --arg t "$2" '{channel: $c, text: $t, unfurl_links: true}')" \
+    | check_ok | jq -r '.ts'
+}
+
+cmd_reply() {
+  [ $# -eq 3 ] || die "usage: reply <#name|ID> <thread_ts> <text>"
+  local ch; ch="$(resolve "$1")"
+  slack_post chat.postMessage \
+    "$(jq -n --arg c "$ch" --arg th "$2" --arg t "$3" '{channel: $c, thread_ts: $th, text: $t}')" \
+    | check_ok | jq -r '.ts'
+}
+
+# Slack auto-links URLs as <url> in stored text, so match on the bare substring.
+cmd_find_ts() {
+  [ $# -eq 2 ] || die "usage: find-ts <#name|ID> <substring>"
+  local ch; ch="$(resolve "$1")"
+  slack_get conversations.history "channel=$ch&limit=200" | check_ok \
+    | jq -r --arg u "$2" '[.messages[] | select(.text | contains($u)) | .ts][0] // ""'
+}
+
+# Idempotent: a pre-existing :done: (already_reacted) counts as success.
+cmd_done() {
+  [ $# -eq 2 ] || die "usage: done <#name|ID> <ts>"
+  local ch resp ok err
+  ch="$(resolve "$1")"
+  resp="$(slack_post reactions.add \
+    "$(jq -n --arg c "$ch" --arg ts "$2" '{channel: $c, timestamp: $ts, name: "done"}')")"
+  [ -n "$resp" ] || die "empty response from reactions.add"
+  ok="$(printf '%s' "$resp" | jq -r '.ok')"
+  err="$(printf '%s' "$resp" | jq -r '.error // ""')"
+  [ "$ok" = "true" ] || [ "$err" = "already_reacted" ] || die "reactions.add failed: $err"
+  echo ok
+}
+
+[ $# -ge 1 ] || die "usage: slack_pr.sh <check|channel-id|history|post|reply|find-ts|done> ..."
+cmd="$1"; shift
+case "$cmd" in
+  check)      cmd_check "$@" ;;
+  channel-id) channel_id "$@" ;;
+  history)    cmd_history "$@" ;;
+  post)       cmd_post "$@" ;;
+  reply)      cmd_reply "$@" ;;
+  find-ts)    cmd_find_ts "$@" ;;
+  done)       cmd_done "$@" ;;
+  *)          die "unknown command: $cmd" ;;
+esac


### PR DESCRIPTION
## What

Adds a `post-pr-to-slack` skill (`.claude/skills/post-pr-to-slack/`) that
announces Sculptor pull requests in the team's Slack merges channel: a one-line
summary when a PR opens, an in-thread reply on meaningful changes, and a
`:done:` reaction when it merges.

## Why

Ports a personal MR-announcement skill into the repo so it's versioned and
shared. Renamed `mr` → `pr` for our GitHub workflow, modernized to use `gh`
(`gh pr create --base main`, `gh pr view --json url`), and reworked to be
agent-agnostic — it relies only on `latchkey`, `jq`, `gh`, and `bash`, with no
agent-specific tooling (the old version delegated drafting to a Claude
sub-agent).

## How

The Slack mechanics live in `scripts/slack_pr.sh` (subcommands: `check`,
`channel-id`, `history`, `post`, `reply`, `find-ts`, `done`) so each step is
deterministic instead of hand-built `curl`:

- paginated `conversations.list` channel lookup (tolerates renames / >1000 channels)
- `jq`-built JSON payloads, safe with backticks/quotes/`&` in the message text
- find-message-by-URL for the merge-time reaction
- idempotent `:done:` (`already_reacted` counts as success)
- self-discovers an nvm-installed `latchkey`, so it works from non-login shells

`SKILL.md` carries the judgment: when to post, how to draft a standalone
one-liner, and the pre-authorized scope for the merges channel.

## Verification

- `shellcheck --severity=warning`, file-hygiene, and `just ratchets` pass on the
  changed files.
- Live read-only checks: `slack_pr.sh check` authenticates and the default
  channel resolves. The write paths were not exercised beyond this PR's own
  announcement.
