### PR TITLE
fix-bug skill: scope self-review diff to the remote base branch

### DIFF
--- a/sculptor/sculptor-workflow/skills/fix-bug/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/fix-bug/SKILL.md
@@ -278,7 +278,12 @@ section against the diff produced by this fix.
 - **If the section names a skill** (e.g. `Skill: /code-review-checklist`):
   invoke that skill with:
   - Working directory: the repo root.
-  - Diff range: `<merge base>...HEAD`.
+  - Diff range: `<base branch>...HEAD`, where `<base branch>` is the
+    up-to-date remote-tracking base ref (e.g. `origin/main`) — NOT local
+    `main`, which may be stale and silently widen the diff to include
+    commits already merged upstream. The three-dot syntax scopes the
+    review to this branch's own commits (it diffs against the merge base
+    automatically).
   - Stated goal: a short summary of the bug and the intended behaviour
     (the same content you've been building in Phase 1).
 
@@ -549,7 +554,12 @@ this run has produced.
 - **If the section names a skill** (e.g. `Skill: /code-review-checklist`):
   invoke that skill with:
   - Working directory: the repo root.
-  - Diff range: `<merge base>...HEAD`.
+  - Diff range: `<base branch>...HEAD`, where `<base branch>` is the
+    up-to-date remote-tracking base ref (e.g. `origin/main`) — NOT local
+    `main`, which may be stale and silently widen the diff to include
+    commits already merged upstream. The three-dot syntax scopes the
+    review to this branch's own commits (it diffs against the merge base
+    automatically).
   - Stated goal: the assembled MR body draft (root cause, fix, repro,
     proof) you will publish in A5 — pass the actual draft, not just the
     bug description. The review skill needs the body to evaluate "Proof of


### PR DESCRIPTION
## What

The fix-bug skill's self-review pass told the reviewer to use a diff range of `<merge base>...HEAD`, but was silent about *what to compute the merge base against*. The literal-looking `<merge base>` placeholder invited resolving the base to local `main` — which can be stale, silently widening the review diff to include commits already merged upstream.

This names the base explicitly as the up-to-date remote-tracking ref (e.g. `origin/main`) and notes that three-dot syntax scopes the review to this branch's own commits automatically. Applied to both self-review passes in the skill (Phase 4 and Phase A4.5).

## Why

Hit in practice: local `main` was stale, so `<merge base>...HEAD` would have widened the review diff beyond the branch's actual commits. Using `origin/main...HEAD` scoped it correctly to just the new work.

## Scope

Documentation-only change to `sculptor/sculptor-workflow/skills/fix-bug/SKILL.md` (12 insertions, 2 deletions). Pre-commit `just check` passed.

(Sent by Claude)