### PR TITLE
Fix SCU-1660: don't end the turn when a task-notification precedes the user prompt

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -302,6 +302,26 @@ class ClaudeOutputProcessor:
         # for the wakeup turn (a second init → assistant → result cycle) to
         # arrive from the CLI.
         self._pending_wakeup: bool = False
+        # SCU-1660: when a Monitor background task completes at the instant a
+        # new prompt is dispatched, the CLI delivers the pending
+        # ``<task-notification>`` as a full turn (init → assistant → result)
+        # *before* it processes the user's message — all in the single CLI
+        # process spawned for that prompt. That notification turn's ``result``
+        # must NOT end the loop, or the process manager tears the CLI down while
+        # the user's real request has run at most one tool call.
+        #
+        # ``_awaiting_notification_turn_init`` is armed when a task-notification
+        # arrives before the user's turn has ended (found_final_message still
+        # False). It is only *confirmed* as a separate turn if a new
+        # ``system/init`` (a fresh request cycle) then arrives — that is what
+        # distinguishes a notification delivered as its own turn (this bug)
+        # from an inline mid-turn notification that does not start a new cycle
+        # (SCU-267). On confirmation the flag is promoted into
+        # ``_pending_notification_turn_results``: a count of notification-turn
+        # results still to be skipped so the loop stays open for the user's own
+        # turn.
+        self._awaiting_notification_turn_init: bool = False
+        self._pending_notification_turn_results: int = 0
         # Last time we received any stdout line from the CLI. Used to detect
         # hangs where the CLI stops producing output after an interrupt.
         self._last_output_time: float = time.monotonic()
@@ -674,11 +694,28 @@ class ClaudeOutputProcessor:
                 if not self._completed_pending_deferred:
                     self._completed_pending_deferred_deadline = None
                 # A new turn (init → assistant → result) always follows a
-                # task_notification, so reset found_final_message to keep the
-                # loop open for it.  Without this, the loop exits immediately
-                # after the last pending task is cleared — before reading the
-                # post-notification assistant response.
-                self.found_final_message = False
+                # task_notification. Keep the loop open for it — but the way we
+                # do that depends on whether the user's own message turn has
+                # already ended:
+                #
+                #  - found_final_message is True: the common ordering — the
+                #    user's turn finished, THEN the background task completed.
+                #    The notification's follow-up turn is the LAST turn, so
+                #    clearing found_final_message here (and letting the
+                #    follow-up's result set it again) is exactly right.
+                #
+                #  - found_final_message is False: the notification arrived
+                #    BEFORE the user's turn produced a result. Either the CLI is
+                #    delivering it ahead of the user's prompt as its own turn
+                #    (SCU-1660), or it is an inline mid-turn notification with no
+                #    new request cycle (SCU-267). We cannot yet tell which, so
+                #    arm the flag; _parse_init_response confirms the former if a
+                #    fresh init follows, and _parse_stream_end_response drops it
+                #    for the latter.
+                if self.found_final_message:
+                    self.found_final_message = False
+                else:
+                    self._awaiting_notification_turn_init = True
                 self.output_message_queue.put(
                     BackgroundTaskNotificationAgentMessage(
                         message_id=AgentMessageID(),
@@ -821,6 +858,16 @@ class ClaudeOutputProcessor:
         self.session_id_written_event.set()
         logger.info("Stored session_id: {}", session_id)
 
+        # A task-notification that arrived before the user's turn ended armed
+        # _awaiting_notification_turn_init. This init is a fresh request cycle,
+        # which confirms the notification was delivered as its own turn ahead
+        # of the user's prompt (SCU-1660) rather than inline mid-turn. Promote
+        # it to a pending notification-turn result so _parse_stream_end_response
+        # skips that turn's result and keeps the loop open for the user's turn.
+        if self._awaiting_notification_turn_init:
+            self._awaiting_notification_turn_init = False
+            self._pending_notification_turn_results += 1
+
         # A ScheduleWakeup fires as a second init message on the same session.
         # When the wakeup init arrives, reset found_final_message so the loop
         # processes the wakeup turn (assistant → result) instead of exiting.
@@ -920,6 +967,19 @@ class ClaudeOutputProcessor:
 
         self.found_final_message = True
         self._final_message_time = time.monotonic()
+
+        # SCU-1660: if this result terminates a task-notification turn the CLI
+        # delivered ahead of the user's own message turn, it is not the end of
+        # the invocation — the user's real turn still has to run. Re-open the
+        # loop so it is not torn down after its first tool result.
+        if self._pending_notification_turn_results > 0:
+            self._pending_notification_turn_results -= 1
+            self.found_final_message = False
+        # A notification that never started a fresh request cycle before this
+        # result was an inline mid-turn notification (SCU-267), not a separate
+        # turn — drop the pending classification so it doesn't leak into a later
+        # turn's result.
+        self._awaiting_notification_turn_init = False
 
         # Clear pending background tasks that already completed via task_updated.
         # The CLI emits task_updated(status=completed) when a background task

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -1295,3 +1295,110 @@ class TestSubagentInterleavedTurnIds:
 
         expected_tools = {agent_tool, sub_tool, sub_tool_2, main_tool_2, main_tool_3}
         assert expected_tools <= visible_tool_ids, "agent tool calls went missing from the chat"
+
+
+def _collect_text(messages: Iterable) -> str:
+    """Concatenate all TextBlock text reachable across the given chat messages."""
+    texts: list[str] = []
+    for message in messages:
+        for block in message.content:
+            if isinstance(block, TextBlock):
+                texts.append(block.text)
+    return "\n".join(texts)
+
+
+class TestNotificationTurnBeforeUserTurn:
+    """Regression tests for SCU-1660: a task-notification turn delivered *before*
+    the user's own message turn must not end the CLI invocation early.
+
+    When a Monitor background task completes right as a new user prompt is
+    dispatched, the Claude CLI delivers the pending ``<task-notification>`` as
+    its own turn (init → assistant → result) *ahead* of the user's message
+    turn, all within the single CLI process Sculptor spawned for that prompt.
+
+    The turn-completion loop in ``_process_output`` keys on the first ``result``
+    it sees (``found_final_message``). Treating the notification turn's result
+    as terminal makes the loop exit and the process manager tears the CLI down
+    while the user's real request has run at most one tool call — silently
+    abandoning it. The loop must instead stay open until the user's own turn
+    produces its result.
+    """
+
+    @staticmethod
+    def _notification_then_user_turn_jsonl(user_tool_id: str, continuation_text: str) -> list[dict]:
+        """A notification turn (init → assistant → result) followed by the user's
+        own turn that issues one tool call and then continues afterwards.
+
+        The task-notification frame arrives before any ``result``, i.e. while
+        ``found_final_message`` is still False — this is what distinguishes the
+        notification-before-user ordering from the common notification-after
+        ordering that ``handle_background_task_notification`` models.
+        """
+        return [
+            # The CLI delivers the completed Monitor task's notification first.
+            make_task_notification_message(
+                task_id="task_monitor_1",
+                tool_use_id="toolu_monitor_1",
+                status="completed",
+                summary="test-unit watcher finished",
+            ),
+            # Notification turn: the agent briefly acknowledges the notification.
+            make_init_message(session_id="s1"),
+            make_assistant_message(
+                message_id="msg_notif",
+                content_blocks=[make_text_block("This is just the stale Monitor task being cleaned up.")],
+            ),
+            make_end_message(session_id="s1"),
+            # The user's real turn: fetch, then act on the result.
+            make_init_message(session_id="s1"),
+            make_assistant_message(
+                message_id="msg_user_a",
+                content_blocks=[make_text_block("I'll fetch the latest state of that branch.")],
+            ),
+            make_assistant_message(
+                message_id="msg_user_b",
+                content_blocks=[make_tool_use_block(user_tool_id, "Bash", {"command": "git fetch origin"})],
+            ),
+            make_tool_result_message(user_tool_id, "Fetched new commits."),
+            make_assistant_message(
+                message_id="msg_user_c",
+                content_blocks=[make_text_block(continuation_text)],
+            ),
+            make_end_message(session_id="s1"),
+        ]
+
+    def test_user_turn_after_notification_turn_is_not_abandoned(self) -> None:
+        """The user's turn (its tool call and its post-tool continuation) must
+        survive when a notification turn precedes it.
+
+        Before the fix the loop exits at the notification turn's ``result``, so
+        the user turn's frames are never processed and its tool call and
+        continuation text never reach the chat.
+        """
+        user_tool_id = "toolu_user_merge"
+        continuation_text = "MERGE COMPLETE — pushed."
+        jsonl = self._notification_then_user_turn_jsonl(user_tool_id, continuation_text)
+
+        emitted = _run_process_output(jsonl)
+
+        request_id = AgentMessageID()
+        stream = (
+            [
+                ChatInputUserMessage(message_id=request_id, text="merge and repush", files=[]),
+                RequestStartedAgentMessage(request_id=request_id),
+            ]
+            + emitted
+            + [RequestSuccessAgentMessage(request_id=request_id)]
+        )
+        update = convert_agent_messages_to_task_update(stream, TaskID(), {}, CLAUDE_CODE_HARNESS)
+        chat_messages = list(update.chat_messages)
+        if update.in_progress_chat_message is not None:
+            chat_messages.append(update.in_progress_chat_message)
+
+        visible_tool_ids = _collect_tool_ids(chat_messages)
+        assert user_tool_id in visible_tool_ids, (
+            "the user turn's tool call went missing: the loop exited at the notification turn's result and abandoned the user's request"
+        )
+        assert continuation_text in _collect_text(chat_messages), (
+            "the user turn's post-tool continuation never reached the chat: the turn was terminated after its first tool result"
+        )

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -348,7 +348,10 @@ def _feed_jsonl(processor: ClaudeOutputProcessor, jsonl_dicts: list[dict]) -> No
             processor._completed_pending_deferred.discard(result.task_id)
             if not processor._completed_pending_deferred:
                 processor._completed_pending_deferred_deadline = None
-            processor.found_final_message = False
+            if processor.found_final_message:
+                processor.found_final_message = False
+            else:
+                processor._awaiting_notification_turn_init = True
             processor.output_message_queue.put(
                 BackgroundTaskNotificationAgentMessage(
                     message_id=AgentMessageID(),

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -1248,6 +1248,84 @@ def handle_background_task_notification(args: dict, emit_streaming: bool) -> lis
     return messages
 
 
+def handle_notification_turn_then_response(args: dict, emit_streaming: bool) -> list[dict]:
+    """Emit a task-notification turn *followed by* the user's own message turn.
+
+    Reproduces SCU-1660: a Monitor background task completes just as a new user
+    prompt is dispatched, so the CLI delivers the pending ``<task-notification>``
+    as its own turn (init -> assistant -> result) BEFORE processing the user's
+    message. Everything below sits inside a single FakeClaude invocation (one
+    CLI process), between the process's own opening ``init`` and the closing
+    ``end`` that ``fake_claude.main()`` appends — that closing ``end`` is the
+    user turn's result.
+
+    Frame order returned by this handler:
+      1. system/task_notification (the Monitor completion, delivered first)
+      2. notification turn: init -> assistant(ack) -> result
+      3. user turn: init -> assistant(text) -> assistant(Bash tool_use) ->
+         tool_result -> assistant(continuation)
+
+    The notification turn's ``result`` is the trap: if the output processor
+    treats it as terminal, the loop exits and the CLI is torn down before the
+    user turn's frames are processed, silently abandoning the request after its
+    first tool result.
+
+    Args:
+        args: Optional "task_id", "tool_use_id", "summary", "ack_text",
+              "user_pre_text", "user_tool_command", "user_post_text".
+    """
+    task_id = args.get("task_id", "task_monitor_1")
+    tool_use_id = args.get("tool_use_id", generate_id("toolu"))
+    summary = args.get("summary", "Background task completed")
+    ack_text = args.get("ack_text", "This is just the stale Monitor task being cleaned up.")
+    user_pre_text = args.get("user_pre_text", "I'll fetch the latest state of that branch.")
+    user_tool_command = args.get("user_tool_command", "git fetch origin")
+    user_post_text = args.get("user_post_text", "Done — merged and repushed.")
+
+    session_id = generate_id("session")
+    user_tool_id = generate_id("toolu")
+    messages: list[dict] = []
+
+    # 1. The completed Monitor task's notification, delivered ahead of the user turn.
+    messages.append(
+        make_task_notification_message(
+            task_id=task_id,
+            tool_use_id=tool_use_id,
+            status="completed",
+            summary=summary,
+        )
+    )
+
+    # 2. Notification turn: init -> assistant(ack) -> result.
+    messages.append(make_init_message(session_id=session_id))
+    ack_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=ack_msg_id, text=ack_text))
+    messages.append(make_assistant_message(message_id=ack_msg_id, content_blocks=[make_text_block(ack_text)]))
+    messages.append(make_end_message(session_id=session_id))
+
+    # 3. User turn: init -> text -> Bash tool_use -> tool_result -> continuation.
+    messages.append(make_init_message(session_id=session_id))
+    pre_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=pre_msg_id, text=user_pre_text))
+    messages.append(make_assistant_message(message_id=pre_msg_id, content_blocks=[make_text_block(user_pre_text)]))
+
+    tool_block = make_tool_use_block(tool_id=user_tool_id, tool_name="Bash", tool_input={"command": user_tool_command})
+    tool_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_tool_events(message_id=tool_msg_id, tool_blocks=[tool_block]))
+    messages.append(make_assistant_message(message_id=tool_msg_id, content_blocks=[tool_block]))
+    messages.append(make_tool_result_message(tool_use_id=user_tool_id, content="Fetched new commits."))
+
+    post_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=post_msg_id, text=user_post_text))
+    messages.append(make_assistant_message(message_id=post_msg_id, content_blocks=[make_text_block(user_post_text)]))
+
+    return messages
+
+
 def handle_subagent(args: dict, emit_streaming: bool) -> list[dict]:
     """Simulate a subagent (Agent tool) call.
 
@@ -2247,6 +2325,7 @@ COMMAND_REGISTRY: dict[str, Callable[..., list[dict]]] = {
     "background_task_started": handle_background_task_started,
     "background_task_notification": handle_background_task_notification,
     "emit_task_notification": handle_emit_task_notification,
+    "notification_turn_then_response": handle_notification_turn_then_response,
     "auto_bg_bash": handle_auto_bg_bash,
     "multi_step": handle_multi_step,
     "parallel_tools": handle_parallel_tools,

--- a/sculptor/sculptor/testing/elements/chat_panel.py
+++ b/sculptor/sculptor/testing/elements/chat_panel.py
@@ -72,6 +72,11 @@ class PlaywrightChatPanelElement(PlaywrightFilePreviewAndUploadMixin, Playwright
         return self._locator.locator(", ".join((alpha_pill, alpha_bash, alpha_file)))
 
     def get_bash_blocks(self) -> Locator:
+        """Bash tool calls (``ALPHA_CHAT_BASH_BLOCK``).
+
+        Bash renders as a dedicated bash block, not as a generic
+        ``get_tool_pills`` pill — assert on a Bash tool call through here.
+        """
         return self.get_by_test_id(ElementIDs.ALPHA_CHAT_BASH_BLOCK)
 
     def get_bash_output(self) -> Locator:
@@ -263,6 +268,13 @@ class PlaywrightChatPanelElement(PlaywrightFilePreviewAndUploadMixin, Playwright
         return self.get_by_test_id(ElementIDs.ALPHA_CHAT_TOOL_PILL_ROW)
 
     def get_tool_pills(self) -> Locator:
+        """Generic tool pills only (``ALPHA_CHAT_TOOL_PILL``).
+
+        This does NOT match every tool: Bash renders as a bash block (use
+        ``get_bash_blocks``) and Write / Edit / MultiEdit render as file chips
+        (use ``get_file_chips``). To match every tool surface regardless of
+        which tool ran, use ``get_completed_tool_calls``.
+        """
         return self.get_by_test_id(ElementIDs.ALPHA_CHAT_TOOL_PILL)
 
     def get_tool_pill_popover(self) -> Locator:

--- a/sculptor/tests/integration/frontend/test_notification_before_user_turn.py
+++ b/sculptor/tests/integration/frontend/test_notification_before_user_turn.py
@@ -1,0 +1,71 @@
+"""Integration test for SCU-1660: a task-notification turn colliding with a user prompt.
+
+When a Monitor background task completes at (or very near) the instant a new
+user prompt is dispatched, the Claude CLI delivers the pending
+``<task-notification>`` as its own turn (init -> assistant -> result) *ahead*
+of the user's message turn — all inside the single CLI process Sculptor spawned
+for that prompt. The turn-completion loop must not treat the notification
+turn's ``result`` as the end of the invocation; if it does, the CLI is torn
+down while the user's real request has run at most one tool call, silently
+abandoning it.
+
+FakeClaude reproduces the collision deterministically via the
+``notification_turn_then_response`` command, which scripts the exact
+notification-turn-then-user-turn frame order that the timing race produces.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+NOTIFICATION_ACK_TEXT = "NOTIF-ACK stale Monitor task cleaned up"
+USER_TURN_DONE_TEXT = "USER-TURN-COMPLETE merged and repushed"
+
+NOTIFICATION_BEFORE_USER_TURN_COMMAND = f"""\
+fake_claude:notification_turn_then_response `{{
+  "task_id": "task-watchdog",
+  "tool_use_id": "toolu-watchdog",
+  "summary": "test-unit watcher finished",
+  "ack_text": "{NOTIFICATION_ACK_TEXT}",
+  "user_pre_text": "I'll fetch the latest state of that branch.",
+  "user_tool_command": "git fetch origin",
+  "user_post_text": "{USER_TURN_DONE_TEXT}"
+}}`"""
+
+
+@user_story("to verify a user prompt is not abandoned when a task-notification turn precedes it")
+def test_user_turn_after_notification_turn_completes(sculptor_instance_: SculptorInstance) -> None:
+    """The user's turn must run to completion even when a task-notification turn
+    is delivered ahead of it within the same CLI process.
+
+    Before the fix the output loop exits at the notification turn's ``result``,
+    so the user turn's Bash tool call and its post-tool continuation never reach
+    the chat — the request is abandoned after (at most) its first tool result.
+    With the fix, the loop stays open until the user turn's own result, so the
+    full response renders.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=NOTIFICATION_BEFORE_USER_TURN_COMMAND,
+    )
+    chat_panel = task_page.get_chat_panel()
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+
+    messages = chat_panel.get_messages()
+
+    # The notification turn's acknowledgement should be present (both turns ran).
+    expect(messages.filter(has_text=NOTIFICATION_ACK_TEXT).first).to_be_visible()
+
+    # The crux: the user turn's post-tool continuation must be visible. Its
+    # absence is exactly the silent abandonment SCU-1660 describes.
+    expect(messages.filter(has_text=USER_TURN_DONE_TEXT).first).to_be_visible()
+
+    # The user turn's Bash tool call must also have rendered — the request got
+    # past its first tool result rather than stalling on it. (Bash renders as a
+    # dedicated bash block, not a generic tool pill.) When the turn is abandoned
+    # no bash block renders at all.
+    expect(chat_panel.get_bash_blocks()).to_have_count(1)


### PR DESCRIPTION
## Original bug

**SCU-1660.** A Claude agent turn terminated prematurely — after the **first tool result came back** — when an auto-injected `<task-notification>` collided with a user prompt in the same queue tick. Sculptor treated the loop as finished and ended the `claude` process, so the user's request (a merge + repush) was silently left one `git fetch` deep, with no merge/check/push. Reconstructed from a real session transcript.

## Reproduction

Deterministic, via the frame ordering the timing race produces (real Claude cannot trigger it on demand — the ticket flagged it as timing-dependent). Within the single `claude` CLI process Sculptor spawns for one dispatched user message, the CLI delivers a pending Monitor `<task-notification>` as its **own turn** *before* it processes the user's message:

1. **Notification turn:** `task_notification` → `init` → `assistant` ("stale Monitor…") → **`result`**
2. **User turn:** `init` → `assistant` ("I'll fetch…") → `tool_use` Bash → `tool_result` → *(should continue: merge / check / push)*

Both tests script exactly this order: the unit test through the real `_process_output` loop, and the integration test through a new `notification_turn_then_response` FakeClaude command.

## Hypothesis / root cause

`ClaudeOutputProcessor` runs one CLI process per dispatched user message and ends its turn-completion loop (`_process_output`) on the first `result` frame it sees (`found_final_message`). The existing `task_notification` handler resets `found_final_message=False` to keep the loop open — but only for a single follow-up turn, and only correctly when the notification arrives *after* the user's turn ended. When the notification turn is delivered *ahead* of the user's turn, its `result` sets `found_final_message=True` with no pending background tasks, the loop condition goes false, and the process manager tears the CLI down (`close_stdin → SIGTERM → SIGKILL`) while the user's real turn has run at most one tool call.

Log evidence from the failing integration run:

```
Process stream ended (found_final_message=True, pending_bg_tasks=set(), pending_wakeup=False, process_finished=False, queue_empty=False)
```

— the loop exits with the user turn's frames still queued.

## Fix

`output_processor.py`: distinguish a notification turn delivered *ahead* of the user's turn from an inline mid-turn notification (SCU-267, which starts no new request cycle):

- When a `task_notification` arrives while `found_final_message` is still `False`, arm `_awaiting_notification_turn_init`.
- A following `system/init` (a fresh request cycle) confirms it as a separate turn → promote it to `_pending_notification_turn_results`.
- `_parse_stream_end_response` then skips that turn's `result` (re-opening the loop) so it stays open for the user's own turn. A notification that never starts a new cycle drops the flag at its result and is treated normally.

The common notification-*after* ordering (`found_final_message` already `True`) keeps the pre-existing reset, unchanged.

## Proof the fix works

**Unit test** — `output_processor_test.py::TestNotificationTurnBeforeUserTurn`. Red without the fix (re-confirmed by reverting only the production file):

```
Process stream ended (found_final_message=True, ..., queue_empty=False)
FAILED ... assert 'toolu_user_merge' in set()
```

Green with the fix:

```
1 passed in 0.15s
```

**Integration test** — `test_notification_before_user_turn.py`, end-to-end via FakeClaude. Red without the fix (loop exits early; the user turn's Bash block never renders). Green with the fix:

```
1 passed in 12.53s
```

With the fix the user turn's Bash block and its post-tool continuation both render, and the turn footer shows a clean completion.

Full `just test-unit` passes; the 47-test `output_processor` suite has no regressions (SCU-267 mid-stream, deferred-completion, and wakeup handling all still green).

- Failing-tests commit: `70ff21df0b6`
- Fix commit: `a6c3de14565`

## Deferred follow-ups

The ticket's two *secondary* symptoms, not the root cause fixed here:

- Debug-view mispairs the auto-notification reply with the adjacent user prompt — [SCU-1661](https://linear.app/imbue/issue/SCU-1661/debug-view-mispairs-auto-notification-reply-with-adjacent-user-prompt)
- Auto-recovery "Continue from where you left off." nudge is answered as a no-op — [SCU-1662](https://linear.app/imbue/issue/SCU-1662/auto-recovery-continue-from-where-you-left-off-nudge-is-answered-as-a)

## Review notes

_(no outstanding review notes)_

(Sent by Claude)
