### PR TITLE
[SCU-1375] Style horizontal scrollbars to match the thin vertical bars

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AgentTasksPanel.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AgentTasksPanel.module.scss
@@ -116,13 +116,6 @@
   padding: var(--space-2);
 
   @include thin-scrollbar(both);
-
-  // Suppress the default light-square corner where the horizontal and vertical
-  // scrollbars meet — the rest of thin-scrollbar already paints transparent
-  // tracks, so the corner should match.
-  &::-webkit-scrollbar-corner {
-    background-color: transparent;
-  }
 }
 
 // When the dependency graph is on, the popover body becomes a horizontal

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/BinaryPreview.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/BinaryPreview.module.scss
@@ -4,7 +4,7 @@
   flex: 1;
   overflow: auto;
 
-  @include thin-scrollbar;
+  @include thin-scrollbar(both);
 }
 
 .imageContainer {

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/ReadOnlyPreview.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/ReadOnlyPreview.module.scss
@@ -11,9 +11,12 @@
   background-color: light-dark(var(--color-panel-solid), var(--color-background));
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
+  overflow: auto;
 
-  @include thin-scrollbar;
+  // `both` — wide rendered-markdown content (e.g. a large GFM table) makes
+  // this container scroll sideways, and the horizontal bar should be the
+  // same thin bar as the vertical one.
+  @include thin-scrollbar(both);
 }
 
 // Layout for the rendered-markdown view. GFM features need a few extra rules
@@ -59,6 +62,8 @@
     margin: 0.5em 0;
     overflow-x: auto;
     padding: 0.75em 1em;
+
+    @include thin-scrollbar(horizontal);
 
     code {
       background: none;

--- a/sculptor/frontend/src/styles/_scrollbar.scss
+++ b/sculptor/frontend/src/styles/_scrollbar.scss
@@ -62,6 +62,13 @@
   &::-webkit-scrollbar-track {
     background-color: transparent;
   }
+
+  // Suppress the default light-square corner where the horizontal and
+  // vertical scrollbars meet — the tracks are transparent, so the corner
+  // should match. Harmless when only one scrollbar is present.
+  &::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
 }
 
 @mixin hidden-scrollbar {


### PR DESCRIPTION
## What

Style the **horizontal** scrollbars in the diff/preview panes to match the thin vertical ones, resolving [SCU-1375](https://linear.app/imbue/issue/SCU-1375). Several scroll containers only styled the vertical scrollbar (width only), so any horizontal overflow — e.g. a wide GFM table or a long line in a fenced code block in the rendered-markdown preview — fell back to the thick, unstyled native bar that looked ~10× the size of the vertical one.

## Why

The horizontal and vertical scrollbars should share the same thin styling. This applies the existing `thin-scrollbar` mixin to both axes where horizontal overflow can occur, and centralizes the transparent scrollbar-corner into the mixin so two thin bars meeting no longer leave a light corner square.

## Changes

- **`styles/_scrollbar.scss`** — paint `::-webkit-scrollbar-corner` transparent inside the `thin-scrollbar` mixin (a no-op when only one bar is present), instead of per call site.
- **`diffPanel/ReadOnlyPreview.module.scss`** — the rendered-markdown container now scrolls on both axes (`overflow: auto`) with `thin-scrollbar(both)`; fenced code blocks get `thin-scrollbar(horizontal)`.
- **`diffPanel/BinaryPreview.module.scss`** — `thin-scrollbar` → `thin-scrollbar(both)`.
- **`chat-alpha/AgentTasksPanel.module.scss`** — drop the now-redundant per-call-site corner rule (covered by the mixin).

## Note on scope

This is a targeted transfer of the scrollbar-styling fix. The chat scroll container (`AlphaChatInterface`) is intentionally **not** part of this change: `main` already clips its horizontal overflow (`overflow: hidden auto`, with wide blocks scrolling in their own inner containers) and renders its vertical bar via the overlay scrollbar component — so it needs no thin horizontal bar. Applying the older both-axis approach there would have regressed that behavior, so it was left as-is.

## Verification

This is a **purely visual** change (per the repo's testing policy, visual changes are verified by inspection, not automated tests):

- `stylelint` clean on all four changed files.
- `just ratchets` — OK, no regressions.
- Code-review pass (`/code-review-checklist`) across all categories — no issues found. Audited all ~50 `thin-scrollbar` call sites to confirm centralizing the corner rule regresses nothing.

To eyeball it: open a `.md` file with a wide table in the rendered-markdown preview and confirm the horizontal bar is now thin and matches the vertical one.

(Sent by Claude)
