### PR TITLE
Harvest frontend flake-fix patterns into review rules; fail build on broken dist

### DIFF
--- a/.claude/skills/debug-integration-test/SKILL.md
+++ b/.claude/skills/debug-integration-test/SKILL.md
@@ -74,6 +74,24 @@ fake_claude:<command> `<json_args>`
 ```
 The JSON must be wrapped in backticks. Use multiline strings for complex JSON to avoid formatting mistakes.
 
+## Known Flakes and Chord-Repro Caveats
+
+### Not every failure is a regression
+
+Some integration-test failures are known **infrastructure** flakes, not bugs in your change — offload-runner hiccups, transient WebSocket/backend timing, or a slow runner tripping a tight wait. Before treating a red run as a regression caused by your diff:
+
+- **Re-run the failing test.** If it passes on re-run and your change doesn't touch the failing area, it's almost certainly infra, not a regression.
+- **Check the failure signature.** A timeout with no relevant error in the backend logs, in a test your diff didn't touch, that doesn't reproduce locally, is a classic infra-flake shape.
+- **Confirm reproducibility before deep-diving.** Only treat it as a real regression once it reproduces deterministically (or fails every run).
+
+This is not license to paper over genuine flakes you introduced — if your change *added* a sleep-then-assert or a chord race, fix it (see the flaky-pattern rules in `docs/development/review/integration_tests.md`). It's about not burning hours bisecting an unrelated infra blip.
+
+### Verify keyboard-chord fixes on offload-Linux, not local macOS
+
+Keyboard-chord flakes don't reproduce faithfully on a local macOS machine. macOS Chromium intermittently **drops the modifier `keyup`** after a chord like `Meta+K`, leaving the modifier "held" so the next plain key arrives modified (e.g. `Escape` → `Cmd+Escape`). The `press_keyboard_shortcut()` helper (`sculptor/sculptor/testing/pages/project_layout.py`) papers over this by explicitly releasing the modifiers — which means a local macOS run can **mask the real chord flake** and make a fix look verified when it isn't.
+
+When you change keyboard-shortcut handling or a chord-driven test, verify the fix on **offload-Linux** (the CI environment), not just locally on macOS. Run it there a few times to shake out the flake; a single green local run is not sufficient evidence for a chord fix.
+
 ## Playwright Test Artifacts
 
 When a test fails, Playwright records several artifacts that are invaluable for debugging. The available artifacts depend on the flags passed to pytest:

--- a/.claude/skills/write-integration-test/SKILL.md
+++ b/.claude/skills/write-integration-test/SKILL.md
@@ -70,6 +70,14 @@ Key conventions:
 - Use `only()` from `imbue_core.itertools` when expecting exactly one element
 - Read `docs/development/review/integration_tests.md` to avoid common anti-patterns (flaky sleeps, snapshot races, missing waits)
 
+#### Await a deterministic ready signal, not a sleep
+
+When a component finishes an async mount or initialization step that a test must wait for, the robust pattern is: production code stamps a stable `data-*` attribute once it's ready, and the test awaits it with `expect(...).to_have_attribute(...)`. This beats a fixed `page.wait_for_timeout(...)`, which races under load, and it gives Playwright a real condition to retry against.
+
+The in-repo exemplar is `data-editor-ready`: `Editor.tsx` stamps `data-editor-ready="true"` on the contenteditable once the editor has mounted, and `sculptor/sculptor/testing/elements/base.py` awaits it via `expect(chat_input).to_have_attribute("data-editor-ready", "true")` before typing into the chat input.
+
+Stamp the attribute **unconditionally in production** — not behind `import.meta.env.DEV`. The integration suite runs the production `vite build`, so a DEV-gated signal is dead-code-eliminated and the wait will hang (see `no_test_only_code_in_production` in `docs/development/review/integration_tests.md`).
+
 #### Minimal example (default response — no commands needed):
 
 ```python

--- a/docs/development/review/integration_tests.md
+++ b/docs/development/review/integration_tests.md
@@ -271,6 +271,26 @@ Many tools read configuration the test does not control: a login shell sources t
 
 ---
 
+## Test Environment
+
+### `no_test_only_code_in_production`
+
+**Question:** Does this test depend on behavior gated behind `import.meta.env.DEV` (or `process.env.NODE_ENV`), or on a hook added to production code solely so the test can observe state?
+
+The integration suite builds the frontend with **`vite build` (production)** — `just test-integration` depends on `build-frontend`, which runs `pnpm run build`, and Vite builds at `NODE_ENV=production`. So `import.meta.env.DEV` is `false` and any `if (import.meta.env.DEV)` block is dead-code-eliminated from the bundle the test exercises. A test that relies on DEV-only wiring — a DEV-only data attribute, a DEV-only global, a dev-server-only affordance — will never see it under the production build and will hang until it times out, even though it passes against the local dev server. (This is the SCU-1322 shape: the default TanStack devtools entry stubs itself to `() => null` whenever `NODE_ENV !== "development"`, so the panel only reproduces under the integration build's production bundle.)
+
+More fundamentally, **don't add test-only code to production at all.** A `window.__TEST_*` global or a data attribute that only renders under a test flag ships to users, rots, and couples the test to a special escape hatch instead of the behavior the user actually experiences. Tests should observe the *real* application state.
+
+**What to look for:**
+- A test that depends on an `if (import.meta.env.DEV)` / `if (process.env.NODE_ENV !== "production")` branch — the production build strips it
+- A `window.__SOMETHING__` global, conditional data attribute, or DOM hook added to production code only so a test can read it
+- A test that asserts on a devtools-only / dev-server-only affordance
+- A test that passes locally (dev server) but times out only in the integration suite (production build)
+
+**Fix:** Observe the real DOM and behavior a user sees. If a test legitimately needs a deterministic readiness signal, stamp a stable `data-*` attribute that ships in production (not gated on DEV) and await it with `to_have_attribute` — see the `write-integration-test` skill's note on `data-editor-ready` for the in-repo pattern. If a third-party tool gates itself on `NODE_ENV`, import its explicit production entry rather than relying on the dev default.
+
+---
+
 ## Test Placement
 
 ### `correct_launch_mode_markers`
@@ -369,3 +389,18 @@ Access elements through the POM class hierarchy (`pages/` → `elements/`). Raw 
 - Repeated element-access patterns across multiple tests that should be a single POM method
 
 **Exceptions:** Quick one-off checks in test helpers or conftest fixtures where introducing a POM method would be over-abstraction.
+
+---
+
+### `use_keyboard_shortcut_helper`
+
+**Question:** Is this test firing a keyboard chord with a raw `page.keyboard.press("Meta+...")` instead of the shared `press_keyboard_shortcut()` POM helper?
+
+A chord like `Meta+K` must have its modifier released afterward. On macOS Chromium the modifier `keyup` is intermittently dropped after a chord, leaving the modifier "held" — so the next plain key (e.g. `Escape`) arrives as `Cmd+Escape` and the OS layer can swallow it before the browser sees it. The shared `press_keyboard_shortcut()` helper (`sculptor/sculptor/testing/pages/project_layout.py`) works around this by explicitly releasing every non-trailing key in the chord after the press. A raw `page.keyboard.press("Meta+K")` skips that release and reintroduces the flake — the failure shows up on the *next* interaction, not the chord itself, which makes it hard to trace back.
+
+**What to look for:**
+- `page.keyboard.press("Meta+...")` / `"Control+..."` / any modifier chord in a test or POM method, instead of `press_keyboard_shortcut(...)`
+- A test that presses a chord and then a plain key (Escape, Enter) and intermittently fails on the *second* key
+- A new POM method that re-implements chord-pressing rather than delegating to the existing helper
+
+**Fix:** Route chord presses through `press_keyboard_shortcut()` (or a POM method that already wraps it, e.g. `open_command_palette_with_keyboard`). It releases the modifiers so the following keypress isn't poisoned. Reserve raw `page.keyboard.press(...)` for single, unmodified keys.

--- a/docs/development/review/react.md
+++ b/docs/development/review/react.md
@@ -782,3 +782,37 @@ Reflect the gate through an attribute the rendering and test frameworks already 
 **Fix:** Bind `disabled` (native controls) or `aria-disabled` (non-native elements) to the exact condition the handler early-returns on, so the element is honest about its readiness in the DOM.
 
 **Exceptions:** Handlers that early-return on a transient event detail (`if (event.key !== "Enter") return;`), a null ref, or any guard unrelated to the control's interactive readiness are not gating actionability and do not need a `disabled` attribute.
+
+---
+
+## `read_live_route_in_global_handlers`
+
+**Question:** Does this long-lived global handler (a `window`/`document` `keydown`, `popstate`, or pointer listener registered once in an effect) read the current route from live browser state, or from a React value it closed over when the listener was registered?
+
+A listener registered in a `useEffect` captures every value in its closure at registration time. If the handler branches on the current route — read from React Router state, a route prop, or a `location` value from a router hook — that captured value goes stale the moment the user navigates, unless the route is in the effect's dependency array (which churns the listener on every navigation) or the value is funneled through a ref. The handler then makes route-dependent decisions against a stale route: a shortcut that should only fire on one page fires on another, or a "where am I" branch takes the wrong arm. Because the listener still runs and still does *something*, there's no error — just wrong behavior that depends on navigation history, which is miserable to reproduce.
+
+The robust pattern for a global handler is to read the route from live browser state at handler-invocation time — `window.location.hash` (or `window.location.pathname`) — which is always current regardless of when the listener was registered. The in-repo exemplar is `usePageLayoutKeyboardShortcuts`, whose handler computes `isOnWorkspacePage` from `window.location.hash` on every keydown rather than closing over a router value.
+
+**What to look for:**
+- A `window.addEventListener("keydown" | "popstate" | ...)` (or `document.addEventListener`) inside a `useEffect` whose handler reads a route value from a router hook / prop / state variable
+- A global handler that branches on "which page am I on" using a closed-over React value rather than `window.location.*`
+- A route value added to a global-listener effect's dependency array purely so the closure stays fresh — re-registering the listener on every navigation is a smell that the value should be read live (or held in a ref) instead
+
+**Fix:** Read the route from `window.location.hash` / `window.location.pathname` inside the handler so it's always live, or — if the value genuinely must come from React — mirror it into a ref that an `useEffect` keeps current and read `ref.current` in the handler. Either way, keep the route out of the listener-registration effect's dependency array so the listener isn't torn down and rebuilt on every navigation.
+
+**Exceptions:** Handlers attached to a component's own JSX (`<div onKeyDown=...>`) re-render with fresh props/state each render and don't have this staleness problem — this rule is about *persistent* listeners registered imperatively on `window`/`document`.
+
+---
+
+## `fully_qualify_shortcut_modifiers`
+
+**Question:** Does each keyboard-shortcut branch fully specify which modifier keys must be *absent*, not just which must be present — so that a superset chord can't accidentally satisfy a subset branch?
+
+A branch like `if ((e.metaKey || e.ctrlKey) && e.key === "w")` matches the bare Cmd+W chord *and also* Cmd+Shift+W, Cmd+Alt+W, and every other superset, because it never checks that Shift and Alt are *up*. When a distinct command is bound to the superset chord (Cmd+Shift+W), pressing it satisfies both branches; whichever runs first wins, and the user's intended command is silently shadowed by the under-qualified one. The fix is to make each branch assert the full modifier state it requires — present modifiers with `e.metaKey`/`e.ctrlKey`, and *absent* modifiers with `!e.shiftKey && !e.altKey` — so a subset branch rejects a superset chord. The in-repo exemplar guards its bare close-workspace chord with `(e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "w"` precisely so that Cmd+Shift+W (a different command) doesn't trip it.
+
+**What to look for:**
+- A `keydown` branch that checks only the modifiers it wants present and never negates the others — `e.metaKey && e.key === "k"` with no `!e.shiftKey`/`!e.altKey`
+- Two shortcuts where one chord is a modifier-superset of another (Cmd+K vs Cmd+Shift+K) and the subset branch doesn't exclude the extra modifier
+- A custom shortcut matcher that compares a subset of `{ctrl, meta, shift, alt}` rather than all four
+
+**Fix:** In each branch, assert the complete modifier state: require the modifiers that must be held and explicitly negate the ones that must not be (`!e.shiftKey && !e.altKey`). Centralizing chord-matching in a shared helper that compares all four modifier flags against the binding avoids re-deriving this per branch.

--- a/docs/development/review/sculptor.md
+++ b/docs/development/review/sculptor.md
@@ -313,3 +313,33 @@ virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
 isProgrammaticScrollRef.current = true;
 virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
 ```
+
+---
+
+## `radix_portal_keeps_theme_scope`
+
+**Question:** Does this overlay that portals its content (a Radix `Popover`/`DropdownMenu`/`Dialog`/`Tooltip`/`HoverCard`/`Select`, or a hand-rolled `createPortal`) render that content inside the app's `.radix-themes` scope rather than on `document.body`?
+
+Radix Themes defines every design token — the accent scale, surface/panel backgrounds, scrollbar colors, the `--gray-a*` ramp — on the `.radix-themes` root that `<Theme>` renders. A portal that targets `document.body` lands *outside* that root, so the portaled node resolves all `var(--*)` tokens to their empty/initial values: backgrounds paint transparent, text loses its color scale, and the surface is unreadable or invisible. The trap is that the component looks correct in isolation — Storybook wraps everything in a single `<Theme>` — and only breaks in the full app, where the portal escapes the token scope. `VerticalOverlayScrollbar` is the in-repo exemplar: it portals into the theme root specifically because a `<body>` portal resolves no color and paints the thumb transparent.
+
+**What to look for:**
+- A Radix overlay primitive (or its `*.Portal`) whose content has no explicit `container` — these default to `document.body`
+- A manual `createPortal(node, document.body)` for themed UI
+- An overlay that renders with a transparent or unstyled background only when mounted in the real app, not in Storybook
+
+**Fix:** Portal into the nearest themed ancestor instead of `document.body` — pass a `container` resolved from the trigger via `triggerRef.current?.closest(".radix-themes")` (the shared `THEME_ROOT_SELECTOR` constant). The content then inherits the token scope and paints correctly in the full app. The theme root still sits outside the host's `overflow` clip, so this does not reintroduce clipping.
+
+---
+
+## `use_select_for_flat_option_lists`
+
+**Question:** Is this a flat list of mutually-exclusive options that should be a Radix `Select`, rather than a `DropdownMenu`?
+
+Radix `Select` is the right primitive for picking one value from a flat list of options (a model picker, a branch picker, an enum setting). `DropdownMenu` is for command/action menus — especially true *nested* cascades with submenus. Reaching for `DropdownMenu` to render a flat option list is not just a semantic mismatch: `DropdownMenu`'s open/close lifecycle reopen-flakes in the full app (the menu intermittently fails to reopen after a close), which surfaces as a flaky interaction in integration tests. `Select` does not have this failure mode for flat lists.
+
+**What to look for:**
+- A `DropdownMenu` whose items are all single-value choices with no submenus — a flat option list wearing a menu's clothing
+- A picker built from `DropdownMenu` that an integration test has to retry or that flakes on reopen
+- A new single-select control where `Select` would express the intent directly
+
+**Fix:** Use Radix `Select` for flat, mutually-exclusive option lists. Reserve `DropdownMenu` for action menus and genuine nested cascades (submenus). If you need custom-rendered options beyond what `Select` supports, prefer a `Popover` with an explicit listbox over a `DropdownMenu` pressed into single-select duty.

--- a/justfile
+++ b/justfile
@@ -967,6 +967,9 @@ uninstall-hooks:
 [group("build")]
 build-frontend: install-frontend
     #! /usr/bin/env bash
+    # Without `set -e` a failed `pnpm run build` would fall through to the
+    # unconditional `cp` below and ship a stale dist/.
+    set -euo pipefail
     {{ nvm_use }}
     cd "{{justfile_directory()}}/sculptor/frontend"
     # NOTE: intentionally not calling setup-build-vars here so test/dev builds don't pelt sentry.


### PR DESCRIPTION
## What

Harvests a round of durable frontend flake-fix patterns into the review-rule docs and integration-test skills, and fixes one live build-safety bug. (SCU-1640)

### Review rules (`docs/development/review/`)
- **`sculptor.md` · `radix_portal_keeps_theme_scope`** — a Radix overlay portaled to `document.body` falls outside the `.radix-themes` token scope and paints transparent; portal into the nearest `.radix-themes` ancestor instead.
- **`sculptor.md` · `use_select_for_flat_option_lists`** — use Radix `Select` for flat single-select lists; reserve `DropdownMenu` for true nested cascades.
- **`react.md` · `read_live_route_in_global_handlers`** — persistent `window`/`document` handlers must read the route from live browser state (`window.location.*`), not a closed-over React route value that goes stale on navigation.
- **`react.md` · `fully_qualify_shortcut_modifiers`** — shortcut branches must negate the modifiers that must be absent (`!e.shiftKey && !e.altKey`) so a superset chord can't satisfy a subset branch.
- **`integration_tests.md` · `use_keyboard_shortcut_helper`** — fire chords via the shared `press_keyboard_shortcut()` helper, not raw `page.keyboard.press`, to avoid the dropped-modifier-keyup flake.
- **`integration_tests.md` · `no_test_only_code_in_production`** — integration tests run a production `vite build`, so `import.meta.env.DEV` gates are stripped; don't rely on DEV-only hooks or ship test-only code — observe real app state.

### Skills (`.claude/skills/`)
- **`write-integration-test`** — note the deterministic `data-*` ready-signal pattern (`data-editor-ready`, awaited with `to_have_attribute`), stamped unconditionally in production.
- **`debug-integration-test`** — known-flakes / chord-repro caveat: re-run before treating infra flakes as regressions, and verify keyboard-chord fixes on offload-Linux rather than local macOS (macOS Chromium drops the modifier keyup, masking the real flake).

### Build fix (`justfile`)
- `build-frontend` now runs `set -euo pipefail` (matching its sibling `nvm_use`-based recipes), so a failed `pnpm run build` aborts instead of falling through to the unconditional `cp` that would copy a stale `dist/`.

## Why

Each rule is distilled from a recurring frontend/test flake so future reviews catch the *class* of issue rather than re-discovering it; every rule is grounded in a concrete in-repo exemplar. The build fix closes a gap where a broken frontend build silently shipped stale output.

## Testing

Docs plus a one-line build-recipe guard — no executable code changed. `just ratchets` and the file-hygiene check pass; the justfile parses and the `build-frontend` recipe renders correctly. Frontend-dependent gates (eslint / full `just check` / `test-unit-frontend`) require `just rebuild` and were not run in this docs-only worktree.

(Sent by Claude)
