### PR TITLE
Tighten no-sculptor-subprocess and no-integration-non-testid-queries

### DIFF
--- a/ratchet-counts.toml
+++ b/ratchet-counts.toml
@@ -117,7 +117,7 @@
 "." = 1
 
 [no-sculptor-subprocess]
-"." = 2
+"." = 1
 
 [no-ssh-subprocess]
 "." = 0

--- a/ratchet-counts.toml
+++ b/ratchet-counts.toml
@@ -42,7 +42,7 @@
 "." = 0
 
 [no-integration-non-testid-queries]
-"." = 1
+"." = 0
 
 [no-integration-page-evaluate]
 "." = 22

--- a/sculptor/sculptor/testing/elements/action_dialog.py
+++ b/sculptor/sculptor/testing/elements/action_dialog.py
@@ -66,6 +66,15 @@ class PlaywrightActionDialogElement(PlaywrightIntegrationTestElement):
         """Get the group select trigger."""
         return self.get_by_test_id(ElementIDs.ACTION_DIALOG_GROUP_SELECT)
 
+    def get_group_option(self, group_name: str) -> Locator:
+        """Get an option in the (open) group dropdown by its visible name.
+
+        Radix renders select options at the page level, so this queries the page
+        rather than the dialog locator. Encapsulating the role-based lookup in the
+        POM keeps integration tests free of raw get_by_role calls.
+        """
+        return self._page.get_by_role("option", name=group_name)
+
     def get_auto_submit_switch(self) -> Locator:
         """Get the auto-submit switch."""
         return self.get_by_test_id(ElementIDs.ACTION_DIALOG_AUTO_SUBMIT_SWITCH)

--- a/sculptor/sculptor/testing/elements/action_dialog.py
+++ b/sculptor/sculptor/testing/elements/action_dialog.py
@@ -70,8 +70,7 @@ class PlaywrightActionDialogElement(PlaywrightIntegrationTestElement):
         """Get an option in the (open) group dropdown by its visible name.
 
         Radix renders select options at the page level, so this queries the page
-        rather than the dialog locator. Encapsulating the role-based lookup in the
-        POM keeps integration tests free of raw get_by_role calls.
+        rather than the dialog locator.
         """
         return self._page.get_by_role("option", name=group_name)
 

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -3255,14 +3255,13 @@ def _get_remote_branches(repo_path: Path, remote_filter: str | None = "origin") 
             Pass ``None`` to include branches from all remotes.
     """
     try:
-        result = subprocess.run(
+        result = run_blocking(
             ["git", "branch", "-r", "--format=%(refname:short)"],
             cwd=repo_path,
-            capture_output=True,
-            text=True,
             timeout=_GIT_INFO_TIMEOUT_SECONDS,
+            is_checked=False,
         )
-        if result.returncode != 0:
+        if result.returncode != 0 or result.is_timed_out:
             return []
         branches = []
         for line in result.stdout.strip().splitlines():
@@ -3276,7 +3275,7 @@ def _get_remote_branches(repo_path: Path, remote_filter: str | None = "origin") 
                 continue
             branches.append(branch)
         return branches
-    except (subprocess.TimeoutExpired, OSError):
+    except ProcessSetupError:
         return []
 
 

--- a/sculptor/tests/integration/frontend/test_custom_actions.py
+++ b/sculptor/tests/integration/frontend/test_custom_actions.py
@@ -300,7 +300,7 @@ def test_builtin_chips(sculptor_instance_: SculptorInstance) -> None:
     dialog = get_action_dialog(page)
     expect(dialog).to_be_visible()
     dialog.get_group_select().click()
-    expect(page.get_by_role("option", name="Sculptor")).to_have_count(0)
+    expect(dialog.get_group_option("Sculptor")).to_have_count(0)
     page.keyboard.press("Escape")  # close select
 
     # Create a user group so we can verify Sculptor renders above it.


### PR DESCRIPTION
## Summary

This continues the ratchet-tightening effort by clearing two more lint classes. Each change is its own commit.

> **Stacked on #222.** This branch is based on `danver/fix-ratchet-rules-by` (PR #222), so until that merges this PR's diff also contains #222's five commits. The two commits unique to this branch are the ones described below; review #222 for the rest.

## New in this branch

1. **`no-sculptor-subprocess` 2 → 1** — convert the one production call site, `_get_remote_branches()` in the web app, from `subprocess.run` to the `run_blocking()` helper the rule prefers. Behavior is preserved: with `is_checked=False`, `run_blocking` doesn't raise on a non-zero exit or a timeout (it returns a `FinishedProcess` with `is_timed_out` set), so the existing returncode guard is extended to also treat a timeout as a failure and return `[]`; a process that can't start raises `ProcessSetupError`, which replaces the old `OSError` catch; and `FinishedProcess.stdout` is already a decoded `str`, so the parsing loop is unchanged.

   The other flagged site — `dev_git_sha()` in `version.py` — is intentionally left as-is. It carries an explicit *"do not migrate to `run_blocking`"* note (doing so would introduce a cyclic dependency) and only runs at build time, never during product runtime. That documented exception is why the budget lands at **1** rather than 0.

2. **`no-integration-non-testid-queries` 1 → 0** — the rule bans raw `get_by_role` / `get_by_text` / `query_selector` calls inside integration test files; the page object models are the sanctioned home for those lookups. Move the builtin-chips test's `page.get_by_role("option", name="Sculptor")` into a new `get_group_option()` method on the action-dialog POM and call it from the test. The locator is identical, so behavior is unchanged.

## Verification

- `ratchets check` passes (both budgets at their new values).
- `pyrefly check`: 0 errors.
- `ruff` format + lint clean on changed files.
- `run_blocking` was exercised against this repo to confirm the `git branch -r` path: happy path returns branches, a bad working directory raises `ProcessSetupError`, and a non-git directory yields a non-zero return code — matching the previous `subprocess.run` behavior.

Note: the affected frontend integration test needs a live browser/`node` toolchain, which isn't available in this worktree; the POM change is a behavior-identical refactor (same locator, same page). All changes here are Python only.

(Sent by Claude)
