### PR TITLE
Add living pi-integration reference under agent_docs/pi-integration (SCU-1637)

### DIFF
--- a/.claude/skills/pi/SKILL.md
+++ b/.claude/skills/pi/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: pi
+description: |
+  Point at the living pi-integration reference (agent_docs/pi-integration/).
+  Use at the start of any task that touches Sculptor's pi harness integration —
+  RPC model selection, CLI launch flags, provider auth, or skills mapping — so
+  you read the consolidated facts instead of re-deriving them from the code.
+---
+
+# pi Integration Reference
+
+`pi` is a third-party, version-pinned, **immutable** coding-agent harness that
+Sculptor drives as a subprocess. Sculptor never modifies pi-core; it extends pi
+only through a pinned extension set plus Sculptor-side wiring.
+
+Before changing or reasoning about any pi-integration surface, read the living
+reference under [`agent_docs/pi-integration/`](../../../agent_docs/pi-integration/README.md):
+
+- **[README.md](../../../agent_docs/pi-integration/README.md)** — invariants:
+  pi-core immutability, the pinned-version + pinned-extension model, the current
+  pin, and where the de-facto live reference lives (the `harness.py` /
+  `agent_wrapper.py` module docstrings).
+- **[rpc.md](../../../agent_docs/pi-integration/rpc.md)** — the model-selection
+  RPC trio (`get_available_models` / `get_state` / `set_model`); why model
+  identity is `(provider, modelId)` fetched at runtime, not Sculptor's
+  `LLMModel` enum.
+- **[cli-flags.md](../../../agent_docs/pi-integration/cli-flags.md)** — the full
+  launch argv and `--session-id` resume semantics.
+- **[auth.md](../../../agent_docs/pi-integration/auth.md)** —
+  `~/.pi/agent/auth.json` as the shared source of truth; presence-not-validity
+  catalog gating; per-provider `/logout`.
+- **[skills.md](../../../agent_docs/pi-integration/skills.md)** — how Sculptor's
+  skills/commands map onto pi's `--skill`.
+
+The reference cites a live source file for every non-obvious claim. Citations
+drift — re-confirm against the cited file before acting, and update the doc in
+the same change if the code has moved.

--- a/agent_docs/pi-integration/README.md
+++ b/agent_docs/pi-integration/README.md
@@ -1,0 +1,146 @@
+# pi Integration — Living Reference
+
+A consolidated, **living** reference for how Sculptor integrates the third-party
+`pi` harness. The goal is narrow: stop every pi integration cycle from
+re-deriving the same RPC / CLI / auth / skills facts from scratch. Each page
+below summarizes one surface and **cites a live source file for every
+non-obvious claim**, so when the code moves, the doc has a fixed point to be
+checked against.
+
+> **Verify before you trust.** Citations are `path:line` against the tree at
+> commit `5a0d94bb` (2026-06-30). Line numbers drift; treat them as a pointer to
+> the right function, and re-confirm against the file before acting. If a cited
+> claim no longer matches the code, **the code is the source of truth** — fix
+> this doc.
+
+## What pi is (and the one invariant that governs everything)
+
+`pi` is a separate, upstream coding-agent harness (the
+[`earendil-works/pi`](https://github.com/earendil-works/pi) project) that
+Sculptor drives as a subprocess over a JSONL RPC protocol. It is **not ours to
+modify**.
+
+**pi-core is immutable.** Sculptor never patches, forks, or rebuilds pi. Every
+pi-side capability Sculptor adds is reached through exactly two seams:
+
+1. **The pinned extension set** — a small, version-pinned set of TypeScript
+   extensions that Sculptor ships and loads explicitly (see
+   [the pinned-extension model](#the-pinned-extension-model) below).
+2. **Sculptor-side wiring** — the adapter code in
+   `sculptor/sculptor/agents/pi_agent/` that maps pi's wire protocol onto
+   Sculptor's harness-agnostic contracts, plus driving pi's own interactive
+   commands (e.g. `/login`, `/logout`) through a PTY.
+
+Anything that would require changing pi-core itself is **out of scope** — it
+defers until the pinned version is bumped to a pi release that already supports
+it. When you read "X is not supported," read it as "the pinned pi version does
+not expose X," not "we could patch it in."
+
+## The pinned-version model
+
+Sculptor pins pi to **one exact version** so the RPC schema, CLI flags, and
+session format stay known and testable.
+
+| Fact | Value | Source of truth |
+| --- | --- | --- |
+| Current pinned version | **`0.80.2`** | `sculptor/sculptor/services/pi_version.py:10` (`PI_PINNED_VERSION`) |
+| Per-platform download pin (asset + sha256) | darwin-arm64 / darwin-x64 / linux-x64 | `sculptor/sculptor/services/managed_tools.py:66-82` (`PI_PIN`) |
+| Allowed version range | min == max == recommended == the pin | `sculptor/sculptor/services/managed_tools.py:170-174` (`PI_VERSION_RANGE`) |
+| Release source | `https://github.com/earendil-works/pi/releases/download` | `sculptor/sculptor/services/managed_tools.py:165` (`_PI_RELEASE_BASE_URL`) |
+| Bump path | `just compute-pi-pin <version>` → paste the printed `platforms={...}` block into `PI_PIN`, then update `PI_PINNED_VERSION` | `scripts/compute_pi_pin.py`; `justfile:937-938` |
+
+pi publishes no checksums of its own, so Sculptor computes them per version and
+bakes them into `PI_PIN`; the install path verifies every download against the
+baked sha256 (`managed_tools.py:51-63`, `PiManagedTool.resolve_distribution` at
+`managed_tools.py:197-208`). The version string lives in its own dependency-free
+module (`pi_version.py`) so the test harness's `fake_pi` stub can answer
+`pi --version` without importing the heavier `managed_tools` stack.
+
+> **Watch for stale version strings.** Doc-style version references inside the
+> code can lag the real pin. As of this writing the `agent_wrapper.py` module
+> docstring still cites "pi 0.78.0" (`agent_wrapper.py:35`) and the
+> `compute_pi_pin.py` usage examples use `0.78.0` — both are illustrative text,
+> not the live pin. The live pin is **`0.80.2`** (`pi_version.py:10`). Trust the
+> constant, not the prose.
+
+## The pinned-extension model
+
+pi has its own extension-discovery mechanism. Sculptor **disables it** and loads
+only its own curated set, so the immutability guarantee holds (only Sculptor's
+version-pinned extensions ever run):
+
+- Launch passes `--no-extensions` (disables pi's own discovery) **and** an
+  explicit `-e <path>` for each pinned extension
+  (`agent_wrapper.py:704-707`, `_install_pinned_extensions` at
+  `agent_wrapper.py:960-984`).
+- The pinned set is three TypeScript extensions shipped as package data next to
+  the agent module (`sculptor/sculptor/agents/pi_agent/extensions/`):
+  - `sculptor_backchannel.ts` — ask-user-question + plan mode
+  - `sculptor_subagent.ts` — sub-agents (each child is its own `pi` process)
+  - `sculptor_background.ts` — background tasks
+- `PI_PIN.plugin_set_revision` is a reserved constant (`"bundled"`) — a sentinel
+  slot for pinning a pi *plugin* set if one is ever needed
+  (`managed_tools.py:61-63`).
+
+## The de-facto live reference already lives in two module docstrings
+
+This doc **summarizes and links**; it deliberately does not re-derive the
+protocol. The authoritative, code-adjacent narratives are:
+
+- **`sculptor/sculptor/agents/pi_agent/harness.py`** (module docstring,
+  lines 1-35) — the capability declaration: what pi supports and why. The
+  truthful, gated values are the `capabilities()` override at
+  `harness.py:85-158`, which consumers read.
+- **`sculptor/sculptor/agents/pi_agent/agent_wrapper.py`** (module docstring,
+  lines 1-36) — the wire-protocol narrative: how the subprocess is launched,
+  how the three stdout channels multiplex, how tool calls render, how
+  sub-agents/background tasks yield.
+
+Read those first. The pages here are the index and the fast-path summary.
+
+### Capability snapshot (from `capabilities()`, `harness.py:85-158`)
+
+| Capability | Pinned pi (`0.80.2`) | Mechanism |
+| --- | --- | --- |
+| Tool-use rendering | ✅ `True` | tool-execution lane → harness tool blocks |
+| Session resume | ✅ `True` | `--session-dir` / `--session-id` persisted JSONL |
+| Skills | ✅ `True` | `--skill <dir>` flags (see [skills.md](./skills.md)) |
+| Interactive backchannel (ask-user / plan mode) | ✅ `True` | `sculptor_backchannel` extension |
+| Sub-agents | ✅ `True` | `sculptor_subagent` extension |
+| Background tasks | ✅ `True` | `sculptor_background` extension |
+| Model selection | ✅ `True` | RPC `set_model` (see [rpc.md](./rpc.md)) |
+| Fast mode | ❌ `False` | no natural mapping to pi's models |
+
+The truthful, gated declaration is the `capabilities()` override in `harness.py`
+— prefer it over this table if they ever disagree.
+
+## Pages
+
+| Page | Covers |
+| --- | --- |
+| [rpc.md](./rpc.md) | The model-selection RPC trio — `get_available_models`, `get_state`, `set_model`; why model identity is `(provider, modelId)` fetched at runtime, not Sculptor's `LLMModel` enum; why no `--provider` / `--api-key` flags |
+| [cli-flags.md](./cli-flags.md) | The full launch argv; `--session-id` (not `--session`) and its adopt-verbatim / create-if-missing / corrupt-tail-tolerant behavior; `--session-dir`, `--no-extensions`, `-e`, `--append-system-prompt`, `--skill` |
+| [auth.md](./auth.md) | `~/.pi/agent/auth.json` as the shared source of truth; presence-not-validity catalog gating; auth.json-vs-env precedence; per-provider `/logout`; `getAgentDir` (`PI_CODING_AGENT_DIR`) resolution |
+| [skills.md](./skills.md) | How Sculptor's skills/commands map onto pi's `--skill`; un-namespaced plugin skills; loose `.claude/commands` wrapping; the no-description-doesn't-load rule; the full skill-source list |
+
+## Related cycles
+
+- **`agent_docs/pi-auth/`** (on `main`) — the spec/architecture/requirements/
+  review/mocks for organic provider auth from Settings. [auth.md](./auth.md)
+  builds directly on it; that folder is the deeper dive on the auth UX and the
+  empirical phase-0 feasibility findings.
+- **`agent_docs/pi-capabilities/`** — **not on `main`.** It lives only on an
+  unmerged `pi-capabilities` working branch (search the repo's branches for the
+  `pi-capabilities` slug). Its capability-matrix content could be folded into
+  this reference once it lands; until then, do not assume it is present. (Do not
+  merge that branch as part of a docs task.)
+
+## How to keep this living
+
+When you touch any pi-integration surface, update the matching page here in the
+same change, and re-check that the cited `path:line` still points at the claim.
+A page that cites code is only useful while the citation is true.
+
+---
+
+_This is an internal engineering reference, not user-facing documentation._

--- a/agent_docs/pi-integration/auth.md
+++ b/agent_docs/pi-integration/auth.md
@@ -1,0 +1,108 @@
+# pi Auth — Credentials & the Authenticated Catalog
+
+How Sculptor and pi agree on which LLM providers are authenticated, where that
+state lives, and how Sculptor reads/writes it.
+
+> Source of truth: `sculptor/sculptor/agents/pi_agent/authenticated_providers.py`
+> (path resolution, reading, presence model) and
+> `sculptor/sculptor/services/pi_login_service.py` (driving pi's interactive
+> `/login` and `/logout`). The deeper design rationale and the empirical phase-0
+> feasibility findings are in `agent_docs/pi-auth/` — this page is the
+> code-anchored quick reference.
+
+## `~/.pi/agent/auth.json` is the shared source of truth
+
+pi stores provider credentials in `auth.json` inside its agent directory.
+Sculptor treats **the same file** as the source of truth, so Sculptor-managed pi
+and standalone pi converge on one credential store.
+
+`auth.json` is a flat object whose **top-level keys are provider ids** (e.g.
+`{"anthropic": {"type": "api_key", "key": "..."}}`)
+(`read_auth_json_provider_ids` at `authenticated_providers.py:40-57`).
+
+### `getAgentDir` resolution
+
+`resolve_pi_auth_json_path` (`authenticated_providers.py:26-37`) mirrors pi's own
+`getAgentDir()`:
+
+1. If the env var **`PI_CODING_AGENT_DIR`** is set and non-empty → use it
+   (expanded).
+2. Otherwise → `~/.pi/agent`.
+
+`auth.json` lives directly inside that directory.
+
+> When Sculptor drives pi's interactive `/login`/`/logout`, the PTY **inherits
+> the user's real environment and explicitly does NOT set `PI_CODING_AGENT_DIR`**,
+> so pi reads/writes the user's real `~/.pi/agent/auth.json`
+> (`pi_login_service.py:245-247`). That is how the standalone-pi and
+> Sculptor-pi views stay the same file.
+
+## Catalog gating is on credential **presence**, not validity
+
+A provider's models appear in pi's catalog if a credential **exists** for it —
+even an empty or expired one. There is no validity check at gating time.
+
+- `ProviderAuthStatus.in_auth_json` "reflects presence of the provider id as a
+  top-level key in `auth.json` (presence, not validity, matching pi's gating)"
+  (`authenticated_providers.py:10-16`).
+- Test: a file containing `{"anthropic": {"key": ""}}` (empty/invalid key) still
+  reports `{"anthropic"}` as authenticated
+  (`authenticated_providers_test.py`, `test_reader_presence_not_validity`).
+- Sculptor mirrors pi's behavior when curating the picker: `_curate_models` drops
+  options whose provider is not in the authenticated set, precisely because "pi
+  gates its catalog on credential presence, not validity, so a stray ambient key
+  would otherwise leak that provider's models into the picker"
+  (`agent_wrapper.py:333-337`, `350-351`).
+
+**Consequence:** "this provider is in the catalog" means "a credential is
+present," not "the credential works." A present-but-bogus key still surfaces the
+provider's whole model set.
+
+## Precedence: read carefully — two different layers
+
+There are two distinct notions of precedence; do not conflate them.
+
+1. **pi's own runtime credential resolution.** When a provider has both an
+   `auth.json` entry and an environment variable, **pi prefers the `auth.json`
+   entry** (auth.json > env). This is pi-core behavior, documented in the
+   architecture write-up (`agent_docs/pi-auth/architecture.md`), not something
+   Sculptor implements.
+2. **Sculptor's authenticated-set computation (for catalog gating).** Sculptor
+   does **not** apply precedence — it takes the **union**:
+   `compute_authenticated_provider_ids()` returns
+   `read_auth_json_provider_ids() | detect_env_authenticated_provider_ids()`
+   (`authenticated_providers.py:71-73`). A provider counts as authenticated if it
+   has a credential in **either** source.
+
+So: Sculptor decides *whether to show* a provider by union (either source), and
+pi decides *which credential value to actually use* by preferring `auth.json`.
+
+## Writing credentials (`write_auth_json_entry`)
+
+When Sculptor writes a key from Settings, it does a **merge-safe** read-modify-
+write (`write_auth_json_entry` at `authenticated_providers.py:80-102`):
+
+- Sets `data[provider_id] = {"type": "api_key", "key": <value>}`, preserving
+  every other entry (including OAuth / unknown entries).
+- The value is stored **verbatim** — a literal key, a `$ENV` reference, or a
+  `!command` — so pi resolves it at read time and **no secret is resolved or
+  logged** in Sculptor.
+- Written atomically (temp file + rename) at mode **`0600`**
+  (`_write_auth_json_atomically` at `authenticated_providers.py:105-116`).
+- A garbled (non-dict / unparseable) existing file raises `PiAuthJsonError`
+  rather than clobbering the user's credentials.
+
+## `/logout` is per-provider
+
+Logout removes **one** provider's stored key at a time — it is not an
+all-providers reset.
+
+`_drive_pi_session` (`pi_login_service.py:206-224`) submits `/logout`, waits for
+pi's logout selector, then **fuzzy-filters pi's provider list to the chosen
+`provider_id`** (typing the id narrows to its row) and presses Return to remove
+that provider's stored key. The provider to remove is known up front (the user
+clicked its Disconnect), and is passed as `spawn(mode, pi_binary_path,
+provider_id)` (`pi_login_service.py:240-248`).
+
+`/login` and `/logout` are both driven through an ephemeral PTY, never via
+flags — Sculptor reaches pi's interactive surface, it does not reimplement it.

--- a/agent_docs/pi-integration/cli-flags.md
+++ b/agent_docs/pi-integration/cli-flags.md
@@ -1,0 +1,83 @@
+# pi CLI — Launch Flags
+
+The exact command line Sculptor builds to launch pi, and the behavior of the
+load-bearing flags.
+
+> Source of truth: `PiAgent.start()` in
+> `sculptor/sculptor/agents/pi_agent/agent_wrapper.py`. The argv is assembled at
+> `agent_wrapper.py:708-721`.
+
+## The full argv
+
+```
+pi \
+  --mode rpc \
+  --session-dir <state>/<PI_SESSION_DIR_NAME> \
+  --session-id <sculptor-pinned id> \
+  --no-extensions \
+  -e <state>/sculptor_backchannel.ts \
+  -e <state>/sculptor_subagent.ts \
+  -e <state>/sculptor_background.ts \
+  --append-system-prompt <assembled prompt> \
+  [--skill <dir> ...]
+```
+
+| Flag | Purpose | Built at |
+| --- | --- | --- |
+| `--mode rpc` | JSONL request/response protocol over stdin/stdout | `agent_wrapper.py:710-711` |
+| `--session-dir <dir>` | Per-task directory holding the persisted JSONL session | `agent_wrapper.py:712-713`; dir is `get_state_path() / PI_SESSION_DIR_NAME` (`agent_wrapper.py:681`) |
+| `--session-id <id>` | The Sculptor-pinned session id — the resume lever | `agent_wrapper.py:714-715` |
+| `--no-extensions` | Disables pi's **own** extension discovery | `agent_wrapper.py:716` |
+| `-e <path>` (×3) | Loads each pinned extension explicitly | `agent_wrapper.py:717`; `_install_pinned_extensions` at `agent_wrapper.py:960-984` |
+| `--append-system-prompt <prompt>` | Sculptor's assembled system prompt | `agent_wrapper.py:718-719`; `_build_system_prompt` |
+| `--skill <dir>` (×N) | Workspace's Claude-visible skill sources | `agent_wrapper.py:720`; `_build_skill_launch_args` at `agent_wrapper.py:891-922` (see [skills.md](./skills.md)) |
+
+The process is then started with `isolate_process_group=True` so a Stop/shutdown
+signal cascades to pi's descendants (e.g. a background-tool child)
+(`agent_wrapper.py:722-733`).
+
+## `--no-extensions` plus `-e` is the immutability lever
+
+These two are a pair. `--no-extensions` turns off pi's own extension discovery;
+the explicit `-e <path>` flags then load **only** Sculptor's curated, pinned set.
+Together they enforce the invariant that nothing but Sculptor's three
+version-pinned extensions ever loads (`agent_wrapper.py:704-707`). See the
+[pinned-extension model](./README.md#the-pinned-extension-model) in the README.
+
+## `--session-id` (not `--session`) and its behavior
+
+Sculptor pins the session id **Sculptor-side** and passes it with `--session-id`.
+This was a deliberate choice over `--session <id>`
+(`agent_wrapper.py:699-704`):
+
+- **Adopts the id verbatim.** pi takes the `--session-id` value exactly as given;
+  a reported id that differed would signal a pi-behavior change, which
+  `_verify_resumed_session` logs loud (`agent_wrapper.py:1083-1091`,
+  `1100-1107`).
+- **Creates the session if missing.** `--session-id` never errors on an
+  absent/corrupt session — pi creates one with that id. (Real pi `0.78.0` was
+  observed to exit non-zero for an unknown `--session`, which would crash-loop.)
+  A lost session file therefore degrades to a **loud fresh start**, not a crash
+  (`agent_wrapper.py:699-704`, `1108-1112`).
+- **Tolerant of a truncated JSONL tail.** If the persisted session file has a
+  corrupt/truncated tail, pi resumes the **valid prefix** rather than failing
+  (`agent_wrapper.py:703`).
+
+### How resume actually works
+
+- On first launch, Sculptor mints an id (`generate_id()`), writes it to
+  `PI_SESSION_ID_STATE_FILE`, and passes it. On a later launch it reads that file
+  back; a present file means "resume" (`agent_wrapper.py:680-689`).
+- After a `new_session` (context clear), pi mints a **new** id; Sculptor reads it
+  back via `get_state` and overwrites the state file so the next resume targets
+  the post-clear session (`_persist_post_clear_session_id` at
+  `agent_wrapper.py:1722-1743`).
+- The per-task session dir lives under the environment state path, so parallel pi
+  workspaces never share a session.
+
+## Credentials are not passed as flags
+
+Neither `--provider` nor `--api-key` appears anywhere in the launch — confirmed
+absent from `agent_wrapper.py`. API keys flow through the **process environment**
+as `Secret`s instead (`_collect_api_key_secrets` at `agent_wrapper.py:986-993`),
+and model choice is made over RPC. See [rpc.md](./rpc.md) and [auth.md](./auth.md).

--- a/agent_docs/pi-integration/rpc.md
+++ b/agent_docs/pi-integration/rpc.md
@@ -1,0 +1,123 @@
+# pi RPC — Model Selection
+
+How Sculptor reads pi's model catalog, reads pi's session state, and switches
+pi's model — all over the JSONL RPC channel, never via CLI flags.
+
+> Source of truth: the wire-protocol narrative in
+> `sculptor/sculptor/agents/pi_agent/agent_wrapper.py` (module docstring) and the
+> three blocking request helpers cited below. The RPC requests/responses below
+> are taken from the live `_send_rpc` call sites and the
+> `agent_wrapper_test.py` fixtures.
+
+## The three methods
+
+All three are request/response RPC commands: Sculptor sends `{"type": <command>,
+"id": <request_id>, …}` on stdin and waits (between turns) for a matching
+`{"type": "response", "command": <command>, "id": <request_id>, "success": …,
+"data": …}` on stdout. The match is on `(command, id)`
+(`_consume_until_command_response` at `agent_wrapper.py:1064`).
+
+### `get_available_models` — fetch the catalog at runtime
+
+`_request_available_models_blocking` (`agent_wrapper.py:1116-1134`).
+
+```jsonc
+// request
+{"type": "get_available_models", "id": "<request_id>"}
+// response.data
+{"models": [{"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}, ...]}
+```
+
+Returns the raw `data.models` list (each a dict). Returns `[]` on timeout,
+process exit, or a malformed payload (`agent_wrapper.py:1129-1134`).
+
+### `get_state` — read the session's id, message count, and current model
+
+`_request_state_blocking` (`agent_wrapper.py:1068-1081`).
+
+```jsonc
+// request
+{"type": "get_state", "id": "<request_id>"}
+// response.data (RpcSessionState)
+{"sessionId": "...", "messageCount": 1, "model": {"id": "...", "name": "...", "provider": "..."}}
+```
+
+Used for two safety checks beyond model display:
+- **Resume verification** — `_verify_resumed_session` (`agent_wrapper.py:1083-1114`)
+  confirms pi resumed the `--session-id` we asked for and that the session is
+  non-empty; both anomalies are logged loud so context loss is never silent.
+- **Post-clear id capture** — `_persist_post_clear_session_id`
+  (`agent_wrapper.py:1722-1743`) reads back the fresh session id after a
+  `new_session` so a later resume targets it.
+
+### `set_model` — switch the model
+
+`_handle_set_model` (`agent_wrapper.py:1745-1789`); a non-raising variant
+`_request_set_model_blocking` (`agent_wrapper.py:1136-1154`) backs the internal
+auto-reselect.
+
+```jsonc
+// request
+{"type": "set_model", "id": "<command_id>", "provider": "anthropic", "modelId": "claude-opus-4-8"}
+// response.data — the new current Model
+{"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+```
+
+Note the request key is **`modelId`** (camelCase), distinct from the `model_id`
+field Sculptor uses internally.
+
+**Session-level and persistent — one mechanism, not two.** `set_model` applies to
+the live session **and persists for later turns** within it
+(`agent_wrapper.py:1749-1750`). There is no separate "default model" RPC: the
+selection is written into pi's persisted session, so it survives a process
+resume *because the session itself is resumed* (`--session-id`, see
+[cli-flags.md](./cli-flags.md)). On success pi returns the new `Model`; Sculptor
+re-emits a `ModelsAvailableAgentMessage` (same catalog, new current model) so the
+persisted selection and the switcher follow. A `success:false` (e.g. `Model not
+found`) or no acknowledgement raises `PiSetModelError` and leaves the current
+model unchanged (`agent_wrapper.py:1765-1774`).
+
+### Concurrency constraint
+
+All three helpers share a **sole-reader** safety constraint: they consume pi's
+stdout directly, so they are only safe to call **between turns**, when the
+message-processing thread is not also reading the queue
+(`agent_wrapper.py:1071-1072`, `1748-1749`). Model commands are routed through
+the `_input_agent_messages` FIFO to guarantee this.
+
+## Model identity is `(provider, modelId)`, not the `LLMModel` enum
+
+A pi model is identified by a **`(provider, modelId)` pair**, not by Sculptor's
+internal `LLMModel` enum. The whole catalog is therefore **fetched at runtime**
+and cannot be hardcoded:
+
+- `_model_option_from_pi` (`agent_wrapper.py:360-376`) maps one pi `Model` dict
+  `{id, name, provider, …}` onto a `ModelOption(provider, model_id,
+  display_name)`. `provider` defaults to `"anthropic"` when pi omits it (Sculptor
+  launches pi against the Anthropic catalog); `display_name` falls back to the
+  id.
+- `ModelOption` lives in `sculptor/sculptor/state/messages.py` — a free-form
+  `(provider, model_id, display_name)` triple, deliberately **not** an enum, so
+  any provider/model pi reports can flow through.
+- `_curate_models` (`agent_wrapper.py:321-357`) trims pi's raw catalog
+  (blacklist, dated-pin duplicates, newest-first sort) but always keeps the
+  current model so the switcher is never empty — it operates on whatever pi
+  returned, not a fixed list.
+
+Practical consequence: **never hardcode pi model ids in Sculptor.** Call
+`get_available_models` and pick from what pi reports.
+
+## Do not pass `--provider` or `--api-key`
+
+Model selection is **entirely an RPC concern**. Neither `--provider` nor
+`--api-key` is ever passed on pi's command line (`grep` finds neither anywhere in
+`agent_wrapper.py`; the full argv is in [cli-flags.md](./cli-flags.md) and at
+`agent_wrapper.py:708-721`).
+
+Credentials reach pi a different way: API keys are read from the **process
+environment** at launch and injected as `Secret`s
+(`_collect_api_key_secrets` at `agent_wrapper.py:986-993`, passed as
+`secrets=` to `run_process_in_background` at `agent_wrapper.py:724`). Which
+provider is authenticated is governed by `~/.pi/agent/auth.json` plus env vars —
+see [auth.md](./auth.md). The model *choice* is then made over RPC against
+whatever catalog those credentials unlock.

--- a/agent_docs/pi-integration/skills.md
+++ b/agent_docs/pi-integration/skills.md
@@ -1,0 +1,92 @@
+# pi Skills — How Sculptor's Skills Map onto `--skill`
+
+How Sculptor points pi at the same skills the slash picker offers, and the four
+mapping rules that make pi's skill model line up with Sculptor's.
+
+> Source of truth: `_build_skill_launch_args`, `_synthesize_command_skills`,
+> `_rewrite_skill_invocation`, and `_render_synthesized_skill` in
+> `sculptor/sculptor/agents/pi_agent/agent_wrapper.py`; the source-directory
+> authority is `get_skill_source_directories` in
+> `sculptor/sculptor/web/skills.py`.
+
+## The single source of truth for *where* skills come from
+
+`get_skill_source_directories` (`web/skills.py:181-223`) is the one authority for
+the skill roots, used by **both** `discover_skills` (which feeds the slash
+picker) **and** `_build_skill_launch_args` (which feeds pi). They derive from the
+same roots so the picker list and pi's loaded set stay in lockstep
+(`agent_wrapper.py:891-909`, `_discover_skill_names` at `agent_wrapper.py:880-889`).
+
+The sources, **in discovery order** (`web/skills.py:202-222`):
+
+| # | Path | Kind | Namespaced? |
+| --- | --- | --- | --- |
+| 0 | `<plugin>/skills/` | `SKILL_DIR` | yes — plugin name from `.claude-plugin/plugin.json` |
+| 1 | `<repo>/.claude/skills/` | `SKILL_DIR` | no |
+| 2 | `<repo>/.claude/commands/` | `COMMAND_FILES` | no |
+| 3 | `<home>/.claude/skills/` | `SKILL_DIR` | no |
+| 4 | `<home>/.claude/commands/` | `COMMAND_FILES` | no |
+
+`home` is overridable via `home_path` so it resolves against the agent's
+environment, not the host (`web/skills.py:196-200`).
+
+## Rule 1 — `SKILL.md` directories map cleanly
+
+A `SKILL_DIR` source (a directory of `<name>/SKILL.md` subdirectories — the
+agentskills.io standard) maps **directly** onto pi's own skill discovery: each
+becomes a `--skill <path>` flag (`agent_wrapper.py:912-916`). Missing source dirs
+are skipped quietly — a repo without `.claude/skills` is normal
+(`agent_wrapper.py:913-914`).
+
+## Rule 2 — plugin skills are passed **un-namespaced**
+
+pi has no plugin-namespace concept; it registers plugin skills with their bare
+names. So when Sculptor rewrites a picked skill invocation into pi's
+`/skill:<name>` shape, a plugin-namespaced `<plugin>:<skill>` is **reduced to its
+bare `<skill>`** (`_rewrite_skill_invocation` at `agent_wrapper.py:427-451`,
+specifically `bare_name = name.rsplit(":", 1)[-1]` at line 450, "because pi
+registers plugin skills un-namespaced" at lines 438-440).
+
+- The frontend stays harness-agnostic: it sends `/name [args]` the same way it
+  sends Claude. For pi, that becomes `/skill:<bare-name> [args]` when `name` is
+  one of the discovered skills; otherwise the text passes through untouched.
+- Test: `/sculptor-workflow:review` rewrites to `/skill:review`
+  (`agent_wrapper_test.py`, `test_rewrite_skill_invocation_strips_plugin_namespace`).
+- Pseudo-skills (`/clear`, `/copy`, `/btw`) are parsed frontend-side, never reach
+  the rewrite, and pass through.
+
+## Rule 3 — loose `.claude/commands/*.md` don't map directly (they're wrapped)
+
+pi discovers skills **only** as `SKILL.md` directories, not the loose `.md`
+command files Claude also supports. So a `COMMAND_FILES` source is **not** handed
+to pi as-is. Instead each `*.md` is wrapped in a synthesized `SKILL.md`
+directory, and the wrapper parent is passed as a single `--skill`
+(`_build_skill_launch_args` at `agent_wrapper.py:917-921`;
+`_synthesize_command_skills` at `agent_wrapper.py:924-958`).
+
+The synthesized wrappers are written under the **per-task state dir**
+(`<state>/pi_skills/<name>/SKILL.md`) — outside the repo and outside `~/.claude`
+— so neither `discover_skills` nor pi's own ancestor auto-discovery lists them a
+second time; only the explicit `--skill` loads them
+(`agent_wrapper.py:929-938`). The file stem is the skill name and first-name-wins,
+matching `discover_skills`' cross-source precedence.
+
+## Rule 4 — a skill with no description does not load
+
+pi **refuses to load a skill whose description is missing**
+(`_render_synthesized_skill` at `agent_wrapper.py:454-464`, specifically lines
+460-461). Sculptor defends against this for wrapped commands by synthesizing a
+fallback description when the command file has none: `parse_command_frontmatter(body)
+or f"Project command '{name}' (from {command_file.name})."`
+(`agent_wrapper.py:954`). The rendered frontmatter always includes a `description`
+(JSON-encoded and flattened to one line so colons/quotes can't break the YAML)
+(`agent_wrapper.py:463-464`).
+
+- Test: a command with no frontmatter still loads — a description is synthesized
+  (`agent_wrapper_test.py`, around the synthesized-skill cases).
+
+> Implication for hand-authored skills: a `SKILL.md` in a real `SKILL_DIR`
+> source is passed to pi **directly** (Rule 1) — it is **not** run through the
+> fallback-description synthesis, which only covers wrapped loose commands. So a
+> hand-authored skill that omits `description` will silently fail to load in pi.
+> Always give a skill a `description`.


### PR DESCRIPTION
## What & why

`pi` is a third-party, version-pinned, immutable harness, but it had no
consolidated living reference — so each integration cycle re-derived the same
RPC / CLI / auth / skills facts from the code. This stands up
`agent_docs/pi-integration/` as that reference (SCU-1637).

The folder **summarizes and links** the de-facto live reference (the `harness.py`
and `agent_wrapper.py` module docstrings) rather than duplicating it, and **cites
a live source file for every non-obvious claim** so the doc has a fixed point to
be re-checked against as the code moves.

## Contents

- **README.md** — invariants: pi-core immutability, the pinned-version + pinned-extension model, the current pin, a capability snapshot, and how it relates to `agent_docs/pi-auth/` (and the not-yet-merged `pi-capabilities` work).
- **rpc.md** — the model-selection RPC trio (`get_available_models` / `get_state` / `set_model`); why model identity is `(provider, modelId)` fetched at runtime, not an internal enum; why no `--provider` / `--api-key`.
- **cli-flags.md** — the full launch argv; `--session-id` (not `--session`) and its adopt-verbatim / create-if-missing / corrupt-tail-tolerant resume behavior.
- **auth.md** — `~/.pi/agent/auth.json` as the shared source of truth; catalog gating on credential *presence* (not validity); the auth.json-vs-env precedence distinction; per-provider `/logout`; `getAgentDir` (`PI_CODING_AGENT_DIR`) resolution.
- **skills.md** — how Sculptor skills/commands map onto pi's `--skill`; un-namespaced plugin skills; loose `.claude/commands` wrapping; the no-description-doesn't-load rule; the full skill-source list.

## Notes for reviewers

- **Verified against live code, not the ticket.** Two facts in the source material were stale and are corrected here: the live pin is **`0.80.2`** (some in-code prose still says `0.78.0`), and the "auth.json > env" precedence is **pi's own** runtime resolution — Sculptor itself computes a *union* of the two sources for catalog gating. The doc states both layers distinctly.
- **One small functional addition.** Besides the docs, this adds a thin `/pi` skill (`.claude/skills/pi/SKILL.md`) that points at the reference so it's discoverable from the slash picker. It's a new slash command (handed to pi and Claude as a skill), so this PR is "docs-only" with that one caveat. No `sculptor/` code changes; no behavior change to pi-integration code itself.
- **Citations are line-pinned and will drift.** That's inherent to the approach and called out in the doc's own "verify before you trust" disclaimer plus a "keep this living" section.

## Verification

`just format`, `just check`, and `just test-unit` all run green (the gates need `node` on PATH via nvm and the worktree's frontend deps installed). `/crispy-comments` (no code comments in the diff) and `/code-review-checklist` (clean) were run before opening this PR.

(Sent by Claude)
