### PR TITLE
Extend style guide comment-authoring rules (SCU-1639)

### DIFF
--- a/docs/development/style/backend.md
+++ b/docs/development/style/backend.md
@@ -352,6 +352,8 @@ Always use absolute imports from the original definition.
 
 ### Comments
 
+See [Comments](../style_guide.md#comments) for the repo-wide rule (write for a future reader, present-tense rationale, no change-narration).
+
 Prefer clear naming and semantically meaningful types over comments.
 
 Create docstrings for public members; keep docstrings short. Never put type information in docstrings, use type annotations and function signatures.

--- a/docs/development/style_guide.md
+++ b/docs/development/style_guide.md
@@ -15,3 +15,13 @@ Do not narrate the change itself: avoid "the old code did X", "this used to be Y
 The exception is forward-looking, not historical: a `TODO`/`FIXME` may reference a tracking issue for planned work that hasn't landed yet, since that orients the future reader toward what's coming rather than rehashing what changed. This is the single carve-out — other guides inherit it and shouldn't add their own ticket-reference exceptions.
 
 Litmus test: if a comment would read as confusing or misleading once its PR is ancient history, it is grounded in the task — rewrite it to stand on its own. Reframe history as present-tense rationale: "we used to key on `head_ref` and main builds ran concurrently" becomes "`head_ref` is empty on push events, so key on `github.ref`".
+
+Don't let a comment litigate the code's correctness. A line that protests too much — "no race here, because the lock is held", "this can never be null", or a paragraph walking through why the algorithm is sound — usually betrays unease about the code rather than illuminating it for the next reader. Tests are where we assert that the code is correct; let them carry that weight. A comment should explain why the code is shaped the way it is, not argue that it works.
+
+Don't mirror a sibling comment. Adding an inline comment to one branch, field, or helper merely because the neighboring one has it spreads noise instead of meaning — and the comment you are copying may itself be overdue for removal. Judge each comment on whether it earns its place, not on whether its neighbors have one.
+
+Delete commented-out code outright rather than leaving it parked behind a comment. Version control already remembers it, and a dormant block only makes the next reader wonder whether it still matters.
+
+Don't restate facts from the surrounding code that are apt to drift — the number of subclasses, the list of allowed variants, the call sites of a function. Such a comment pins itself to a single moment and goes stale as soon as the code moves on; follow DRY and let the code remain the single source of truth.
+
+Skip ASCII-art banners and box-drawing section dividers. A plain one-line comment conveys the same thing without the visual noise, and the art only drifts out of alignment as the code around it changes.


### PR DESCRIPTION
## What

Extends the authoring-time `## Comments` section in `docs/development/style_guide.md` with the comment categories it didn't yet spell out, and adds a cross-reference to it from the backend style guide.

The section already bans change-narration history and ticket-IDs cited to explain edits. This adds the remaining categories that our comment-pruning review removes but the guide didn't cover at authoring time:

- **Don't litigate correctness** — negative-space "no race here because…" / "this can never be null" safety comments and persuasive proof-of-correctness prose. Tests assert correctness; a comment should explain why the code is shaped the way it is, not argue that it works.
- **Don't mirror a sibling comment** — copying a neighbor's inline comment just because it exists spreads noise, and the copied one may itself be overdue for removal.
- **Delete commented-out code** — version control already remembers it.
- **Don't restate DRY-rot facts** — subclass counts, variant lists, call sites go stale as the code moves on.
- **Skip ASCII-art banners and box-drawing dividers** — visual noise a plain one-line comment conveys without.

Also adds a one-line cross-reference from `docs/development/style/backend.md`'s Comments section up to `style_guide.md#comments`, mirroring what the frontend guide already does.

## Why

Keeps the guidance discoverable in-repo at authoring time, instead of only surfacing later during review/pruning.

## Scope

Docs-only; no code changes. Markdown-only, so the code lint/type/test gates don't apply; `just check-file-hygiene` passes.

(Sent by Claude)