### PR TITLE
Fix agent crash on background-task notification missing tool_use_id

### DIFF
--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -1183,6 +1183,9 @@ def handle_emit_task_notification(args: dict, emit_streaming: bool) -> list[dict
 
     Args:
         args: Must contain "task_id". Optional: "tool_use_id", "status", "summary".
+            Pass "tool_use_id": null to omit the field, reproducing the orphaned-
+            task-on-restart notification the real CLI emits (see SCU-1666). When
+            "tool_use_id" is absent a placeholder id is generated instead.
     """
     return [
         make_task_notification_message(

--- a/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
@@ -63,7 +63,7 @@ def make_task_started_message(
 
 def make_task_notification_message(
     task_id: str,
-    tool_use_id: str,
+    tool_use_id: str | None,
     status: str = "completed",
     summary: str = "",
     duration_ms: int | None = None,
@@ -72,15 +72,21 @@ def make_task_notification_message(
 
     When ``duration_ms`` is provided it is emitted nested under ``usage`` to
     match the real Claude CLI shape (see SCU-1151).
+
+    Pass ``tool_use_id=None`` to omit the field entirely. The real CLI drops
+    ``tool_use_id`` when a background task is orphaned by a process exit (e.g. a
+    restart) and reported as failed on resume, because the launching tool call's
+    id was lost with the dead process — see SCU-1666.
     """
     msg: dict = {
         "type": "system",
         "subtype": "task_notification",
         "task_id": task_id,
-        "tool_use_id": tool_use_id,
         "status": status,
         "summary": summary,
     }
+    if tool_use_id is not None:
+        msg["tool_use_id"] = tool_use_id
     if duration_ms is not None:
         msg["usage"] = {"duration_ms": duration_ms}
     return msg

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -104,6 +104,29 @@ def test_task_notification_message_roundtrip() -> None:
     assert parsed.summary == "Tests passed"
 
 
+def test_task_notification_message_without_tool_use_id_parses() -> None:
+    """A task_notification missing tool_use_id must parse, not raise KeyError.
+
+    The CLI omits tool_use_id when a background task orphaned by a process exit
+    is reported as failed on resume (see SCU-1666). Parsing must degrade to an
+    empty tool_use_id instead of crashing the agent's output-processing thread.
+    """
+    msg = make_task_notification_message(
+        task_id="task-123",
+        tool_use_id=None,
+        status="failed",
+        summary="Background task did not complete",
+    )
+    assert "tool_use_id" not in msg
+    result = parse_claude_code_json_lines_simple(json.dumps(msg))
+    assert result is not None
+    _msg_type, parsed = result
+    assert isinstance(parsed, ParsedTaskNotificationResponse)
+    assert parsed.task_id == "task-123"
+    assert parsed.tool_use_id == ""
+    assert parsed.status == "failed"
+
+
 def test_assistant_text_message_roundtrip() -> None:
     msg_id = f"msg-{uuid4().hex}"
     msg = make_assistant_message(msg_id, [make_text_block("hello")])

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -127,6 +127,28 @@ def test_task_notification_message_without_tool_use_id_parses() -> None:
     assert parsed.status == "failed"
 
 
+def test_task_started_message_without_tool_use_id_parses() -> None:
+    """task_started tolerates a missing tool_use_id too (parity with task_notification).
+
+    The notification handler is where the orphaned-on-restart payload actually
+    drops the key, but task_started reads it the same defensive way, so a variant
+    payload there must degrade to an empty id rather than crashing the agent.
+    """
+    msg = make_task_started_message(
+        task_id="task-123",
+        tool_use_id="toolu-456",
+        description="Run tests",
+        task_type="local_bash",
+    )
+    del msg["tool_use_id"]
+    result = parse_claude_code_json_lines_simple(json.dumps(msg))
+    assert result is not None
+    _msg_type, parsed = result
+    assert isinstance(parsed, ParsedTaskStartedResponse)
+    assert parsed.task_id == "task-123"
+    assert parsed.tool_use_id == ""
+
+
 def test_assistant_text_message_roundtrip() -> None:
     msg_id = f"msg-{uuid4().hex}"
     msg = make_assistant_message(msg_id, [make_text_block("hello")])

--- a/sculptor/sculptor/state/claude_state.py
+++ b/sculptor/sculptor/state/claude_state.py
@@ -283,7 +283,9 @@ class ParsedTaskNotificationResponse(ParsedAgentResponse):
 
     object_type: str = Field(default="ParsedTaskNotificationResponse")
     task_id: str = Field(description="Background task ID matching the task_started event")
-    tool_use_id: str = Field(description="Tool use ID of the tool call that launched the background task")
+    tool_use_id: str = Field(
+        description="Tool use ID of the tool call that launched the background task. Empty when the CLI omits it, e.g. a task orphaned by a process exit and reported as failed on resume (see SCU-1666).",
+    )
     status: str = Field(description="Completion status (e.g. completed)")
     summary: str = Field(default="", description="Human-readable summary of the background task result")
     duration_ms: int | None = Field(
@@ -386,9 +388,11 @@ def _handle_init_message(data: dict[str, Any]) -> ParsedInitResponse:
 
 def _handle_task_started_message(data: dict[str, Any]) -> ParsedTaskStartedResponse:
     """Handle system/task_started message type."""
+    # ``tool_use_id`` is read defensively (see _handle_task_notification_message)
+    # to keep a variant payload from crashing the whole agent.
     return ParsedTaskStartedResponse(
         task_id=data["task_id"],
-        tool_use_id=data["tool_use_id"],
+        tool_use_id=data.get("tool_use_id", ""),
         description=data.get("description", ""),
         task_type=data.get("task_type", ""),
     )
@@ -401,9 +405,13 @@ def _handle_task_notification_message(data: dict[str, Any]) -> ParsedTaskNotific
     # unparsed until a caller asks for them.
     usage = data.get("usage") or {}
     raw_duration_ms = usage.get("duration_ms") if isinstance(usage, dict) else None
+    # ``tool_use_id`` is absent when a background task orphaned by a process exit
+    # is reported as failed on resume: the launching tool call's id died with the
+    # previous process (see SCU-1666). Default to "" rather than indexing so the
+    # notification is surfaced instead of a missing key killing the agent.
     return ParsedTaskNotificationResponse(
         task_id=data["task_id"],
-        tool_use_id=data["tool_use_id"],
+        tool_use_id=data.get("tool_use_id", ""),
         status=data.get("status", ""),
         summary=data.get("summary", ""),
         duration_ms=int(raw_duration_ms) if isinstance(raw_duration_ms, (int, float)) else None,

--- a/sculptor/sculptor/state/claude_state.py
+++ b/sculptor/sculptor/state/claude_state.py
@@ -273,7 +273,9 @@ class ParsedTaskStartedResponse(ParsedAgentResponse):
 
     object_type: str = Field(default="ParsedTaskStartedResponse")
     task_id: str = Field(description="Background task ID assigned by Claude Code")
-    tool_use_id: str = Field(description="Tool use ID of the tool call that launched the background task")
+    tool_use_id: str = Field(
+        description="Tool use ID of the tool call that launched the background task. Empty when the CLI omits it (parity with ParsedTaskNotificationResponse — see SCU-1666).",
+    )
     description: str = Field(default="", description="Human-readable description of the background task")
     task_type: str = Field(default="", description="Type of background task (e.g. local_bash)")
 

--- a/sculptor/tests/integration/frontend/test_background_task_notification_missing_tool_use_id.py
+++ b/sculptor/tests/integration/frontend/test_background_task_notification_missing_tool_use_id.py
@@ -1,0 +1,66 @@
+"""Regression test for SCU-1666: a background-task notification missing ``tool_use_id``.
+
+When a background task is orphaned by a process exit (e.g. the machine restarts
+while the task is running), the Claude CLI reports it as failed on resume with a
+``system/task_notification`` that has no ``tool_use_id`` — the launching tool
+call's id was lost with the dead process. The agent must process that
+notification gracefully and stay alive, rather than crashing on a missing key.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# Drive FakeClaude to emit a failed task_notification with NO tool_use_id
+# (``"tool_use_id": null`` omits the field), mirroring the orphaned-on-restart
+# message the real CLI emits, then a final text marker. If the notification
+# crashes the output-processing thread the marker never renders.
+ORPHANED_NOTIFICATION_COMMAND = """\
+fake_claude:multi_step `{
+  "steps": [
+    {"command": "emit_task_notification", "args": {
+      "task_id": "a924753e20158e44b",
+      "tool_use_id": null,
+      "status": "failed",
+      "summary": "Background agent was running when the previous Claude Code process exited and did not complete."
+    }},
+    {"command": "text", "args": {"text": "Agent survived the orphaned notification — ORPHAN-NOTIFY-DONE"}}
+  ]
+}`"""
+
+
+@user_story("to have my agent survive an orphaned background-task notification after a restart")
+def test_task_notification_without_tool_use_id_does_not_crash_agent(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """A task_notification missing tool_use_id must not kill the agent.
+
+    Repro: FakeClaude emits a failed ``task_notification`` with no
+    ``tool_use_id`` followed by a text marker. Before the fix,
+    ``_handle_task_notification_message`` indexed ``data["tool_use_id"]``
+    directly, so the missing key raised ``KeyError: 'tool_use_id'`` on the
+    output-processing thread and crashed the whole agent (the marker never
+    rendered and the turn ended in an error). With the fix the notification is
+    handled, the marker renders, and follow-up turns still work.
+    """
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=sculptor_instance_.page,
+        prompt=ORPHANED_NOTIFICATION_COMMAND,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # The turn should finish (not hang), and the post-notification marker must
+    # render — proof the agent kept processing after the malformed message.
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+    expect(chat_panel.get_messages().filter(has_text="ORPHAN-NOTIFY-DONE").first).to_be_visible()
+
+    # The missing key must not surface as a crash / error block.
+    expect(chat_panel.get_error_block()).to_have_count(0)
+
+    # The agent should still be usable — send a follow-up message.
+    send_chat_message(chat_panel, 'fake_claude:text `{"text": "Recovery after orphaned notification"}`')
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+    expect(chat_panel.get_messages().last).to_contain_text("Recovery after orphaned notification")


### PR DESCRIPTION
## Original bug

> `KeyError: ('tool_use_id',)` killed my agent upon restart

Linear: SCU-1666. Reported via a diagnostics traceback upload.

> **Builds on #252 (SCU-1660).** This branch is rebased on `maciek/bugs/scu-1660`, so it is effectively stacked on #252 and this diff is scoped to just the SCU-1666 changes. #252 is a complementary sibling fix (the CLI delivering a task-notification turn *before* the user's turn was prematurely closing the loop); the two fixes touch disjoint core code — `output_processor.py` (turn loop) there vs. `claude_state.py` (parser) here. **Please review/merge #252 first**, then this can merge on top.

## Root cause

When a background task (an `Agent`/`run_in_background` tool call) is still
running as the Claude Code process exits — e.g. the machine restarts — the CLI
loses that task's in-process state. On the next resume it emits a
`system/task_notification` reporting the task as **failed**, but with **no
`tool_use_id`**: the id of the tool call that launched the task died with the
previous process. The exact payload from the reporter's logs:

```json
{"type":"system","subtype":"task_notification","task_id":"a924753e20158e44b",
 "status":"failed","output_file":"...",
 "summary":"Background agent \"...\" was running when the previous Claude Code
            process exited and did not complete. Its in-process state was lost...",
 "session_id":"...","uuid":"..."}
```

`_handle_task_notification_message` in `sculptor/sculptor/state/claude_state.py`
read `data["tool_use_id"]` with a hard dict index, so the missing key raised
`KeyError: 'tool_use_id'`. That exception propagated out of the output-processing
thread (`output_processor._process_output` → `parse_claude_code_json_lines_simple`)
and killed the whole agent — exactly "killed my agent upon restart".

## Fix

Read `tool_use_id` defensively — `data.get("tool_use_id", "")` — in
`_handle_task_notification_message` and, for parity, in the sibling
`_handle_task_started_message`. An absent id now degrades to "no associated tool
call" and the failed-task notification is surfaced to the user, instead of a
missing key crashing the agent. `tool_use_id` stays a `str` on the parsed model
(the parser always supplies one), so there is no schema/wire-contract change.

## Reproduction

**Repro steps (e2e, FakeClaude):** drive FakeClaude via `multi_step` to emit a
failed `task_notification` with no `tool_use_id` (using the new
`"tool_use_id": null` omit-the-key path), followed by a text marker, then send a
follow-up message. Before the fix the agent thread crashes: the marker never
renders and the turn ends in an error block. After the fix the notification is
handled, the marker renders, and the follow-up turn works.

**Before (failing test — the reported crash reproduced):**

```
File "sculptor/sculptor/state/claude_state.py", line 406, in _handle_task_notification_message
    tool_use_id=data["tool_use_id"],
KeyError: 'tool_use_id'
...
FAILED sculptor/tests/integration/frontend/test_background_task_notification_missing_tool_use_id.py::test_task_notification_without_tool_use_id_does_not_crash_agent
```

**After (same test passes):**

```
============================== 1 passed in 12.59s ==============================
```

## Tests

- **e2e regression:** `sculptor/tests/integration/frontend/test_background_task_notification_missing_tool_use_id.py`
  — asserts the agent survives the orphaned notification, the post-notification
  marker renders, no error block appears, and a follow-up turn still works.
  Kind: integration (Playwright + FakeClaude), the repo default.
  - Failing-test commit: `6b3ad02`
  - Fix commit: `695c51f`
- **parse-level unit tests:** `sculptor/sculptor/agents/testing/tests/test_fake_claude.py`
  — `test_task_notification_message_without_tool_use_id_parses` and
  `test_task_started_message_without_tool_use_id_parses` assert the parse
  degrades to `tool_use_id == ""` instead of raising.

## Test harness change

`make_task_notification_message` (FakeClaude) now accepts `tool_use_id=None` to
omit the field, and the `emit_task_notification` command documents
`"tool_use_id": null`. Backward-compatible: an absent key still generates a
placeholder id, so existing callers are unaffected.

(Sent by Claude)
