### PR TITLE
Classify Claude API errors via structured api_error_status

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -899,7 +899,17 @@ class ClaudeOutputProcessor:
         if result.is_error:
             if self._interrupted_event is not None and self._interrupted_event.is_set():
                 logger.info("Suppressing error end response because agent was interrupted: {}", result.result)
+            elif result.api_error_status is not None:
+                # The CLI reports the HTTP status of the failing API call directly, so classify
+                # from that rather than parsing result text — the latter breaks silently if the
+                # CLI rewords its error messages.
+                logger.info("API Error: stdout={}, stderr={}", self.process.read_stdout(), self.process.read_stderr())
+                if result.api_error_status in TRANSIENT_ERROR_CODES:
+                    raise AgentTransientError(result.result, exit_code=self.process.returncode)
+                raise ClaudeAPIError(result.result, exit_code=self.process.returncode)
             elif result.result.startswith("API Error"):
+                # Fallback for CLIs that predate the structured api_error_status field: recover
+                # the status by matching the "API Error: <code> ..." text prefix.
                 logger.info("API Error: stdout={}, stderr={}", self.process.read_stdout(), self.process.read_stderr())
                 if any(result.result.startswith(f"API Error: {code}") for code in TRANSIENT_ERROR_CODES):
                     raise AgentTransientError(result.result, exit_code=self.process.returncode)

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from sculptor.agents.default.claude_code_sdk.errors import ClaudeAPIError
 from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
 from sculptor.agents.default.claude_code_sdk.mcp_server import SculptorMcpServer
 from sculptor.agents.default.claude_code_sdk.output_processor import ClaudeOutputProcessor
@@ -30,6 +31,7 @@ from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
 from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.errors import AgentClientError
+from sculptor.interfaces.agents.errors import AgentTransientError
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import TaskID
 from sculptor.primitives.ids import ToolUseID
@@ -769,6 +771,60 @@ class TestInterruptedErrorSuppression:
 
         with pytest.raises(AgentClientError):
             _feed_jsonl(processor, [init, end])
+
+
+class TestApiErrorClassification:
+    """Transient-vs-permanent classification of error end responses.
+
+    These feed real JSONL frames through the parser and processor dispatch loop
+    (via _feed_jsonl), so they exercise both the api_error_status parse site and
+    _parse_stream_end_response's classification end-to-end. The exception type is
+    the only observable that reflects the classification — at the UI layer every
+    recoverable AgentClientError renders identically, so this is the level that
+    can distinguish them.
+    """
+
+    def test_structured_transient_status_raises_transient_error(self) -> None:
+        """A structured api_error_status in TRANSIENT_ERROR_CODES (429) is transient."""
+        processor = _make_processor_for_interrupt_test(interrupted_event=Event())
+        init = make_init_message(session_id="session_001")
+        # Reworded text that does NOT start with "API Error", proving the structured
+        # field drives classification rather than the string-prefix fallback.
+        end = make_end_message(session_id=None, is_error=True, result="Overloaded", api_error_status=429)
+
+        with pytest.raises(AgentTransientError):
+            _feed_jsonl(processor, [init, end])
+
+    def test_structured_permanent_status_raises_claude_api_error(self) -> None:
+        """A structured api_error_status outside TRANSIENT_ERROR_CODES (400) is permanent."""
+        processor = _make_processor_for_interrupt_test(interrupted_event=Event())
+        init = make_init_message(session_id="session_001")
+        end = make_end_message(session_id=None, is_error=True, result="Bad request", api_error_status=400)
+
+        with pytest.raises(ClaudeAPIError) as exc_info:
+            _feed_jsonl(processor, [init, end])
+        # A permanent API error must not be mistaken for a retryable transient one.
+        assert not isinstance(exc_info.value, AgentTransientError)
+
+    def test_string_prefix_fallback_still_classifies_transient(self) -> None:
+        """Without the structured field, "API Error: 429 ..." text still maps to transient."""
+        processor = _make_processor_for_interrupt_test(interrupted_event=Event())
+        init = make_init_message(session_id="session_001")
+        end = make_end_message(session_id=None, is_error=True, result="API Error: 429 Rate limited")
+
+        with pytest.raises(AgentTransientError):
+            _feed_jsonl(processor, [init, end])
+
+    def test_plain_error_text_raises_generic_client_error(self) -> None:
+        """A non-API error with neither the field nor the prefix stays a plain client error."""
+        processor = _make_processor_for_interrupt_test(interrupted_event=Event())
+        init = make_init_message(session_id="session_001")
+        end = make_end_message(session_id=None, is_error=True, result="Something else went wrong")
+
+        with pytest.raises(AgentClientError) as exc_info:
+            _feed_jsonl(processor, [init, end])
+        # Neither transient nor a Claude API error — the base client error, not a subclass.
+        assert type(exc_info.value) is AgentClientError
 
 
 def _make_processor_with_mcp_server(

--- a/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
@@ -215,9 +215,18 @@ def make_hook_callback_control_request(
     }
 
 
-def make_end_message(session_id: str | None, is_error: bool = False, result: str = "") -> dict:
-    """Return a dict for the end-of-stream message."""
-    return {
+def make_end_message(
+    session_id: str | None,
+    is_error: bool = False,
+    result: str = "",
+    api_error_status: int | None = None,
+) -> dict:
+    """Return a dict for the end-of-stream message.
+
+    ``api_error_status`` mirrors the real CLI: the HTTP status is included only when
+    the turn failed on an API error, and the key is omitted entirely otherwise.
+    """
+    message = {
         "type": "result",
         "subtype": "success",
         "is_error": is_error,
@@ -234,6 +243,9 @@ def make_end_message(session_id: str | None, is_error: bool = False, result: str
         },
         "total_cost_usd": 0,
     }
+    if api_error_status is not None:
+        message["api_error_status"] = api_error_status
+    return message
 
 
 def make_streaming_text_events(

--- a/sculptor/sculptor/state/claude_state.py
+++ b/sculptor/sculptor/state/claude_state.py
@@ -259,6 +259,10 @@ class ParsedEndResponse(ParsedAgentResponse):
     input_tokens: int | None = Field(default=None, description="Input tokens")
     output_tokens: int | None = Field(default=None, description="Output tokens")
     total_cost_usd: float | None = Field(default=None, description="Total cost of agent session")
+    api_error_status: int | None = Field(
+        default=None,
+        description="HTTP status of the API error that ended the turn (e.g. 429/500/529), or None if the turn did not fail on an API error",
+    )
 
 
 class ParsedCompactionSummaryResponse(ParsedAgentResponse):
@@ -520,6 +524,8 @@ def _handle_stream_end_message(data: dict[str, Any]) -> ParsedEndResponse:
         input_tokens=data.get("usage", {}).get("input_tokens", 0),
         output_tokens=data.get("usage", {}).get("output_tokens", 0),
         total_cost_usd=data.get("total_cost_usd", 0),
+        # Present only when the turn failed on an API error; the CLI omits it otherwise.
+        api_error_status=data.get("api_error_status"),
     )
 
 

--- a/sculptor/sculptor/state/claude_state_test.py
+++ b/sculptor/sculptor/state/claude_state_test.py
@@ -1,8 +1,10 @@
 import json
 
+from sculptor.agents.testing.fake_claude_jsonl import make_end_message
 from sculptor.state.chat_state import FileBlock
 from sculptor.state.chat_state import TextBlock
 from sculptor.state.claude_state import ParsedAssistantResponse
+from sculptor.state.claude_state import _handle_stream_end_message
 from sculptor.state.claude_state import extract_media_tags_from_text
 from sculptor.state.claude_state import get_tool_invocation_string
 from sculptor.state.claude_state import parse_claude_code_json_lines_simple
@@ -385,3 +387,18 @@ def test_get_tool_invocation_string_skill_returns_skill_name() -> None:
 def test_get_tool_invocation_string_skill_without_args() -> None:
     result = get_tool_invocation_string("Skill", {"skill": "commit"})
     assert result == "commit"
+
+
+def test_handle_stream_end_message_reads_api_error_status() -> None:
+    """A result frame carrying api_error_status populates the parsed field."""
+    data = make_end_message(session_id="s1", is_error=True, result="Overloaded", api_error_status=429)
+    parsed = _handle_stream_end_message(data)
+    assert parsed.api_error_status == 429
+
+
+def test_handle_stream_end_message_api_error_status_defaults_to_none() -> None:
+    """A result frame without api_error_status leaves the parsed field None."""
+    data = make_end_message(session_id="s1", is_error=False, result="")
+    assert "api_error_status" not in data
+    parsed = _handle_stream_end_message(data)
+    assert parsed.api_error_status is None


### PR DESCRIPTION
## What & why

When a `claude` turn ends with an error, Sculptor classifies it as transient (retryable) vs. permanent by **string-matching the result text** — `result.startswith("API Error")`, then `startswith(f"API Error: {code}")` for each code in `TRANSIENT_ERROR_CODES` (429/500/529). If the CLI ever rewords its error text, that classification silently breaks: a retryable 429/500/529 would be raised as a permanent `ClaudeAPIError` instead of a transient `AgentTransientError`.

The CLI now reports the failing call's HTTP status directly on `result` frames via a structured `api_error_status` field. This change parses that field and prefers it for classification, keeping the string-matching only as a fallback for older CLIs.

Resolves SCU-1668.

## Changes

- **Parse the field** (`state/claude_state.py`): `_handle_stream_end_message` reads `data.get("api_error_status")`; `ParsedEndResponse` gains an optional `api_error_status: int | None = None`.
- **Prefer it for classification** (`agents/default/claude_code_sdk/output_processor.py`): in `_parse_stream_end_response`, when `result.is_error` and `api_error_status` is present, raise `AgentTransientError` if the status is in `TRANSIENT_ERROR_CODES`, else `ClaudeAPIError`. When the field is absent, fall back to the existing string-prefix logic (older CLIs; non-API errors still raise `AgentClientError`). The interrupt-suppression branch and the stdout/stderr `logger.info` dump on API errors are preserved. `TRANSIENT_ERROR_CODES` holds ints, so the status compares directly.

## Tests

- **Parse-site unit tests** (`state/claude_state_test.py`): a frame with `api_error_status: 429` populates the field; a frame without it leaves it `None`.
- **Classification tests** (`agents/default/claude_code_sdk/output_processor_test.py`, new `TestApiErrorClassification`): structured `429` → `AgentTransientError`; structured `400` → `ClaudeAPIError` (and not transient); no field but `"API Error: 429 ..."` text → `AgentTransientError` (fallback still works); plain error text → base `AgentClientError`. The structured-field cases use reworded (non-`"API Error"`) text, so they genuinely fail against the old string-only logic.
- `make_end_message` (test helper) gains an optional `api_error_status` that, mirroring the real CLI, is emitted only when set.

## Decisions worth calling out

- **e2e coverage is at the output-processor loop level, not a frontend integration test.** The classification tests feed real JSONL frames through the actual parse + dispatch loop (`_feed_jsonl` → `parse_claude_code_json_lines` → `_parse_stream_end_response`), so an error frame carrying `api_error_status` is exercised end-to-end through the output processor. A true FakeClaude-driven frontend integration test would be **non-differential** here: in the default agent wrapper, `AgentTransientError` and every other recoverable `AgentClientError` are caught by the same handler and render identically in the UI (error block, agent stays running), so the UI cannot observe the transient-vs-permanent distinction that `api_error_status` drives. The exception type raised by `_parse_stream_end_response` is the only observable that reflects the classification, which is exactly what these tests assert. (Per the ticket's explicit allowance for an output-processor-level test when a true integration test is disproportionate.)
- **Scoped to `api_error_status` only.** The ticket flagged optionally also carrying `stop_reason` / `permission_denials` / `structured_output` / `errors`. I left those out: unlike `api_error_status` (which is read by the classifier), they'd be parsed-but-unused with no consumer today, so adding them now would be speculative dead data. Easy to add later when something reads them.

## Validation

`just format`, `just check` (ratchets, typecheck, lint, `generate-api`), and `just test-unit` (backend, frontend, foundation, sculpt) all pass. `generate-api` reports no changes — `ParsedEndResponse` is backend-internal and not part of the frontend contract.

(Sent by Claude)
