### PR TITLE
Cherry-pick #252, #253 into 0.40.0: task-notification turn/crash fixes

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -302,6 +302,26 @@ class ClaudeOutputProcessor:
         # for the wakeup turn (a second init → assistant → result cycle) to
         # arrive from the CLI.
         self._pending_wakeup: bool = False
+        # SCU-1660: when a Monitor background task completes at the instant a
+        # new prompt is dispatched, the CLI delivers the pending
+        # ``<task-notification>`` as a full turn (init → assistant → result)
+        # *before* it processes the user's message — all in the single CLI
+        # process spawned for that prompt. That notification turn's ``result``
+        # must NOT end the loop, or the process manager tears the CLI down while
+        # the user's real request has run at most one tool call.
+        #
+        # ``_awaiting_notification_turn_init`` is armed when a task-notification
+        # arrives before the user's turn has ended (found_final_message still
+        # False). It is only *confirmed* as a separate turn if a new
+        # ``system/init`` (a fresh request cycle) then arrives — that is what
+        # distinguishes a notification delivered as its own turn (this bug)
+        # from an inline mid-turn notification that does not start a new cycle
+        # (SCU-267). On confirmation the flag is promoted into
+        # ``_pending_notification_turn_results``: a count of notification-turn
+        # results still to be skipped so the loop stays open for the user's own
+        # turn.
+        self._awaiting_notification_turn_init: bool = False
+        self._pending_notification_turn_results: int = 0
         # Last time we received any stdout line from the CLI. Used to detect
         # hangs where the CLI stops producing output after an interrupt.
         self._last_output_time: float = time.monotonic()
@@ -674,11 +694,28 @@ class ClaudeOutputProcessor:
                 if not self._completed_pending_deferred:
                     self._completed_pending_deferred_deadline = None
                 # A new turn (init → assistant → result) always follows a
-                # task_notification, so reset found_final_message to keep the
-                # loop open for it.  Without this, the loop exits immediately
-                # after the last pending task is cleared — before reading the
-                # post-notification assistant response.
-                self.found_final_message = False
+                # task_notification. Keep the loop open for it — but the way we
+                # do that depends on whether the user's own message turn has
+                # already ended:
+                #
+                #  - found_final_message is True: the common ordering — the
+                #    user's turn finished, THEN the background task completed.
+                #    The notification's follow-up turn is the LAST turn, so
+                #    clearing found_final_message here (and letting the
+                #    follow-up's result set it again) is exactly right.
+                #
+                #  - found_final_message is False: the notification arrived
+                #    BEFORE the user's turn produced a result. Either the CLI is
+                #    delivering it ahead of the user's prompt as its own turn
+                #    (SCU-1660), or it is an inline mid-turn notification with no
+                #    new request cycle (SCU-267). We cannot yet tell which, so
+                #    arm the flag; _parse_init_response confirms the former if a
+                #    fresh init follows, and _parse_stream_end_response drops it
+                #    for the latter.
+                if self.found_final_message:
+                    self.found_final_message = False
+                else:
+                    self._awaiting_notification_turn_init = True
                 self.output_message_queue.put(
                     BackgroundTaskNotificationAgentMessage(
                         message_id=AgentMessageID(),
@@ -821,6 +858,16 @@ class ClaudeOutputProcessor:
         self.session_id_written_event.set()
         logger.info("Stored session_id: {}", session_id)
 
+        # A task-notification that arrived before the user's turn ended armed
+        # _awaiting_notification_turn_init. This init is a fresh request cycle,
+        # which confirms the notification was delivered as its own turn ahead
+        # of the user's prompt (SCU-1660) rather than inline mid-turn. Promote
+        # it to a pending notification-turn result so _parse_stream_end_response
+        # skips that turn's result and keeps the loop open for the user's turn.
+        if self._awaiting_notification_turn_init:
+            self._awaiting_notification_turn_init = False
+            self._pending_notification_turn_results += 1
+
         # A ScheduleWakeup fires as a second init message on the same session.
         # When the wakeup init arrives, reset found_final_message so the loop
         # processes the wakeup turn (assistant → result) instead of exiting.
@@ -920,6 +967,19 @@ class ClaudeOutputProcessor:
 
         self.found_final_message = True
         self._final_message_time = time.monotonic()
+
+        # SCU-1660: if this result terminates a task-notification turn the CLI
+        # delivered ahead of the user's own message turn, it is not the end of
+        # the invocation — the user's real turn still has to run. Re-open the
+        # loop so it is not torn down after its first tool result.
+        if self._pending_notification_turn_results > 0:
+            self._pending_notification_turn_results -= 1
+            self.found_final_message = False
+        # A notification that never started a fresh request cycle before this
+        # result was an inline mid-turn notification (SCU-267), not a separate
+        # turn — drop the pending classification so it doesn't leak into a later
+        # turn's result.
+        self._awaiting_notification_turn_init = False
 
         # Clear pending background tasks that already completed via task_updated.
         # The CLI emits task_updated(status=completed) when a background task

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -1295,3 +1295,110 @@ class TestSubagentInterleavedTurnIds:
 
         expected_tools = {agent_tool, sub_tool, sub_tool_2, main_tool_2, main_tool_3}
         assert expected_tools <= visible_tool_ids, "agent tool calls went missing from the chat"
+
+
+def _collect_text(messages: Iterable) -> str:
+    """Concatenate all TextBlock text reachable across the given chat messages."""
+    texts: list[str] = []
+    for message in messages:
+        for block in message.content:
+            if isinstance(block, TextBlock):
+                texts.append(block.text)
+    return "\n".join(texts)
+
+
+class TestNotificationTurnBeforeUserTurn:
+    """Regression tests for SCU-1660: a task-notification turn delivered *before*
+    the user's own message turn must not end the CLI invocation early.
+
+    When a Monitor background task completes right as a new user prompt is
+    dispatched, the Claude CLI delivers the pending ``<task-notification>`` as
+    its own turn (init → assistant → result) *ahead* of the user's message
+    turn, all within the single CLI process Sculptor spawned for that prompt.
+
+    The turn-completion loop in ``_process_output`` keys on the first ``result``
+    it sees (``found_final_message``). Treating the notification turn's result
+    as terminal makes the loop exit and the process manager tears the CLI down
+    while the user's real request has run at most one tool call — silently
+    abandoning it. The loop must instead stay open until the user's own turn
+    produces its result.
+    """
+
+    @staticmethod
+    def _notification_then_user_turn_jsonl(user_tool_id: str, continuation_text: str) -> list[dict]:
+        """A notification turn (init → assistant → result) followed by the user's
+        own turn that issues one tool call and then continues afterwards.
+
+        The task-notification frame arrives before any ``result``, i.e. while
+        ``found_final_message`` is still False — this is what distinguishes the
+        notification-before-user ordering from the common notification-after
+        ordering that ``handle_background_task_notification`` models.
+        """
+        return [
+            # The CLI delivers the completed Monitor task's notification first.
+            make_task_notification_message(
+                task_id="task_monitor_1",
+                tool_use_id="toolu_monitor_1",
+                status="completed",
+                summary="test-unit watcher finished",
+            ),
+            # Notification turn: the agent briefly acknowledges the notification.
+            make_init_message(session_id="s1"),
+            make_assistant_message(
+                message_id="msg_notif",
+                content_blocks=[make_text_block("This is just the stale Monitor task being cleaned up.")],
+            ),
+            make_end_message(session_id="s1"),
+            # The user's real turn: fetch, then act on the result.
+            make_init_message(session_id="s1"),
+            make_assistant_message(
+                message_id="msg_user_a",
+                content_blocks=[make_text_block("I'll fetch the latest state of that branch.")],
+            ),
+            make_assistant_message(
+                message_id="msg_user_b",
+                content_blocks=[make_tool_use_block(user_tool_id, "Bash", {"command": "git fetch origin"})],
+            ),
+            make_tool_result_message(user_tool_id, "Fetched new commits."),
+            make_assistant_message(
+                message_id="msg_user_c",
+                content_blocks=[make_text_block(continuation_text)],
+            ),
+            make_end_message(session_id="s1"),
+        ]
+
+    def test_user_turn_after_notification_turn_is_not_abandoned(self) -> None:
+        """The user's turn (its tool call and its post-tool continuation) must
+        survive when a notification turn precedes it.
+
+        Before the fix the loop exits at the notification turn's ``result``, so
+        the user turn's frames are never processed and its tool call and
+        continuation text never reach the chat.
+        """
+        user_tool_id = "toolu_user_merge"
+        continuation_text = "MERGE COMPLETE — pushed."
+        jsonl = self._notification_then_user_turn_jsonl(user_tool_id, continuation_text)
+
+        emitted = _run_process_output(jsonl)
+
+        request_id = AgentMessageID()
+        stream = (
+            [
+                ChatInputUserMessage(message_id=request_id, text="merge and repush", files=[]),
+                RequestStartedAgentMessage(request_id=request_id),
+            ]
+            + emitted
+            + [RequestSuccessAgentMessage(request_id=request_id)]
+        )
+        update = convert_agent_messages_to_task_update(stream, TaskID(), {}, CLAUDE_CODE_HARNESS)
+        chat_messages = list(update.chat_messages)
+        if update.in_progress_chat_message is not None:
+            chat_messages.append(update.in_progress_chat_message)
+
+        visible_tool_ids = _collect_tool_ids(chat_messages)
+        assert user_tool_id in visible_tool_ids, (
+            "the user turn's tool call went missing: the loop exited at the notification turn's result and abandoned the user's request"
+        )
+        assert continuation_text in _collect_text(chat_messages), (
+            "the user turn's post-tool continuation never reached the chat: the turn was terminated after its first tool result"
+        )

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -348,7 +348,10 @@ def _feed_jsonl(processor: ClaudeOutputProcessor, jsonl_dicts: list[dict]) -> No
             processor._completed_pending_deferred.discard(result.task_id)
             if not processor._completed_pending_deferred:
                 processor._completed_pending_deferred_deadline = None
-            processor.found_final_message = False
+            if processor.found_final_message:
+                processor.found_final_message = False
+            else:
+                processor._awaiting_notification_turn_init = True
             processor.output_message_queue.put(
                 BackgroundTaskNotificationAgentMessage(
                     message_id=AgentMessageID(),

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -1183,6 +1183,9 @@ def handle_emit_task_notification(args: dict, emit_streaming: bool) -> list[dict
 
     Args:
         args: Must contain "task_id". Optional: "tool_use_id", "status", "summary".
+            Pass "tool_use_id": null to omit the field, reproducing the orphaned-
+            task-on-restart notification the real CLI emits (see SCU-1666). When
+            "tool_use_id" is absent a placeholder id is generated instead.
     """
     return [
         make_task_notification_message(

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -1248,6 +1248,84 @@ def handle_background_task_notification(args: dict, emit_streaming: bool) -> lis
     return messages
 
 
+def handle_notification_turn_then_response(args: dict, emit_streaming: bool) -> list[dict]:
+    """Emit a task-notification turn *followed by* the user's own message turn.
+
+    Reproduces SCU-1660: a Monitor background task completes just as a new user
+    prompt is dispatched, so the CLI delivers the pending ``<task-notification>``
+    as its own turn (init -> assistant -> result) BEFORE processing the user's
+    message. Everything below sits inside a single FakeClaude invocation (one
+    CLI process), between the process's own opening ``init`` and the closing
+    ``end`` that ``fake_claude.main()`` appends — that closing ``end`` is the
+    user turn's result.
+
+    Frame order returned by this handler:
+      1. system/task_notification (the Monitor completion, delivered first)
+      2. notification turn: init -> assistant(ack) -> result
+      3. user turn: init -> assistant(text) -> assistant(Bash tool_use) ->
+         tool_result -> assistant(continuation)
+
+    The notification turn's ``result`` is the trap: if the output processor
+    treats it as terminal, the loop exits and the CLI is torn down before the
+    user turn's frames are processed, silently abandoning the request after its
+    first tool result.
+
+    Args:
+        args: Optional "task_id", "tool_use_id", "summary", "ack_text",
+              "user_pre_text", "user_tool_command", "user_post_text".
+    """
+    task_id = args.get("task_id", "task_monitor_1")
+    tool_use_id = args.get("tool_use_id", generate_id("toolu"))
+    summary = args.get("summary", "Background task completed")
+    ack_text = args.get("ack_text", "This is just the stale Monitor task being cleaned up.")
+    user_pre_text = args.get("user_pre_text", "I'll fetch the latest state of that branch.")
+    user_tool_command = args.get("user_tool_command", "git fetch origin")
+    user_post_text = args.get("user_post_text", "Done — merged and repushed.")
+
+    session_id = generate_id("session")
+    user_tool_id = generate_id("toolu")
+    messages: list[dict] = []
+
+    # 1. The completed Monitor task's notification, delivered ahead of the user turn.
+    messages.append(
+        make_task_notification_message(
+            task_id=task_id,
+            tool_use_id=tool_use_id,
+            status="completed",
+            summary=summary,
+        )
+    )
+
+    # 2. Notification turn: init -> assistant(ack) -> result.
+    messages.append(make_init_message(session_id=session_id))
+    ack_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=ack_msg_id, text=ack_text))
+    messages.append(make_assistant_message(message_id=ack_msg_id, content_blocks=[make_text_block(ack_text)]))
+    messages.append(make_end_message(session_id=session_id))
+
+    # 3. User turn: init -> text -> Bash tool_use -> tool_result -> continuation.
+    messages.append(make_init_message(session_id=session_id))
+    pre_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=pre_msg_id, text=user_pre_text))
+    messages.append(make_assistant_message(message_id=pre_msg_id, content_blocks=[make_text_block(user_pre_text)]))
+
+    tool_block = make_tool_use_block(tool_id=user_tool_id, tool_name="Bash", tool_input={"command": user_tool_command})
+    tool_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_tool_events(message_id=tool_msg_id, tool_blocks=[tool_block]))
+    messages.append(make_assistant_message(message_id=tool_msg_id, content_blocks=[tool_block]))
+    messages.append(make_tool_result_message(tool_use_id=user_tool_id, content="Fetched new commits."))
+
+    post_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=post_msg_id, text=user_post_text))
+    messages.append(make_assistant_message(message_id=post_msg_id, content_blocks=[make_text_block(user_post_text)]))
+
+    return messages
+
+
 def handle_subagent(args: dict, emit_streaming: bool) -> list[dict]:
     """Simulate a subagent (Agent tool) call.
 
@@ -2247,6 +2325,7 @@ COMMAND_REGISTRY: dict[str, Callable[..., list[dict]]] = {
     "background_task_started": handle_background_task_started,
     "background_task_notification": handle_background_task_notification,
     "emit_task_notification": handle_emit_task_notification,
+    "notification_turn_then_response": handle_notification_turn_then_response,
     "auto_bg_bash": handle_auto_bg_bash,
     "multi_step": handle_multi_step,
     "parallel_tools": handle_parallel_tools,

--- a/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
@@ -63,7 +63,7 @@ def make_task_started_message(
 
 def make_task_notification_message(
     task_id: str,
-    tool_use_id: str,
+    tool_use_id: str | None,
     status: str = "completed",
     summary: str = "",
     duration_ms: int | None = None,
@@ -72,15 +72,21 @@ def make_task_notification_message(
 
     When ``duration_ms`` is provided it is emitted nested under ``usage`` to
     match the real Claude CLI shape (see SCU-1151).
+
+    Pass ``tool_use_id=None`` to omit the field entirely. The real CLI drops
+    ``tool_use_id`` when a background task is orphaned by a process exit (e.g. a
+    restart) and reported as failed on resume, because the launching tool call's
+    id was lost with the dead process — see SCU-1666.
     """
     msg: dict = {
         "type": "system",
         "subtype": "task_notification",
         "task_id": task_id,
-        "tool_use_id": tool_use_id,
         "status": status,
         "summary": summary,
     }
+    if tool_use_id is not None:
+        msg["tool_use_id"] = tool_use_id
     if duration_ms is not None:
         msg["usage"] = {"duration_ms": duration_ms}
     return msg

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -104,6 +104,29 @@ def test_task_notification_message_roundtrip() -> None:
     assert parsed.summary == "Tests passed"
 
 
+def test_task_notification_message_without_tool_use_id_parses() -> None:
+    """A task_notification missing tool_use_id must parse, not raise KeyError.
+
+    The CLI omits tool_use_id when a background task orphaned by a process exit
+    is reported as failed on resume (see SCU-1666). Parsing must degrade to an
+    empty tool_use_id instead of crashing the agent's output-processing thread.
+    """
+    msg = make_task_notification_message(
+        task_id="task-123",
+        tool_use_id=None,
+        status="failed",
+        summary="Background task did not complete",
+    )
+    assert "tool_use_id" not in msg
+    result = parse_claude_code_json_lines_simple(json.dumps(msg))
+    assert result is not None
+    _msg_type, parsed = result
+    assert isinstance(parsed, ParsedTaskNotificationResponse)
+    assert parsed.task_id == "task-123"
+    assert parsed.tool_use_id == ""
+    assert parsed.status == "failed"
+
+
 def test_assistant_text_message_roundtrip() -> None:
     msg_id = f"msg-{uuid4().hex}"
     msg = make_assistant_message(msg_id, [make_text_block("hello")])

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -127,6 +127,28 @@ def test_task_notification_message_without_tool_use_id_parses() -> None:
     assert parsed.status == "failed"
 
 
+def test_task_started_message_without_tool_use_id_parses() -> None:
+    """task_started tolerates a missing tool_use_id too (parity with task_notification).
+
+    The notification handler is where the orphaned-on-restart payload actually
+    drops the key, but task_started reads it the same defensive way, so a variant
+    payload there must degrade to an empty id rather than crashing the agent.
+    """
+    msg = make_task_started_message(
+        task_id="task-123",
+        tool_use_id="toolu-456",
+        description="Run tests",
+        task_type="local_bash",
+    )
+    del msg["tool_use_id"]
+    result = parse_claude_code_json_lines_simple(json.dumps(msg))
+    assert result is not None
+    _msg_type, parsed = result
+    assert isinstance(parsed, ParsedTaskStartedResponse)
+    assert parsed.task_id == "task-123"
+    assert parsed.tool_use_id == ""
+
+
 def test_assistant_text_message_roundtrip() -> None:
     msg_id = f"msg-{uuid4().hex}"
     msg = make_assistant_message(msg_id, [make_text_block("hello")])

--- a/sculptor/sculptor/state/claude_state.py
+++ b/sculptor/sculptor/state/claude_state.py
@@ -283,7 +283,9 @@ class ParsedTaskNotificationResponse(ParsedAgentResponse):
 
     object_type: str = Field(default="ParsedTaskNotificationResponse")
     task_id: str = Field(description="Background task ID matching the task_started event")
-    tool_use_id: str = Field(description="Tool use ID of the tool call that launched the background task")
+    tool_use_id: str = Field(
+        description="Tool use ID of the tool call that launched the background task. Empty when the CLI omits it, e.g. a task orphaned by a process exit and reported as failed on resume (see SCU-1666).",
+    )
     status: str = Field(description="Completion status (e.g. completed)")
     summary: str = Field(default="", description="Human-readable summary of the background task result")
     duration_ms: int | None = Field(
@@ -386,9 +388,11 @@ def _handle_init_message(data: dict[str, Any]) -> ParsedInitResponse:
 
 def _handle_task_started_message(data: dict[str, Any]) -> ParsedTaskStartedResponse:
     """Handle system/task_started message type."""
+    # ``tool_use_id`` is read defensively (see _handle_task_notification_message)
+    # to keep a variant payload from crashing the whole agent.
     return ParsedTaskStartedResponse(
         task_id=data["task_id"],
-        tool_use_id=data["tool_use_id"],
+        tool_use_id=data.get("tool_use_id", ""),
         description=data.get("description", ""),
         task_type=data.get("task_type", ""),
     )
@@ -401,9 +405,13 @@ def _handle_task_notification_message(data: dict[str, Any]) -> ParsedTaskNotific
     # unparsed until a caller asks for them.
     usage = data.get("usage") or {}
     raw_duration_ms = usage.get("duration_ms") if isinstance(usage, dict) else None
+    # ``tool_use_id`` is absent when a background task orphaned by a process exit
+    # is reported as failed on resume: the launching tool call's id died with the
+    # previous process (see SCU-1666). Default to "" rather than indexing so the
+    # notification is surfaced instead of a missing key killing the agent.
     return ParsedTaskNotificationResponse(
         task_id=data["task_id"],
-        tool_use_id=data["tool_use_id"],
+        tool_use_id=data.get("tool_use_id", ""),
         status=data.get("status", ""),
         summary=data.get("summary", ""),
         duration_ms=int(raw_duration_ms) if isinstance(raw_duration_ms, (int, float)) else None,

--- a/sculptor/sculptor/state/claude_state.py
+++ b/sculptor/sculptor/state/claude_state.py
@@ -273,7 +273,9 @@ class ParsedTaskStartedResponse(ParsedAgentResponse):
 
     object_type: str = Field(default="ParsedTaskStartedResponse")
     task_id: str = Field(description="Background task ID assigned by Claude Code")
-    tool_use_id: str = Field(description="Tool use ID of the tool call that launched the background task")
+    tool_use_id: str = Field(
+        description="Tool use ID of the tool call that launched the background task. Empty when the CLI omits it (parity with ParsedTaskNotificationResponse — see SCU-1666).",
+    )
     description: str = Field(default="", description="Human-readable description of the background task")
     task_type: str = Field(default="", description="Type of background task (e.g. local_bash)")
 

--- a/sculptor/sculptor/testing/elements/chat_panel.py
+++ b/sculptor/sculptor/testing/elements/chat_panel.py
@@ -72,6 +72,11 @@ class PlaywrightChatPanelElement(PlaywrightFilePreviewAndUploadMixin, Playwright
         return self._locator.locator(", ".join((alpha_pill, alpha_bash, alpha_file)))
 
     def get_bash_blocks(self) -> Locator:
+        """Bash tool calls (``ALPHA_CHAT_BASH_BLOCK``).
+
+        Bash renders as a dedicated bash block, not as a generic
+        ``get_tool_pills`` pill — assert on a Bash tool call through here.
+        """
         return self.get_by_test_id(ElementIDs.ALPHA_CHAT_BASH_BLOCK)
 
     def get_bash_output(self) -> Locator:
@@ -263,6 +268,13 @@ class PlaywrightChatPanelElement(PlaywrightFilePreviewAndUploadMixin, Playwright
         return self.get_by_test_id(ElementIDs.ALPHA_CHAT_TOOL_PILL_ROW)
 
     def get_tool_pills(self) -> Locator:
+        """Generic tool pills only (``ALPHA_CHAT_TOOL_PILL``).
+
+        This does NOT match every tool: Bash renders as a bash block (use
+        ``get_bash_blocks``) and Write / Edit / MultiEdit render as file chips
+        (use ``get_file_chips``). To match every tool surface regardless of
+        which tool ran, use ``get_completed_tool_calls``.
+        """
         return self.get_by_test_id(ElementIDs.ALPHA_CHAT_TOOL_PILL)
 
     def get_tool_pill_popover(self) -> Locator:

--- a/sculptor/tests/integration/frontend/test_background_task_notification_missing_tool_use_id.py
+++ b/sculptor/tests/integration/frontend/test_background_task_notification_missing_tool_use_id.py
@@ -1,0 +1,66 @@
+"""Regression test for SCU-1666: a background-task notification missing ``tool_use_id``.
+
+When a background task is orphaned by a process exit (e.g. the machine restarts
+while the task is running), the Claude CLI reports it as failed on resume with a
+``system/task_notification`` that has no ``tool_use_id`` — the launching tool
+call's id was lost with the dead process. The agent must process that
+notification gracefully and stay alive, rather than crashing on a missing key.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# Drive FakeClaude to emit a failed task_notification with NO tool_use_id
+# (``"tool_use_id": null`` omits the field), mirroring the orphaned-on-restart
+# message the real CLI emits, then a final text marker. If the notification
+# crashes the output-processing thread the marker never renders.
+ORPHANED_NOTIFICATION_COMMAND = """\
+fake_claude:multi_step `{
+  "steps": [
+    {"command": "emit_task_notification", "args": {
+      "task_id": "a924753e20158e44b",
+      "tool_use_id": null,
+      "status": "failed",
+      "summary": "Background agent was running when the previous Claude Code process exited and did not complete."
+    }},
+    {"command": "text", "args": {"text": "Agent survived the orphaned notification — ORPHAN-NOTIFY-DONE"}}
+  ]
+}`"""
+
+
+@user_story("to have my agent survive an orphaned background-task notification after a restart")
+def test_task_notification_without_tool_use_id_does_not_crash_agent(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """A task_notification missing tool_use_id must not kill the agent.
+
+    Repro: FakeClaude emits a failed ``task_notification`` with no
+    ``tool_use_id`` followed by a text marker. Before the fix,
+    ``_handle_task_notification_message`` indexed ``data["tool_use_id"]``
+    directly, so the missing key raised ``KeyError: 'tool_use_id'`` on the
+    output-processing thread and crashed the whole agent (the marker never
+    rendered and the turn ended in an error). With the fix the notification is
+    handled, the marker renders, and follow-up turns still work.
+    """
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=sculptor_instance_.page,
+        prompt=ORPHANED_NOTIFICATION_COMMAND,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # The turn should finish (not hang), and the post-notification marker must
+    # render — proof the agent kept processing after the malformed message.
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+    expect(chat_panel.get_messages().filter(has_text="ORPHAN-NOTIFY-DONE").first).to_be_visible()
+
+    # The missing key must not surface as a crash / error block.
+    expect(chat_panel.get_error_block()).to_have_count(0)
+
+    # The agent should still be usable — send a follow-up message.
+    send_chat_message(chat_panel, 'fake_claude:text `{"text": "Recovery after orphaned notification"}`')
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+    expect(chat_panel.get_messages().last).to_contain_text("Recovery after orphaned notification")

--- a/sculptor/tests/integration/frontend/test_notification_before_user_turn.py
+++ b/sculptor/tests/integration/frontend/test_notification_before_user_turn.py
@@ -1,0 +1,71 @@
+"""Integration test for SCU-1660: a task-notification turn colliding with a user prompt.
+
+When a Monitor background task completes at (or very near) the instant a new
+user prompt is dispatched, the Claude CLI delivers the pending
+``<task-notification>`` as its own turn (init -> assistant -> result) *ahead*
+of the user's message turn — all inside the single CLI process Sculptor spawned
+for that prompt. The turn-completion loop must not treat the notification
+turn's ``result`` as the end of the invocation; if it does, the CLI is torn
+down while the user's real request has run at most one tool call, silently
+abandoning it.
+
+FakeClaude reproduces the collision deterministically via the
+``notification_turn_then_response`` command, which scripts the exact
+notification-turn-then-user-turn frame order that the timing race produces.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+NOTIFICATION_ACK_TEXT = "NOTIF-ACK stale Monitor task cleaned up"
+USER_TURN_DONE_TEXT = "USER-TURN-COMPLETE merged and repushed"
+
+NOTIFICATION_BEFORE_USER_TURN_COMMAND = f"""\
+fake_claude:notification_turn_then_response `{{
+  "task_id": "task-watchdog",
+  "tool_use_id": "toolu-watchdog",
+  "summary": "test-unit watcher finished",
+  "ack_text": "{NOTIFICATION_ACK_TEXT}",
+  "user_pre_text": "I'll fetch the latest state of that branch.",
+  "user_tool_command": "git fetch origin",
+  "user_post_text": "{USER_TURN_DONE_TEXT}"
+}}`"""
+
+
+@user_story("to verify a user prompt is not abandoned when a task-notification turn precedes it")
+def test_user_turn_after_notification_turn_completes(sculptor_instance_: SculptorInstance) -> None:
+    """The user's turn must run to completion even when a task-notification turn
+    is delivered ahead of it within the same CLI process.
+
+    Before the fix the output loop exits at the notification turn's ``result``,
+    so the user turn's Bash tool call and its post-tool continuation never reach
+    the chat — the request is abandoned after (at most) its first tool result.
+    With the fix, the loop stays open until the user turn's own result, so the
+    full response renders.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=NOTIFICATION_BEFORE_USER_TURN_COMMAND,
+    )
+    chat_panel = task_page.get_chat_panel()
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()
+
+    messages = chat_panel.get_messages()
+
+    # The notification turn's acknowledgement should be present (both turns ran).
+    expect(messages.filter(has_text=NOTIFICATION_ACK_TEXT).first).to_be_visible()
+
+    # The crux: the user turn's post-tool continuation must be visible. Its
+    # absence is exactly the silent abandonment SCU-1660 describes.
+    expect(messages.filter(has_text=USER_TURN_DONE_TEXT).first).to_be_visible()
+
+    # The user turn's Bash tool call must also have rendered — the request got
+    # past its first tool result rather than stalling on it. (Bash renders as a
+    # dedicated bash block, not a generic tool pill.) When the turn is abandoned
+    # no bash block renders at all.
+    expect(chat_panel.get_bash_blocks()).to_have_count(1)


### PR DESCRIPTION
Bundles two stacked task-notification fixes from `main` into the 0.40.0 release branch. Cherry-picked in merge order (#252 first, then #253 which was stacked on it).

## Included
- **#252 — Fix SCU-1660: don't end the turn when a task-notification precedes the user prompt**
  - `70ff21df0b6` Add failing tests for SCU-1660 task-notification/user-prompt collision
  - `a6c3de14565` Fix SCU-1660: keep the loop open when a task-notification turn precedes the user turn
  - `8617a8daeb1` Document that get_tool_pills excludes Bash and file-chip tool surfaces
- **#253 — Fix agent crash on background-task notification missing tool_use_id (SCU-1666)**
  - `25fdef12e41` Add failing test for orphaned background-task notification
  - `f235eb38550` Fix agent crash on background-task notification missing tool_use_id
  - `62a1685d5c9` Add unit test for task_started missing tool_use_id
  - `9e6b2b21efc` Document that task_started tool_use_id can be empty

Each SHA is the original commit on `main`. Clean cherry-pick, no conflicts.

Both fix the same class of bug: a background task-notification arriving around a user prompt could either prematurely end the agent turn (SCU-1660) or crash the agent when it lacked a `tool_use_id` (SCU-1666). After this merges, `just fixup` on the release branch will tag rc2 and kick off the build.

(Sent by Claude)