### PR TITLE
[SCU-1657] Default chat markdown tables to wrapped rendering

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaTable.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaTable.test.tsx
@@ -433,7 +433,7 @@ describe("AlphaTable", () => {
 
       // Toggle wrap while the revert timer is pending. In the old code this re-ran
       // the ResizeObserver effect cleanup, clearing the timer so it never fired.
-      const wrapButton = container.querySelector('button[aria-label="Switch to wrap"]')!;
+      const wrapButton = container.querySelector('button[data-testid="ALPHA_CHAT_TABLE_WRAP_TOGGLE"]')!;
       fireEvent.click(wrapButton);
 
       act(() => vi.advanceTimersByTime(1500));
@@ -454,43 +454,43 @@ describe("AlphaTable", () => {
   });
 
   describe("wrap toggle", () => {
-    it("renders the toggle button with 'Switch to wrap' tooltip in scroll mode (default)", () => {
+    it("renders the toggle button with 'Switch to scroll' tooltip in wrap mode (default)", () => {
       const { container } = render(twoColumnTable());
-      const button = container.querySelector('button[aria-label="Switch to wrap"]');
+      const button = container.querySelector('button[aria-label="Switch to scroll"]');
       expect(button).toBeTruthy();
     });
 
-    it("applies the scroll class to the wrapper by default", () => {
+    it("applies the wrap class to the wrapper by default", () => {
       const { container } = render(twoColumnTable());
-      const wrapper = container.querySelector("table")!.parentElement!;
-      expect(wrapper.className).toMatch(/scroll/);
-      expect(wrapper.className).not.toMatch(/wrap/);
-    });
-
-    it("flips to wrap mode when clicked", () => {
-      const { container } = render(twoColumnTable());
-      const button = container.querySelector('button[aria-label="Switch to wrap"]')!;
-
-      fireEvent.click(button);
-
-      expect(container.querySelector('button[aria-label="Switch to scroll"]')).toBeTruthy();
       const wrapper = container.querySelector("table")!.parentElement!;
       expect(wrapper.className).toMatch(/wrap/);
       expect(wrapper.className).not.toMatch(/scroll/);
     });
 
-    it("flips back to scroll mode on a second click", () => {
+    it("flips to scroll mode when clicked", () => {
       const { container } = render(twoColumnTable());
-      const button = container.querySelector('button[aria-label="Switch to wrap"]')!;
+      const button = container.querySelector('button[aria-label="Switch to scroll"]')!;
 
       fireEvent.click(button);
-      const flipped = container.querySelector('button[aria-label="Switch to scroll"]')!;
-      fireEvent.click(flipped);
 
       expect(container.querySelector('button[aria-label="Switch to wrap"]')).toBeTruthy();
       const wrapper = container.querySelector("table")!.parentElement!;
       expect(wrapper.className).toMatch(/scroll/);
       expect(wrapper.className).not.toMatch(/wrap/);
+    });
+
+    it("flips back to wrap mode on a second click", () => {
+      const { container } = render(twoColumnTable());
+      const button = container.querySelector('button[aria-label="Switch to scroll"]')!;
+
+      fireEvent.click(button);
+      const flipped = container.querySelector('button[aria-label="Switch to wrap"]')!;
+      fireEvent.click(flipped);
+
+      expect(container.querySelector('button[aria-label="Switch to scroll"]')).toBeTruthy();
+      const wrapper = container.querySelector("table")!.parentElement!;
+      expect(wrapper.className).toMatch(/wrap/);
+      expect(wrapper.className).not.toMatch(/scroll/);
     });
 
     it("each AlphaTable owns its own wrap state", () => {
@@ -512,14 +512,14 @@ describe("AlphaTable", () => {
           </AlphaTable>
         </>,
       );
-      const toggles = container.querySelectorAll('button[aria-label="Switch to wrap"]');
+      const toggles = container.querySelectorAll('button[aria-label="Switch to scroll"]');
       expect(toggles).toHaveLength(2);
 
       fireEvent.click(toggles[0]);
 
-      // First flipped, second still in default scroll mode.
-      expect(container.querySelectorAll('button[aria-label="Switch to scroll"]')).toHaveLength(1);
+      // First flipped, second still in default wrap mode.
       expect(container.querySelectorAll('button[aria-label="Switch to wrap"]')).toHaveLength(1);
+      expect(container.querySelectorAll('button[aria-label="Switch to scroll"]')).toHaveLength(1);
     });
   });
 });

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaTable.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaTable.tsx
@@ -16,18 +16,19 @@ const COPY_FEEDBACK_DURATION_MS = 1500;
 const CONTROL_ICON_SIZE = 14;
 
 /**
- * Wraps a markdown-rendered table in a horizontally scrollable container with
- * a copy button and a per-table wrap toggle. Wrap state is component-local
- * and resets on remount; this is intentional so toggling one table doesn't
- * resize others on the page (which would cause large layout shifts in the
- * virtualized chat).
+ * Wraps a markdown-rendered table in a container with a copy button and a
+ * per-table wrap toggle. Tables wrap their cell text by default; the toggle
+ * switches an individual table to a horizontally scrollable, no-wrap layout.
+ * Wrap state is component-local and resets on remount; this is intentional so
+ * toggling one table doesn't resize others on the page (which would cause
+ * large layout shifts in the virtualized chat).
  */
 export const AlphaTable = memo(({ children }: AlphaTableProps): ReactElement => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [isCopied, setIsCopied] = useState(false);
-  const [isWrapping, setIsWrapping] = useState(false);
+  const [isWrapping, setIsWrapping] = useState(true);
 
   const updateScrollState = useCallback((): void => {
     const el = wrapperRef.current;

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -319,6 +319,32 @@ def scroll_alpha_chat_by(page: Page, delta: int) -> None:
     )
 
 
+def scroll_test_id_into_chat_viewport(page: Page, test_id: str, *, top_margin: int = 120) -> None:
+    """Scroll the alpha chat so the first element with ``test_id`` sits
+    ``top_margin`` px below the scroll container's top edge.
+
+    This positions the element fully inside the viewport for a subsequent
+    :func:`click_visible_in_chat_viewport` (which refuses to scroll-into-view),
+    without assuming anything about how tall the surrounding content renders — a
+    fixed pixel delta from the bottom is not robust to content whose height
+    varies (e.g. tables that wrap vs. scroll). Fires a ``scroll`` event so the
+    chat's scroll listeners run, mirroring a real user scroll.
+    """
+    page.evaluate(
+        f"""({{ testId, topMargin }}) => {{
+        const container = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        const el = container && container.querySelector('[data-testid="' + testId + '"]');
+        if (!container || !el) throw new Error("cannot scroll " + testId + " into view: not found");
+        const cRect = container.getBoundingClientRect();
+        const eRect = el.getBoundingClientRect();
+        container.dispatchEvent(new Event('wheel'));
+        container.scrollTop += (eRect.top - cRect.top) - topMargin;
+        container.dispatchEvent(new Event('scroll'));
+    }}""",
+        {"testId": test_id, "topMargin": top_margin},
+    )
+
+
 def click_visible_in_chat_viewport(page: Page, test_id: str) -> None:
     """Dispatch a synthetic click on the first element with ``test_id`` that is
     fully inside the alpha chat scroll viewport.

--- a/sculptor/tests/integration/frontend/test_alpha_chat_table_wrap_toggle.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_table_wrap_toggle.py
@@ -68,9 +68,9 @@ def test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat(sculptor_instan
 
     wrap_toggles = alpha_view.get_table_wrap_toggles()
     expect(wrap_toggles).to_have_count(2)
-    # Default per-table state is "scroll" — both toggles say "Switch to wrap".
-    expect(wrap_toggles.nth(0)).to_have_attribute("aria-label", "Switch to wrap")
-    expect(wrap_toggles.nth(1)).to_have_attribute("aria-label", "Switch to wrap")
+    # Default per-table state is "wrap" — both toggles say "Switch to scroll".
+    expect(wrap_toggles.nth(0)).to_have_attribute("aria-label", "Switch to scroll")
+    expect(wrap_toggles.nth(1)).to_have_attribute("aria-label", "Switch to scroll")
 
     # Scroll up so we are not pinned at the bottom — only then can we see if
     # the toggle yanks the scroll.
@@ -89,9 +89,9 @@ def test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat(sculptor_instan
 
     # Exactly one toggle should have flipped — the other table's wrap state
     # must stay independent.
-    switched = alpha_view.get_table_wrap_toggles_with_label("Switch to scroll")
+    switched = alpha_view.get_table_wrap_toggles_with_label("Switch to wrap")
     expect(switched).to_have_count(1)
-    unchanged = alpha_view.get_table_wrap_toggles_with_label("Switch to wrap")
+    unchanged = alpha_view.get_table_wrap_toggles_with_label("Switch to scroll")
     expect(unchanged).to_have_count(1)
 
     # Confirm scroll did not jump to the bottom after layout settles.

--- a/sculptor/tests/integration/frontend/test_alpha_chat_table_wrap_toggle.py
+++ b/sculptor/tests/integration/frontend/test_alpha_chat_table_wrap_toggle.py
@@ -13,8 +13,8 @@ from playwright.sync_api import expect
 from sculptor.constants import ElementIDs
 from sculptor.testing.elements.alpha_chat_view import click_visible_in_chat_viewport
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
-from sculptor.testing.elements.alpha_chat_view import get_alpha_container_height
-from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
+from sculptor.testing.elements.alpha_chat_view import get_alpha_scroll_position
+from sculptor.testing.elements.alpha_chat_view import scroll_test_id_into_chat_viewport
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
@@ -72,16 +72,22 @@ def test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat(sculptor_instan
     expect(wrap_toggles.nth(0)).to_have_attribute("aria-label", "Switch to scroll")
     expect(wrap_toggles.nth(1)).to_have_attribute("aria-label", "Switch to scroll")
 
-    # Scroll up so we are not pinned at the bottom — only then can we see if
-    # the toggle yanks the scroll.
-    container_height = get_alpha_container_height(page)
-    scroll_alpha_chat_by(page, -int(container_height))
+    # Bring the first table's wrap toggle into the viewport, positioned near the
+    # top. Because that table sits high in the (tall) response, plenty of content
+    # remains below it — so we are not pinned at the bottom, and any scroll yank
+    # caused by the toggle would be observable. Scrolling a specific toggle into
+    # view is robust to how tall the wrapped tables render; a fixed pixel delta
+    # from the bottom is not.
+    scroll_test_id_into_chat_viewport(page, ElementIDs.ALPHA_CHAT_TABLE_WRAP_TOGGLE)
     page.wait_for_function(
         f"""() => {{
             const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
-            return el ? el.scrollTop > 100 : false;
+            if (!el) return false;
+            return (el.scrollHeight - el.scrollTop - el.clientHeight) > 200;
         }}"""
     )
+
+    scroll_before = get_alpha_scroll_position(page)
 
     # Dispatch the click directly so Playwright doesn't first scroll the
     # element into view (which would itself shift scrollTop).
@@ -94,11 +100,16 @@ def test_table_wrap_toggle_is_per_table_and_does_not_scroll_chat(sculptor_instan
     unchanged = alpha_view.get_table_wrap_toggles_with_label("Switch to scroll")
     expect(unchanged).to_have_count(1)
 
-    # Confirm scroll did not jump to the bottom after layout settles.
+    # The toggle changes the table's height, which the virtualizer would
+    # normally compensate for by bumping scrollTop; the per-item skip flag must
+    # suppress that so the view stays put. Confirm scrollTop held steady (and we
+    # did not get yanked toward the bottom) after layout settles.
     page.wait_for_function(
-        f"""() => {{
+        f"""(before) => {{
             const el = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
             if (!el) return false;
-            return (el.scrollHeight - el.scrollTop - el.clientHeight) > 200;
-        }}"""
+            return Math.abs(el.scrollTop - before) < 100 &&
+                   (el.scrollHeight - el.scrollTop - el.clientHeight) > 200;
+        }}""",
+        arg=scroll_before,
     )


### PR DESCRIPTION
## What

Make **wrapped** the default rendering mode for markdown tables in the alpha chat.

Previously, chat tables defaulted to a horizontally-scrollable, no-wrap layout, and the reader had to click the per-table toggle to wrap cell text. This flips the default so tables wrap their cell text out of the box — wide tables are readable without horizontal scrolling. The per-table toggle is preserved: readers can still switch an individual table to the scroll/no-wrap layout when they prefer it.

## Why

Wrapped tables are more legible in the chat's constrained width; horizontal scrolling hides content and is easy to miss. Wrap-by-default matches the more common reading preference while keeping the scroll layout one click away.

## Changes

- `AlphaTable.tsx` — initialize the per-table wrap state to wrapped by default (one-line default flip); refresh the component doc comment to describe wrap-as-default. Tooltip/aria-label are already derived from state, so they update automatically.
- `AlphaTable.test.tsx` — invert the default-mode assertions and cover both toggle directions; select the toggle by `data-testid` in the copy-revert regression test (its label is no longer "Switch to wrap" at rest).
- `test_alpha_chat_table_wrap_toggle.py` — flip the default-label and post-click assertions to match.

Wrap state stays component-local and resets on remount, so toggling one table doesn't reflow others in the virtualized chat.

## Note

The wrap toggle button carries an accent "active" highlight whenever wrap mode is on. Because wrap is now the default, that highlight appears on every table at rest (it honestly reflects the current mode; the controls are hover-revealed, so it's low-noise). Happy to change the highlight to indicate only the non-default scroll state instead if reviewers prefer.

## Testing

`just format`, `just check`, and `just test-unit` all pass. The `AlphaTable.test.tsx` suite (26 tests) passes. The wrap-toggle integration test's assertions were updated for the new default.

(Sent by Claude)