### PR TITLE
Fix detached-HEAD placeholder shown as a selectable source branch

### DIFF
--- a/sculptor/sculptor/services/git_repo_service/default_implementation.py
+++ b/sculptor/sculptor/services/git_repo_service/default_implementation.py
@@ -75,8 +75,13 @@ class _ReadOnlyGitRepoSharedMethods(_GitRepoSharedMethods, ABC):
 
     @log_runtime_decorator("get_all_branches")
     def get_all_branches(self) -> list[str]:
-        # Get all local branches in alphabetical order
-        all_branches_result = self._run_git(["branch", "--format=%(refname:short)"])
+        # Enumerate real local branches (refs/heads/) in alphabetical order.
+        # We use `for-each-ref` (plumbing) rather than `git branch` (porcelain)
+        # because, in a detached-HEAD state, `git branch` prepends a placeholder
+        # line like "(HEAD detached at <ref>)" that is not a branch. That
+        # placeholder would otherwise surface in the source-branch picker and, if
+        # selected, be passed to `git worktree add` as a ref git rejects.
+        all_branches_result = self._run_git(["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
         all_branches = [b.strip() for b in all_branches_result.strip().split("\n") if b.strip()]
 
         if not all_branches:

--- a/sculptor/sculptor/testing/pages/add_workspace_page.py
+++ b/sculptor/sculptor/testing/pages/add_workspace_page.py
@@ -62,6 +62,14 @@ class PlaywrightAddWorkspacePage(PlaywrightProjectLayoutPage):
     def get_branch_selector(self) -> Locator:
         return self.get_by_test_id(ElementIDs.BRANCH_SELECTOR)
 
+    def open_branch_selector(self) -> None:
+        """Open the source-branch dropdown so its options are rendered."""
+        self.get_branch_selector().click()
+
+    def get_branch_options(self) -> Locator:
+        """All branch options rendered in the (open) source-branch dropdown."""
+        return self.get_by_test_id(ElementIDs.BRANCH_OPTION)
+
     def select_branch(self, branch_name: str) -> None:
         self.get_branch_selector().click()
         branch_option = (

--- a/sculptor/tests/integration/frontend/test_add_workspace_detached_head.py
+++ b/sculptor/tests/integration/frontend/test_add_workspace_detached_head.py
@@ -1,0 +1,50 @@
+"""Regression test for the source-branch dropdown when the base repo is on a
+detached HEAD.
+
+``git branch`` (a porcelain command) prints a placeholder line for a detached
+HEAD, e.g. ``(HEAD detached at origin/main)``. If that placeholder leaks into
+the New Workspace *source* dropdown, a user can select it, and the verbose
+string is then handed to ``git worktree add <path> <base_ref>`` as the base
+ref — which git rejects, so workspace creation fails. The dropdown must list
+only real local branches.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.pages.add_workspace_page import PlaywrightAddWorkspacePage
+from sculptor.testing.playwright_utils import navigate_to_add_workspace_page
+from sculptor.testing.sculptor_instance import SculptorInstanceFactory
+from sculptor.testing.user_stories import user_story
+
+
+@user_story("to not see git's '(HEAD detached ...)' placeholder as a selectable source branch")
+def test_detached_head_placeholder_not_listed_as_source_branch(
+    sculptor_instance_factory_: SculptorInstanceFactory,
+) -> None:
+    """On a detached-HEAD base repo, the source dropdown lists real branches only.
+
+    A dedicated factory instance is used so detaching HEAD does not leak into the
+    shared instance's checkout (other tests assume it is on ``testing``). The repo
+    keeps its real ``main`` and ``testing`` branches; only the working copy is
+    detached before the backend enumerates branches.
+    """
+    # Detach HEAD before the backend starts so get_repo_info enumerates branches
+    # against a detached working copy — the exact state that produces the
+    # placeholder entry.
+    sculptor_instance_factory_.base_repo.repo.run_git(("checkout", "--detach", "HEAD"))
+
+    with sculptor_instance_factory_.spawn_instance() as instance:
+        page = instance.page
+        navigate_to_add_workspace_page(page)
+        add_ws_page = PlaywrightAddWorkspacePage(page=page)
+
+        add_ws_page.open_branch_selector()
+        options = add_ws_page.get_branch_options()
+
+        # The real branches must still be offered (this also waits for the
+        # dropdown to finish loading before the negative assertion below runs).
+        expect(options.filter(has_text="testing")).to_have_count(1)
+        expect(options.filter(has_text="main")).to_have_count(1)
+
+        # git's detached-HEAD placeholder must never appear as a selectable option.
+        expect(options.filter(has_text="HEAD detached")).to_have_count(0)


### PR DESCRIPTION
## Original bug

When the base repo is on a **detached HEAD**, the New Workspace "source" branch dropdown lists git's placeholder line `(HEAD detached at <ref>)` as if it were a real branch. Selecting it makes workspace creation fail, because the verbose string is passed to `git worktree add` as the base ref — which git rejects.

Linear: [SCU-1658](https://linear.app/imbue/issue/SCU-1658/detached-head-placeholder-appears-as-a-selectable-source-branch-on-the)

## Repro

1. Put the project's repo on a detached HEAD (e.g. `git checkout --detach origin/main`).
2. Open the "Name your workspace" page and open the **source** branch dropdown.
3. The dropdown shows `(HEAD detached at origin/main)` as a selectable option.
4. Select it and click **Create workspace**.

**Expected:** the dropdown lists only real local branches; the placeholder never appears.

**Actual:** the placeholder is selectable, and selecting it fails workspace creation.

## Root cause

`get_all_branches()` in `sculptor/sculptor/services/git_repo_service/default_implementation.py` enumerated branches with `git branch --format=%(refname:short)`. `git branch` is a porcelain command, and in a detached-HEAD state it prepends a placeholder line:

```
$ git branch --format='%(refname:short)'   # on a detached HEAD
(HEAD detached at 383068d)
main
testing
```

That non-branch string flowed unfiltered through `RepoInfo.recent_branches` into the source picker (`BranchSelector`), where it rendered as a selectable option and, once chosen, was handed to `git worktree add ... <base_ref>`.

## Fix

Enumerate real branch refs with `git for-each-ref --format=%(refname:short) refs/heads/` (plumbing), which lists only actual local branches and structurally cannot emit the placeholder. Alphabetical ordering and the empty→current-branch fallback are unchanged. Both callers of `get_all_branches()` (the repo-info endpoint and `branch_poller`) benefit.

## Test

- Path: `sculptor/tests/integration/frontend/test_add_workspace_detached_head.py`
- Kind: e2e (Playwright). Detaches HEAD on an isolated factory instance's base repo, opens the source dropdown, and asserts the real branches are listed while the `(HEAD detached ...)` placeholder is not.
- Failing-test commit: `39dc351`
- Fix commit: `4e1d8a5`

**Before the fix** (test asserts the placeholder is absent):

```
>   expect(options.filter(has_text="HEAD detached")).to_have_count(0)
E   AssertionError: Locator expected to have count '0'
E   Actual value: 1
============================== 1 failed in 36.84s ==============================
```

**After the fix:**

```
============================== 1 passed in 8.12s ==============================
```

Also verified: existing `TestGetAllBranches` unit test still passes, and the full backend unit suite (`2089 passed, 4 skipped`) and `just check` are green.

(Sent by Claude)
