### PR TITLE
[SCU-1651] Plugin SDK: workspace hooks for home views (curated useWorkspaces, navigate, multi-key settings)

### DIFF
--- a/sculptor/frontend/src/common/state/hooks/useWorkspaceNavigation.ts
+++ b/sculptor/frontend/src/common/state/hooks/useWorkspaceNavigation.ts
@@ -6,6 +6,7 @@ import { useImbueLocation, useImbueNavigate } from "../../NavigateUtils.ts";
 import { agentIdsByWorkspaceAtom, convertHomeTabToWorkspaceAtom, openWorkspaceTabAtom } from "../atoms/workspaces.ts";
 
 type WorkspaceNavigationResult = {
+  navigateToWorkspaceById: (workspaceId: string) => void;
   handleWorkspaceClick: (workspace: RecentWorkspaceResponse) => void;
   handleOpenInNewTab: (workspace: RecentWorkspaceResponse) => void;
 };
@@ -21,28 +22,37 @@ export const useWorkspaceNavigation = (): WorkspaceNavigationResult => {
   const agentIdsByWorkspace = useAtomValue(agentIdsByWorkspaceAtom);
   const openTab = useSetAtom(openWorkspaceTabAtom);
   const convertHomeTab = useSetAtom(convertHomeTabToWorkspaceAtom);
-  const handleWorkspaceClick = useCallback(
-    (workspace: RecentWorkspaceResponse): void => {
+  // The id-keyed core of the click handler, so callers that only hold a
+  // workspace id (e.g. the plugin SDK's navigate verb) get the same tab-opening
+  // and MRU-agent resolution without reconstructing a RecentWorkspaceResponse.
+  const navigateToWorkspaceById = useCallback(
+    (workspaceId: string): void => {
       // When navigating from the home page, replace the home tab with the workspace tab.
       if (isHomeRoute) {
-        convertHomeTab(workspace.objectId);
+        convertHomeTab(workspaceId);
       } else {
         // Ensure the workspace has an open tab (re-opens closed tabs)
-        openTab(workspace.objectId);
+        openTab(workspaceId);
       }
 
       // Use the saved agent id from tabsAtom if available for instant navigation.
-      const savedAgentId = agentIdsByWorkspace.get(workspace.objectId);
+      const savedAgentId = agentIdsByWorkspace.get(workspaceId);
       if (savedAgentId) {
-        navigateToAgent(workspace.objectId, savedAgentId);
+        navigateToAgent(workspaceId, savedAgentId);
         return;
       }
 
       // No saved agent yet — navigate to the workspace URL and let
       // WorkspacePage's validation effect pick a fallback agent.
-      navigateToWorkspace(workspace.objectId);
+      navigateToWorkspace(workspaceId);
     },
     [isHomeRoute, openTab, convertHomeTab, agentIdsByWorkspace, navigateToAgent, navigateToWorkspace],
+  );
+  const handleWorkspaceClick = useCallback(
+    (workspace: RecentWorkspaceResponse): void => {
+      navigateToWorkspaceById(workspace.objectId);
+    },
+    [navigateToWorkspaceById],
   );
 
   const handleOpenInNewTab = useCallback(
@@ -54,5 +64,5 @@ export const useWorkspaceNavigation = (): WorkspaceNavigationResult => {
     [openTab],
   );
 
-  return { handleWorkspaceClick, handleOpenInNewTab };
+  return { navigateToWorkspaceById, handleWorkspaceClick, handleOpenInNewTab };
 };

--- a/sculptor/frontend/src/pages/home/HomeViewSwitcher.tsx
+++ b/sculptor/frontend/src/pages/home/HomeViewSwitcher.tsx
@@ -20,7 +20,9 @@ export const HomeViewSwitcher = (): ReactElement => {
       {options.map(({ id, title, icon: Icon }) => (
         <SegmentedControl.Item key={id} value={id}>
           <Flex align="center" gap="2">
-            {Icon ? <Icon /> : null}
+            {/* 16px matches the codebase's SegmentedControl icon size; Lucide's
+                24px default sits taller than the item text. */}
+            {Icon ? <Icon size={16} /> : null}
             {title}
           </Flex>
         </SegmentedControl.Item>

--- a/sculptor/frontend/src/pages/home/homeViews.ts
+++ b/sculptor/frontend/src/pages/home/homeViews.ts
@@ -17,7 +17,8 @@ const BUILTIN_HOME_VIEW_TITLE = "Recent workspaces";
 export type HomeViewOption = {
   id: string;
   title: string;
-  icon?: ComponentType;
+  // Accepts `size` so the switcher can render it at the segmented-control's icon size.
+  icon?: ComponentType<{ size?: number | string }>;
 };
 
 /**

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -3,28 +3,25 @@ import { atomFamily, atomWithStorage, selectAtom } from "jotai/utils";
 import { useContext, useEffect, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
 
-import type { CodingAgentTaskView, Workspace } from "~/api";
+import type { CodingAgentTaskView } from "~/api";
 import { prStatusAtomFamily } from "~/common/state/atoms/prStatus.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { workspaceBranchAtomFamily } from "~/common/state/atoms/workspaceBranch.ts";
 import { workspaceAtomFamily, workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
+import { useWorkspaceNavigation } from "~/common/state/hooks/useWorkspaceNavigation.ts";
 
 import { usePluginContext } from "../PluginContext.tsx";
 import { useWorkspacePluginContext, WorkspacePluginContext } from "../WorkspaceContext.tsx";
 
 /**
- * Every non-deleted workspace known to the host, or `undefined` until the
- * first batch has loaded. App-global: it reads a shared atom and needs no
- * workspace context, so it works in an overlay as well as a panel.
+ * A curated, plugin-facing view of a single workspace: identity, label, live git
+ * branch, and code-host link. Deliberately a subset — not the host's full
+ * `Workspace` model — so the plugin contract doesn't couple to backend
+ * internals. The element type of `useWorkspaces` and the return of
+ * `useCurrentWorkspace`, so a plugin reads the same shape whether it looks at
+ * one workspace or all of them.
  */
-export const useWorkspaces = (): ReadonlyArray<Workspace> | undefined => useAtomValue(workspacesArrayAtom);
-
-/**
- * A curated, plugin-facing view of a single workspace: identity, label, and
- * live git branch. Deliberately a subset — not the host's full `Workspace`
- * model — so the plugin contract doesn't couple to backend internals.
- */
-export type CurrentWorkspace = {
+export type WorkspaceView = {
   id: string;
   description: string;
   /** Live current branch, or `null` until the backend has reported it. */
@@ -40,11 +37,15 @@ export type CurrentWorkspace = {
   pullRequestUrl: string | null;
 };
 
+/** @deprecated Use {@link WorkspaceView}; kept as an alias for the prior name. */
+export type CurrentWorkspace = WorkspaceView;
+
 // One derived view atom per workspace id, composing the workspace model with
-// its live branch (which the host keeps in a separate atom) into the curated
-// CurrentWorkspace shape.
-const currentWorkspaceViewAtomFamily = atomFamily((id: string) =>
-  atom((get): CurrentWorkspace | null => {
+// its live branch and PR status (which the host keeps in separate atoms) into
+// the curated WorkspaceView shape. Shared by the single- and all-workspaces
+// hooks so the curated mapping lives in exactly one place.
+const workspaceViewAtomFamily = atomFamily((id: string) =>
+  atom((get): WorkspaceView | null => {
     const workspace = get(workspaceAtomFamily(id));
     if (!workspace) return null;
     return {
@@ -57,9 +58,28 @@ const currentWorkspaceViewAtomFamily = atomFamily((id: string) =>
   }),
 );
 
+// The curated view of every non-deleted workspace, composed from the same
+// per-id view atom so the all-workspaces list and the current-workspace hook
+// can never report a workspace differently.
+const allWorkspaceViewsAtom = atom((get): ReadonlyArray<WorkspaceView> | undefined => {
+  const workspaces = get(workspacesArrayAtom);
+  if (workspaces === undefined) return undefined;
+  return workspaces
+    .map((workspace) => get(workspaceViewAtomFamily(workspace.objectId)))
+    .filter((view): view is WorkspaceView => view !== null);
+});
+
+/**
+ * Every non-deleted workspace known to the host as a curated {@link
+ * WorkspaceView} (including live branch and PR URL), or `undefined` until the
+ * first batch has loaded. App-global: it needs no workspace context, so it
+ * works in an overlay or home view as well as a panel.
+ */
+export const useWorkspaces = (): ReadonlyArray<WorkspaceView> | undefined => useAtomValue(allWorkspaceViewsAtom);
+
 // Stable fallback for when there is no current workspace, so the hook's
 // memoized selection always has a constant source atom.
-const noCurrentWorkspaceAtom = atom<CurrentWorkspace | null>(null);
+const noCurrentWorkspaceAtom = atom<WorkspaceView | null>(null);
 
 /**
  * The workspace the user is currently in — the panel's workspace when mounted
@@ -76,8 +96,8 @@ const noCurrentWorkspaceAtom = atom<CurrentWorkspace | null>(null);
  * The selector should be pure over the workspace (no external closure state):
  * its identity may change between renders, but its logic must not.
  */
-export function useCurrentWorkspace<T = CurrentWorkspace | null>(
-  selector?: (workspace: CurrentWorkspace | null) => T,
+export function useCurrentWorkspace<T = WorkspaceView | null>(
+  selector?: (workspace: WorkspaceView | null) => T,
   equalityFn?: (a: T, b: T) => boolean,
 ): T {
   // Resolve the active id: the panel's workspace if mounted in one (read
@@ -100,12 +120,12 @@ export function useCurrentWorkspace<T = CurrentWorkspace | null>(
   });
 
   const sourceAtom = useMemo(
-    () => (workspaceId ? currentWorkspaceViewAtomFamily(workspaceId) : noCurrentWorkspaceAtom),
+    () => (workspaceId ? workspaceViewAtomFamily(workspaceId) : noCurrentWorkspaceAtom),
     [workspaceId],
   );
   const selectedAtom = useMemo(
     () =>
-      selectAtom<CurrentWorkspace | null, T>(
+      selectAtom<WorkspaceView | null, T>(
         sourceAtom,
         // eslint-disable-next-line react-hooks/refs -- jotai invokes these wrappers when it evaluates the atom, not during render; the ref indirection is what keeps the wrappers' identity stable so selectAtom subscribes once.
         (workspace) => (selectorRef.current ? selectorRef.current(workspace) : (workspace as unknown as T)),
@@ -117,12 +137,28 @@ export function useCurrentWorkspace<T = CurrentWorkspace | null>(
   return useAtomValue(selectedAtom);
 }
 
+/**
+ * Returns a function that navigates to a workspace by id — the host's own
+ * workspace-open behavior: it opens (or converts the home tab into) the
+ * workspace's tab and jumps to its most-recently-used agent. The blessed seam
+ * for a plugin to send the user into a workspace (e.g. a home view opening the
+ * workspace a ticket is being worked in), so the navigation stays consistent
+ * with clicking a workspace in the host's own lists.
+ */
+export const useNavigateToWorkspace = (): ((workspaceId: string) => void) =>
+  // navigateToWorkspaceById is already a stable callback, so hand it back as-is.
+  useWorkspaceNavigation().navigateToWorkspaceById;
+
 // One persisted atom per (plugin, key). atomFamily caches by the full storage
 // key; getOnInit reads localStorage synchronously so the value is present on
 // first render instead of flashing the default.
 const pluginSettingAtomFamily = atomFamily((storageKey: string) =>
   atomWithStorage<string>(storageKey, "", undefined, { getOnInit: true }),
 );
+
+// The localStorage namespace for one of a plugin's settings. Shared by the
+// single- and multi-key hooks so the key shape can't drift between them.
+const settingStorageKey = (pluginId: string, key: string): string => `sculptor-plugin:${pluginId}:${key}`;
 
 /**
  * A persisted string setting scoped to the calling plugin. Backed by
@@ -131,7 +167,37 @@ const pluginSettingAtomFamily = atomFamily((storageKey: string) =>
  */
 export const usePluginSetting = (key: string): [string, (value: string) => void] => {
   const { pluginId } = usePluginContext();
-  return useAtom(pluginSettingAtomFamily(`sculptor-plugin:${pluginId}:${key}`));
+  return useAtom(pluginSettingAtomFamily(settingStorageKey(pluginId, key)));
+};
+
+/**
+ * Read several of the calling plugin's persisted settings at once, reactively —
+ * the multi-key companion to {@link usePluginSetting} for when the set of keys
+ * is dynamic, so you can't call `usePluginSetting` once per key (e.g. one
+ * per-workspace key, with the workspace list coming from `useWorkspaces`).
+ * Returns a map from each requested key to its current value (the empty string
+ * for an unset key) and re-renders when any of those keys changes — including a
+ * write from another surface of the plugin, since both share the same per-key
+ * atoms.
+ */
+export const usePluginSettings = (keys: ReadonlyArray<string>): ReadonlyMap<string, string> => {
+  const { pluginId } = usePluginContext();
+  // Encode the key set so the derived atom is rebuilt only when the set itself
+  // changes — a fresh `keys` array every render would otherwise rebuild it each
+  // time. Plugin keys are `<name>:<id>`-style and never contain a newline, so it
+  // is a safe separator to split back out inside the atom.
+  const encodedKeys = keys.join("\n");
+  const mapAtom = useMemo(
+    () =>
+      atom((get): ReadonlyMap<string, string> => {
+        const requestedKeys = encodedKeys === "" ? [] : encodedKeys.split("\n");
+        return new Map(
+          requestedKeys.map((key) => [key, get(pluginSettingAtomFamily(settingStorageKey(pluginId, key)))]),
+        );
+      }),
+    [pluginId, encodedKeys],
+  );
+  return useAtomValue(mapAtom);
 };
 
 /**

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -5,9 +5,16 @@
  */
 export { openExternal } from "./actions.ts";
 export { Markdown, PanelHeader } from "./components.ts";
-export type { CurrentWorkspace } from "./hooks.ts";
-export { useCurrentWorkspace, usePluginSetting, useWorkspaces, useWorkspaceTasks } from "./hooks.ts";
-export type { CodingAgentTaskView, Workspace } from "~/api";
+export type { CurrentWorkspace, WorkspaceView } from "./hooks.ts";
+export {
+  useCurrentWorkspace,
+  useNavigateToWorkspace,
+  usePluginSetting,
+  usePluginSettings,
+  useWorkspaces,
+  useWorkspaceTasks,
+} from "./hooks.ts";
+export type { CodingAgentTaskView } from "~/api";
 // The contract a plugin's `activate(api)` targets. Re-exported as types so
 // plugins reference the host's real definitions instead of hand-redeclaring
 // the registration shape (types are erased at build, so no runtime stub).

--- a/sculptor/frontend/src/plugins/types.ts
+++ b/sculptor/frontend/src/plugins/types.ts
@@ -36,7 +36,7 @@ export type PluginManifest = {
  * whole app (across every route) for as long as the plugin is loaded. The
  * component draws into a full-viewport, click-through layer, so it must opt
  * its own interactive box back into pointer events. Use the workspace SDK
- * hooks (`useWorkspaces`, `useCurrentWorkspaceId`) to react to app state —
+ * hooks (`useWorkspaces`, `useCurrentWorkspace`) to react to app state —
  * there is no single workspace context, because an overlay outlives any one
  * workspace page.
  */
@@ -85,15 +85,19 @@ export type WorkspaceWidgetDefinition = {
  * Like an app-global overlay (and unlike a panel/workspace widget) it is mounted
  * with no `WorkspacePluginContext`: the homepage is not scoped to a single
  * workspace, so a home view reads app state through the SDK hooks
- * (`useWorkspaces`, `useCurrentWorkspaceId`) instead of a fixed context.
+ * (`useWorkspaces`, `useCurrentWorkspace`) instead of a fixed context.
  */
 export type HomeViewDefinition = {
   /** Stable id; registering twice with the same id replaces the previous one. */
   id: string;
   /** Label shown for this view in the homepage switcher. */
   title: string;
-  /** Optional Lucide icon shown beside the title in the switcher. */
-  icon?: ComponentType;
+  /**
+   * Optional Lucide icon shown beside the title in the switcher. Typed to accept
+   * a `size` prop so the switcher can render it at a consistent size rather than
+   * Lucide's 24px default (which sits taller than the segmented-control text).
+   */
+  icon?: ComponentType<{ size?: number | string }>;
   component: ComponentType;
 };
 


### PR DESCRIPTION
## Summary

Extends the frontend plugin SDK with the host-side surface a homepage "board" plugin needs, on top of the SCU-1610 home-view slot. **Split out from the Linear board (SCU-1636, #218)** so the SDK can be reviewed and shipped in a build independently of the plugin — e.g. so a runtime-loaded home-view plugin can be loaded against a host that has this surface.

> **Stacked on #200 (SCU-1610).** This PR's base is `maciek/scu-1610-plugin-slot-on`, so its diff is *only* the SDK commit. Merge/rebase #200 first.

## What changed (`sculptor/frontend/src/`)

- **`useWorkspaces()`** now returns the same curated `WorkspaceView` that `useCurrentWorkspace` returns (`id`, `description`, live `branch`, `targetBranch`, `pullRequestUrl`), composed from one per-id view atom so the single- and all-workspace hooks can't report a workspace differently.
- **`useNavigateToWorkspace()`** — returns `(workspaceId) => void` that opens a workspace the host's own way (opens or converts its tab, then jumps to its most-recently-used agent), via a small `useWorkspaceNavigation` refactor that exposes `navigateToWorkspaceById`.
- **`usePluginSettings(keys)`** — a reactive multi-key reader for a plugin's settings, for when the key set is dynamic (e.g. one key per workspace, with the list coming from `useWorkspaces`).
- **Home-view switcher** renders the contributed icon at 16px, and **`HomeViewDefinition.icon`** accepts a `size` prop — Lucide's 24px default sat taller than the segmented-control text. Plus a stale `useCurrentWorkspaceId` doc reference fixed.

## Backwards compatibility

Mostly compatible — everything is additive (new hooks) or a safe type widening — **with two technically-breaking changes that have no shipped consumers**:

1. **`useWorkspaces()` return type** changed from the raw backend `Workspace[]` to the curated `WorkspaceView[]`. A plugin that read raw `Workspace` fields (e.g. `objectId`, `projectId`) off it would break.
2. **The `Workspace` type re-export was dropped** from the SDK barrel (`@sculptor/plugin-sdk`). A plugin importing that type would break.

No bundled or in-repo plugin used either (the only plugin, `linear-issue`, doesn't import `Workspace` or call `useWorkspaces` before this work), so nothing actually breaks today — verified by the existing plugin still typechecking against this SDK. `useCurrentWorkspace` keeps its shape (and `CurrentWorkspace` stays exported as an alias of `WorkspaceView`), so it is unaffected. If we want a strictly non-breaking SDK contract for external plugins, those two would be a major-version bump — or we keep `useWorkspaces` returning the raw model and add the curated view under a new name instead.

## Testing

`just check` and the full frontend unit suite pass on this branch.

(Sent by Claude)