### PR TITLE
Tighten match-must-assert-never (5→4): assert_never in get_harness_for_config

### DIFF
--- a/ratchet-counts.toml
+++ b/ratchet-counts.toml
@@ -9,7 +9,7 @@
 "." = 4
 
 [match-must-assert-never]
-"." = 5
+"." = 4
 
 [no-asyncio-run]
 "." = 8

--- a/sculptor/sculptor/agents/harness_registry.py
+++ b/sculptor/sculptor/agents/harness_registry.py
@@ -8,6 +8,8 @@ here and adding one `case` branch to each function below.
 
 from __future__ import annotations
 
+from typing import assert_never
+
 from sculptor.agents.default.claude_code_sdk.agent_wrapper import ClaudeCodeSDKAgent
 from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
 from sculptor.agents.hello_agent.agent_wrapper import HelloAgent
@@ -48,8 +50,8 @@ def get_harness_for_config(config: AgentConfigTypes) -> Harness:
             return PI_HARNESS
         case TerminalAgentConfig() | RegisteredTerminalAgentConfig():
             return TERMINAL_HARNESS
-        case _:
-            raise UnknownAgentConfigError(f"Unknown agent config: {config}")
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 def create_agent_for_run(context: AgentRunContext) -> Agent:


### PR DESCRIPTION
## Summary

Tightens `match-must-assert-never` by one, converting the single match that is genuinely exhaustive.

`get_harness_for_config` (in `agents/harness_registry.py`) matches over `AgentConfigTypes` — a closed union of five config classes, all of which it already handles. Its unreachable `case _: raise UnknownAgentConfigError` becomes `case _ as unreachable: assert_never(unreachable)`, the form the rule requires. pyrefly now enforces exhaustiveness there: adding a sixth config type becomes a type error until this match handles it. `UnknownAgentConfigError` is still raised by `create_agent_for_run` (intentionally non-exhaustive), so it stays.

### Why 5 → 4 and not 5 → 0

The other four flagged matches are non-exhaustive **by design**, so `assert_never` does not belong on them:

- `tasks/handlers/run_agent/v1.py` matches an arbitrary caught exception — the wildcard wraps unknown errors as an `UnexpectedErrorRunnerMessage`.
- both `agents/.../agent_wrapper.py` matches dispatch only a subset of the `Message` union (the wildcard's `return False` is the "not handled here" signal).
- `harness_registry.py`'s `create_agent_for_run` deliberately handles only the chat configs; terminal configs are dispatched elsewhere (documented in-code).

Forcing `assert_never` onto those would be a type error and/or would turn meaningful runtime handling into an `AssertionError`, so they remain as the budget's tolerated exceptions.

## Verification

- `pyrefly check`: 0 errors (confirms the union is exhausted, so `assert_never` type-checks).
- `ruff` format + lint clean.
- `harness_registry_test.py` passes.
- `ratchets check` passes with the budget tightened to 4.

(Sent by Claude)
