### PR TITLE
Update Pi model selector before the first message (SCU-1605)

### DIFF
--- a/sculptor/sculptor/agents/harness_registry.py
+++ b/sculptor/sculptor/agents/harness_registry.py
@@ -96,6 +96,9 @@ def create_agent_for_run(context: AgentRunContext) -> Agent:
                 system_prompt=context.task_data.system_prompt or "",
                 on_diff_needed=context.on_diff_needed,
                 harness=PI_HARNESS,
+                # The switcher's persisted selection (possibly chosen before the first
+                # message, when no pi process existed) so start() adopts it onto pi.
+                preselected_model=context.task_state.current_model,
             )
         # Terminal configs (TerminalAgentConfig / RegisteredTerminalAgentConfig)
         # never reach this function: they are dispatched to

--- a/sculptor/sculptor/agents/harness_registry.py
+++ b/sculptor/sculptor/agents/harness_registry.py
@@ -96,8 +96,6 @@ def create_agent_for_run(context: AgentRunContext) -> Agent:
                 system_prompt=context.task_data.system_prompt or "",
                 on_diff_needed=context.on_diff_needed,
                 harness=PI_HARNESS,
-                # The switcher's persisted selection (possibly chosen before the first
-                # message, when no pi process existed) so start() adopts it onto pi.
                 preselected_model=context.task_state.current_model,
             )
         # Terminal configs (TerminalAgentConfig / RegisteredTerminalAgentConfig)

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1212,17 +1212,14 @@ class PiAgent(DefaultAgentWrapper):
     def _adopt_preselected_model(
         self, pi_default: ModelOption | None, options: list[ModelOption], authenticated: set[str]
     ) -> ModelOption | None:
-        """Adopt the switcher's persisted selection (`preselected_model`) onto pi at start.
+        """Adopt the persisted `preselected_model` onto pi at start, returning the model
+        to surface as current.
 
-        A model chosen before the agent went live lands only in task state — the pi
-        process did not yet exist to receive the `set_model` — so at start pi still
-        reports its own default. Apply the selection here, before the catalog is
-        surfaced, so pi runs it from the first turn and the switcher shows it without
-        flickering through pi's default. Only a selection pi still offers and whose
-        provider is authenticated is adopted; otherwise (e.g. the provider was
-        disconnected) pi's default is kept rather than a model that cannot run, and a
-        failed switch falls back to pi's default too. Returns the model to surface as
-        current.
+        Applied before the catalog is surfaced so pi runs the selection from the first
+        turn without the switcher flickering through pi's default. Only a selection pi
+        still offers and whose provider is authenticated is adopted (via `set_model`);
+        otherwise — a disconnected provider, or a failed switch — pi's own default is
+        kept rather than a model that cannot run.
         """
         preselected = self.preselected_model
         if preselected is None:
@@ -1269,9 +1266,6 @@ class PiAgent(DefaultAgentWrapper):
             if option is not None:
                 options.append(option)
         authenticated = compute_authenticated_provider_ids()
-        # Adopt the switcher's persisted selection (a model the user may have picked
-        # before this pi process existed) so pi runs it from the first turn and the
-        # switcher does not flicker through pi's own default.
         current_model = self._adopt_preselected_model(current_model, options, authenticated)
         curated = _curate_models(options, current_model, authenticated)
         # Don't strand the agent on a model whose provider was just deauthorized

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -562,6 +562,13 @@ class PiAgent(DefaultAgentWrapper):
     harness: PiHarness
     config: PiAgentConfig
     git_hash: str
+    # The switcher's persisted value at construction (`AgentTaskStateV2.current_model`).
+    # A user can switch models before the first message — before this pi process
+    # exists — so the switch lands only in task state, not in pi's session. `start()`
+    # adopts it (`_adopt_preselected_model`) so pi runs the selected model from the
+    # first turn and the switcher does not flicker back to pi's own default. None when
+    # the switcher has no persisted selection yet (pi's default is used).
+    preselected_model: ModelOption | None = None
     # Carries chat turns AND between-turns control messages (context reset,
     # model switch) through one FIFO so each runs strictly after any in-flight
     # turn — the sole-reader window where the control RPCs' responses can be
@@ -1202,6 +1209,46 @@ class PiAgent(DefaultAgentWrapper):
         )
         return new_model
 
+    def _adopt_preselected_model(
+        self, pi_default: ModelOption | None, options: list[ModelOption], authenticated: set[str]
+    ) -> ModelOption | None:
+        """Adopt the switcher's persisted selection (`preselected_model`) onto pi at start.
+
+        A model chosen before the agent went live lands only in task state — the pi
+        process did not yet exist to receive the `set_model` — so at start pi still
+        reports its own default. Apply the selection here, before the catalog is
+        surfaced, so pi runs it from the first turn and the switcher shows it without
+        flickering through pi's default. Only a selection pi still offers and whose
+        provider is authenticated is adopted; otherwise (e.g. the provider was
+        disconnected) pi's default is kept rather than a model that cannot run, and a
+        failed switch falls back to pi's default too. Returns the model to surface as
+        current.
+        """
+        preselected = self.preselected_model
+        if preselected is None:
+            return pi_default
+        if (
+            pi_default is not None
+            and preselected.provider == pi_default.provider
+            and preselected.model_id == pi_default.model_id
+        ):
+            return pi_default
+        if preselected.provider not in authenticated:
+            return pi_default
+        if not any(
+            option.provider == preselected.provider and option.model_id == preselected.model_id for option in options
+        ):
+            return pi_default
+        adopted = self._request_set_model_blocking(
+            preselected.provider, preselected.model_id, _MODEL_FETCH_TIMEOUT_SECONDS
+        )
+        if adopted is None:
+            logger.info(
+                "PiAgent could not adopt preselected model {} at start; using pi default", preselected.model_id
+            )
+            return pi_default
+        return adopted
+
     def _fetch_models_into_state(self) -> None:
         """Fetch pi's model catalog + current model and surface them onto task state.
 
@@ -1222,6 +1269,10 @@ class PiAgent(DefaultAgentWrapper):
             if option is not None:
                 options.append(option)
         authenticated = compute_authenticated_provider_ids()
+        # Adopt the switcher's persisted selection (a model the user may have picked
+        # before this pi process existed) so pi runs it from the first turn and the
+        # switcher does not flicker through pi's own default.
+        current_model = self._adopt_preselected_model(current_model, options, authenticated)
         curated = _curate_models(options, current_model, authenticated)
         # Don't strand the agent on a model whose provider was just deauthorized
         # (e.g. the user disconnected it): switch to an authenticated model and
@@ -1766,9 +1817,11 @@ class PiAgent(DefaultAgentWrapper):
         session-level and persists for later turns. On success pi returns the new
         Model; we re-emit a `ModelsAvailableAgentMessage` carrier (same catalog,
         new current model) so the persisted current model and the switcher's
-        selection follow. A `success:false` response (e.g. `Model not found`) or
-        no acknowledgement is raised as `PiSetModelError`, leaving the current
-        model unchanged.
+        selection follow. A `success:false` response (e.g. `Model not found`) is
+        raised as `PiSetModelError` after rolling the switcher back to pi's real
+        current model (the endpoint wrote the requested model optimistically); an
+        unacknowledged switch (pi unreachable) is raised without a rollback, since pi
+        cannot be queried for its state.
         """
         with self._handle_user_message(message):
             command_id = generate_id()
@@ -1783,6 +1836,7 @@ class PiAgent(DefaultAgentWrapper):
                     "pi did not acknowledge set_model within the timeout", exit_code=None, metadata=None
                 )
             if not response.success:
+                self._emit_current_model_rollback()
                 raise PiSetModelError(
                     response.error or f"pi rejected set_model for {message.provider}/{message.model_id}",
                     exit_code=None,
@@ -1808,6 +1862,31 @@ class PiAgent(DefaultAgentWrapper):
                     current_model=new_model,
                 )
             )
+
+    def _emit_current_model_rollback(self) -> None:
+        """Re-emit the model pi is actually on, undoing an optimistically-written switch.
+
+        The set-model endpoint writes the requested model onto task state before pi
+        confirms it, so a rejected switch would otherwise leave the switcher showing a
+        model pi never adopted. Query pi's real current model and re-emit the cached
+        catalog with it so the switcher rolls back. Best-effort: only runs with a
+        cached catalog, and skips when pi reports no current model — the switch
+        failure itself is surfaced separately as a RequestFailure.
+        """
+        if not self._available_models:
+            return
+        state = self._request_state_blocking()
+        current_raw = state.get("model") if isinstance(state, dict) else None
+        current_model = _model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
+        if current_model is None:
+            return
+        self._output_messages.put(
+            ModelsAvailableAgentMessage(
+                message_id=AgentMessageID(),
+                available_models=self._available_models,
+                current_model=current_model,
+            )
+        )
 
     def _handle_refresh_models(self, message: RefreshModelsUserMessage) -> None:
         """Re-fetch pi's catalog and re-emit it after a global credential change.

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -86,13 +86,13 @@ from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import ModelOption
 from sculptor.state.messages import ResponseBlockAgentMessage
 
-
 _PROMPT_ID = "prompt-1"
 
 
 def _make_agent(
     environment: AgentExecutionEnvironment | None = None,
     on_diff_needed: Callable[[], None] | None = None,
+    preselected_model: ModelOption | None = None,
 ) -> PiAgent:
     env = environment if environment is not None else MagicMock(spec=AgentExecutionEnvironment)
     return PiAgent(
@@ -103,6 +103,7 @@ def _make_agent(
         system_prompt="",
         git_hash="deadbeef",
         on_diff_needed=on_diff_needed,
+        preselected_model=preselected_model,
     )
 
 
@@ -2299,10 +2300,20 @@ class TestSetModel:
         assert any(isinstance(m, RequestSuccessAgentMessage) for m in emitted)
         assert not any(isinstance(m, RequestFailureAgentMessage) for m in emitted)
 
-    def test_set_model_failure_on_success_false_surfaces_error_without_mutation(self) -> None:
-        """set_model success:false → RequestFailure, no current-model carrier, handler does not raise."""
+    def test_set_model_failure_on_success_false_surfaces_error_and_rolls_back(self) -> None:
+        """set_model success:false → RequestFailure AND a corrective carrier restoring the
+        switcher to pi's actual current model, without the handler raising out.
+
+        The set-model endpoint writes the requested model onto task state before the
+        switch is confirmed (so the switcher responds immediately), so a rejected
+        switch must roll the switcher back to the model pi is really on rather than
+        leave it stranded on the model that did not take."""
         agent = _make_agent()
-        agent._available_models = (ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Opus"),)
+        agent._available_models = (
+            ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Opus"),
+            ModelOption(provider="anthropic", model_id="claude-haiku-4-5", display_name="Haiku"),
+        )
+        actual = {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
         agent._process = _make_process(
             [
                 _event(
@@ -2313,10 +2324,11 @@ class TestSetModel:
                         "id": "cmd-set",
                         "error": "Model not found: anthropic/claude-nope",
                     }
-                )
+                ),
+                _state_response_with_model(actual),
             ]
         )
-        with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-set"]):
+        with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-set", "cmd-state"]):
             # Must NOT raise out of the handler — the AgentClientError path reports and continues.
             agent._handle_set_model(
                 SetModelUserMessage(message_id=AgentMessageID(), provider="anthropic", model_id="claude-nope")
@@ -2326,8 +2338,11 @@ class TestSetModel:
         assert len(failures) == 1
         # The failure carries pi's error so the frontend can toast it.
         assert "Model not found" in str(failures[0].error.args[0])
-        # No current-model mutation on failure.
-        assert not any(isinstance(m, ModelsAvailableAgentMessage) for m in emitted)
+        # The switcher is rolled back to pi's real current model, undoing the optimistic write.
+        carriers = [m for m in emitted if isinstance(m, ModelsAvailableAgentMessage)]
+        assert len(carriers) == 1
+        assert carriers[0].current_model is not None
+        assert carriers[0].current_model.model_id == "claude-opus-4-8"
 
     def test_set_model_failure_on_no_response_surfaces_error(self) -> None:
         """No set_model ack (process exited / timeout) → failed request, no carrier, no crash."""
@@ -3327,6 +3342,87 @@ class TestModelCatalogFetch:
         with patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-models", "cmd-state"]):
             agent._fetch_models_into_state()
         assert not [m for m in _drain(agent._output_messages) if isinstance(m, ModelsAvailableAgentMessage)]
+
+    def test_fetch_models_into_state_adopts_preselected_model_over_pi_default(self) -> None:
+        """A model the user selected before the agent went live (preselected_model)
+        is applied to pi at start and surfaced as current, instead of pi's own default.
+
+        Without this, a pre-message switch would flicker back to pi's default the
+        moment the first turn starts the agent, then re-apply on the queued switch.
+        """
+        preselected = ModelOption(provider="anthropic", model_id="claude-sonnet-4-6", display_name="Claude Sonnet 4.6")
+        agent = _make_agent(preselected_model=preselected)
+        pi_default = {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+        adopted = {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "provider": "anthropic"}
+        process = _make_process(
+            [_models_response(_RAW_PI_MODELS), _state_response_with_model(pi_default), _set_model_response(adopted)]
+        )
+        agent._process = process
+        with (
+            patch(
+                "sculptor.agents.pi_agent.agent_wrapper.generate_id",
+                side_effect=["cmd-models", "cmd-state", "cmd-setmodel"],
+            ),
+            patch(
+                "sculptor.agents.pi_agent.agent_wrapper.compute_authenticated_provider_ids", return_value={"anthropic"}
+            ),
+        ):
+            agent._fetch_models_into_state()
+
+        # A set_model RPC adopted the preselected model on pi's side.
+        writes = [call.args[0] for call in process.write_stdin.call_args_list]
+        assert any('"type":"set_model"' in w and '"claude-sonnet-4-6"' in w for w in writes)
+
+        emitted = [m for m in _drain(agent._output_messages) if isinstance(m, ModelsAvailableAgentMessage)]
+        assert len(emitted) == 1
+        assert emitted[0].current_model is not None
+        assert emitted[0].current_model.model_id == "claude-sonnet-4-6"
+
+    def test_fetch_models_into_state_ignores_preselected_model_absent_from_catalog(self) -> None:
+        """A preselected model pi no longer offers (e.g. its provider was deauthorized)
+        is not adopted — the switcher falls back to pi's default rather than a model
+        that cannot run. No set_model RPC is sent for the unavailable model."""
+        preselected = ModelOption(provider="openrouter", model_id="openai/gpt-4o", display_name="GPT-4o")
+        agent = _make_agent(preselected_model=preselected)
+        pi_default = {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+        process = _make_process([_models_response(_RAW_PI_MODELS), _state_response_with_model(pi_default)])
+        agent._process = process
+        with (
+            patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-models", "cmd-state"]),
+            patch(
+                "sculptor.agents.pi_agent.agent_wrapper.compute_authenticated_provider_ids", return_value={"anthropic"}
+            ),
+        ):
+            agent._fetch_models_into_state()
+
+        writes = [call.args[0] for call in process.write_stdin.call_args_list]
+        assert not any('"type":"set_model"' in w for w in writes)
+        emitted = [m for m in _drain(agent._output_messages) if isinstance(m, ModelsAvailableAgentMessage)]
+        assert len(emitted) == 1
+        assert emitted[0].current_model is not None
+        assert emitted[0].current_model.model_id == "claude-opus-4-8"
+
+    def test_fetch_models_into_state_skips_set_model_when_preselected_is_pi_default(self) -> None:
+        """When the preselected model already matches pi's default, no redundant
+        set_model RPC is sent — the default is surfaced directly."""
+        preselected = ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8")
+        agent = _make_agent(preselected_model=preselected)
+        pi_default = {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+        process = _make_process([_models_response(_RAW_PI_MODELS), _state_response_with_model(pi_default)])
+        agent._process = process
+        with (
+            patch("sculptor.agents.pi_agent.agent_wrapper.generate_id", side_effect=["cmd-models", "cmd-state"]),
+            patch(
+                "sculptor.agents.pi_agent.agent_wrapper.compute_authenticated_provider_ids", return_value={"anthropic"}
+            ),
+        ):
+            agent._fetch_models_into_state()
+
+        writes = [call.args[0] for call in process.write_stdin.call_args_list]
+        assert not any('"type":"set_model"' in w for w in writes)
+        emitted = [m for m in _drain(agent._output_messages) if isinstance(m, ModelsAvailableAgentMessage)]
+        assert emitted[0].current_model is not None
+        assert emitted[0].current_model.model_id == "claude-opus-4-8"
 
     def test_handle_refresh_models_re_fetches_and_re_emits_catalog(self) -> None:
         """A delivered refresh re-runs the fetch between turns and re-emits the catalog.

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -236,11 +236,8 @@ def run_agent_task_v1(
                         input_message_queue, task_state, shutdown_event
                     )
 
-                    # A model switch made while waiting for the first message writes the
-                    # selection straight to task state (the set_model endpoint), out of
-                    # band from this in-memory copy. Pull those model fields back in so
-                    # the selection reaches agent construction and finalize_task_setup
-                    # does not write the stale in-memory value back over it.
+                    # A pre-first-message model switch is written to task state out of band
+                    # from this in-memory copy; re-read so the selection is not lost here.
                     task_state = _refresh_model_fields_from_db(task.object_id, task_state, services)
 
                     with title_prediction_context(

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -1161,7 +1161,7 @@ def _refresh_model_fields_from_db(
     agent waits for its first message, so this handler's in-memory copy goes stale.
     Refresh only those two fields (leaving the rest of the in-memory state as-is) so a
     pre-message switch reaches agent construction and survives `finalize_task_setup`'s
-    write-back. A no-op when nothing changed or the row is unreadable.
+    write-back. A no-op when nothing changed or the task row is missing.
     """
     with services.data_model_service.open_task_transaction() as transaction:
         task_row = transaction.get_task(task_id)

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -236,6 +236,13 @@ def run_agent_task_v1(
                         input_message_queue, task_state, shutdown_event
                     )
 
+                    # A model switch made while waiting for the first message writes the
+                    # selection straight to task state (the set_model endpoint), out of
+                    # band from this in-memory copy. Pull those model fields back in so
+                    # the selection reaches agent construction and finalize_task_setup
+                    # does not write the stale in-memory value back over it.
+                    task_state = _refresh_model_fields_from_db(task.object_id, task_state, services)
+
                     with title_prediction_context(
                         task_state,
                         initial_message,
@@ -1144,6 +1151,32 @@ def _record_available_models_in_state(
         task_state=task_state,
         services=services,
     )
+
+
+def _refresh_model_fields_from_db(
+    task_id: TaskID,
+    task_state: AgentTaskStateV2,
+    services: ServiceCollectionForTask,
+) -> AgentTaskStateV2:
+    """Pull the switcher's model fields (`available_models` / `current_model`) from the DB.
+
+    The set_model endpoint writes the selected model straight to task state while the
+    agent waits for its first message, so this handler's in-memory copy goes stale.
+    Refresh only those two fields (leaving the rest of the in-memory state as-is) so a
+    pre-message switch reaches agent construction and survives `finalize_task_setup`'s
+    write-back. A no-op when nothing changed or the row is unreadable.
+    """
+    with services.data_model_service.open_task_transaction() as transaction:
+        task_row = transaction.get_task(task_id)
+    if task_row is None:
+        return task_state
+    db_state = AgentTaskStateV2.model_validate(task_row.current_state)
+    if db_state.available_models == task_state.available_models and db_state.current_model == task_state.current_model:
+        return task_state
+    mutable_task_state = evolver(task_state)
+    assign(mutable_task_state.available_models, lambda: db_state.available_models)
+    assign(mutable_task_state.current_model, lambda: db_state.current_model)
+    return chill(mutable_task_state)
 
 
 def _persist_available_models(

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -71,7 +71,9 @@ Model selection: ``get_available_models`` returns a fixed catalog (``_FAKE_PI_MO
 and ``get_state`` reports a current model, so PiAgent surfaces them onto task state
 and the chat switcher offers pi's own models. ``set_model`` echoes the chosen model
 back and updates the current model, so a switch persists for a following ``get_state``
-— the hook the model-selection integration test asserts on.
+— the hook the model-selection integration test asserts on. The ``fake_pi:report_model``
+directive echoes that current model into the turn text, so a test can assert a switch
+reached pi (the turn ran under it), not just that the switcher's display updated.
 
 Wire-protocol reference: the pi RPC protocol notes (pi 0.78.0).
 """
@@ -902,6 +904,19 @@ def _handle_report_inputs(args: dict, builder: _TurnBuilder, abort_event: Event,
     builder.emit(summary)
 
 
+def _handle_report_model(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
+    """Echo the model FakePi is running this turn (its session `current_model`).
+
+    Lets a test assert that a model switch actually reached pi — that the turn ran
+    under the selected model — not merely that the switcher's display updated.
+    """
+    model_id = state.current_model.get("id", "") if state.current_model else ""
+    summary = f"[FakePi] current_model={model_id}"
+    accumulated = builder.full_text + summary
+    _emit_text_delta(summary, accumulated)
+    builder.emit(summary)
+
+
 def _handle_wait_for_file(args: dict, builder: _TurnBuilder, abort_event: Event, state: _SessionState) -> None:
     timeout_seconds = float(args.get("timeout_seconds", 120))
     sentinel = Path(args["path"])
@@ -999,6 +1014,7 @@ _COMMAND_REGISTRY: dict[str, Callable[[dict, _TurnBuilder, Event, _SessionState]
     "wait_for_file": _handle_wait_for_file,
     "recall": _handle_recall,
     "report_inputs": _handle_report_inputs,
+    "report_model": _handle_report_model,
     "compaction": _handle_compaction,
     "ui_request": _handle_ui_request,
 }

--- a/sculptor/sculptor/testing/fake_pi_test.py
+++ b/sculptor/sculptor/testing/fake_pi_test.py
@@ -726,6 +726,20 @@ def test_fake_pi_set_model_rejects_unknown_model() -> None:
     assert state["data"]["model"]["id"] == "fake-pi-opus-4-8"
 
 
+def test_fake_pi_report_model_echoes_the_switched_current_model() -> None:
+    """`fake_pi:report_model` echoes the session's current model into the turn text, and a
+    preceding `set_model` is reflected — the hook the pre-message-switch integration test
+    uses to prove a switch reached pi (the turn ran under it), not just the display."""
+    set_model = json.dumps({"type": "set_model", "id": "sm", "provider": "anthropic", "modelId": "fake-pi-sonnet-4-6"})
+    result = _run_fake_pi(
+        ["--mode", "rpc", "--no-session", "--append-system-prompt", ""],
+        stdin_input=set_model + "\n" + _send_prompt("fake_pi:report_model"),
+    )
+    assert result.returncode == 0
+    events = _parse_jsonl(result.stdout)
+    assert "fake-pi-sonnet-4-6" in _last_assistant_text(events)
+
+
 def test_fake_pi_rpc_rejects_non_rpc_mode_with_exit_2() -> None:
     result = _run_fake_pi(["--mode", "something-else"])
 

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2736,6 +2736,13 @@ def interrupt_workspace_agent(
             )
 
 
+# How long the set-model request waits for a live agent to resolve the switch (so a
+# rejection surfaces as a synchronous 400 the frontend can toast). A switch that
+# nothing resolves in time — most importantly, a pre-first-message switch with no live
+# agent — returns 200 on the optimistic write rather than hanging.
+_SET_MODEL_OUTCOME_TIMEOUT_SECONDS = 5.0
+
+
 @router.post("/api/v1/workspaces/{workspace_id}/agents/{agent_id}/set_model")
 def set_workspace_agent_model(
     workspace_id: str,
@@ -2776,14 +2783,40 @@ def set_workspace_agent_model(
         # SetModelUserMessage handler, so reject it rather than block the request
         # forever on a message nothing resolves.
         model_state = task.current_state if isinstance(task.current_state, AgentTaskStateV2) else None
-        if not harness.get_available_models(model_state):
+        available_models = harness.get_available_models(model_state)
+        if not available_models:
             raise HTTPException(
                 status_code=400,
                 detail="this agent does not support switching models",
             )
 
+    # Optimistically reflect the switch in task state so the server-driven switcher
+    # updates at once — even before a pi process exists to acknowledge it, which is
+    # the source of the "sticky" pre-message selector. The agent reconciles pi to this
+    # selection when it next runs (adopting it at start, or on the queued switch) and
+    # rolls it back if pi rejects it. Only a model pi actually offers is written; an
+    # unknown model is left for the switch below to reject.
+    selected_model = next(
+        (
+            option
+            for option in available_models
+            if option.provider == set_model_request.provider and option.model_id == set_model_request.model_id
+        ),
+        None,
+    )
+    if selected_model is not None:
+        with user_session.open_transaction(services) as transaction:
+            services.task_service.update_available_models(
+                task_id=task.object_id,
+                available_models=available_models,
+                current_model=selected_model,
+                transaction=transaction,
+            )
+
     message_id = AgentMessageID()
-    with await_request_outcome(message_id, task.object_id, services) as outcome:
+    with await_request_outcome(
+        message_id, task.object_id, services, timeout=_SET_MODEL_OUTCOME_TIMEOUT_SECONDS
+    ) as outcome:
         with user_session.open_transaction(services) as transaction:
             services.task_service.create_message(
                 message=SetModelUserMessage(
@@ -2794,8 +2827,10 @@ def set_workspace_agent_model(
                 task_id=task.object_id,
                 transaction=transaction,
             )
-    # The adapter resolves a rejected switch (e.g. pi "Model not found") as a
-    # RequestFailure; surface it to the caller so the frontend toasts it.
+    # A live agent that rejects the switch resolves it as a RequestFailure within the
+    # wait; surface it as a 400 so the frontend toasts. A switch nothing resolves in
+    # time (no live agent yet) returns 200 — the optimistic write already reflects the
+    # selection, and the agent applies (or rolls back) the switch when it next runs.
     terminal = outcome[0] if outcome else None
     if isinstance(terminal, RequestFailureAgentMessage):
         detail = str(terminal.error.args[0]) if terminal.error.args else "Failed to set model"
@@ -2930,21 +2965,29 @@ def await_request_outcome(
     message_id: AgentMessageID,
     task_id: TaskID,
     services: CompleteServiceCollection,
+    timeout: float,
 ) -> Generator[list[PersistentRequestCompleteAgentMessage], None, None]:
-    """Like `await_message_response`, but captures the terminal request message.
+    """Like `await_message_response`, but captures the terminal request message and
+    bounds the wait.
 
     Yields a one-element list the caller reads after the block to inspect the
     outcome (e.g. distinguish RequestSuccess from RequestFailure and surface the
-    failure to the HTTP caller). The list is empty only if the subscription is
-    torn down before the request resolves.
+    failure to the HTTP caller). The list is empty if the subscription is torn down
+    before the request resolves, or if `timeout` (seconds) elapses first — so a
+    request nothing resolves (e.g. no live agent to process the message) returns
+    rather than blocking forever.
     """
     outcome: list[PersistentRequestCompleteAgentMessage] = []
     with services.task_service.subscribe_to_task(task_id) as updates_queue:
         yield outcome
         logger.debug("Waiting for outcome of message {} in task {}", message_id, task_id)
+        deadline = time.monotonic() + timeout
         while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
             try:
-                update = updates_queue.get(timeout=1.0)
+                update = updates_queue.get(timeout=min(1.0, remaining))
             except queue.Empty:
                 pass
             else:

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -92,7 +92,6 @@ from sculptor.interfaces.agents.agent import PersistentRequestCompleteAgentMessa
 from sculptor.interfaces.agents.agent import PiAgentConfig
 from sculptor.interfaces.agents.agent import RegisteredTerminalAgentConfig
 from sculptor.interfaces.agents.agent import RemoveQueuedMessageUserMessage
-from sculptor.interfaces.agents.agent import RequestFailureAgentMessage
 from sculptor.interfaces.agents.agent import SetModelUserMessage
 from sculptor.interfaces.agents.agent import TerminalAgentConfig
 from sculptor.interfaces.agents.agent import TerminalAgentSignalRunnerMessage
@@ -2736,13 +2735,6 @@ def interrupt_workspace_agent(
             )
 
 
-# How long the set-model request waits for a live agent to resolve the switch (so a
-# rejection surfaces as a synchronous 400 the frontend can toast). A switch that
-# nothing resolves in time — most importantly, a pre-first-message switch with no live
-# agent — returns 200 on the optimistic write rather than hanging.
-_SET_MODEL_OUTCOME_TIMEOUT_SECONDS = 5.0
-
-
 @router.post("/api/v1/workspaces/{workspace_id}/agents/{agent_id}/set_model")
 def set_workspace_agent_model(
     workspace_id: str,
@@ -2754,9 +2746,11 @@ def set_workspace_agent_model(
     """Switch a running agent's model (the pi out-of-band `set_model` path).
 
     Used by harnesses with a backend model list (pi); Claude's model rides each
-    turn instead. The request blocks until the agent resolves the switch and
-    returns 400 with the agent's error message when the switch is rejected (e.g.
-    pi reports "Model not found"), so the frontend can toast it.
+    turn instead. Rejects (400) a harness that cannot switch models or a model not
+    in the agent's catalog; otherwise records the selection — written onto task
+    state so the server-driven switcher reflects it at once (even before a pi
+    process exists) and enqueued for the agent, which applies it to pi when it next
+    runs and rolls the switcher back if pi rejects it.
     """
     services = get_services_from_request_or_websocket(request)
 
@@ -2778,10 +2772,9 @@ def set_workspace_agent_model(
                 detail="model selection requires a harness that supports it",
             )
         # supports_model_selection also covers per-turn switching (Claude); the
-        # out-of-band set_model RPC is only honored by a harness that sources a
+        # out-of-band set_model path is only honored by a harness that sources a
         # backend model list (pi). A harness without a catalog has no
-        # SetModelUserMessage handler, so reject it rather than block the request
-        # forever on a message nothing resolves.
+        # SetModelUserMessage handler.
         model_state = task.current_state if isinstance(task.current_state, AgentTaskStateV2) else None
         available_models = harness.get_available_models(model_state)
         if not available_models:
@@ -2789,51 +2782,42 @@ def set_workspace_agent_model(
                 status_code=400,
                 detail="this agent does not support switching models",
             )
-
-    # Optimistically reflect the switch in task state so the server-driven switcher
-    # updates at once, even before a pi process exists to acknowledge it. The agent
-    # reconciles pi to this selection when it next runs (adopting it at start, or on the
-    # queued switch) and rolls it back if pi rejects it. Only a model pi actually offers
-    # is written; an unknown model is left for the switch below to reject.
-    selected_model = next(
-        (
-            option
-            for option in available_models
-            if option.provider == set_model_request.provider and option.model_id == set_model_request.model_id
-        ),
-        None,
-    )
-    if selected_model is not None:
-        with user_session.open_transaction(services) as transaction:
-            services.task_service.update_available_models(
-                task_id=task.object_id,
-                available_models=available_models,
-                current_model=selected_model,
-                transaction=transaction,
+        # The switcher only offers models from this catalog, so a request for anything
+        # else cannot be honored — reject it rather than record a selection the agent
+        # would never apply (with no live agent, that would be a silent no-op).
+        selected_model = next(
+            (
+                option
+                for option in available_models
+                if option.provider == set_model_request.provider and option.model_id == set_model_request.model_id
+            ),
+            None,
+        )
+        if selected_model is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"model {set_model_request.provider}/{set_model_request.model_id} is not available for this agent",
             )
 
-    message_id = AgentMessageID()
-    with await_request_outcome(
-        message_id, task.object_id, services, timeout=_SET_MODEL_OUTCOME_TIMEOUT_SECONDS
-    ) as outcome:
-        with user_session.open_transaction(services) as transaction:
-            services.task_service.create_message(
-                message=SetModelUserMessage(
-                    message_id=message_id,
-                    provider=set_model_request.provider,
-                    model_id=set_model_request.model_id,
-                ),
-                task_id=task.object_id,
-                transaction=transaction,
-            )
-    # A live agent that rejects the switch resolves it as a RequestFailure within the
-    # wait; surface it as a 400 so the frontend toasts. A switch nothing resolves in
-    # time (no live agent yet) returns 200 — the optimistic write already reflects the
-    # selection, and the agent applies (or rolls back) the switch when it next runs.
-    terminal = outcome[0] if outcome else None
-    if isinstance(terminal, RequestFailureAgentMessage):
-        detail = str(terminal.error.args[0]) if terminal.error.args else "Failed to set model"
-        raise HTTPException(status_code=400, detail=detail)
+    # Record the selection in one write: reflect it on the server-driven switcher now
+    # (optimistically, so it updates even with no live agent to acknowledge it), and
+    # enqueue the switch for the agent to apply to pi — adopted at start, or on the
+    # queued message — rolling the switcher back if pi rejects it.
+    with user_session.open_transaction(services) as transaction:
+        services.task_service.update_available_models(
+            task_id=task.object_id,
+            available_models=available_models,
+            current_model=selected_model,
+            transaction=transaction,
+        )
+        services.task_service.create_message(
+            message=SetModelUserMessage(
+                provider=set_model_request.provider,
+                model_id=set_model_request.model_id,
+            ),
+            task_id=task.object_id,
+            transaction=transaction,
+        )
 
 
 @router.post("/api/v1/workspaces/{workspace_id}/agents/{agent_id}/btw")
@@ -2956,43 +2940,6 @@ def await_message_response(
             else:
                 if isinstance(update, PersistentRequestCompleteAgentMessage):
                     if update.request_id == message_id:
-                        break
-
-
-@contextlib.contextmanager
-def await_request_outcome(
-    message_id: AgentMessageID,
-    task_id: TaskID,
-    services: CompleteServiceCollection,
-    timeout: float,
-) -> Generator[list[PersistentRequestCompleteAgentMessage], None, None]:
-    """Like `await_message_response`, but captures the terminal request message and
-    bounds the wait.
-
-    Yields a one-element list the caller reads after the block to inspect the
-    outcome (e.g. distinguish RequestSuccess from RequestFailure and surface the
-    failure to the HTTP caller). The list is empty if the subscription is torn down
-    before the request resolves, or if `timeout` (seconds) elapses first — so a
-    request nothing resolves (e.g. no live agent to process the message) returns
-    rather than blocking forever.
-    """
-    outcome: list[PersistentRequestCompleteAgentMessage] = []
-    with services.task_service.subscribe_to_task(task_id) as updates_queue:
-        yield outcome
-        logger.debug("Waiting for outcome of message {} in task {}", message_id, task_id)
-        deadline = time.monotonic() + timeout
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            try:
-                update = updates_queue.get(timeout=min(1.0, remaining))
-            except queue.Empty:
-                pass
-            else:
-                if isinstance(update, PersistentRequestCompleteAgentMessage):
-                    if update.request_id == message_id:
-                        outcome.append(update)
                         break
 
 

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2791,11 +2791,10 @@ def set_workspace_agent_model(
             )
 
     # Optimistically reflect the switch in task state so the server-driven switcher
-    # updates at once — even before a pi process exists to acknowledge it, which is
-    # the source of the "sticky" pre-message selector. The agent reconciles pi to this
-    # selection when it next runs (adopting it at start, or on the queued switch) and
-    # rolls it back if pi rejects it. Only a model pi actually offers is written; an
-    # unknown model is left for the switch below to reject.
+    # updates at once, even before a pi process exists to acknowledge it. The agent
+    # reconciles pi to this selection when it next runs (adopting it at start, or on the
+    # queued switch) and rolls it back if pi rejects it. Only a model pi actually offers
+    # is written; an unknown model is left for the switch below to reject.
     selected_model = next(
         (
             option

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -8,7 +8,6 @@ NOTE: Endpoints are not currently tested for cross-user authorization (preventin
 
 from pathlib import Path
 from typing import Generator
-from unittest.mock import patch
 
 import httpx
 import pytest
@@ -720,12 +719,11 @@ def test_set_model_before_first_message_persists_selection_without_a_live_agent(
         task = _create_pi_task_with_catalog(
             transaction, user_session, test_project, test_services, workspace, current_model=_PI_CATALOG[0]
         )
-    # No agent runs to resolve the switch; a short outcome bound keeps the test fast.
-    with patch("sculptor.web.app._SET_MODEL_OUTCOME_TIMEOUT_SECONDS", 0.5):
-        response = client.post(
-            f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/set_model",
-            json=model_dump(SetModelRequest(provider="anthropic", model_id="claude-haiku-4-5"), is_camel_case=True),
-        )
+    # No agent runs to resolve the switch; the endpoint records the selection and returns.
+    response = client.post(
+        f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/set_model",
+        json=model_dump(SetModelRequest(provider="anthropic", model_id="claude-haiku-4-5"), is_camel_case=True),
+    )
     assert response.status_code == 200, response.text
     with user_session.open_transaction(test_services) as transaction:
         updated = test_services.task_service.get_task(task.object_id, transaction)
@@ -733,6 +731,31 @@ def test_set_model_before_first_message_persists_selection_without_a_live_agent(
     state = AgentTaskStateV2.model_validate(updated.current_state)
     assert state.current_model is not None
     assert state.current_model.model_id == "claude-haiku-4-5"
+
+
+def test_set_model_rejects_a_model_not_in_the_catalog(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    """A model the agent's catalog does not offer is rejected at the boundary (400)
+    rather than recorded as a selection the agent would never apply."""
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        workspace = _create_workspace(transaction, test_services, test_project)
+        task = _create_pi_task_with_catalog(
+            transaction, user_session, test_project, test_services, workspace, current_model=_PI_CATALOG[0]
+        )
+    response = client.post(
+        f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/set_model",
+        json=model_dump(SetModelRequest(provider="anthropic", model_id="claude-not-a-real-model"), is_camel_case=True),
+    )
+    assert response.status_code == 400, response.text
+    # The rejected request leaves the current model untouched.
+    with user_session.open_transaction(test_services) as transaction:
+        updated = test_services.task_service.get_task(task.object_id, transaction)
+    assert updated is not None
+    state = AgentTaskStateV2.model_validate(updated.current_state)
+    assert state.current_model is not None
+    assert state.current_model.model_id == _PI_CATALOG[0].model_id
 
 
 def test_update_naming_pattern_performs_update(

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -8,6 +8,7 @@ NOTE: Endpoints are not currently tested for cross-user authorization (preventin
 
 from pathlib import Path
 from typing import Generator
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -45,6 +46,7 @@ from sculptor.services.user_config.user_config import set_user_config_instance
 from sculptor.state.chat_state import ToolUseBlock
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import LLMModel
+from sculptor.state.messages import ModelOption
 from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.web.app import _agent_config_for_request
 from sculptor.web.auth import SESSION_TOKEN_HEADER_NAME
@@ -672,6 +674,65 @@ def test_set_model_rejects_claude_harness_without_a_backend_catalog(
         json=model_dump(SetModelRequest(provider="anthropic", model_id="claude-haiku-4-5"), is_camel_case=True),
     )
     assert response.status_code == 400, response.text
+
+
+_PI_CATALOG = [
+    ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8"),
+    ModelOption(provider="anthropic", model_id="claude-haiku-4-5", display_name="Claude Haiku 4.5"),
+]
+
+
+def _create_pi_task_with_catalog(
+    transaction: DataModelTransaction,
+    user_session: UserSession,
+    project: Project,
+    services: CompleteServiceCollection,
+    workspace: Workspace,
+    current_model: ModelOption,
+) -> Task:
+    """A pi task whose state already carries pi's catalog (as the pre-message probe
+    leaves it) but with no live agent — the pre-first-message situation."""
+    task = Task(
+        object_id=TaskID(),
+        user_reference=user_session.user_reference,
+        organization_reference=user_session.organization_reference,
+        project_id=project.object_id,
+        input_data=AgentTaskInputsV2(agent_config=PiAgentConfig(), git_hash="doesn't matter", system_prompt=None),
+        current_state=AgentTaskStateV2(
+            workspace_id=workspace.object_id,
+            available_models=list(_PI_CATALOG),
+            current_model=current_model,
+        ),
+    )
+    services.task_service.create_task(task, transaction)
+    return task
+
+
+def test_set_model_before_first_message_persists_selection_without_a_live_agent(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    """A pi model switch made before the first message (no live agent to acknowledge it)
+    optimistically persists the selection onto task state, so the server-driven switcher
+    updates at once, and the request returns rather than hanging (SCU-1605)."""
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        workspace = _create_workspace(transaction, test_services, test_project)
+        task = _create_pi_task_with_catalog(
+            transaction, user_session, test_project, test_services, workspace, current_model=_PI_CATALOG[0]
+        )
+    # No agent runs to resolve the switch; a short outcome bound keeps the test fast.
+    with patch("sculptor.web.app._SET_MODEL_OUTCOME_TIMEOUT_SECONDS", 0.5):
+        response = client.post(
+            f"/api/v1/workspaces/{workspace.object_id}/agents/{task.object_id}/set_model",
+            json=model_dump(SetModelRequest(provider="anthropic", model_id="claude-haiku-4-5"), is_camel_case=True),
+        )
+    assert response.status_code == 200, response.text
+    with user_session.open_transaction(test_services) as transaction:
+        updated = test_services.task_service.get_task(task.object_id, transaction)
+    assert updated is not None
+    state = AgentTaskStateV2.model_validate(updated.current_state)
+    assert state.current_model is not None
+    assert state.current_model.model_id == "claude-haiku-4-5"
 
 
 def test_update_naming_pattern_performs_update(

--- a/sculptor/tests/integration/frontend/test_pi_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_pi_capability_gating.py
@@ -319,6 +319,75 @@ def test_fresh_pi_agent_switcher_shows_pi_models_without_a_message(sculptor_inst
     page.keyboard.press("Escape")
 
 
+@user_story("to switch a fresh pi agent's model before sending any message and see the switcher update")
+def test_pi_model_switch_before_first_message_updates_switcher(sculptor_instance_: SculptorInstance) -> None:
+    """Switching a fresh pi agent's model BEFORE the first message updates the switcher
+    right away, instead of staying stuck on the old model until a turn runs (SCU-1605).
+
+    No message is sent, so no pi process is live to echo the switch; the selection is
+    persisted onto task state optimistically, and the server-driven switcher reflects
+    it. The switch is applied to pi (and reconciled) only when the agent later runs."""
+    install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
+    page = sculptor_instance_.page
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        workspace_name="Pi Pre-Message Switch",
+        model_name=None,
+        agent_type="pi",
+    )
+    chat_panel = task_page.get_chat_panel()
+    default_model_name = _FAKE_PI_MODELS[0]["name"]
+    other_model_name = _FAKE_PI_MODELS[2]["name"]
+
+    # The fresh switcher shows pi's default model before any message.
+    expect(chat_panel.get_model_selector()).to_contain_text(default_model_name, timeout=30000)
+
+    # Switch to a different model with no message sent (no live agent to echo it).
+    select_model_by_name(chat_panel=chat_panel, model_name=other_model_name)
+
+    # The switcher reflects the new selection immediately, with no failure surfaced.
+    expect(chat_panel.get_model_selector()).to_contain_text(other_model_name)
+    expect(page.get_by_test_id(ElementIDs.TOAST).filter(has_text="Failed to switch")).to_have_count(0)
+
+
+@user_story("to switch a fresh pi agent's model before the first message and have that model run the turn")
+def test_pi_pre_message_switch_is_applied_to_the_first_turn(sculptor_instance_: SculptorInstance) -> None:
+    """After switching a fresh pi agent's model BEFORE the first message, the first turn
+    runs under the selected model and the switcher stays on it — the pre-message selection
+    is reconciled onto pi at start rather than reverting to pi's default (SCU-1605).
+
+    `fake_pi:report_model` echoes the model pi ran the turn under, so this asserts the
+    switch actually reached pi, not merely that the switcher's display updated."""
+    install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
+    page = sculptor_instance_.page
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        workspace_name="Pi Pre-Message Switch Applied",
+        model_name=None,
+        agent_type="pi",
+    )
+    chat_panel = task_page.get_chat_panel()
+    default_model_name = _FAKE_PI_MODELS[0]["name"]
+    other_model_name = _FAKE_PI_MODELS[2]["name"]
+    other_model_id = _FAKE_PI_MODELS[2]["id"]
+
+    # Switch to a non-default model before sending any message.
+    expect(chat_panel.get_model_selector()).to_contain_text(default_model_name, timeout=30000)
+    select_model_by_name(chat_panel=chat_panel, model_name=other_model_name)
+    # The switch has visibly landed (its optimistic write persisted) before the first
+    # message starts the agent, so the turn below cannot race ahead of the selection.
+    expect(chat_panel.get_model_selector()).to_contain_text(other_model_name)
+
+    # Send the first message; fake_pi echoes the model it actually runs the turn under.
+    send_chat_message(chat_panel=chat_panel, message="fake_pi:report_model")
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2, timeout=30000)
+
+    # The turn ran under the model chosen pre-message (not pi's default), and the switcher
+    # stays on it through first-turn startup — no revert or flicker.
+    expect(chat_panel.get_assistant_messages().last).to_contain_text(other_model_id)
+    expect(chat_panel.get_model_selector()).to_contain_text(other_model_name)
+
+
 @pytest.mark.parametrize("harness", ["claude", "pi"], indirect=True)
 @user_story("to attach files in a pi workspace and have images and paths reach the agent")
 def test_uploads_usable_and_deliver_under_pi(sculptor_instance_: SculptorInstance, harness: HarnessTestConfig) -> None:


### PR DESCRIPTION
## Summary

Fix the Pi model selector appearing "stuck" on the old model when you switch **before** sending the first message.

The Pi switcher is server-driven off the agent's `current_model` in task state, but that field was only ever written by a *live* agent — and the Pi agent isn't started until the first chat message. So a pre-message switch didn't register until the first turn ran.

## Approach

Persist the selection to task state at switch time, so the server-driven switcher updates immediately and durably (it survives a page refresh), independent of whether an agent is live. **Task state is the single source of truth; the agent reconciles pi to it** rather than the reverse.

- **`set_model` endpoint** — validates the requested model against the agent's catalog (400 if it isn't offered), then *records* the selection in one write: an optimistic switcher update plus an enqueued switch. It returns immediately — it does not wait on the agent.
- **Run-agent handler** — re-reads the model fields from the DB after the initial-message wait, so the selection reaches agent construction and isn't clobbered by stale in-memory state.
- **Pi agent** — at start, adopts the persisted selection onto pi (the first turn runs under it, with no flicker back to pi's default); on a rejected switch it rolls the switcher back to pi's real model. The agent is the sole authority for reconciling model state — there is no separate endpoint wait to keep in sync.

## Testing

- **Unit** — start-time adoption (adopt / skip-when-already-default / ignore-gone-model), rejection rollback, and boundary validation (unknown model → 400).
- **Endpoint** — `set_model` with no live agent records the selection and returns 200 (no hang).
- **Browser end-to-end (2)** — a pre-message switch updates the switcher; and a pre-message switch actually runs the first turn under the chosen model (via a `fake_pi:report_model` directive) and stays put through startup.

Backend checks green (ruff, pyrefly, ratchets); unit + endpoint suites pass.

## Review follow-up

Rejects a model not in the catalog at the API boundary instead of recording a silent no-op. Since that makes a pi rejection a rare edge the agent already reconciles, the endpoint collapses to record-only — deleting the bounded-wait machinery so the agent is the single authority on model state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
