### PR TITLE
Fix alpha-chat scroll jumps at turn end (pin to content bottom, stale anchor, footer reveal)

### DIFF
--- a/docs/development/scroll_state_unification.md
+++ b/docs/development/scroll_state_unification.md
@@ -423,6 +423,17 @@ must not overwrite the position we are preserving), stored on the machine beside
 `geometryAtBottom` and read **only** by `projectReflow` — it never drives a render,
 so it updates state in place without notifying subscribers.
 
+The anchor is a *scrolled-up* reading position, so it is **cleared the moment
+authority enters `following` or `anchoringTurn`** (in the store's `dispatch`, the
+single writer of authority): the user is now watching the live tail or a fresh turn,
+not the message the anchor points at. Without this, a stale anchor from an earlier
+scroll survived the turn and, when the turn ended (→ `userControlled`), the next
+content reflow — the turn footer landing after we had left `following` — resolved to
+`holdAnchor` and snapped the whole conversation back to that old position, cutting off
+the message the user had just sent. Clearing on entry keeps `holdAnchor` for its real
+job (an idle scrolled-up reader whose view reflows) while a turn end leaves the view
+exactly where `following` left it.
+
 TanStack Virtual already preserves scroll across item-size changes via
 `shouldAdjustScrollPositionOnItemSizeChange`: when an item *entirely above* the fold
 grows, it shifts scrollTop by the same delta. Two reasons that is not enough on its

--- a/docs/development/scroll_state_unification.md
+++ b/docs/development/scroll_state_unification.md
@@ -338,6 +338,25 @@ padding) made the viewport read as "not at the bottom" while visibly at the bott
 Subtracting `paddingEnd` is the single correction, shared by every at-bottom check
 as the one `distanceFromContentBottom` primitive.
 
+The same correction governs *pinning* to the bottom, not just *measuring* it. Every
+"scroll to the bottom" site (the `following` pin, the anchoring→following handoff,
+the jump-to-bottom button, the restore-to-bottom) sets `scrollTop` to the inverse of
+that primitive — `contentBottomOffset = scrollHeight − paddingEnd − clientHeight` —
+so the last message's content bottom sits flush with the viewport bottom
+(`distanceFromContentBottom == 0`), leaving `paddingEnd` as empty slack *below*
+`scrollTop`. It deliberately does **not** pin with `virtualizer.scrollToIndex(last,
+{ align: "end" })`: for the final item TanStack resolves that to
+`getMaxScrollOffset()` — the very bottom of the *padded* scroll range — which parks
+`scrollTop` inside the `paddingEnd` gap with **zero** slack. Two failures followed:
+the last line floated a `paddingEnd`-tall gap above the viewport bottom
+while following, and — the turn-end jump — when a turn ended and its streaming cursor
+was removed, the last message shrank with no slack to absorb it, so the browser
+clamped `scrollTop` down by the shrink and the whole conversation jumped up. Pinning
+to the content bottom leaves the `paddingEnd` slack the shrink is absorbed into. The
+pin is also **down-only**: it follows the live tail's growth toward the bottom but
+never scrolls *up*, so a turn-end shrink is left where it is rather than chased
+(authority has already handed back to `userControlled` by then anyway).
+
 ### 4. Search suppression is a top-level guard
 
 When in-chat search is open, auto-scroll behaviors are suspended. Rather than add

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -61,6 +61,16 @@ const triggerResize = (): void => {
   }
 };
 
+/**
+ * Assert the container is pinned to the content bottom. The pin primitive now
+ * sets scrollTop directly to contentBottomOffset (scrollHeight - paddingEnd -
+ * clientHeight) instead of calling scrollToIndex(last, {align:"end"}), so tests
+ * assert that observable scroll position rather than a virtualizer mock call.
+ */
+const expectPinnedToBottom = (el: HTMLDivElement, paddingEnd = 0): void => {
+  expect(el.scrollTop).toBe(Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight));
+};
+
 describe("useAlphaAutoScroll", () => {
   beforeEach(() => {
     vi.stubGlobal("ResizeObserver", MockResizeObserver);
@@ -249,7 +259,7 @@ describe("useAlphaAutoScroll", () => {
       result.current.scrollToBottom();
     });
 
-    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(9, { align: "end" });
+    expectPinnedToBottom(el);
     expect(result.current.isEngaged).toBe(true);
   });
 
@@ -264,7 +274,7 @@ describe("useAlphaAutoScroll", () => {
       result.current.scrollToBottom();
     });
 
-    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(9, { align: "end" });
+    expectPinnedToBottom(el);
     expect(result.current.isEngaged).toBe(false);
   });
 
@@ -375,8 +385,8 @@ describe("useAlphaAutoScroll", () => {
     setScrollPosition(el, 1500, 2300); // distance = 2300 - 1500 - 500 = 300 > threshold
     rerender({ messageCount: 11 });
 
-    // Should scroll to show the new message
-    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(10, { align: "end" });
+    // Should scroll to show the new message (pinned to the content bottom: 2300 - 500)
+    expectPinnedToBottom(el);
   });
 
   it("does NOT pin-to-bottom when user is scrolled away", () => {
@@ -507,12 +517,15 @@ describe("useAlphaAutoScroll", () => {
 
     vi.mocked(virtualizer.scrollToIndex).mockClear();
 
-    // Simulate content growing (streaming adds text)
+    // Simulate content growing (streaming adds text) so the content bottom drifts
+    // below the viewport, then a resize fires.
+    setScrollPosition(el, 1500, 2500); // grew; distance = 2500 - 1500 - 500 = 500
     act(() => {
       triggerResize();
     });
 
-    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(9, { align: "end" });
+    // The resize re-pins to the new content bottom (2500 - 500).
+    expectPinnedToBottom(el);
   });
 
   it("ResizeObserver disconnects when disengaged", () => {
@@ -1103,30 +1116,39 @@ describe("useAlphaAutoScroll", () => {
 
       vi.mocked(virtualizer.scrollToIndex).mockClear();
 
-      // Call scrollToBottom — should clear filling phase and scroll to end
+      // Anchoring places the user message near the top; start from a realistic
+      // scrolled-up position rather than parked in the empty tail padding.
+      setScrollPosition(el, 500, 2000);
+
+      // Call scrollToBottom — should clear filling phase and pin to the content
+      // bottom (scrollHeight 2000 - paddingEnd 100 - clientHeight 500 = 1400).
       act(() => {
         result.current.scrollToBottom();
       });
 
-      expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(10, { align: "end" });
+      expectPinnedToBottom(el, 100);
 
-      // Trigger a resize — should now scroll with align: "end" (not in filling
-      // mode anymore), confirming filling phase was cleared.
-      vi.mocked(virtualizer.scrollToIndex).mockClear();
+      // Drift up, then a resize should re-pin to the content bottom (following),
+      // not hold the position (filling/holdTurn) — confirming filling was cleared.
+      setScrollPosition(el, 1000, 2000);
       act(() => {
         triggerResize();
       });
-      expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(10, { align: "end" });
+      expectPinnedToBottom(el, 100);
     });
 
     it("isAtBottom tracks via ResizeObserver even when not engaged during streaming", () => {
       // Start streaming but NOT engaged (far from bottom).
       // The merged observer should still track isAtBottom regardless of engagement.
-      const el = createMockScrollContainer(200, 2000, 500); // distance=1300, far from bottom
+      const el = createMockScrollContainer(200, 2000, 500); // distance=1200, far from bottom
       const ref = { current: el };
       const virtualizer = createMockVirtualizerWithFilling(300, 100);
 
-      const { result } = renderHook(() => useAlphaAutoScroll(ref, true, 10, virtualizer, null, -1, "test-task"));
+      // lastMessageRole=USER so the on-mount pin-to-bottom bails (it only pins for
+      // non-user messages), keeping this test's scrolled-up, not-engaged premise.
+      const { result } = renderHook(() =>
+        useAlphaAutoScroll(ref, true, 10, virtualizer, ChatMessageRole.USER, -1, "test-task"),
+      );
 
       // Not engaged because too far from bottom when streaming started
       expect(result.current.isEngaged).toBe(false);
@@ -1138,7 +1160,7 @@ describe("useAlphaAutoScroll", () => {
       expect(result.current.isAtBottom).toBe(false);
 
       // Change scroll position to near bottom, trigger another resize
-      setScrollPosition(el, 1350, 2000); // distance = 2000 - 1350 - 500 = 150 ≤ 200
+      setScrollPosition(el, 1350, 2000); // distance = 2000 - 100 - 1350 - 500 = 50 ≤ 200
       act(() => {
         triggerResize();
       });
@@ -1239,18 +1261,22 @@ describe("useAlphaAutoScroll", () => {
       const anchorEnd = anchorStart + anchorSize;
       vi.mocked(virtualizer.getTotalSize).mockReturnValue(anchorEnd + el.clientHeight + 200);
 
-      // Trigger resize — should detect overflow and switch to pin-to-bottom
-      act(() => {
-        triggerResize();
-      });
-      expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(11, { align: "end" });
+      // Anchoring holds the user message near the top; start scrolled up.
+      setScrollPosition(el, 500, 2000);
 
-      // Trigger another resize — should continue scrolling with align "end" (no longer filling)
-      vi.mocked(virtualizer.scrollToIndex).mockClear();
+      // Trigger resize — should detect overflow and pin to the content bottom
+      // (scrollHeight 2000 - paddingEnd 100 - clientHeight 500 = 1400).
       act(() => {
         triggerResize();
       });
-      expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(11, { align: "end" });
+      expectPinnedToBottom(el, 100);
+
+      // Drift up, then another resize should re-pin (following, no longer filling).
+      setScrollPosition(el, 1000, 2000);
+      act(() => {
+        triggerResize();
+      });
+      expectPinnedToBottom(el, 100);
     });
 
     it("filling phase overflow accounts for user message height (not full clientHeight)", () => {
@@ -1313,12 +1339,15 @@ describe("useAlphaAutoScroll", () => {
       // getTotalSize = contentBottom + paddingEnd = 1000 + 100 = 1100
       vi.mocked(virtualizer.getTotalSize).mockReturnValue(1100);
 
+      // Anchoring holds the user message near the top; start scrolled up.
+      setScrollPosition(el, 500, 2000);
+
       act(() => {
         triggerResize();
       });
 
-      // Should have transitioned to pin-to-bottom (overflow detected)
-      expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(11, { align: "end" });
+      // Transitioned to following: pinned to the content bottom (2000 - 100 - 500).
+      expectPinnedToBottom(el, 100);
     });
 
     it("does NOT scroll at streaming end when still in filling phase (short response)", () => {
@@ -1376,15 +1405,11 @@ describe("useAlphaAutoScroll", () => {
         isStreaming: false,
       });
 
-      // The problematic anchor scroll (isEngaged + !isFillingRef path) must NOT fire,
-      // because the inflated paddingEnd causes scrollToIndex to land near scrollTop=0.
-      // Clearing filling phase does set isAtBottom=true, which lets pin-to-bottom
-      // fire exactly once — that call is a harmless no-op for short responses where
-      // content already fits in the viewport.
-      const endCalls = vi
-        .mocked(virtualizer.scrollToIndex)
-        .mock.calls.filter((call) => (call[1] as { align: string })?.align === "end");
-      expect(endCalls).toHaveLength(1); // exactly the pin-to-bottom call, not the anchor scroll
+      // The problematic anchor scroll (the old isEngaged + !isFilling path) must
+      // NOT fire at streaming end while still anchoring a short response — with the
+      // inflated paddingEnd it would have landed near scrollTop=0. The down-only
+      // content-bottom pin leaves the view exactly where it was instead.
+      expect(el.scrollTop).toBe(1500);
     });
 
     it("second user message during filling cancels previous and re-enters filling", () => {
@@ -1934,12 +1959,10 @@ describe("useAlphaAutoScroll", () => {
 
     vi.mocked(virtualizer.scrollToIndex).mockClear();
 
-    // Streaming stops while drifted — anchor scroll should re-pin
+    // Streaming stops while drifted — the final settle should re-pin to the
+    // content bottom (2000 - 500).
     rerender({ isStreaming: false });
 
-    const endCalls = vi
-      .mocked(virtualizer.scrollToIndex)
-      .mock.calls.filter((call) => (call[1] as { align: string })?.align === "end");
-    expect(endCalls).toHaveLength(1);
+    expectPinnedToBottom(el);
   });
 });

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -62,10 +62,9 @@ const triggerResize = (): void => {
 };
 
 /**
- * Assert the container is pinned to the content bottom. The pin primitive now
- * sets scrollTop directly to contentBottomOffset (scrollHeight - paddingEnd -
- * clientHeight) instead of calling scrollToIndex(last, {align:"end"}), so tests
- * assert that observable scroll position rather than a virtualizer mock call.
+ * Assert the container is pinned to the content bottom — scrollTop at
+ * contentBottomOffset (scrollHeight - paddingEnd - clientHeight), the observable
+ * position rather than a virtualizer mock call.
  */
 const expectPinnedToBottom = (el: HTMLDivElement, paddingEnd = 0): void => {
   expect(el.scrollTop).toBe(Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight));
@@ -1405,10 +1404,9 @@ describe("useAlphaAutoScroll", () => {
         isStreaming: false,
       });
 
-      // The problematic anchor scroll (the old isEngaged + !isFilling path) must
-      // NOT fire at streaming end while still anchoring a short response — with the
-      // inflated paddingEnd it would have landed near scrollTop=0. The down-only
-      // content-bottom pin leaves the view exactly where it was instead.
+      // At streaming end while still anchoring a short response, the view must stay
+      // put: the down-only content-bottom pin leaves scrollTop where it was rather
+      // than jumping toward the top.
       expect(el.scrollTop).toBe(1500);
     });
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
@@ -64,7 +64,8 @@ describe("useAlphaScrollPersistence", () => {
       vi.advanceTimersByTime(16);
     });
 
-    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(2, { align: "end" });
+    // Restored to the content bottom (scrollHeight 2000 - paddingEnd 0 - clientHeight 500).
+    expect(el.scrollTop).toBe(1500);
   });
 
   it("saves scroll position on scroll events", () => {
@@ -87,6 +88,10 @@ describe("useAlphaScrollPersistence", () => {
     act(() => {
       vi.advanceTimersByTime(48);
     });
+
+    // The restore-to-bottom moved scrollTop; put it where this test's user scroll
+    // lands (item index 1 spans it) before recording the position.
+    el.scrollTop = 300;
 
     // Trigger scroll
     act(() => {
@@ -124,7 +129,8 @@ describe("useAlphaScrollPersistence", () => {
       vi.advanceTimersByTime(16);
     });
 
-    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(2, { align: "end" });
+    // Restored to the content bottom (scrollHeight 2000 - paddingEnd 0 - clientHeight 500).
+    expect(el.scrollTop).toBe(1500);
   });
 
   it("restores to message position when saved", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -671,14 +671,15 @@ export const useAlphaAutoScroll = (
       const distance = distanceFromContentBottom(el, virtualizer);
       machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
       // Reveal the turn footer that grew the content just after a followed turn
-      // ended: re-pin to the (grown) content bottom. Down-only, only while the user
-      // has not taken over, only once the content actually grew past its stream-stop
-      // height, only while the viewport is unchanged (so a width/height resize reflow
-      // is excluded — that keeps its own reading-anchor behavior), and only within the
-      // bounded window opened at streaming stop.
+      // ended: re-pin (down-only) to the grown content bottom. Fires only within the
+      // bounded window opened at streaming stop (a user scroll zeroes it, so a
+      // takeover wins), while still in the settled userControlled phase (a new turn
+      // started within the window is anchoringTurn, not userControlled, and must not
+      // be yanked down), once the content actually grew past its stream-stop height
+      // (the footer landing, not a no-op reflow), and while the viewport is unchanged
+      // (a width/height resize reflow keeps its own reading-anchor behavior instead).
       if (
         performance.now() < revealFooterUntilRef.current &&
-        !isUserScrollingRef.current &&
         machine.getState().authority.kind === "userControlled" &&
         el.scrollHeight > revealFooterBaseHeightRef.current + 1 &&
         `${el.clientWidth}x${el.clientHeight}` === revealFooterViewportRef.current

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExter
 
 import { ChatMessageRole } from "~/api";
 
-import { distanceFromContentBottom } from "../scroll/geometry.ts";
+import { contentBottomOffset, distanceFromContentBottom } from "../scroll/geometry.ts";
 import type { ReadingAnchor } from "../scroll/scrollStateMachine.ts";
 import {
   createScrollStateMachine,
@@ -141,6 +141,22 @@ export const useAlphaAutoScroll = (
     },
     [virtualizer, machine],
   );
+
+  // The single "scroll to the bottom" primitive: pin the last message's content
+  // bottom flush with the viewport, leaving paddingEnd as slack (see
+  // contentBottomOffset for why not scrollToIndex). Down-only — every caller reaches
+  // the bottom from above (a turn anchored at the top, a scrolled-up view, the
+  // growing live tail), so an upward move could only be chasing a turn-end shrink,
+  // which is the jump we prevent (and the slack already keeps the browser from
+  // clamping on that shrink).
+  const pinToContentBottom = useCallback((): void => {
+    const el = scrollContainerRef.current;
+    if (!el || messageCount === 0) return;
+    const desired = contentBottomOffset(el, virtualizer);
+    if (desired <= el.scrollTop + 1) return;
+    isProgrammaticScroll.current = true;
+    el.scrollTop = desired;
+  }, [scrollContainerRef, virtualizer, messageCount, isProgrammaticScroll]);
 
   // Suppress the jump-to-bottom button between message send and response arrival.
   const [isJumpSuppressed, setIsJumpSuppressed] = useState(false);
@@ -465,8 +481,8 @@ export const useAlphaAutoScroll = (
     // synchronously — so this never acts on a stale value.
     if (!atBottom()) return;
     if (lastMessageRole === ChatMessageRole.USER) return;
-    virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
-  }, [messageCount, isAtBottom, isSuppressed, virtualizer, lastMessageRole, atBottom]);
+    pinToContentBottom();
+  }, [messageCount, isAtBottom, isSuppressed, lastMessageRole, atBottom, pinToContentBottom]);
 
   // Engage when streaming starts while at bottom; disengage when streaming stops.
   // Reads the live scroll position rather than the isAtBottom state, which can be
@@ -484,22 +500,15 @@ export const useAlphaAutoScroll = (
         }
       }
     } else if (!isStreaming) {
-      // Final scroll-to-bottom before disengaging: the ResizeObserver
-      // disconnects when streaming stops, so later virtualizer re-measurements
-      // won't be compensated. A single scrollToIndex anchors the view at the
-      // bottom before those adjustments land. Skip while anchoring (a short
-      // response that never overflowed — only `following` was pinned here) and
-      // when already at the very bottom (liveDistance ≤ 1px), where re-firing
-      // would cause a visible jump if paddingEnd changed in the same render.
-      // messageCount/virtualizer are read from the closure intentionally: this
-      // branch only matters on the isStreaming transition.
+      // Final settle onto the content bottom before disengaging: the
+      // ResizeObserver disconnects when streaming stops, so later virtualizer
+      // re-measurements won't be compensated. pinToContentBottom anchors the view
+      // at the content bottom before those adjustments land. It is down-only and a
+      // no-op when already flush, so a turn-end shrink (the streaming cursor being
+      // removed) is left alone rather than chased upward. Skip while anchoring (a
+      // short response that never overflowed — only `following` was pinned here).
       if (isFollowing() && messageCount > 0) {
-        const el = scrollContainerRef.current;
-        const liveDistance = el ? distanceFromContentBottom(el, virtualizer) : 0;
-        if (liveDistance > 1) {
-          isProgrammaticScroll.current = true;
-          virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
-        }
+        pinToContentBottom();
       }
       // Streaming stopped: leave following/anchoring for userControlled. The
       // leave-anchoring subscription tears down the animation and jump
@@ -570,15 +579,16 @@ export const useAlphaAutoScroll = (
           restoreReadingAnchor(action.anchor);
           return;
         case "pinBottom": {
-          // Following the live tail — keep the end in view.
-          // A user actively scrolling away during a stream hands control back.
+          // Following the live tail — keep the last message's content bottom in
+          // view. A user actively scrolling away during a stream hands control back.
           if (distance > BOTTOM_THRESHOLD && isUserScrollingRef.current) {
             machine.dispatch({ kind: "userScrolled" });
             return;
           }
           if (messageCount === 0) return;
-          isProgrammaticScroll.current = true;
-          virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
+          // Down-only: follow growth toward the bottom, but never chase a turn-end
+          // shrink (the streaming cursor being removed) upward — that was the jump.
+          pinToContentBottom();
           machine.setGeometryAtBottom(true);
           return;
         }
@@ -599,9 +609,8 @@ export const useAlphaAutoScroll = (
           // Compare against (clientHeight - anchorSize): the user message already
           // occupies the top portion of the viewport.
           if (tailHeight >= el.clientHeight - anchorSize - FILLING_OVERFLOW_BUFFER) {
-            isProgrammaticScroll.current = true;
             machine.dispatch({ kind: "turnAnchored" });
-            virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
+            pinToContentBottom();
           }
           return;
         }
@@ -612,7 +621,7 @@ export const useAlphaAutoScroll = (
         }
       }
     },
-    [machine, virtualizer, messageCount, isProgrammaticScroll, restoreReadingAnchor],
+    [machine, virtualizer, messageCount, restoreReadingAnchor, pinToContentBottom],
   );
 
   // Unified content-resize observer. One observer, always connected while not
@@ -638,8 +647,7 @@ export const useAlphaAutoScroll = (
     // pinBottom, so idle reconnects fall through untouched.
     if (isStreaming && messageCount > 0 && projectReflow(machine.getState()).kind === "pinBottom") {
       if (distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD) {
-        isProgrammaticScroll.current = true;
-        virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
+        pinToContentBottom();
       }
     }
 
@@ -654,18 +662,17 @@ export const useAlphaAutoScroll = (
     messageCount,
     virtualizer,
     scrollContainerRef,
-    isProgrammaticScroll,
     machine,
     applyReflow,
+    pinToContentBottom,
   ]);
 
   const scrollToBottom = useCallback((): void => {
     if (messageCount === 0) return;
-    isProgrammaticScroll.current = true;
-    virtualizer.scrollToIndex(messageCount - 1, { align: "end" });
-    // scrollToIndex(align:"end") lands at the content bottom; record it so the
-    // jump-to-bottom button hides immediately even if the resulting scroll event
-    // is async or coalesced (a non-streaming jump has no other trigger).
+    pinToContentBottom();
+    // Record at-bottom so the jump-to-bottom button hides immediately even if the
+    // resulting scroll event is async or coalesced (a non-streaming jump has no
+    // other trigger).
     machine.setGeometryAtBottom(true);
     if (isStreaming) {
       // Follow the stream (also exits anchoring → following).
@@ -676,7 +683,7 @@ export const useAlphaAutoScroll = (
       // suppression.
       machine.dispatch({ kind: "userScrolled" });
     }
-  }, [messageCount, virtualizer, isStreaming, isProgrammaticScroll, machine]);
+  }, [messageCount, isStreaming, machine, pinToContentBottom]);
 
   const scrollToTop = useCallback((): void => {
     if (messageCount === 0) return;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -37,9 +37,9 @@ const SCROLL_ANIMATION_EASING = "cubic-bezier(0.33, 1, 0.68, 1)"; // ease-out
 // actively scrolling, before the user-scroll flag is debounced back off.
 const USER_SCROLL_DEBOUNCE_MS = 150;
 
-// After a turn we were following ends, keep revealing the tail at the bottom for
-// this long — the turn footer (turn summary) mounts a beat after the stream stops
-// and would otherwise be left just below the fold. Bounded so it never lingers.
+// How long after a followed turn ends the content observer keeps revealing the
+// tail, so the turn footer (which mounts a beat after the stream stops) is not left
+// below the fold.
 const FOOTER_REVEAL_WINDOW_MS = 1200;
 
 /** Cancel any in-progress scroll-to-top transform animation and restore
@@ -149,11 +149,8 @@ export const useAlphaAutoScroll = (
 
   // The single "scroll to the bottom" primitive: pin the last message's content
   // bottom flush with the viewport, leaving paddingEnd as slack (see
-  // contentBottomOffset for why not scrollToIndex). Down-only — every caller reaches
-  // the bottom from above (a turn anchored at the top, a scrolled-up view, the
-  // growing live tail), so an upward move could only be chasing a turn-end shrink,
-  // which is the jump we prevent (and the slack already keeps the browser from
-  // clamping on that shrink).
+  // contentBottomOffset). Down-only — callers reach the bottom from above, so an
+  // upward move would only chase a turn-end shrink, which we leave in place.
   const pinToContentBottom = useCallback((): void => {
     const el = scrollContainerRef.current;
     if (!el || messageCount === 0) return;
@@ -203,12 +200,9 @@ export const useAlphaAutoScroll = (
   >(null);
 
   // Turn-footer reveal window: the timestamp (performance.now) until which the
-  // content observer keeps re-pinning to the bottom after a followed turn ends, plus
-  // the content height and viewport size at that moment. We only re-pin once the
-  // footer actually grows the content (height past base) AND the viewport is
-  // unchanged — so a width/height resize reflow (which also grows content) is left to
-  // its own reading-anchor behavior, not glued to the bottom. Zeroed the instant the
-  // user scrolls, so a user who takes over always wins.
+  // content observer re-pins to the bottom after a followed turn ends, plus the
+  // content height and viewport size sampled then (the reveal condition below
+  // compares against both). Zeroed on user takeover.
   const revealFooterUntilRef = useRef(0);
   const revealFooterBaseHeightRef = useRef(0);
   const revealFooterViewportRef = useRef("");
@@ -232,8 +226,7 @@ export const useAlphaAutoScroll = (
 
     const onUserInput = (): void => {
       markUserScrolling();
-      // A genuine user input ends the post-turn footer-reveal window immediately —
-      // whatever the user does with the surface wins over revealing the footer.
+      // A user input ends the footer-reveal window immediately: a takeover wins.
       revealFooterUntilRef.current = 0;
       // Disengage on user wheel/touch/keydown before the scroll event fires.
       // During streaming the ResizeObserver sets isProgrammaticScroll and scrolls;
@@ -521,20 +514,15 @@ export const useAlphaAutoScroll = (
         }
       }
     } else if (!isStreaming) {
-      // Final settle onto the content bottom before disengaging: the
-      // ResizeObserver disconnects when streaming stops, so later virtualizer
-      // re-measurements won't be compensated. pinToContentBottom anchors the view
-      // at the content bottom before those adjustments land. It is down-only and a
-      // no-op when already flush, so a turn-end shrink (the streaming cursor being
-      // removed) is left alone rather than chased upward. Skip while anchoring (a
-      // short response that never overflowed — only `following` was pinned here).
+      // Final settle onto the content bottom before disengaging: the ResizeObserver
+      // disconnects when streaming stops, so later virtualizer re-measurements won't
+      // be compensated — pin now, before they land. Skip while anchoring (a short
+      // response that never overflowed).
       if (isFollowing() && messageCount > 0) {
         pinToContentBottom();
-        // We were following the tail. The turn footer (turn summary) mounts a beat
-        // later and grows the content below the fold; open a short window so the
-        // content observer re-pins to reveal it at the bottom (one margin above the
-        // input), matching where focusing the input lands. Only for followed turns —
-        // a short anchored turn is left as-is.
+        // The turn footer mounts a beat later and grows the content below the fold;
+        // open a short window so the content observer re-pins to reveal it at the
+        // bottom, matching where focusing the input lands.
         const el = scrollContainerRef.current;
         if (el) {
           revealFooterUntilRef.current = performance.now() + FOOTER_REVEAL_WINDOW_MS;
@@ -618,8 +606,6 @@ export const useAlphaAutoScroll = (
             return;
           }
           if (messageCount === 0) return;
-          // Down-only: follow growth toward the bottom, but never chase a turn-end
-          // shrink (the streaming cursor being removed) upward — that was the jump.
           pinToContentBottom();
           machine.setGeometryAtBottom(true);
           return;
@@ -670,14 +656,11 @@ export const useAlphaAutoScroll = (
       if (messageCount === 0) return;
       const distance = distanceFromContentBottom(el, virtualizer);
       machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
-      // Reveal the turn footer that grew the content just after a followed turn
-      // ended: re-pin (down-only) to the grown content bottom. Fires only within the
-      // bounded window opened at streaming stop (a user scroll zeroes it, so a
-      // takeover wins), while still in the settled userControlled phase (a new turn
-      // started within the window is anchoringTurn, not userControlled, and must not
-      // be yanked down), once the content actually grew past its stream-stop height
-      // (the footer landing, not a no-op reflow), and while the viewport is unchanged
-      // (a width/height resize reflow keeps its own reading-anchor behavior instead).
+      // Reveal the turn footer that grew the content just after a followed turn ended:
+      // re-pin (down-only) to the grown content bottom, within the window opened at
+      // streaming stop. The two non-obvious guards: still userControlled (a new turn
+      // opened within the window is anchoringTurn and must not be yanked down), and an
+      // unchanged viewport (a resize reflow keeps its own reading-anchor behavior).
       if (
         performance.now() < revealFooterUntilRef.current &&
         machine.getState().authority.kind === "userControlled" &&

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -37,6 +37,11 @@ const SCROLL_ANIMATION_EASING = "cubic-bezier(0.33, 1, 0.68, 1)"; // ease-out
 // actively scrolling, before the user-scroll flag is debounced back off.
 const USER_SCROLL_DEBOUNCE_MS = 150;
 
+// After a turn we were following ends, keep revealing the tail at the bottom for
+// this long — the turn footer (turn summary) mounts a beat after the stream stops
+// and would otherwise be left just below the fold. Bounded so it never lingers.
+const FOOTER_REVEAL_WINDOW_MS = 1200;
+
 /** Cancel any in-progress scroll-to-top transform animation and restore
  *  the virtualizer's scroll-position adjustment callback. */
 const clearScrollAnimation = (
@@ -197,6 +202,17 @@ export const useAlphaAutoScroll = (
     Virtualizer<HTMLDivElement, Element>["shouldAdjustScrollPositionOnItemSizeChange"] | null
   >(null);
 
+  // Turn-footer reveal window: the timestamp (performance.now) until which the
+  // content observer keeps re-pinning to the bottom after a followed turn ends, plus
+  // the content height and viewport size at that moment. We only re-pin once the
+  // footer actually grows the content (height past base) AND the viewport is
+  // unchanged — so a width/height resize reflow (which also grows content) is left to
+  // its own reading-anchor behavior, not glued to the bottom. Zeroed the instant the
+  // user scrolls, so a user who takes over always wins.
+  const revealFooterUntilRef = useRef(0);
+  const revealFooterBaseHeightRef = useRef(0);
+  const revealFooterViewportRef = useRef("");
+
   // Mark that the user is actively scrolling, with a debounce to clear it.
   const markUserScrolling = useCallback((): void => {
     isUserScrollingRef.current = true;
@@ -216,6 +232,9 @@ export const useAlphaAutoScroll = (
 
     const onUserInput = (): void => {
       markUserScrolling();
+      // A genuine user input ends the post-turn footer-reveal window immediately —
+      // whatever the user does with the surface wins over revealing the footer.
+      revealFooterUntilRef.current = 0;
       // Disengage on user wheel/touch/keydown before the scroll event fires.
       // During streaming the ResizeObserver sets isProgrammaticScroll and scrolls;
       // a user scroll event that saw that flag would be consumed as programmatic
@@ -323,6 +342,8 @@ export const useAlphaAutoScroll = (
       // meaningless for the incoming task. The first user scroll re-samples it.
       machine.setReadingAnchor(null);
       prevScrollTopRef.current = -1;
+      // Cancel any in-flight footer-reveal window from the outgoing task.
+      revealFooterUntilRef.current = 0;
       // The authority (following/anchoring) is reset by the machine's
       // taskSwitched -> restoring transition (dispatched by the persistence
       // hook); this effect only resets auto-scroll's own observations and
@@ -509,6 +530,17 @@ export const useAlphaAutoScroll = (
       // short response that never overflowed — only `following` was pinned here).
       if (isFollowing() && messageCount > 0) {
         pinToContentBottom();
+        // We were following the tail. The turn footer (turn summary) mounts a beat
+        // later and grows the content below the fold; open a short window so the
+        // content observer re-pins to reveal it at the bottom (one margin above the
+        // input), matching where focusing the input lands. Only for followed turns —
+        // a short anchored turn is left as-is.
+        const el = scrollContainerRef.current;
+        if (el) {
+          revealFooterUntilRef.current = performance.now() + FOOTER_REVEAL_WINDOW_MS;
+          revealFooterBaseHeightRef.current = el.scrollHeight;
+          revealFooterViewportRef.current = `${el.clientWidth}x${el.clientHeight}`;
+        }
       }
       // Streaming stopped: leave following/anchoring for userControlled. The
       // leave-anchoring subscription tears down the animation and jump
@@ -638,6 +670,21 @@ export const useAlphaAutoScroll = (
       if (messageCount === 0) return;
       const distance = distanceFromContentBottom(el, virtualizer);
       machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
+      // Reveal the turn footer that grew the content just after a followed turn
+      // ended: re-pin to the (grown) content bottom. Down-only, only while the user
+      // has not taken over, only once the content actually grew past its stream-stop
+      // height, only while the viewport is unchanged (so a width/height resize reflow
+      // is excluded — that keeps its own reading-anchor behavior), and only within the
+      // bounded window opened at streaming stop.
+      if (
+        performance.now() < revealFooterUntilRef.current &&
+        !isUserScrollingRef.current &&
+        machine.getState().authority.kind === "userControlled" &&
+        el.scrollHeight > revealFooterBaseHeightRef.current + 1 &&
+        `${el.clientWidth}x${el.clientHeight}` === revealFooterViewportRef.current
+      ) {
+        pinToContentBottom();
+      }
       applyReflow(el, distance);
     });
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -80,10 +80,8 @@ export const useAlphaScrollPersistence = (
     if (!el || filteredMessages.length === 0) return;
 
     if (!scrollPosition || scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
-      // First visit or user was at bottom: restore to the content bottom (flush),
-      // not scrollToIndex(last, {align:"end"}) — that lands in the empty tail
-      // padding (see contentBottomOffset), leaving the last line floating a
-      // paddingEnd-tall gap above the viewport bottom after a task switch.
+      // First visit or user was at bottom: restore flush to the content bottom (see
+      // contentBottomOffset — not scrollToIndex, which lands in the tail padding).
       el.scrollTop = contentBottomOffset(el, virtualizer);
       return;
     }

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { alphaScrollPositionAtomFamily } from "~/common/state/atoms/alphaScroll.ts";
 
-import { distanceFromContentBottom } from "../scroll/geometry.ts";
+import { contentBottomOffset, distanceFromContentBottom } from "../scroll/geometry.ts";
 import type { ScrollStateMachine } from "../scroll/scrollStateMachine.ts";
 
 /** Cancel all pending rAFs tracked in the set and clear it. */
@@ -80,8 +80,11 @@ export const useAlphaScrollPersistence = (
     if (!el || filteredMessages.length === 0) return;
 
     if (!scrollPosition || scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
-      // First visit or user was at bottom: scroll to bottom.
-      virtualizer.scrollToIndex(filteredMessages.length - 1, { align: "end" });
+      // First visit or user was at bottom: restore to the content bottom (flush),
+      // not scrollToIndex(last, {align:"end"}) — that lands in the empty tail
+      // padding (see contentBottomOffset), leaving the last line floating a
+      // paddingEnd-tall gap above the viewport bottom after a task switch.
+      el.scrollTop = contentBottomOffset(el, virtualizer);
       return;
     }
 
@@ -94,10 +97,9 @@ export const useAlphaScrollPersistence = (
       el.scrollTop += scrollPosition.pixelOffset;
     } else {
       // Fallback: use distance from the content bottom (synchronous for the same
-      // reason). Inverse of distanceFromContentBottom — paddingEnd is excluded so
-      // this matches how the distance was recorded above.
-      const paddingEnd = virtualizer.options.paddingEnd ?? 0;
-      el.scrollTop = el.scrollHeight - paddingEnd - el.clientHeight - scrollPosition.distanceFromBottom;
+      // reason). contentBottomOffset excludes paddingEnd, matching how the
+      // distance was recorded above.
+      el.scrollTop = contentBottomOffset(el, virtualizer) - scrollPosition.distanceFromBottom;
     }
   }, [scrollContainerRef, virtualizer, filteredMessages, scrollPosition]);
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
@@ -22,15 +22,9 @@ export const distanceFromContentBottom = (
  * viewport bottom — i.e. `distanceFromContentBottom === 0` — leaving the dynamic
  * `paddingEnd` as empty slack *below* `scrollTop`.
  *
- * Use this to pin to the bottom instead of `virtualizer.scrollToIndex(last,
- * { align: "end" })`. For the final item that call resolves to
- * `getMaxScrollOffset()` — the very bottom of the padded scroll range — which
- * parks `scrollTop` inside the `paddingEnd` gap with *zero* slack beneath it.
- * Two problems follow: the last line floats a `paddingEnd`-tall gap above the
- * viewport bottom while following, and (the turn-end jump) the last message has
- * no room to shrink when its streaming cursor is removed — the browser clamps
- * `scrollTop` down by the shrink and the whole view jumps up. Pinning to the
- * content bottom keeps `paddingEnd` as slack the shrink is absorbed into.
+ * Prefer this to `virtualizer.scrollToIndex(last, { align: "end" })`, which for the
+ * final item resolves to `getMaxScrollOffset()` and parks `scrollTop` inside the
+ * `paddingEnd` gap — no slack for a turn-end shrink to absorb.
  */
 export const contentBottomOffset = (el: HTMLElement, virtualizer: Virtualizer<HTMLDivElement, Element>): number => {
   const paddingEnd = virtualizer.options.paddingEnd ?? 0;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
@@ -16,3 +16,23 @@ export const distanceFromContentBottom = (
   const paddingEnd = virtualizer.options.paddingEnd ?? 0;
   return el.scrollHeight - paddingEnd - el.scrollTop - el.clientHeight;
 };
+
+/**
+ * The `scrollTop` at which the last message's content bottom sits flush with the
+ * viewport bottom — i.e. `distanceFromContentBottom === 0` — leaving the dynamic
+ * `paddingEnd` as empty slack *below* `scrollTop`.
+ *
+ * Use this to pin to the bottom instead of `virtualizer.scrollToIndex(last,
+ * { align: "end" })`. For the final item that call resolves to
+ * `getMaxScrollOffset()` — the very bottom of the padded scroll range — which
+ * parks `scrollTop` inside the `paddingEnd` gap with *zero* slack beneath it.
+ * Two problems follow: the last line floats a `paddingEnd`-tall gap above the
+ * viewport bottom while following, and (the turn-end jump) the last message has
+ * no room to shrink when its streaming cursor is removed — the browser clamps
+ * `scrollTop` down by the shrink and the whole view jumps up. Pinning to the
+ * content bottom keeps `paddingEnd` as slack the shrink is absorbed into.
+ */
+export const contentBottomOffset = (el: HTMLElement, virtualizer: Virtualizer<HTMLDivElement, Element>): number => {
+  const paddingEnd = virtualizer.options.paddingEnd ?? 0;
+  return Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight);
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/scrollStateMachine.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/scrollStateMachine.ts
@@ -52,7 +52,9 @@ export type ScrollMachineState = {
   /**
    * The most recent reading anchor sampled on a genuine user scroll, or null
    * before the user has scrolled this task. Consulted only by `projectReflow`
-   * (for the scrolled-up `userControlled` phase); never drives a render.
+   * (for the scrolled-up `userControlled` phase); never drives a render. Cleared
+   * on entering `following`/`anchoringTurn` (the scrolled-up position is
+   * abandoned) so a stale anchor can't be restored when the turn later ends.
    */
   readingAnchor: ReadingAnchor | null;
 };
@@ -164,7 +166,14 @@ export const createScrollStateMachine = (): ScrollStateMachine => {
       if (state.isSuppressed && SUPPRESSIBLE_EVENTS.has(event.kind)) return;
       const authority = nextAuthority(state.authority, event);
       if (authority === state.authority) return;
-      commit({ ...state, authority });
+      // Entering `following` or `anchoringTurn` abandons any scrolled-up reading
+      // position: the user is now watching the live tail / a fresh turn, not the
+      // message a stale anchor points at. Drop the anchor so that when the turn
+      // later ends (→ `userControlled`) a post-turn reflow can't resolve to
+      // `holdAnchor` and snap the whole conversation back to that stale position.
+      const readingAnchor =
+        authority.kind === "following" || authority.kind === "anchoringTurn" ? null : state.readingAnchor;
+      commit({ ...state, authority, readingAnchor });
     },
     dispatchLayout: (event): void => {
       const layout = nextLayout(state.layout, event);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/scrollStateMachine.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/scrollStateMachine.ts
@@ -53,8 +53,7 @@ export type ScrollMachineState = {
    * The most recent reading anchor sampled on a genuine user scroll, or null
    * before the user has scrolled this task. Consulted only by `projectReflow`
    * (for the scrolled-up `userControlled` phase); never drives a render. Cleared
-   * on entering `following`/`anchoringTurn` (the scrolled-up position is
-   * abandoned) so a stale anchor can't be restored when the turn later ends.
+   * on entering `following`/`anchoringTurn` (the scrolled-up position is abandoned).
    */
   readingAnchor: ReadingAnchor | null;
 };
@@ -166,11 +165,9 @@ export const createScrollStateMachine = (): ScrollStateMachine => {
       if (state.isSuppressed && SUPPRESSIBLE_EVENTS.has(event.kind)) return;
       const authority = nextAuthority(state.authority, event);
       if (authority === state.authority) return;
-      // Entering `following` or `anchoringTurn` abandons any scrolled-up reading
-      // position: the user is now watching the live tail / a fresh turn, not the
-      // message a stale anchor points at. Drop the anchor so that when the turn
-      // later ends (→ `userControlled`) a post-turn reflow can't resolve to
-      // `holdAnchor` and snap the whole conversation back to that stale position.
+      // Entering `following`/`anchoringTurn` abandons any scrolled-up reading
+      // position: the user is watching the live tail / a fresh turn, not the message
+      // the anchor points at.
       const readingAnchor =
         authority.kind === "following" || authority.kind === "anchoringTurn" ? null : state.readingAnchor;
       commit({ ...state, authority, readingAnchor });

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -199,6 +199,28 @@ def read_scroll_top_sampler(page: Page) -> dict:
     )
 
 
+def get_last_turn_footer_viewport_gaps(page: Page) -> dict | None:
+    """Position of the last turn footer relative to the alpha chat viewport.
+
+    Returns ``None`` when no turn footer is rendered. Otherwise a dict:
+      - ``bottom_gap``: viewport bottom minus footer bottom, in px. ``>= 0`` means the
+        footer's bottom edge is at or above the viewport bottom (in view); ``< 0``
+        means the footer is cut off below the fold.
+      - ``top_gap``: footer top minus viewport top, in px. ``>= 0`` means the footer's
+        top edge is at or below the viewport top (not scrolled off the top).
+    """
+    return page.evaluate(
+        f"""() => {{
+        const view = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        const footers = document.querySelectorAll('[data-testid="{ElementIDs.TURN_FOOTER}"]');
+        if (!view || footers.length === 0) return null;
+        const v = view.getBoundingClientRect();
+        const f = footers[footers.length - 1].getBoundingClientRect();
+        return {{ bottom_gap: Math.round(v.bottom - f.bottom), top_gap: Math.round(f.top - v.top) }};
+    }}"""
+    )
+
+
 def get_max_following_tail_gap(page: Page, frames: int = 18) -> float | None:
     """Over a short ``requestAnimationFrame`` burst, the max gap (px) from the last
     message's bottom edge UP to the viewport bottom.

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -169,6 +169,36 @@ def get_alpha_scroll_height(page: Page) -> float:
     )
 
 
+def start_scroll_top_sampler(page: Page) -> None:
+    """Start an rAF loop recording the max scrollTop seen (the peak we followed to)."""
+    page.evaluate(
+        f"""() => {{
+        const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        if (!el) return;
+        window.__st = {{ max: el.scrollTop }};
+        const tick = () => {{
+            if (el.scrollTop > window.__st.max) window.__st.max = el.scrollTop;
+            window.__st.raf = requestAnimationFrame(tick);
+        }};
+        window.__st.raf = requestAnimationFrame(tick);
+    }}"""
+    )
+
+
+def read_scroll_top_sampler(page: Page) -> dict:
+    """Stop the sampler; return {"max": peak scrollTop while sampling, "final": current}."""
+    return page.evaluate(
+        f"""() => {{
+        if (window.__st && window.__st.raf) cancelAnimationFrame(window.__st.raf);
+        const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        return {{
+            max: window.__st ? Math.round(window.__st.max) : null,
+            final: el ? Math.round(el.scrollTop) : null,
+        }};
+    }}"""
+    )
+
+
 def get_max_following_tail_gap(page: Page, frames: int = 18) -> float | None:
     """Over a short ``requestAnimationFrame`` burst, the max gap (px) from the last
     message's bottom edge UP to the viewport bottom.

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -169,6 +169,45 @@ def get_alpha_scroll_height(page: Page) -> float:
     )
 
 
+def get_max_following_tail_gap(page: Page, frames: int = 18) -> float | None:
+    """Over a short ``requestAnimationFrame`` burst, the max gap (px) from the last
+    message's bottom edge UP to the viewport bottom.
+
+    A positive gap means the last line is floating above the viewport bottom over
+    empty tail padding; pinned flush to the content bottom is ~0. The max across
+    frames is returned so a transient mid-growth frame (where the streaming tail
+    briefly overflows below the fold, giving a negative gap) does not mask the
+    steady pinned gap. Returns ``None`` if the chat view or its messages are absent.
+    """
+    return page.evaluate(
+        f"""(frames) => new Promise((resolve) => {{
+        const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        if (!el) {{ resolve(null); return; }}
+        let maxGap = null;
+        let count = 0;
+        const tick = () => {{
+            const items = el.querySelectorAll('[data-index]');
+            let lastEl = null, lastIdx = -1;
+            items.forEach((it) => {{
+                const i = parseInt(it.getAttribute('data-index'));
+                if (i > lastIdx) {{ lastIdx = i; lastEl = it; }}
+            }});
+            if (lastEl) {{
+                const gap = el.getBoundingClientRect().bottom - lastEl.getBoundingClientRect().bottom;
+                if (maxGap === null || gap > maxGap) maxGap = gap;
+            }}
+            if (++count < frames) {{
+                requestAnimationFrame(tick);
+            }} else {{
+                resolve(maxGap === null ? null : Math.round(maxGap));
+            }}
+        }};
+        requestAnimationFrame(tick);
+    }})""",
+        frames,
+    )
+
+
 def scroll_alpha_chat_to_top(page: Page) -> None:
     """Scroll the alpha chat to the top.
 

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -1,21 +1,15 @@
-"""Integration test: the chat does not jump when the agent finishes its turn.
+"""Integration tests: the chat does not misbehave when the agent finishes its turn.
 
 The alpha-chat scroll system is an explicit state machine (see
-``docs/development/scroll_state_unification.md``, SCU-1566). While ``following``
-the live tail, the design pins the last message's *content* bottom flush with the
+``docs/development/scroll_state_unification.md``, SCU-1566). While ``following`` the
+live tail, the design pins the last message's *content* bottom flush with the
 viewport bottom, leaving the dynamic ``paddingEnd`` as empty slack *below*
-``scrollTop`` (``distanceFromContentBottom == 0``).
+``scrollTop`` (``distanceFromContentBottom == 0``) — so a turn-end shrink has slack
+to absorb into and the view does not jump.
 
-A regression had the pin land at TanStack's ``getMaxScrollOffset()`` instead — the
-very bottom of the padded scroll range — which parks ``scrollTop`` inside the
-``paddingEnd`` gap with zero slack. That floated the last line a ``paddingEnd``-tall
-gap above the viewport bottom *and* left no room for the last message to shrink when
-the turn ends (its streaming cursor is removed): the browser clamped ``scrollTop``
-down by the shrink and the whole conversation jumped up by a small, annoying amount.
-
-This test sends a follow-on streaming message in a longer chat, lets it overflow and
-pin to the bottom, and asserts the last message sits flush with the viewport bottom
-while following — directly the property whose absence caused the turn-end jump.
+These tests send follow-on streaming messages that overflow and pin to the bottom,
+and assert the turn-end behavior: the last message stays flush with the viewport
+bottom, a stale reading anchor is not restored, and the turn footer scrolls into view.
 """
 
 from playwright.sync_api import expect

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -1,0 +1,88 @@
+"""Integration test: the chat does not jump when the agent finishes its turn.
+
+The alpha-chat scroll system is an explicit state machine (see
+``docs/development/scroll_state_unification.md``, SCU-1566). While ``following``
+the live tail, the design pins the last message's *content* bottom flush with the
+viewport bottom, leaving the dynamic ``paddingEnd`` as empty slack *below*
+``scrollTop`` (``distanceFromContentBottom == 0``).
+
+A regression had the pin land at TanStack's ``getMaxScrollOffset()`` instead — the
+very bottom of the padded scroll range — which parks ``scrollTop`` inside the
+``paddingEnd`` gap with zero slack. That floated the last line a ``paddingEnd``-tall
+gap above the viewport bottom *and* left no room for the last message to shrink when
+the turn ends (its streaming cursor is removed): the browser clamped ``scrollTop``
+down by the shrink and the whole conversation jumped up by a small, annoying amount.
+
+This test sends a follow-on streaming message in a longer chat, lets it overflow and
+pin to the bottom, and asserts the last message sits flush with the viewport bottom
+while following — directly the property whose absence caused the turn-end jump.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
+from sculptor.testing.elements.alpha_chat_view import get_max_following_tail_gap
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.panels import close_bottom_panel
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# Long history responses so the chat is comfortably scrollable.
+_LONG_TEXT = "Lorem ipsum dolor sit amet. " * 120
+# A long streaming response (~5k chars over ~10s) that overflows the viewport and
+# pins to the bottom while it streams.
+_STREAM_TEXT = "The quick brown fox jumps over the lazy dog. " * 112
+
+# While following, the last message's bottom may sit a few px above the viewport
+# bottom (message margins, sub-pixel rounding), but never the full ~64px paddingEnd
+# gap of the bug. (Measured: ~64px before the fix, ~0px after.)
+_FLUSH_TOLERANCE_PX = 24
+
+
+@user_story("to not have the chat jump when the agent finishes its turn (req: stable turn-end)")
+def test_following_pins_last_message_flush_to_viewport_bottom(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
+    )
+    chat_panel = task_page.get_chat_panel()
+    close_bottom_panel(page)
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    # A bit of history so the follow-on user message scrolls off the top and we
+    # genuinely follow the live tail (rather than anchoring a short turn).
+    send_chat_message(chat_panel, f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`')
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
+
+    view = get_alpha_chat_view(page)
+    expect(view).to_be_visible()
+
+    # The follow-on streaming message: overflows the viewport and pins to the bottom.
+    send_chat_message(
+        chat_panel,
+        f'fake_claude:stream_text `{{"text": "{_STREAM_TEXT}", "chunk_size": 50, "delay_seconds": 0.1}}`',
+    )
+
+    # Wait until we are following the live tail, then let it stream for a span so the
+    # measurement is taken mid-stream (well before the turn ends).
+    expect(view).to_have_attribute("data-scroll-phase", "following", timeout=30_000)
+    page.wait_for_timeout(1500)
+    expect(view).to_have_attribute("data-scroll-phase", "following")
+
+    max_gap = get_max_following_tail_gap(page)
+
+    # While following, the last message stays flush with the viewport bottom — it is
+    # not parked in the paddingEnd gap (the ~64px regression that produced the
+    # turn-end jump, because there was no slack for the last message to shrink into).
+    assert max_gap is not None, "alpha chat view or its messages not found while following"
+    assert max_gap <= _FLUSH_TOLERANCE_PX, (
+        f"while following, the last message floated {max_gap}px above the viewport bottom "
+        + f"(expected <= {_FLUSH_TOLERANCE_PX}px); the pin is parking in the paddingEnd gap"
+    )
+
+    # Let the turn finish cleanly before the test ends.
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=60_000)

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -22,6 +22,9 @@ from playwright.sync_api import expect
 
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_max_following_tail_gap
+from sculptor.testing.elements.alpha_chat_view import read_scroll_top_sampler
+from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
+from sculptor.testing.elements.alpha_chat_view import start_scroll_top_sampler
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.elements.panels import close_bottom_panel
@@ -39,6 +42,11 @@ _STREAM_TEXT = "The quick brown fox jumps over the lazy dog. " * 112
 # bottom (message margins, sub-pixel rounding), but never the full ~64px paddingEnd
 # gap of the bug. (Measured: ~64px before the fix, ~0px after.)
 _FLUSH_TOLERANCE_PX = 24
+
+# The view must not scroll UP across the turn boundary. A tiny settle for the turn
+# footer is fine; a jump back to an earlier message is a whole-turn (hundreds of px)
+# regression, so a generous threshold cleanly separates the two.
+_JUMP_BACK_TOLERANCE_PX = 60
 
 
 @user_story("to not have the chat jump when the agent finishes its turn (req: stable turn-end)")
@@ -86,3 +94,62 @@ def test_following_pins_last_message_flush_to_viewport_bottom(sculptor_instance_
 
     # Let the turn finish cleanly before the test ends.
     expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=60_000)
+
+
+@user_story("to not have a prior scroll position dragged back when a later turn ends")
+def test_turn_end_does_not_restore_a_stale_reading_anchor(sculptor_instance_: SculptorInstance) -> None:
+    """A reading anchor captured by an earlier user scroll must not be restored when a
+    *later* turn finishes.
+
+    While `following` the live tail, `projectReflow` pins to the bottom. But the turn
+    end hands authority back to `userControlled`, and if a `readingAnchor` from an
+    earlier scroll is still set, the next content reflow (the turn footer landing after
+    we've left `following`) resolves to `holdAnchor` and restores that stale anchor —
+    scrolling the whole conversation back to a previous message and cutting off the
+    message the user just sent. Entering `following`/`anchoringTurn` must drop the
+    anchor so the turn end leaves the view where following left it (at the bottom).
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
+    )
+    chat_panel = task_page.get_chat_panel()
+    close_bottom_panel(page)
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+    send_chat_message(chat_panel, f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`')
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
+
+    view = get_alpha_chat_view(page)
+    expect(view).to_be_visible()
+
+    # Scroll to the top as a genuine user scroll — this captures a reading anchor on
+    # an early message (the position the bug later snaps back to).
+    scroll_alpha_chat_to_top(page)
+    expect(view).to_have_attribute("data-scroll-phase", "userControlled")
+
+    # Now send a follow-on that overflows and pins to the bottom.
+    send_chat_message(
+        chat_panel,
+        f'fake_claude:stream_text `{{"text": "{_STREAM_TEXT}", "chunk_size": 50, "delay_seconds": 0.1}}`',
+    )
+    expect(view).to_have_attribute("data-scroll-phase", "following", timeout=30_000)
+
+    # Sample the scrollTop we follow to, then let the turn finish and settle.
+    start_scroll_top_sampler(page)
+    page.wait_for_timeout(1500)
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=60_000)
+    expect(view).to_have_attribute("data-scroll-settled", "true", timeout=30_000)
+    page.wait_for_timeout(1000)  # give a late footer reflow time to (not) snap the anchor
+
+    sample = read_scroll_top_sampler(page)
+    assert sample["max"] is not None and sample["final"] is not None, "alpha chat view not found"
+    jump_back = sample["max"] - sample["final"]
+
+    # The turn end must not scroll the view up to the stale anchor.
+    assert jump_back <= _JUMP_BACK_TOLERANCE_PX, (
+        f"the view jumped back {jump_back}px when the turn ended "
+        + f"(max scrollTop {sample['max']} -> final {sample['final']}); "
+        + "a stale reading anchor was restored"
+    )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -21,6 +21,7 @@ while following — directly the property whose absence caused the turn-end jump
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
+from sculptor.testing.elements.alpha_chat_view import get_last_turn_footer_viewport_gaps
 from sculptor.testing.elements.alpha_chat_view import get_max_following_tail_gap
 from sculptor.testing.elements.alpha_chat_view import read_scroll_top_sampler
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
@@ -37,6 +38,8 @@ _LONG_TEXT = "Lorem ipsum dolor sit amet. " * 120
 # A long streaming response (~5k chars over ~10s) that overflows the viewport and
 # pins to the bottom while it streams.
 _STREAM_TEXT = "The quick brown fox jumps over the lazy dog. " * 112
+# Enough Lorem Ipsum to force a scroll (overflow the viewport) while it streams.
+_LOREM_STREAM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor. " * 90
 
 # While following, the last message's bottom may sit a few px above the viewport
 # bottom (message margins, sub-pixel rounding), but never the full ~64px paddingEnd
@@ -47,6 +50,12 @@ _FLUSH_TOLERANCE_PX = 24
 # footer is fine; a jump back to an earlier message is a whole-turn (hundreds of px)
 # regression, so a generous threshold cleanly separates the two.
 _JUMP_BACK_TOLERANCE_PX = 60
+
+# Sub-pixel tolerance for "is this edge inside the viewport".
+_EDGE_TOLERANCE_PX = 6
+# "Close to the bottom" == the footer sits within one standard margin of the viewport
+# bottom (one design-token space above the input box). Generous so it stays rigid.
+_FOOTER_BOTTOM_MARGIN_PX = 72
 
 
 @user_story("to not have the chat jump when the agent finishes its turn (req: stable turn-end)")
@@ -152,4 +161,63 @@ def test_turn_end_does_not_restore_a_stale_reading_anchor(sculptor_instance_: Sc
         f"the view jumped back {jump_back}px when the turn ended "
         + f"(max scrollTop {sample['max']} -> final {sample['final']}); "
         + "a stale reading anchor was restored"
+    )
+
+
+@user_story("to see the turn summary once the agent finishes a turn we were following")
+def test_turn_end_scrolls_turn_footer_into_view_when_following(sculptor_instance_: SculptorInstance) -> None:
+    """When a streamed reply overflowed the viewport (so we were following the tail),
+    the turn footer (turn summary) must be scrolled into view at the bottom once the
+    turn completes — not left cut off below the fold.
+
+    UX contract (rigid, on purpose): after the turn ends, the last turn footer is
+    (1) fully IN VIEW inside the chat viewport and (2) CLOSE TO THE BOTTOM — its
+    bottom edge within one standard margin of the viewport's bottom edge (one design
+    space above the input box).
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt='fake_claude:text `{"text": "Ready."}`',
+    )
+    chat_panel = task_page.get_chat_panel()
+    close_bottom_panel(page)
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    view = get_alpha_chat_view(page)
+    expect(view).to_be_visible()
+
+    # A follow-on whose reply is enough Lorem Ipsum to overflow the viewport, so the
+    # stream forces a scroll and we follow the tail.
+    send_chat_message(
+        chat_panel,
+        f'fake_claude:stream_text `{{"text": "{_LOREM_STREAM}", "chunk_size": 60, "delay_seconds": 0.08}}`',
+    )
+    expect(view).to_have_attribute("data-scroll-phase", "following", timeout=30_000)
+
+    # Let the turn finish and everything settle (the turn footer mounts a beat after
+    # the stream stops).
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=60_000)
+    expect(view).to_have_attribute("data-scroll-settled", "true", timeout=30_000)
+    expect(view.get_turn_footers().last).to_be_visible()
+    page.wait_for_timeout(1000)  # allow the final settle to place the footer
+
+    gaps = get_last_turn_footer_viewport_gaps(page)
+    assert gaps is not None, "no turn footer rendered after the turn completed"
+
+    # (1) IN VIEW: the footer's bottom is not cut off below the fold, and its top is
+    #     not scrolled off the top of the viewport.
+    assert gaps["bottom_gap"] >= -_EDGE_TOLERANCE_PX, (
+        f"the turn footer is cut off below the fold (its bottom is {-gaps['bottom_gap']}px "
+        + "below the viewport bottom); it should be scrolled into view"
+    )
+    assert gaps["top_gap"] >= -_EDGE_TOLERANCE_PX, (
+        f"the turn footer is scrolled off the top of the viewport (top_gap={gaps['top_gap']}px)"
+    )
+
+    # (2) CLOSE TO THE BOTTOM: within one standard margin of the viewport bottom.
+    assert gaps["bottom_gap"] <= _FOOTER_BOTTOM_MARGIN_PX, (
+        f"the turn footer is not close to the bottom (it sits {gaps['bottom_gap']}px above "
+        + f"the viewport bottom, expected <= {_FOOTER_BOTTOM_MARGIN_PX}px)"
     )


### PR DESCRIPTION
Fixes a family of alpha-chat scroll bugs where the view jumps or misbehaves the
moment an agent finishes a turn. All three live at the same boundary — the turn end,
where authority hands back from `following` to `userControlled` — and are fixed in
three commits.

## 1. Pin parked in the paddingEnd gap → small turn-end clamp

The `following` pin used `virtualizer.scrollToIndex(last, { align: "end" })`. For the
final item TanStack resolves that to `getMaxScrollOffset()` — the very bottom of the
*padded* scroll range — so `scrollTop` parked inside the dynamic `paddingEnd` gap
(~64px) with zero slack beneath it. When the streaming cursor was removed at turn-end
the last message shrank with no slack to absorb it; the browser clamped `scrollTop`
down and the view jumped up a small amount. It also floated the last line ~64px above
the viewport bottom the whole time you were following.

**Fix:** a `contentBottomOffset` geometry primitive (the inverse of
`distanceFromContentBottom`: `scrollHeight − paddingEnd − clientHeight`) and a single
**down-only** `pinToContentBottom` helper, routed through every "scroll to the bottom"
site. Pinning to the content bottom keeps `paddingEnd` as slack; down-only leaves a
turn-end shrink where it is rather than chasing it.

## 2. Stale reading anchor snaps the whole conversation back (the big jump)

A `ReadingAnchor` captured by an *earlier* user scroll survived across a later turn.
While `following` the live tail, `projectReflow` pins to the bottom — but the turn end
hands authority back to `userControlled`, and the next content reflow (the turn footer
landing after we've left `following`) resolved to `holdAnchor` and restored that
**stale** anchor. The whole conversation snapped back to a previous message, cutting
off the message the user had just sent. Measured jump: `scrollTop` ~4976px → 0 in the
reproduction.

**Fix:** clear `readingAnchor` the moment authority enters `following`/`anchoringTurn`,
in the store's `dispatch` (the single writer of authority). The user is now watching
the live tail / a fresh turn, so a scrolled-up anchor is abandoned. `holdAnchor` keeps
its real job — an idle scrolled-up reader whose view reflows — while a turn end now
leaves the view where following left it.

## 3. Turn footer left cut off below the fold

With the jump-backs fixed, a followed turn now ends pinned at the bottom — but the
turn footer (the turn summary) mounts a beat *after* the stream stops, once we have
already left `following` for `userControlled`, and grows the content just below the
fold. So it landed cut off below the viewport bottom instead of scrolling into view.
Focusing the input already scrolls the footer to the right place (one standard margin
above the input); a turn we were following should end in that same place.

**Fix:** on streaming stop while following, open a short, bounded window during which
the content observer re-pins to the (grown) content bottom via the same down-only
`pinToContentBottom`, revealing the footer. Guards keep it from firing anywhere else:
only after a turn we were *following*, only while the user has not taken over (any
wheel/touch/keydown, or a task switch, zeroes the window immediately), only once the
content actually grows past its stream-stop height, and only while the viewport is
unchanged — so a width/height resize reflow (which also grows content) keeps its own
reading-anchor behavior rather than being glued to the bottom.

## Verification

- Three integration tests in `test_alpha_scroll_turn_end.py`, one per fix, each of
  which fails on its pre-fix code and passes after: the last message stays flush with
  the viewport bottom while following (~64px → ~0px); a turn end does not restore a
  stale reading anchor (~4976px jump → ~0px); and the turn footer is scrolled into
  view and close to the bottom when a followed turn ends (~64px below the fold → in
  view, within one standard margin).
- The alpha-chat scroll integration suite (45 tests across ten scroll test files,
  including 10 viewport width-change tests) and the scroll unit tests (113) pass; the
  unit tests assert the content-bottom scroll position rather than a `scrollToIndex`
  call.
- `just format` / `just check` (ratchets, typecheck, lint, hygiene) / `just test-unit`
  clean.
- The footer reveal and both jump-back paths are covered by the deterministic
  expectation/reproduction tests above; the pin/anchor fixes were additionally
  confirmed with real-Claude manual QA (the response stays pinned at the bottom while
  streaming).

Builds on the scroll state machine in `docs/development/scroll_state_unification.md`,
which is updated with notes on the content-bottom pin primitive and the reading-anchor
lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
