### PR TITLE
Fix flaky placeholder regression test: Enter is bound to send in the harness (SCU-1663)

### DIFF
--- a/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
+++ b/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
@@ -20,7 +20,7 @@ import re
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.base import get_tiptap_placeholder_paragraphs
-from sculptor.testing.elements.base import type_into_tiptap
+from sculptor.testing.elements.base import type_paragraphs_into_tiptap
 from sculptor.testing.elements.base import type_trigger_char
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -106,22 +106,21 @@ def test_placeholder_hidden_when_editor_has_content(sculptor_instance_: Sculptor
 
     chat_input = chat_panel.get_chat_input()
 
-    # Type text into the editor
-    type_into_tiptap(page, chat_input, "hello world")
+    # Build the regressed document: an empty first paragraph above real content —
+    # the state a user reaches by pressing Enter at the start of their text.
+    #
+    # We assemble it with editor commands rather than a literal
+    # ``page.keyboard.press("Enter")``. The integration harness binds
+    # ``send_message`` to Enter, so a raw Enter keystroke here submits the draft
+    # and clears the editor instead of splitting the paragraph. An empty editor
+    # then renders the placeholder (``editor.isEmpty`` is true), which is exactly
+    # the false failure this test used to hit. ``type_paragraphs_into_tiptap``
+    # drives ``editor.commands.enter()``, which bypasses the send keybinding.
+    type_paragraphs_into_tiptap(chat_input, ["", "hello world"])
     expect(chat_input).to_contain_text("hello world")
 
-    # page.keyboard.press acts on whatever currently holds focus. The chat input
-    # can remount after the agent settles, leaving focus on a detached editor;
-    # re-focus the live contenteditable so the keystrokes below provably edit the
-    # editor holding "hello world" rather than a stale one.
-    chat_input.click()
-    expect(chat_input).to_be_focused()
-
-    # Move cursor to the beginning and press Enter to create an empty paragraph above
-    page.keyboard.press("Home")
-    page.keyboard.press("Enter")
-    page.keyboard.press("ArrowUp")
-
-    # The placeholder text must NOT appear — the editor has content ("hello world").
+    # The placeholder text must NOT appear on the empty first paragraph: the
+    # editor has content, so ``editor.isEmpty`` is false and the Placeholder
+    # extension emits ``data-placeholder=""`` there instead of the prompt text.
     placeholder_paragraphs = get_tiptap_placeholder_paragraphs(chat_input, PLACEHOLDER_TEXT)
     expect(placeholder_paragraphs).to_have_count(0)

--- a/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
+++ b/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
@@ -110,12 +110,11 @@ def test_placeholder_hidden_when_editor_has_content(sculptor_instance_: Sculptor
     # the state a user reaches by pressing Enter at the start of their text.
     #
     # We assemble it with editor commands rather than a literal
-    # ``page.keyboard.press("Enter")``. The integration harness binds
-    # ``send_message`` to Enter, so a raw Enter keystroke here submits the draft
-    # and clears the editor instead of splitting the paragraph. An empty editor
-    # then renders the placeholder (``editor.isEmpty`` is true), which is exactly
-    # the false failure this test used to hit. ``type_paragraphs_into_tiptap``
-    # drives ``editor.commands.enter()``, which bypasses the send keybinding.
+    # ``page.keyboard.press("Enter")``: the integration harness binds
+    # ``send_message`` to Enter, so a raw Enter keystroke here would submit the
+    # draft and clear the editor instead of splitting the paragraph.
+    # ``type_paragraphs_into_tiptap`` drives ``editor.commands.enter()``, which
+    # bypasses the send keybinding.
     type_paragraphs_into_tiptap(chat_input, ["", "hello world"])
     expect(chat_input).to_contain_text("hello world")
 

--- a/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
+++ b/sculptor/tests/integration/regression/test_regression_prompt_placeholder.py
@@ -110,6 +110,13 @@ def test_placeholder_hidden_when_editor_has_content(sculptor_instance_: Sculptor
     type_into_tiptap(page, chat_input, "hello world")
     expect(chat_input).to_contain_text("hello world")
 
+    # page.keyboard.press acts on whatever currently holds focus. The chat input
+    # can remount after the agent settles, leaving focus on a detached editor;
+    # re-focus the live contenteditable so the keystrokes below provably edit the
+    # editor holding "hello world" rather than a stale one.
+    chat_input.click()
+    expect(chat_input).to_be_focused()
+
     # Move cursor to the beginning and press Enter to create an empty paragraph above
     page.keyboard.press("Home")
     page.keyboard.press("Enter")


### PR DESCRIPTION
## Summary

`tests/integration/regression/test_regression_prompt_placeholder.py::test_placeholder_hidden_when_editor_has_content` intermittently hard-failed the merge_group pipeline and blocked PR #245 (Offload run 28563782305, job 84686795360): `expect(placeholder_paragraphs).to_have_count(0)` returned 1 for the full timeout because the editor was empty when the placeholder assertion ran.

## Root cause

The test built its "empty first paragraph above content" state by typing "hello world" and then pressing a bare `page.keyboard.press("Enter")`. But the integration harness binds `send_message` to Enter, so that keystroke **submitted the draft and cleared the editor** instead of splitting the paragraph. An empty editor correctly renders the placeholder (`editor.isEmpty` is true), so `to_have_count(0)` failed. This is a test-construction bug, not a product bug.

## The fix

Build the document with `type_paragraphs_into_tiptap(["", "hello world"])`, which drives `editor.commands.enter()` and bypasses the send keybinding — so the editor keeps its content and the empty-first-paragraph state is exercised directly. Test-side only.

## Production config deliberately untouched

The production Placeholder config at `frontend/src/components/TipTapConfig.ts` — `showOnlyCurrent: false` with `placeholder: ({ editor }) => (editor.isEmpty ? placeholder : "")` — is correct: with content present, `editor.isEmpty` is false, so empty paragraphs get `data-placeholder=""` and the prompt text never appears. It is intentionally **NOT** modified.

## Note on the branch history

The first commit on this branch added a focus guard (`chat_input.click()` + `expect(...).to_be_focused()`) before the keystrokes. That made the failure *deterministic* rather than fixing it — by guaranteeing focus on the live editor it ensured the bare Enter always landed and always sent, which is why the merge_group run failed on every retry. The follow-up commit replaces that approach with the `type_paragraphs_into_tiptap` construction above (the actual fix); a final commit trims incidental history from a comment.

## Test plan

- [x] `just format`
- [x] `just check` (ratchets, typecheck, lint, file-hygiene all OK)
- [x] `/code-review-checklist` + `/crispy-comments`
- [x] Full test file passes locally — 2 passed via the integration runner (verified on the fix commit; note that a healthy runner is required, as agent creation is gated on free disk space)

(Sent by Claude)
