### PR TITLE
[SCU-1670] Fix subagent ask_user_question freezing the whole turn

### DIFF
--- a/sculptor/sculptor-workflow/skills/fix-bug/SKILL.md
+++ b/sculptor/sculptor-workflow/skills/fix-bug/SKILL.md
@@ -146,13 +146,22 @@ Write out your understanding as a summary:
   testing config's **Test Strategy**. Be explicit — do not leave the test kind
   implicit in the file path.
 
+The summary MUST appear as a plain chat message **before** you call the
+question tool. Your internal reasoning is invisible to the user, and the
+question panel only shows short question text — so a diagnosis that lives
+only in your thinking or inside the question tool's input was never shown to
+the user, and asking "does the diagnosis match?" leaves them with nothing to
+confirm. Skipping the written summary and jumping straight to the question
+tool is a known failure mode for this phase — do not do it.
+
 **If you reproduced the bug visually:** include the screenshots inline with
 `<img>` tags. Walk the user through each screenshot, explaining what you did
 and what you observed.
 
-**You MUST ask with your question tool here** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — do NOT use a plain text
-message. The tool triggers a UI notification that grabs the user's attention.
-Ask:
+**You MUST ask with your question tool here** — `mcp__sculptor__ask_user_question` if it's available, otherwise the built-in `AskUserQuestion` — do NOT ask via a plain
+text message. (The written summary above is still a plain text message; only
+the ask itself goes through the tool, which triggers a UI notification that
+grabs the user's attention.) Ask:
 > "Does this match your understanding? Is the test location correct? Please
 > confirm so I can proceed."
 

--- a/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server.py
@@ -89,6 +89,36 @@ class PendingCall(SerializableModel):
     mcp_message_id: int | str
     tool_fqn: str
     tool_use_id: str
+    arguments: dict[str, Any] = {}
+
+
+class ExpectedCall(SerializableModel):
+    """A registered tool_use awaiting its matching `tools/call` request.
+
+    ``tool_input`` is the ToolUseBlock's input from the assistant stream,
+    used to pair by content. ``None`` acts as a wildcard (matches any
+    arguments of the same tool).
+    """
+
+    tool_use_id: str
+    tool_fqn: str
+    tool_input: dict[str, Any] | None = None
+
+
+class UnmatchedCall(SerializableModel):
+    """A `tools/call` that arrived before its tool_use registration.
+
+    For SUBAGENT tool calls the CLI emits the `tools/call` control_request
+    BEFORE the sidechain assistant message that carries the ToolUseBlock —
+    the inverse of the main-agent ordering. The call is held here until
+    ``register_tool_use_id`` pairs it; dropping it would leave the subagent
+    blocked forever on a response that never comes, freezing the turn.
+    """
+
+    control_request_id: str
+    mcp_message_id: int | str
+    tool_fqn: str
+    arguments: dict[str, Any]
 
 
 class SculptorMcpServer:
@@ -97,6 +127,14 @@ class SculptorMcpServer:
     `handle_message` runs on the output-processor thread. `deliver_answer`
     runs on the task-handler thread. The internal pending-call registry is
     guarded by a lock so the two paths can coexist.
+
+    Pairing model: a `tools/call` request does not carry Claude's
+    ``tool_use_id``, so calls are paired with ToolUseBlocks from the
+    assistant stream by tool name + arguments. Either side may arrive
+    first — the main agent emits the assistant message before the
+    `tools/call`, while subagents emit them in the opposite order — so both
+    an expectation queue (registrations awaiting calls) and an
+    unmatched-call queue (calls awaiting registrations) are kept.
     """
 
     def __init__(
@@ -113,35 +151,82 @@ class SculptorMcpServer:
         # (CLI-driven replay after `--resume` re-emits the dangling
         # tool_use with a fresh ``tool_use_id``, so a tool_use_id-keyed
         # cache wouldn't match). Invalidated when a fresh AUQ panel is
-        # shown via ``register_tool_use_id``.
+        # shown via ``register_tool_use_id``, and guarded by the delivered
+        # call's arguments so a NEW question (e.g. from a subagent) is never
+        # answered with the previous question's answer.
         self._last_delivered_text: str | None = None
+        self._last_delivered_arguments: dict[str, Any] | None = None
         self._has_new_auq_since_last_delivery: bool = False
-        self._expected_tool_use_id: str | None = None
+        self._expected_calls: list[ExpectedCall] = []
+        self._unmatched_calls: list[UnmatchedCall] = []
 
     def set_respond(self, respond: Callable[[str, dict[str, Any]], None]) -> None:
         """Rebind the stdin-write callback. Called from each new
         `ClaudeOutputProcessor.__init__` so the long-lived MCP server (owned by
         `ClaudeProcessManager`) always sends responses through the current CLI
         invocation's stdin.
+
+        Also drops queued expectations and unmatched calls: their
+        control_request_ids belong to the previous CLI invocation, so they can
+        never be answered through the new one. (Pending calls are kept — the
+        resume replay cache handles re-asked dangling questions.)
         """
         self._respond = respond
+        with self._lock:
+            self._expected_calls = []
+            self._unmatched_calls = []
 
-    def register_tool_use_id(self, tool_use_id: str, tool_fqn: str) -> None:
-        """Inform the server that a `tools/call` for `tool_use_id` is imminent.
+    def _args_match(self, tool_fqn: str, tool_input: dict[str, Any] | None, arguments: dict[str, Any]) -> bool:
+        """Whether a registered ToolUseBlock input pairs with `tools/call` arguments.
 
-        Called from the output processor when an `assistant` stream surfaces
-        a `ToolUseBlock` whose `name` is a Sculptor MCP FQN. The CLI sends
-        the matching `tools/call` immediately afterwards.
+        ``mcp__sculptor__exit_plan_mode`` has an open input schema (the model's
+        input and the CLI's forwarded arguments may legitimately differ), so it
+        pairs by tool name alone. ``None`` input is a wildcard.
+        """
+        if tool_input is None:
+            return True
+        if tool_fqn == self._harness.mcp_exit_plan_mode_tool_fqn:
+            return True
+        return tool_input == arguments
+
+    def register_tool_use_id(self, tool_use_id: str, tool_fqn: str, tool_input: dict[str, Any] | None = None) -> None:
+        """Inform the server of a ToolUseBlock surfaced by the assistant stream.
+
+        Called from the output processor when an `assistant` message carries a
+        ToolUseBlock whose `name` is a Sculptor MCP FQN. For main-agent calls
+        the matching `tools/call` arrives immediately afterwards; for subagent
+        calls it typically arrived FIRST and is waiting in the unmatched-call
+        queue, in which case it is paired (and held pending) here.
         """
         if tool_fqn not in (self._harness.mcp_ask_tool_fqn, self._harness.mcp_exit_plan_mode_tool_fqn):
             logger.debug("register_tool_use_id called with non-MCP tool_fqn={}", tool_fqn)
             return
         with self._lock:
-            self._expected_tool_use_id = tool_use_id
+            if tool_use_id in self._pending or any(e.tool_use_id == tool_use_id for e in self._expected_calls):
+                return
             if self._last_delivered_text is not None:
                 # A fresh AUQ panel is being shown — the cache from the
                 # previous Q&A no longer applies to this one.
                 self._has_new_auq_since_last_delivery = True
+            for i, unmatched in enumerate(self._unmatched_calls):
+                if unmatched.tool_fqn == tool_fqn and self._args_match(tool_fqn, tool_input, unmatched.arguments):
+                    del self._unmatched_calls[i]
+                    self._pending[tool_use_id] = PendingCall(
+                        control_request_id=unmatched.control_request_id,
+                        mcp_message_id=unmatched.mcp_message_id,
+                        tool_fqn=unmatched.tool_fqn,
+                        tool_use_id=tool_use_id,
+                        arguments=unmatched.arguments,
+                    )
+                    logger.debug(
+                        "Paired held tools/call for {} with tool_use_id={} from the assistant stream",
+                        tool_fqn,
+                        tool_use_id,
+                    )
+                    return
+            self._expected_calls.append(
+                ExpectedCall(tool_use_id=tool_use_id, tool_fqn=tool_fqn, tool_input=tool_input)
+            )
 
     def handle_message(self, control_request_id: str, message: dict[str, Any]) -> None:
         """Dispatch an MCP JSON-RPC message by method."""
@@ -186,6 +271,7 @@ class SculptorMcpServer:
         text = self._format_answer_text(pending.tool_fqn, answer)
         with self._lock:
             self._last_delivered_text = text
+            self._last_delivered_arguments = pending.arguments
             self._has_new_auq_since_last_delivery = False
         self._respond_with_text(pending.control_request_id, pending.mcp_message_id, text)
 
@@ -211,9 +297,9 @@ class SculptorMcpServer:
         # Without this, malformed arguments (e.g. ``multiSelect: 'false'`` as a
         # string, ``options`` JSON-encoded into a string, missing required
         # fields) would dangle: the output processor's UI-side validation
-        # rejects the call and skips ``register_tool_use_id``, leaving the
-        # tools/call here with no expected tool_use_id, which would otherwise
-        # be silently dropped a few lines below. Returning a JSON-RPC error
+        # rejects the call and skips ``register_tool_use_id``, so the
+        # tools/call would sit in the unmatched-call queue with no panel and
+        # no registration ever coming. Returning a JSON-RPC error
         # lets the agent see the failure and retry with corrected types.
         validation_error_message = _validate_arguments(tool_fqn, ask_tool_fqn, params.get("arguments", {}))
         if validation_error_message is not None:
@@ -225,41 +311,68 @@ class SculptorMcpServer:
             )
             return
 
+        arguments = params.get("arguments", {})
         with self._lock:
-            tool_use_id = self._expected_tool_use_id
-            self._expected_tool_use_id = None
+            # A queued registration from the assistant stream takes precedence
+            # over everything else — pair with it and hold for the answer.
+            expectation: ExpectedCall | None = None
+            for i, expected in enumerate(self._expected_calls):
+                if expected.tool_fqn == tool_fqn and self._args_match(tool_fqn, expected.tool_input, arguments):
+                    expectation = expected
+                    del self._expected_calls[i]
+                    break
+
+            if expectation is not None:
+                self._pending[expectation.tool_use_id] = PendingCall(
+                    control_request_id=control_request_id,
+                    mcp_message_id=message["id"],
+                    tool_fqn=tool_fqn,
+                    tool_use_id=expectation.tool_use_id,
+                    arguments=arguments,
+                )
+                return
+
             # Serve the cache for a duplicate tools/call against the just-
-            # answered AUQ — the resumed CLI re-emits the dangling call
+            # answered question — the resumed CLI re-emits the dangling call
             # with a fresh tool_use_id, so we match against
-            # ``_has_new_auq_since_last_delivery`` rather than tool_use_id
-            # equality. ``register_tool_use_id`` flips that flag whenever
-            # a fresh AUQ panel is shown, invalidating the cache. Checked
-            # before the registered-id requirement because a duplicate
-            # tools/call may arrive without a paired register.
+            # ``_has_new_auq_since_last_delivery`` plus argument equality
+            # rather than tool_use_id equality. ``register_tool_use_id``
+            # flips that flag whenever a fresh AUQ panel is shown,
+            # invalidating the cache; the argument guard keeps a NEW question
+            # (e.g. a subagent's, whose tools/call arrives before its
+            # registration) from being answered with the previous question's
+            # answer.
             cached_text: str | None
-            if self._last_delivered_text is not None and not self._has_new_auq_since_last_delivery:
+            if (
+                self._last_delivered_text is not None
+                and not self._has_new_auq_since_last_delivery
+                and self._last_delivered_arguments == arguments
+            ):
                 cached_text = self._last_delivered_text
             else:
                 cached_text = None
 
-        if cached_text is not None:
-            self._respond_with_text(control_request_id, message["id"], cached_text)
-            return
+            if cached_text is None:
+                # No registration yet — the SUBAGENT ordering, where the
+                # tools/call reaches stdout before the sidechain assistant
+                # message. Hold the call; register_tool_use_id pairs it when
+                # the assistant stream catches up. Dropping it would leave
+                # the agent blocked forever on a response that never comes.
+                self._unmatched_calls.append(
+                    UnmatchedCall(
+                        control_request_id=control_request_id,
+                        mcp_message_id=message["id"],
+                        tool_fqn=tool_fqn,
+                        arguments=arguments,
+                    )
+                )
+                logger.debug(
+                    "tools/call for {} arrived before its tool_use registration; holding until the assistant stream catches up",
+                    tool_name_short,
+                )
+                return
 
-        if tool_use_id is None:
-            logger.debug(
-                "tools/call for {} arrived without a registered tool_use_id; dropping (this indicates an out-of-order assistant stream)",
-                tool_name_short,
-            )
-            return
-
-        with self._lock:
-            self._pending[tool_use_id] = PendingCall(
-                control_request_id=control_request_id,
-                mcp_message_id=message["id"],
-                tool_fqn=tool_fqn,
-                tool_use_id=tool_use_id,
-            )
+        self._respond_with_text(control_request_id, message["id"], cached_text)
 
     def _format_answer_text(self, tool_fqn: str, answer: UserQuestionAnswerMessage) -> str:
         if tool_fqn == self._harness.mcp_exit_plan_mode_tool_fqn:

--- a/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server.py
@@ -335,18 +335,21 @@ class SculptorMcpServer:
             # Serve the cache for a duplicate tools/call against the just-
             # answered question — the resumed CLI re-emits the dangling call
             # with a fresh tool_use_id, so we match against
-            # ``_has_new_auq_since_last_delivery`` plus argument equality
+            # ``_has_new_auq_since_last_delivery`` plus argument matching
             # rather than tool_use_id equality. ``register_tool_use_id``
             # flips that flag whenever a fresh AUQ panel is shown,
             # invalidating the cache; the argument guard keeps a NEW question
             # (e.g. a subagent's, whose tools/call arrives before its
             # registration) from being answered with the previous question's
-            # answer.
+            # answer. Uses ``_args_match`` (not raw equality) so it honors
+            # ``exit_plan_mode``'s open schema — a replayed plan-approval call
+            # is served from cache even if its forwarded arguments differ,
+            # rather than being held forever with no registration coming.
             cached_text: str | None
             if (
                 self._last_delivered_text is not None
                 and not self._has_new_auq_since_last_delivery
-                and self._last_delivered_arguments == arguments
+                and self._args_match(tool_fqn, self._last_delivered_arguments, arguments)
             ):
                 cached_text = self._last_delivered_text
             else:

--- a/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server_test.py
@@ -456,6 +456,120 @@ def test_ask_user_question_with_zero_questions_returns_invalid_params_error() ->
     assert "1-4" in mcp_response["error"]["message"]
 
 
+def _make_auq_arguments(question_text: str) -> dict:
+    return {
+        "questions": [
+            {
+                "question": question_text,
+                "header": "Header",
+                "options": [{"label": "A", "description": ""}, {"label": "B", "description": ""}],
+                "multiSelect": False,
+            }
+        ]
+    }
+
+
+def _send_tools_call(server: SculptorMcpServer, request_id: str, rpc_id: int, arguments: dict) -> None:
+    server.handle_message(
+        request_id,
+        {
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "method": "tools/call",
+            "params": {"name": SCULPTOR_MCP_ASK_TOOL_NAME, "arguments": arguments},
+        },
+    )
+
+
+def test_tools_call_arriving_before_registration_is_held_and_paired() -> None:
+    """The SUBAGENT event ordering: the CLI emits the tools/call
+    control_request BEFORE the sidechain assistant message carrying the
+    ToolUseBlock. The call must be held (not dropped) and paired when the
+    registration catches up, so the user's answer can resolve it."""
+    server, respond = _make_server()
+
+    _send_tools_call(server, "req_inverted", 61, _VALID_AUQ_ARGUMENTS)
+    # Held, not dropped and not answered.
+    assert respond.calls == []
+    assert server._pending == {}
+
+    server.register_tool_use_id("toolu_side", SCULPTOR_MCP_ASK_TOOL_FQN, tool_input=_VALID_AUQ_ARGUMENTS)
+    assert "toolu_side" in server._pending
+
+    answer = _make_answer("toolu_side")
+    server.deliver_answer(answer)
+    assert len(respond.calls) == 1
+    request_id, data = respond.calls[0]
+    assert request_id == "req_inverted"
+    assert data["mcp_response"]["id"] == 61
+    assert data["mcp_response"]["result"]["content"][0]["text"] == format_ask_user_question_result(answer)
+
+
+def test_cache_does_not_answer_a_different_question() -> None:
+    """After an answer was delivered, a tools/call for a DIFFERENT question
+    (e.g. a subagent's, arriving before its registration) must NOT be served
+    the previous answer from the replay cache — it must be held."""
+    server, respond = _make_server()
+    first_arguments = _make_auq_arguments("Pick one")
+    server.register_tool_use_id("toolu_first", SCULPTOR_MCP_ASK_TOOL_FQN, tool_input=first_arguments)
+    _send_tools_call(server, "req_first", 71, first_arguments)
+    server.deliver_answer(_make_answer("toolu_first"))
+    assert len(respond.calls) == 1
+
+    second_arguments = _make_auq_arguments("A different question?")
+    _send_tools_call(server, "req_second", 72, second_arguments)
+    # Not served from cache — held until its registration arrives.
+    assert len(respond.calls) == 1
+
+    server.register_tool_use_id("toolu_second", SCULPTOR_MCP_ASK_TOOL_FQN, tool_input=second_arguments)
+    assert "toolu_second" in server._pending
+
+    server.deliver_answer(_make_answer("toolu_second", question_text="A different question?", answer="B"))
+    assert len(respond.calls) == 2
+    assert respond.calls[1][0] == "req_second"
+
+
+def test_two_interleaved_calls_pair_by_question_content() -> None:
+    """Two concurrent subagents asking different questions (each with the
+    inverted ordering) must each pair with their own registration, so each
+    answer resolves the matching control_request."""
+    server, respond = _make_server()
+    arguments_a = _make_auq_arguments("Question A?")
+    arguments_b = _make_auq_arguments("Question B?")
+
+    _send_tools_call(server, "req_a", 81, arguments_a)
+    server.register_tool_use_id("toolu_a", SCULPTOR_MCP_ASK_TOOL_FQN, tool_input=arguments_a)
+    _send_tools_call(server, "req_b", 82, arguments_b)
+    server.register_tool_use_id("toolu_b", SCULPTOR_MCP_ASK_TOOL_FQN, tool_input=arguments_b)
+
+    assert set(server._pending) == {"toolu_a", "toolu_b"}
+
+    server.deliver_answer(_make_answer("toolu_b", question_text="Question B?"))
+    assert len(respond.calls) == 1
+    assert respond.calls[0][0] == "req_b"
+
+    server.deliver_answer(_make_answer("toolu_a", question_text="Question A?"))
+    assert len(respond.calls) == 2
+    assert respond.calls[1][0] == "req_a"
+
+
+def test_set_respond_drops_stale_expectations_and_unmatched_calls() -> None:
+    """Queued expectations and held unmatched calls belong to the previous CLI
+    invocation and can never be answered through the new one — a new
+    invocation's registrations must not pair with them."""
+    server, _respond = _make_server()
+    _send_tools_call(server, "req_stale", 91, _VALID_AUQ_ARGUMENTS)
+    server.register_tool_use_id(
+        "toolu_expected", SCULPTOR_MCP_ASK_TOOL_FQN, tool_input=_make_auq_arguments("Unrelated question?")
+    )
+    assert server._unmatched_calls != []
+    assert server._expected_calls != []
+
+    server.set_respond(lambda _request_id, _data: None)
+    assert server._expected_calls == []
+    assert server._unmatched_calls == []
+
+
 def test_cache_invalidates_when_a_fresh_auq_panel_is_shown_after_delivery() -> None:
     """If the agent moves on to ask a new question after the first answer,
     the cache must NOT serve stale text for the new question."""

--- a/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/mcp_server_test.py
@@ -570,6 +570,45 @@ def test_set_respond_drops_stale_expectations_and_unmatched_calls() -> None:
     assert server._unmatched_calls == []
 
 
+def test_exit_plan_mode_replay_with_differing_arguments_is_served_from_cache() -> None:
+    """``exit_plan_mode`` has an open input schema, so a resume replay may
+    forward arguments that differ from the delivered call's. The cache must
+    still serve the approval (via ``_args_match``'s open-schema handling)
+    rather than holding the call — a held plan-approval replay would dangle
+    forever, since a pure replay brings no fresh registration."""
+    server, respond = _make_server()
+    server.register_tool_use_id("toolu_plan", SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_FQN)
+    server.handle_message(
+        "req_plan",
+        {
+            "jsonrpc": "2.0",
+            "id": 51,
+            "method": "tools/call",
+            "params": {"name": SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_NAME, "arguments": {"plan": "first"}},
+        },
+    )
+    server.deliver_answer(_make_answer("toolu_plan"))
+    assert len(respond.calls) == 1
+    delivered_text = respond.calls[0][1]["mcp_response"]["result"]["content"][0]["text"]
+
+    # Resume replay with DIFFERENT arguments and no fresh registration.
+    server.handle_message(
+        "req_plan_replay",
+        {
+            "jsonrpc": "2.0",
+            "id": 52,
+            "method": "tools/call",
+            "params": {"name": SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_NAME, "arguments": {"plan": "different"}},
+        },
+    )
+    assert len(respond.calls) == 2
+    replay_request_id, replay_data = respond.calls[1]
+    assert replay_request_id == "req_plan_replay"
+    assert replay_data["mcp_response"]["id"] == 52
+    assert replay_data["mcp_response"]["result"]["content"][0]["text"] == delivered_text
+    assert server._unmatched_calls == []
+
+
 def test_cache_invalidates_when_a_fresh_auq_panel_is_shown_after_delivery() -> None:
     """If the agent moves on to ask a new question after the first answer,
     the cache must NOT serve stale text for the new question."""

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -1165,7 +1165,7 @@ class ClaudeOutputProcessor:
             )
         )
         if self._mcp_server is not None:
-            self._mcp_server.register_tool_use_id(tool_block.id, ask_tool_fqn)
+            self._mcp_server.register_tool_use_id(tool_block.id, ask_tool_fqn, tool_input=tool_block.input)
         return True
 
     def _maybe_record_plan_file_write(self, tool_block: ToolUseBlock) -> None:
@@ -1220,7 +1220,7 @@ class ClaudeOutputProcessor:
         # doesn't re-publish the stale path.
         self._recent_plan_file_path = None
         if self._mcp_server is not None:
-            self._mcp_server.register_tool_use_id(tool_block.id, exit_plan_mode_tool_fqn)
+            self._mcp_server.register_tool_use_id(tool_block.id, exit_plan_mode_tool_fqn, tool_input=tool_block.input)
         return True
 
     def _maybe_handle_enter_plan_mode(self, tool_block: ToolUseBlock) -> bool:

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -859,7 +859,9 @@ class TestSculptorMcpToolDetection:
             {"questions": [{"question": "Q?", "header": "Header", "options": [], "multi_select": False}]},
         )
         assert processor._maybe_handle_ask_user_question(block) is True
-        mcp_server.register_tool_use_id.assert_called_once_with(block.id, "mcp__sculptor__ask_user_question")
+        mcp_server.register_tool_use_id.assert_called_once_with(
+            block.id, "mcp__sculptor__ask_user_question", tool_input=block.input
+        )
 
     def test_ask_user_question_handler_does_not_fire_on_builtin_name(self) -> None:
         mcp_server = MagicMock()
@@ -876,7 +878,9 @@ class TestSculptorMcpToolDetection:
         processor = _make_processor_with_mcp_server(mcp_server)
         block = self._make_tool_block("mcp__sculptor__exit_plan_mode", {"plan": "..."})
         assert processor._maybe_handle_exit_plan_mode(block) is True
-        mcp_server.register_tool_use_id.assert_called_once_with(block.id, "mcp__sculptor__exit_plan_mode")
+        mcp_server.register_tool_use_id.assert_called_once_with(
+            block.id, "mcp__sculptor__exit_plan_mode", tool_input=block.input
+        )
 
     def test_exit_plan_mode_handler_does_not_fire_on_builtin_name(self) -> None:
         mcp_server = MagicMock()

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -82,6 +82,36 @@ def _make_tool_assistant_message(
     return messages
 
 
+def _emit_mcp_tool_call(tool_fqn: str, arguments: dict, rpc_id: int = 1) -> str:
+    """Send a `tools/call` MCP control_request on stdout and return its
+    envelope ``request_id`` (used to match the eventual control_response)."""
+    if tool_fqn == SCULPTOR_MCP_ASK_TOOL_FQN:
+        short_name = SCULPTOR_MCP_ASK_TOOL_NAME
+    elif tool_fqn == SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_FQN:
+        short_name = SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_NAME
+    else:
+        raise ValueError(f"Unknown Sculptor MCP tool fqn: {tool_fqn}")
+
+    request_id = generate_id("mcp_req")
+    control_request = {
+        "type": "control_request",
+        "request_id": request_id,
+        "request": {
+            "subtype": "mcp_message",
+            "server_name": SCULPTOR_MCP_SERVER_NAME,
+            "message": {
+                "jsonrpc": "2.0",
+                "id": rpc_id,
+                "method": "tools/call",
+                "params": {"name": short_name, "arguments": arguments},
+            },
+        },
+    }
+    sys.stdout.write(json.dumps(control_request) + "\n")
+    sys.stdout.flush()
+    return request_id
+
+
 def _emit_mcp_tool_call_and_wait_for_response(
     tool_use_id: str,
     tool_fqn: str,
@@ -100,37 +130,20 @@ def _emit_mcp_tool_call_and_wait_for_response(
     Raises ``RuntimeError`` if the response does not arrive within
     ``timeout_seconds``.
     """
-    if tool_fqn == SCULPTOR_MCP_ASK_TOOL_FQN:
-        short_name = SCULPTOR_MCP_ASK_TOOL_NAME
-    elif tool_fqn == SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_FQN:
-        short_name = SCULPTOR_MCP_EXIT_PLAN_MODE_TOOL_NAME
-    else:
-        raise ValueError(f"Unknown Sculptor MCP tool fqn: {tool_fqn}")
-
-    request_id = generate_id("mcp_req")
-    control_request = {
-        "type": "control_request",
-        "request_id": request_id,
-        "request": {
-            "subtype": "mcp_message",
-            "server_name": SCULPTOR_MCP_SERVER_NAME,
-            "message": {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/call",
-                "params": {"name": short_name, "arguments": arguments},
-            },
-        },
-    }
-    sys.stdout.write(json.dumps(control_request) + "\n")
-    sys.stdout.flush()
+    request_id = _emit_mcp_tool_call(tool_fqn=tool_fqn, arguments=arguments)
     return _read_mcp_control_response_text(request_id, tool_use_id, timeout_seconds, expect_error=expect_error)
 
 
-def _read_mcp_control_response_text(
-    expected_request_id: str, tool_use_id: str, timeout_seconds: float, expect_error: bool = False
-) -> str:
-    """Block reading stdin until a matching MCP ``control_response`` arrives.
+# Bytes pulled off stdin by a response reader after its final match. A single
+# os.read can swallow lines destined for a LATER reader in the same process
+# (the SCU-783 buffering flake); parking them here keeps sequential readers
+# (e.g. two AUQ waits in one handler) from losing responses.
+_STDIN_UNCONSUMED: bytes = b""
+
+
+def _read_mcp_control_responses(expected_request_ids: set[str], timeout_seconds: float) -> dict[str, dict]:
+    """Block reading stdin until an MCP ``control_response`` has arrived for
+    every id in ``expected_request_ids``. Returns ``{request_id: mcp_response}``.
 
     Reads from stdin's raw file descriptor rather than ``sys.stdin.readline``
     to avoid a flake (SCU-783) where Sculptor writes a non-matching control
@@ -141,51 +154,79 @@ def _read_mcp_control_response_text(
     ``select.select`` on stdin's fd cannot see it — the helper would spin
     until its 180s timeout while the agent's status pill stayed visible.
     """
+    global _STDIN_UNCONSUMED
     fd = sys.stdin.fileno()
-    pending = b""
+    results: dict[str, dict] = {}
+    remaining_ids = set(expected_request_ids)
+    pending = _STDIN_UNCONSUMED
+    _STDIN_UNCONSUMED = b""
     deadline = time.monotonic() + timeout_seconds
-    while True:
-        while b"\n" in pending:
-            raw_line, _, pending = pending.partition(b"\n")
-            line = raw_line.decode("utf-8", errors="replace").strip()
-            if not line:
-                continue
-            try:
-                data = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(data, dict) or data.get("type") != "control_response":
-                continue
-            response = data.get("response", {})
-            if response.get("request_id") != expected_request_id:
-                continue
-            mcp_response = response.get("response", {}).get("mcp_response", {})
-            if "error" in mcp_response:
-                if expect_error:
-                    err = mcp_response["error"]
-                    return f"MCP error {err.get('code')}: {err.get('message', '')}"
-                raise RuntimeError(f"MCP error response for tool_use_id={tool_use_id}: {mcp_response['error']}")
-            if expect_error:
-                raise RuntimeError(
-                    f"Expected MCP error response for tool_use_id={tool_use_id} but got success: {mcp_response}"
-                )
-            result = mcp_response.get("result", {})
-            content = result.get("content", [])
-            if not content:
-                return ""
-            return content[0].get("text", "")
+    try:
+        while True:
+            while b"\n" in pending:
+                raw_line, _, pending = pending.partition(b"\n")
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict) or data.get("type") != "control_response":
+                    continue
+                response = data.get("response", {})
+                request_id = response.get("request_id")
+                if request_id not in remaining_ids:
+                    continue
+                results[request_id] = response.get("response", {}).get("mcp_response", {})
+                remaining_ids.discard(request_id)
+                if not remaining_ids:
+                    return results
 
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            break
-        ready, _, _ = select.select([fd], [], [], min(remaining, 0.1))
-        if not ready:
-            continue
-        chunk = os.read(fd, 8192)
-        if not chunk:
-            break
-        pending += chunk
-    raise RuntimeError(f"Timed out waiting for MCP control_response for tool_use_id={tool_use_id}")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            ready, _, _ = select.select([fd], [], [], min(remaining, 0.1))
+            if not ready:
+                continue
+            chunk = os.read(fd, 8192)
+            if not chunk:
+                break
+            pending += chunk
+        raise RuntimeError(f"Timed out waiting for MCP control_response(s) for request_ids={sorted(remaining_ids)}")
+    finally:
+        _STDIN_UNCONSUMED = pending
+
+
+def _extract_mcp_response_text(mcp_response: dict) -> str:
+    content = mcp_response.get("result", {}).get("content", [])
+    if not content:
+        return ""
+    return content[0].get("text", "")
+
+
+def _read_mcp_control_response_text(
+    expected_request_id: str, tool_use_id: str, timeout_seconds: float, expect_error: bool = False
+) -> str:
+    """Block reading stdin until a matching MCP ``control_response`` arrives.
+
+    See ``_read_mcp_control_responses`` for the raw-fd reading rationale.
+    """
+    try:
+        responses = _read_mcp_control_responses({expected_request_id}, timeout_seconds)
+    except RuntimeError:
+        raise RuntimeError(f"Timed out waiting for MCP control_response for tool_use_id={tool_use_id}")
+    mcp_response = responses[expected_request_id]
+    if "error" in mcp_response:
+        if expect_error:
+            err = mcp_response["error"]
+            return f"MCP error {err.get('code')}: {err.get('message', '')}"
+        raise RuntimeError(f"MCP error response for tool_use_id={tool_use_id}: {mcp_response['error']}")
+    if expect_error:
+        raise RuntimeError(
+            f"Expected MCP error response for tool_use_id={tool_use_id} but got success: {mcp_response}"
+        )
+    return _extract_mcp_response_text(mcp_response)
 
 
 def handle_default(emit_streaming: bool) -> list[dict]:
@@ -1328,6 +1369,221 @@ def handle_subagent(args: dict, emit_streaming: bool) -> list[dict]:
     return messages
 
 
+def _emit_subagent_launch_and_inverted_ask(
+    questions: list[dict],
+    description: str,
+    emit_streaming: bool,
+) -> tuple[str, str, str]:
+    """Launch an Agent tool call whose subagent asks a question via MCP,
+    replaying the real CLI's SUBAGENT event ordering.
+
+    For main-agent MCP calls the CLI emits the assistant message (carrying the
+    tool_use block) BEFORE the ``tools/call`` control_request. For subagent
+    calls the order is INVERTED: the control_request reaches stdout first and
+    the sidechain assistant line follows (observed on Claude Code 2.1.170,
+    see the SCU freeze trace from 2026-07-01). Sculptor must pair the two
+    regardless of order.
+
+    Emits (in order): the main-agent assistant message with the Agent
+    tool_use; the MCP ``tools/call`` control_request; the sidechain assistant
+    message with the AUQ tool_use. Subagent output reaches the parent stream
+    as full non-streamed assistant lines, so the sidechain message carries no
+    streaming events.
+
+    Returns ``(agent_tool_id, ask_tool_id, mcp_request_id)`` — the caller
+    blocks on the response and emits the post-answer messages.
+    """
+    main_msg_id = generate_id("msg")
+    agent_tool_id = generate_id("toolu")
+    ask_tool_id = generate_id("toolu")
+    subagent_msg_id = generate_id("msg")
+
+    # 1. Main agent: text + Agent tool_use
+    agent_tool_block = make_tool_use_block(
+        tool_id=agent_tool_id,
+        tool_name="Agent",
+        tool_input={"prompt": "Ask the user and report their answer", "description": description},
+    )
+    _emit_messages_to_stdout(
+        _make_tool_assistant_message(
+            message_id=main_msg_id,
+            tool_blocks=[agent_tool_block],
+            emit_streaming=emit_streaming,
+            text_prefix="I'll use a subagent to help with this.",
+        )
+    )
+
+    # 2. The subagent's MCP tools/call — BEFORE the sidechain assistant line.
+    mcp_request_id = _emit_mcp_tool_call(
+        tool_fqn=SCULPTOR_MCP_ASK_TOOL_FQN,
+        arguments={"questions": questions},
+    )
+
+    # 3. The sidechain assistant line carrying the AUQ tool_use block.
+    ask_tool_block = make_tool_use_block(
+        tool_id=ask_tool_id,
+        tool_name=SCULPTOR_MCP_ASK_TOOL_FQN,
+        tool_input={"questions": questions},
+    )
+    _emit_messages_to_stdout(
+        [
+            make_assistant_message(
+                message_id=subagent_msg_id,
+                content_blocks=[ask_tool_block],
+                parent_tool_use_id=agent_tool_id,
+            )
+        ]
+    )
+    return agent_tool_id, ask_tool_id, mcp_request_id
+
+
+def _make_subagent_answer_messages(
+    agent_tool_id: str,
+    ask_tool_id: str,
+    answer_text: str,
+    subagent_label: str,
+) -> list[dict]:
+    """Build the post-answer message tail for a subagent AUQ: the sidechain
+    tool_result, and the Agent tool_result echoing which answer the subagent
+    received (tests assert on the echo to verify answer routing)."""
+    subagent_reply = f"[FakeClaude {subagent_label}] Received answer: {answer_text}"
+    return [
+        make_tool_result_message(tool_use_id=ask_tool_id, content=answer_text, parent_tool_use_id=agent_tool_id),
+        make_tool_result_message(tool_use_id=agent_tool_id, content=str([{"type": "text", "text": subagent_reply}])),
+    ]
+
+
+def handle_subagent_ask_user_question(args: dict, emit_streaming: bool) -> list[dict]:
+    """Simulate a subagent (Agent tool) asking the user a question via MCP.
+
+    Replays the inverted subagent event ordering (see
+    ``_emit_subagent_launch_and_inverted_ask``), blocks until Sculptor's MCP
+    server delivers the user's answer, then emits the tool results and a main
+    agent summary echoing the received answer.
+
+    Args:
+        args: Must contain "questions" (AUQ questions list). Optional:
+              "description".
+    """
+    questions = args["questions"]
+    description = args.get("description", "Ask the user a question")
+
+    agent_tool_id, ask_tool_id, mcp_request_id = _emit_subagent_launch_and_inverted_ask(
+        questions=questions, description=description, emit_streaming=emit_streaming
+    )
+
+    answer_text = _read_mcp_control_response_text(mcp_request_id, ask_tool_id, timeout_seconds=180.0)
+
+    messages = _make_subagent_answer_messages(
+        agent_tool_id=agent_tool_id,
+        ask_tool_id=ask_tool_id,
+        answer_text=answer_text,
+        subagent_label="subagent",
+    )
+    summary_text = f"[FakeClaude] Subagent finished. Received answer: {answer_text}"
+    summary_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=summary_msg_id, text=summary_text))
+    messages.append(make_assistant_message(message_id=summary_msg_id, content_blocks=[make_text_block(summary_text)]))
+    return messages
+
+
+def handle_ask_user_question_then_subagent_ask(args: dict, emit_streaming: bool) -> list[dict]:
+    """A main-agent AUQ (normal ordering, answered first) followed by a
+    subagent AUQ with the inverted subagent event ordering — all in one turn.
+
+    Guards against the MCP server's answered-question replay cache serving the
+    already-delivered FIRST answer to the subagent's DIFFERENT second
+    question. The final summary echoes both answers so the test can assert the
+    subagent received the answer to ITS question, not the cached one.
+
+    Args:
+        args: Must contain "first_questions" and "second_questions".
+    """
+    first_questions = args["first_questions"]
+    second_questions = args["second_questions"]
+
+    # Main-agent AUQ with the normal (assistant line first) ordering.
+    first_msg_id = generate_id("msg")
+    first_tool_id = generate_id("toolu")
+    first_block = make_tool_use_block(
+        tool_id=first_tool_id,
+        tool_name=SCULPTOR_MCP_ASK_TOOL_FQN,
+        tool_input={"questions": first_questions},
+    )
+    _emit_messages_to_stdout(
+        _make_tool_assistant_message(message_id=first_msg_id, tool_blocks=[first_block], emit_streaming=emit_streaming)
+    )
+    first_answer = _emit_mcp_tool_call_and_wait_for_response(
+        tool_use_id=first_tool_id,
+        tool_fqn=SCULPTOR_MCP_ASK_TOOL_FQN,
+        arguments={"questions": first_questions},
+    )
+    _emit_messages_to_stdout([make_tool_result_message(tool_use_id=first_tool_id, content=first_answer)])
+
+    # Subagent AUQ with the inverted ordering.
+    agent_tool_id, ask_tool_id, mcp_request_id = _emit_subagent_launch_and_inverted_ask(
+        questions=second_questions, description="Ask a follow-up question", emit_streaming=emit_streaming
+    )
+    second_answer = _read_mcp_control_response_text(mcp_request_id, ask_tool_id, timeout_seconds=180.0)
+
+    messages = _make_subagent_answer_messages(
+        agent_tool_id=agent_tool_id,
+        ask_tool_id=ask_tool_id,
+        answer_text=second_answer,
+        subagent_label="subagent",
+    )
+    summary_text = f"[FakeClaude] Subagent finished. Subagent received answer: {second_answer}"
+    summary_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=summary_msg_id, text=summary_text))
+    messages.append(make_assistant_message(message_id=summary_msg_id, content_blocks=[make_text_block(summary_text)]))
+    return messages
+
+
+def handle_two_subagents_ask_user_question(args: dict, emit_streaming: bool) -> list[dict]:
+    """Two concurrent subagents each asking a DIFFERENT question via MCP, with
+    the inverted subagent event ordering, interleaved as observed in the real
+    freeze trace: tools/call A, sidechain line A, tools/call B, sidechain
+    line B.
+
+    Blocks until BOTH answers arrive, then emits per-subagent echoes so the
+    test can assert each subagent received the answer to its own question
+    (a single-slot pairing would cross the wires).
+
+    Args:
+        args: Must contain "first_questions" and "second_questions".
+    """
+    first_questions = args["first_questions"]
+    second_questions = args["second_questions"]
+
+    agent_a_id, ask_a_id, request_a_id = _emit_subagent_launch_and_inverted_ask(
+        questions=first_questions, description="Subagent A question", emit_streaming=emit_streaming
+    )
+    agent_b_id, ask_b_id, request_b_id = _emit_subagent_launch_and_inverted_ask(
+        questions=second_questions, description="Subagent B question", emit_streaming=emit_streaming
+    )
+
+    responses = _read_mcp_control_responses({request_a_id, request_b_id}, timeout_seconds=180.0)
+    answer_a = _extract_mcp_response_text(responses[request_a_id])
+    answer_b = _extract_mcp_response_text(responses[request_b_id])
+
+    messages = _make_subagent_answer_messages(
+        agent_tool_id=agent_a_id, ask_tool_id=ask_a_id, answer_text=answer_a, subagent_label="subagent A"
+    )
+    messages.extend(
+        _make_subagent_answer_messages(
+            agent_tool_id=agent_b_id, ask_tool_id=ask_b_id, answer_text=answer_b, subagent_label="subagent B"
+        )
+    )
+    summary_text = f"[FakeClaude] Subagent A received answer: {answer_a} | Subagent B received answer: {answer_b}"
+    summary_msg_id = generate_id("msg")
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=summary_msg_id, text=summary_text))
+    messages.append(make_assistant_message(message_id=summary_msg_id, content_blocks=[make_text_block(summary_text)]))
+    return messages
+
+
 def handle_background_subagent(args: dict, emit_streaming: bool) -> list[dict]:
     """Simulate a background subagent (Agent tool with run_in_background=true).
 
@@ -2262,6 +2518,9 @@ COMMAND_REGISTRY: dict[str, Callable[..., list[dict]]] = {
     "spawn_subprocess_and_hang": handle_spawn_subprocess_and_hang,
     "spawn_sigterm_immune_subprocess_and_hang": handle_spawn_sigterm_immune_subprocess_and_hang,
     "subagent": handle_subagent,
+    "subagent_ask_user_question": handle_subagent_ask_user_question,
+    "ask_user_question_then_subagent_ask": handle_ask_user_question_then_subagent_ask,
+    "two_subagents_ask_user_question": handle_two_subagents_ask_user_question,
     "background_subagent": handle_background_subagent,
     "read_file": handle_read_file,
     "glob": handle_glob,

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -1380,9 +1380,8 @@ def _emit_subagent_launch_and_inverted_ask(
     For main-agent MCP calls the CLI emits the assistant message (carrying the
     tool_use block) BEFORE the ``tools/call`` control_request. For subagent
     calls the order is INVERTED: the control_request reaches stdout first and
-    the sidechain assistant line follows (observed on Claude Code 2.1.170,
-    see the SCU freeze trace from 2026-07-01). Sculptor must pair the two
-    regardless of order.
+    the sidechain assistant line follows (observed on Claude Code 2.1.170).
+    Sculptor must pair the two regardless of order.
 
     Emits (in order): the main-agent assistant message with the Agent
     tool_use; the MCP ``tools/call`` control_request; the sidechain assistant

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -351,9 +351,12 @@ def _run_agent_in_environment(
     last_user_chat_message_id: AgentMessageID | None = None
     # track the full history of persistent messages we've seen
     persistent_message_history: list[PersistentUserMessage | PersistentAgentMessage] = []
-    # tracks whether the agent has asked a question that hasn't been answered yet;
-    # while True, queued messages must not be dequeued — only the answer should be sent
-    is_waiting_for_question_answer: bool = False
+    # tool_use_ids of questions the agent asked that haven't been answered yet;
+    # while non-empty, queued messages must not be dequeued — only answers should
+    # be sent. A set (not a flag) because multiple questions can pend at once:
+    # subagents can each ask mid-turn, and answering one must not make the
+    # runner forget it is still waiting on the others.
+    pending_question_tool_use_ids: set[str] = set()
     with log_runtime("run_agent_in_environment pre-processing"):
         # figure out what command we need to run (eg, which agent to invoke)
         in_testing = settings.TESTING.INTEGRATION_ENABLED
@@ -512,8 +515,8 @@ def _run_agent_in_environment(
         # detect if the agent asked a question during this batch of messages
         for message in new_messages:
             if isinstance(message, AskUserQuestionAgentMessage):
-                is_waiting_for_question_answer = True
-            elif is_waiting_for_question_answer and isinstance(
+                pending_question_tool_use_ids.add(message.question_data.tool_use_id)
+            elif pending_question_tool_use_ids and isinstance(
                 message, (RequestFailureAgentMessage, RequestStoppedAgentMessage)
             ):
                 # SCU-530: the agent's chat request failed or was stopped while we
@@ -521,7 +524,7 @@ def _run_agent_in_environment(
                 # that answer is gone, so stop waiting. Without this, subsequent
                 # ChatInputUserMessages match the guard at line 624 and get silently
                 # appended to ``queued_user_input_messages`` forever.
-                is_waiting_for_question_answer = False
+                pending_question_tool_use_ids.clear()
 
         # add any persistent messages to our history
         for message in new_messages:
@@ -573,8 +576,8 @@ def _run_agent_in_environment(
         # AUQ anymore), so ``is_agent_turn_finished`` never fires for the
         # AUQ-triggering message — gate this block on either condition so
         # the answer can be dispatched mid-turn.
-        if is_agent_turn_finished or is_waiting_for_question_answer:
-            if is_waiting_for_question_answer:
+        if is_agent_turn_finished or pending_question_tool_use_ids:
+            if pending_question_tool_use_ids:
                 # The agent asked a question — don't dequeue the next message yet.
                 # Wait for the UserQuestionAnswerMessage before continuing.
                 # However, the answer may have already arrived and been queued while the
@@ -588,7 +591,7 @@ def _run_agent_in_environment(
                         remaining.append(queued_msg)
                 queued_user_input_messages = remaining
                 if queued_answer is not None:
-                    is_waiting_for_question_answer = False
+                    pending_question_tool_use_ids.discard(queued_answer.tool_use_id)
                     user_input_message_being_processed = _send_user_input_message(
                         agent_wrapper,
                         queued_answer,
@@ -627,13 +630,13 @@ def _run_agent_in_environment(
             if isinstance(message, PersistentUserMessage):
                 if isinstance(message, ChatInputUserMessage) and last_user_chat_message_id is None:
                     last_user_chat_message_id = message.message_id
-                if is_waiting_for_question_answer and not isinstance(message, UserQuestionAnswerMessage):
+                if pending_question_tool_use_ids and not isinstance(message, UserQuestionAnswerMessage):
                     # While the agent is waiting for a question answer, queue all other
                     # messages — only the answer should be sent to the agent.
                     queued_user_input_messages.append(message)
                 elif user_input_message_being_processed is None:
                     if isinstance(message, UserQuestionAnswerMessage):
-                        is_waiting_for_question_answer = False
+                        pending_question_tool_use_ids.discard(message.tool_use_id)
                     user_input_message_being_processed = _send_user_input_message(
                         agent_wrapper,
                         message,

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -815,6 +815,12 @@ class TaskUpdate(SerializableModel):
     # the chat "double printing" / staircase bug.
     streamed_segment_first_response_id: AgentMessageID | None = None
     pending_user_question: AskUserQuestionData | None = None
+    # Every currently-unanswered question, oldest first; pending_user_question
+    # (the one the frontend shows) is always the LAST entry. Multiple
+    # questions can pend concurrently — e.g. two subagents each calling
+    # ask_user_question mid-turn — and answering the visible one must
+    # surface the next, not forget it.
+    pending_user_questions: tuple[AskUserQuestionData, ...] = ()
     submitted_question_answers: dict[str, SubmittedQuestionAnswers] = {}
     is_in_plan_mode: bool = False
     # Buffered TurnMetrics waiting to be stamped onto the message at RequestSuccess/RequestStopped.

--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -167,6 +167,39 @@ def _attach_turn_metrics(in_progress: ChatMessage | None, turn_metrics: TurnMetr
     return in_progress.model_copy(update={"turn_metrics": turn_metrics})
 
 
+def _pend_question(pending_user_questions: list[AskUserQuestionData], question_data: AskUserQuestionData) -> None:
+    """Add a question to the pending queue, replacing any entry with the same
+    tool_use_id (the live ephemeral message and the persisted ToolUseBlock
+    reconstruction both surface the same question)."""
+    for i, existing in enumerate(pending_user_questions):
+        if existing.tool_use_id == question_data.tool_use_id:
+            pending_user_questions[i] = question_data
+            return
+    pending_user_questions.append(question_data)
+
+
+def _reconstruct_pending_questions_from_child_blocks(
+    content: Sequence[ContentBlockTypes],
+    pending_user_questions: list[AskUserQuestionData],
+    submitted_question_answers: dict[str, SubmittedQuestionAnswers],
+    harness: Harness,
+) -> None:
+    """Re-pend unanswered ask_user_question ToolUseBlocks from a SUBAGENT
+    (child) message, for page-reload support. Child messages skip the main
+    reconstruction loop (they `continue` out of the ResponseBlockAgentMessage
+    branch), so without this a subagent's pending question would vanish on
+    reload while its MCP call stays held.
+    """
+    for block in content:
+        if not isinstance(block, ToolUseBlock) or not harness.is_ask_user_question_tool(block.name):
+            continue
+        if block.id in submitted_question_answers:
+            continue
+        reconstructed = harness.reconstruct_pending_ask_user_question(block)
+        if reconstructed is not None:
+            _pend_question(pending_user_questions, reconstructed)
+
+
 def convert_agent_messages_to_task_update(
     new_messages: Sequence[Message | CompletedTransaction],
     task_id: TaskID,
@@ -187,7 +220,13 @@ def convert_agent_messages_to_task_update(
     in_progress_chat_message = current_state.in_progress_chat_message if current_state else None
     current_request_id = current_state.in_progress_user_message_id if current_state else None
     update_artifacts = set()
-    pending_user_question: AskUserQuestionData | None = current_state.pending_user_question if current_state else None
+    # All currently-unanswered questions, oldest first. The frontend shows the
+    # LAST entry (TaskUpdate.pending_user_question); answering it surfaces the
+    # previous one. Multiple questions pend concurrently when subagents call
+    # ask_user_question while another question is already waiting.
+    pending_user_questions: list[AskUserQuestionData] = (
+        list(current_state.pending_user_questions) if current_state else []
+    )
     submitted_question_answers: dict[str, SubmittedQuestionAnswers] = (
         dict(current_state.submitted_question_answers) if current_state else {}
     )
@@ -395,6 +434,9 @@ def convert_agent_messages_to_task_update(
                     )
                     completed_message_by_id[separate_msg.id] = separate_msg
                     completed_chat_messages.append(separate_msg)
+                    _reconstruct_pending_questions_from_child_blocks(
+                        msg.content, pending_user_questions, submitted_question_answers, harness
+                    )
                     continue
 
                 # During streaming, only process tool results - text/tool_use/FileBlocks
@@ -441,6 +483,9 @@ def convert_agent_messages_to_task_update(
                     )
                     completed_message_by_id[separate_msg.id] = separate_msg
                     completed_chat_messages.append(separate_msg)
+                    _reconstruct_pending_questions_from_child_blocks(
+                        msg.content, pending_user_questions, submitted_question_answers, harness
+                    )
                     continue
                 # A main-agent message (parent_tool_use_id None) arriving while a
                 # different-context message is in progress — flush so the main
@@ -543,7 +588,7 @@ def convert_agent_messages_to_task_update(
                     if block.id not in submitted_question_answers:
                         reconstructed_question = harness.reconstruct_pending_ask_user_question(block)
                         if reconstructed_question is not None:
-                            pending_user_question = reconstructed_question
+                            _pend_question(pending_user_questions, reconstructed_question)
                         else:
                             logger.debug(
                                 "Skipping AskUserQuestion pending state from persisted ToolUseBlock with invalid input: {}",
@@ -551,8 +596,9 @@ def convert_agent_messages_to_task_update(
                             )
                 elif isinstance(block, ToolUseBlock) and harness.is_exit_plan_mode_tool(block.name):
                     if block.id not in submitted_question_answers:
-                        pending_user_question = make_plan_approval_question(
-                            block.id, plan_file_path=recent_plan_file_path
+                        _pend_question(
+                            pending_user_questions,
+                            make_plan_approval_question(block.id, plan_file_path=recent_plan_file_path),
                         )
                     # One-shot: clear so a later ExitPlanMode without a fresh
                     # plan write doesn't reuse a stale path.
@@ -624,9 +670,9 @@ def convert_agent_messages_to_task_update(
                 )
             if msg.interrupted:
                 in_progress_chat_message = _mark_stopped(in_progress_chat_message)
-                # Clear any pending AUQ — the agent was interrupted so the question
-                # is no longer valid and the chat input should reappear.
-                pending_user_question = None
+                # Clear any pending AUQs — the agent was interrupted so the questions
+                # are no longer valid and the chat input should reappear.
+                pending_user_questions.clear()
             in_progress_chat_message = _attach_turn_metrics(in_progress_chat_message, pending_turn_metrics)
             pending_turn_metrics = None
             in_progress_chat_message, current_request_id = _finalize_request(
@@ -641,9 +687,9 @@ def convert_agent_messages_to_task_update(
 
         elif isinstance(msg, RequestFailureAgentMessage):
             in_progress_chat_message = _add_error_to_message(in_progress_chat_message, msg)
-            # Clear any pending AUQ — the agent failed so the question
-            # is no longer valid and the chat input should reappear.
-            pending_user_question = None
+            # Clear any pending AUQs — the agent failed so the questions
+            # are no longer valid and the chat input should reappear.
+            pending_user_questions.clear()
             in_progress_chat_message, current_request_id = _finalize_request(
                 current_request_id,
                 msg.request_id,
@@ -682,10 +728,10 @@ def convert_agent_messages_to_task_update(
                 in_progress_chat_message = _mark_stopped(in_progress_chat_message)
                 in_progress_chat_message = _attach_turn_metrics(in_progress_chat_message, pending_turn_metrics)
                 pending_turn_metrics = None
-                # Clear any pending AUQ — the turn was stopped so the
-                # question is no longer answerable and the chat input
+                # Clear any pending AUQs — the turn was stopped so the
+                # questions are no longer answerable and the chat input
                 # should reappear.
-                pending_user_question = None
+                pending_user_questions.clear()
             in_progress_chat_message, current_request_id = _finalize_request(
                 current_request_id,
                 msg.request_id,
@@ -809,7 +855,7 @@ def convert_agent_messages_to_task_update(
 
         elif isinstance(msg, AskUserQuestionAgentMessage):
             if msg.question_data.tool_use_id not in submitted_question_answers:
-                pending_user_question = msg.question_data
+                _pend_question(pending_user_questions, msg.question_data)
 
         elif isinstance(msg, PlanModeAgentMessage):
             is_in_plan_mode = msg.is_in_plan_mode
@@ -832,7 +878,10 @@ def convert_agent_messages_to_task_update(
                 in_progress_chat_message = None
                 streaming.message_was_streamed = False
 
-            pending_user_question = None
+            # Retire only the answered question; any other still-unanswered
+            # question (e.g. a second concurrent subagent question) surfaces
+            # next via the queue's new last entry.
+            pending_user_questions[:] = [q for q in pending_user_questions if q.tool_use_id != msg.tool_use_id]
             current_request_id = msg.message_id
             submitted_question_answers[msg.tool_use_id] = SubmittedQuestionAnswers(
                 question_data=msg.question_data,
@@ -853,7 +902,8 @@ def convert_agent_messages_to_task_update(
         in_progress_message_was_streamed=streaming.message_was_streamed,
         streamed_assistant_message_ids=frozenset(streaming.streamed_assistant_message_ids),
         streamed_segment_first_response_id=streaming.current_segment_first_response_id,
-        pending_user_question=pending_user_question,
+        pending_user_question=pending_user_questions[-1] if pending_user_questions else None,
+        pending_user_questions=tuple(pending_user_questions),
         submitted_question_answers=submitted_question_answers,
         is_in_plan_mode=is_in_plan_mode,
         pending_turn_metrics=pending_turn_metrics,

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -960,6 +960,82 @@ def test_user_question_answer_sets_in_progress_user_message_id() -> None:
     assert state.in_progress_user_message_id == answer_message.message_id
 
 
+def _make_simple_question_data(question_text: str, tool_use_id: str) -> AskUserQuestionData:
+    return AskUserQuestionData(
+        questions=[
+            UserQuestion(
+                question=question_text,
+                header="Header",
+                options=[
+                    QuestionOption(label="A", description="first"),
+                    QuestionOption(label="B", description="second"),
+                ],
+                multi_select=False,
+            )
+        ],
+        tool_use_id=tool_use_id,
+    )
+
+
+def test_answering_one_of_two_pending_questions_surfaces_the_other() -> None:
+    """Two questions can pend concurrently (e.g. two subagents each asking
+    mid-turn). Answering the visible one must surface the other instead of
+    forgetting it — the frozen-question half of the subagent AUQ bug.
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+
+    question_a = _make_simple_question_data("Question A?", "tool-use-ask-a")
+    question_b = _make_simple_question_data("Question B?", "tool-use-ask-b")
+
+    state = convert_agent_messages_to_task_update(
+        [
+            AskUserQuestionAgentMessage(message_id=AgentMessageID(), question_data=question_a),
+            AskUserQuestionAgentMessage(message_id=AgentMessageID(), question_data=question_b),
+        ],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+    # The most recent question is the visible one; both are tracked.
+    assert state.pending_user_question is not None
+    assert state.pending_user_question.tool_use_id == "tool-use-ask-b"
+    assert [q.tool_use_id for q in state.pending_user_questions] == ["tool-use-ask-a", "tool-use-ask-b"]
+
+    answer_b = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Question B?": "A"},
+        question_data=question_b,
+        tool_use_id="tool-use-ask-b",
+    )
+    state = convert_agent_messages_to_task_update(
+        [answer_b],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    assert state.pending_user_question is not None
+    assert state.pending_user_question.tool_use_id == "tool-use-ask-a"
+
+    answer_a = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Question A?": "B"},
+        question_data=question_a,
+        tool_use_id="tool-use-ask-a",
+    )
+    state = convert_agent_messages_to_task_update(
+        [answer_a],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    assert state.pending_user_question is None
+    assert state.pending_user_questions == ()
+
+
 def test_request_started_sets_current_request_id_without_queued_message() -> None:
     """RequestStartedAgentMessage should set current_request_id even when there is
     no matching queued message (e.g. for UserQuestionAnswerMessage which doesn't

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -1036,6 +1036,56 @@ def test_answering_one_of_two_pending_questions_surfaces_the_other() -> None:
     assert state.pending_user_questions == ()
 
 
+def test_subagent_question_reconstructed_from_persisted_child_block() -> None:
+    """On page reload the live AskUserQuestionAgentMessage (ephemeral) is gone;
+    a SUBAGENT's pending question must be reconstructed from the persisted
+    child ResponseBlockAgentMessage carrying its ToolUseBlock, just as
+    main-agent questions are reconstructed from theirs.
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+
+    question_data = _make_simple_question_data("Subagent question?", "toolu_sub_ask")
+    ask_tool_block = ToolUseBlock(
+        id=ToolUseID("toolu_sub_ask"),
+        name="mcp__sculptor__ask_user_question",
+        input={"questions": [q.model_dump() for q in question_data.questions]},
+    )
+    child_message = ResponseBlockAgentMessage(
+        role="assistant",
+        assistant_message_id=AssistantMessageID("assistant-subagent-ask"),
+        message_id=AgentMessageID(),
+        content=(ask_tool_block,),
+        parent_tool_use_id="toolu_agent_launch",
+    )
+
+    # Fresh state (as after a reload) — only the persisted child message replays.
+    state = convert_agent_messages_to_task_update(
+        [child_message],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+    assert state.pending_user_question is not None
+    assert state.pending_user_question.tool_use_id == "toolu_sub_ask"
+
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Subagent question?": "A"},
+        question_data=question_data,
+        tool_use_id="toolu_sub_ask",
+    )
+    state = convert_agent_messages_to_task_update(
+        [answer],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    assert state.pending_user_question is None
+
+
 def test_request_started_sets_current_request_id_without_queued_message() -> None:
     """RequestStartedAgentMessage should set current_request_id even when there is
     no matching queued message (e.g. for UserQuestionAnswerMessage which doesn't

--- a/sculptor/tests/integration/frontend/test_ask_user_question_subagent.py
+++ b/sculptor/tests/integration/frontend/test_ask_user_question_subagent.py
@@ -1,0 +1,165 @@
+"""Integration tests for ask_user_question calls made by SUBAGENTS.
+
+When a subagent (Agent tool) calls ``mcp__sculptor__ask_user_question``, the
+Claude CLI emits the MCP ``tools/call`` control_request BEFORE the sidechain
+assistant message that carries the tool_use block — the inverse of the
+main-agent ordering that Sculptor's MCP pairing was built around (observed on
+Claude Code 2.1.170; freeze trace from 2026-07-01). These tests replay that
+real ordering through FakeClaude and assert the user's answer still reaches
+the subagent so the turn completes instead of freezing:
+
+- ``test_subagent_ask_user_question_completes_turn``: the basic freeze — an
+  unmatched tools/call must not be silently dropped.
+- ``test_subagent_question_not_answered_from_stale_cache``: an
+  already-answered main-agent question must not be replayed from the answer
+  cache onto the subagent's different question.
+- ``test_two_concurrent_subagent_questions_route_answers``: two subagents
+  asking concurrently must each receive the answer to their own question.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+_LANGUAGE_QUESTION_JSON = """\
+{
+  "question": "What language do you prefer?",
+  "header": "Language",
+  "options": [
+    {"label": "Python", "description": "A versatile language"},
+    {"label": "Rust", "description": "For systems programming"}
+  ],
+  "multiSelect": false
+}"""
+
+_EDITOR_QUESTION_JSON = """\
+{
+  "question": "What editor do you use?",
+  "header": "Editor",
+  "options": [
+    {"label": "VS Code", "description": "Popular editor"},
+    {"label": "Neovim", "description": "Terminal editor"}
+  ],
+  "multiSelect": false
+}"""
+
+
+@user_story("to answer a question asked by a subagent so the turn can finish")
+def test_subagent_ask_user_question_completes_turn(sculptor_instance_: SculptorInstance) -> None:
+    """A subagent's question is answered via the panel and the answer reaches
+    the subagent, letting the whole turn complete.
+
+    FakeClaude replays the real subagent event ordering: the MCP tools/call
+    arrives before the sidechain assistant line. If Sculptor drops the
+    unmatched tools/call, the answer never reaches the subagent and the
+    summary message never appears (the turn freezes).
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f"""\
+fake_claude:subagent_ask_user_question `{{
+  "questions": [{_LANGUAGE_QUESTION_JSON}]
+}}`""",
+        wait_for_agent_to_finish=False,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # The subagent's question panel appears (the sidechain assistant line
+    # carrying the tool_use block still reaches the UI).
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel).to_be_visible(timeout=30_000)
+    expect(auq_panel.get_question_text()).to_contain_text("What language do you prefer?")
+
+    auq_panel.select_option("Python")
+    auq_panel.submit()
+
+    # The answer must reach the subagent: FakeClaude echoes it in the main
+    # agent's summary message and the turn completes.
+    expect(chat_panel.get_messages().last).to_contain_text("Subagent finished", timeout=60_000)
+    expect(chat_panel.get_messages().last).to_contain_text("Python")
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=30_000)
+
+
+@user_story("to have a subagent's question answered by me, not by a stale cached answer")
+def test_subagent_question_not_answered_from_stale_cache(sculptor_instance_: SculptorInstance) -> None:
+    """After a main-agent question was answered in the same turn, a subagent's
+    DIFFERENT question must still be shown to the user and receive the user's
+    fresh answer — not the cached answer to the earlier question.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f"""\
+fake_claude:ask_user_question_then_subagent_ask `{{
+  "first_questions": [{_LANGUAGE_QUESTION_JSON}],
+  "second_questions": [{_EDITOR_QUESTION_JSON}]
+}}`""",
+        wait_for_agent_to_finish=False,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # First (main-agent) question — answer "Python".
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel).to_be_visible(timeout=30_000)
+    expect(auq_panel.get_question_text()).to_contain_text("What language do you prefer?")
+    auq_panel.select_option("Python")
+    auq_panel.submit()
+
+    # Second (subagent) question — must surface and wait for the user rather
+    # than being auto-answered from the first answer's cache.
+    expect(auq_panel).to_be_visible(timeout=30_000)
+    expect(auq_panel.get_question_text()).to_contain_text("What editor do you use?")
+    auq_panel.select_option("Neovim")
+    auq_panel.submit()
+
+    # The subagent must receive the ANSWER TO ITS QUESTION (Neovim), not the
+    # stale first answer (Python).
+    expect(chat_panel.get_messages().last).to_contain_text("Subagent received answer:", timeout=60_000)
+    expect(chat_panel.get_messages().last).to_contain_text("Neovim")
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=30_000)
+
+
+@user_story("to answer questions from two concurrent subagents and have each get its own answer")
+def test_two_concurrent_subagent_questions_route_answers(sculptor_instance_: SculptorInstance) -> None:
+    """Two subagents ask different questions concurrently (interleaved with
+    the inverted subagent event ordering). Each answer must be routed to the
+    subagent that asked — single-slot pairing crosses the wires.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f"""\
+fake_claude:two_subagents_ask_user_question `{{
+  "first_questions": [{_LANGUAGE_QUESTION_JSON}],
+  "second_questions": [{_EDITOR_QUESTION_JSON}]
+}}`""",
+        wait_for_agent_to_finish=False,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # Both questions are pending; the panel shows the most recent one first
+    # (subagent B's editor question), then re-pends subagent A's.
+    auq_panel = get_ask_user_question_panel(page)
+    expect(auq_panel).to_be_visible(timeout=30_000)
+    expect(auq_panel.get_question_text()).to_contain_text("What editor do you use?")
+    auq_panel.select_option("Neovim")
+    auq_panel.submit()
+
+    expect(auq_panel).to_be_visible(timeout=30_000)
+    expect(auq_panel.get_question_text()).to_contain_text("What language do you prefer?")
+    auq_panel.select_option("Python")
+    auq_panel.submit()
+
+    # Each subagent must echo the answer to ITS OWN question.
+    summary = chat_panel.get_messages().last
+    expect(summary).to_contain_text("Subagent A received answer:", timeout=60_000)
+    expect(summary).to_contain_text('"What language do you prefer?"="Python"')
+    expect(summary).to_contain_text('"What editor do you use?"="Neovim"')
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=30_000)


### PR DESCRIPTION
Fixes SCU-1670.

## Original bug

When the main agent spawns a subagent (Agent tool) and that subagent calls `mcp__sculptor__ask_user_question`, the whole turn freezes permanently. The question panel appears, but answering it does nothing — the backend logs `Discarding stale question answer … no pending MCP call matches` — and the turn spins forever. Reproduced from a real session where a plan-execution fan-out launched 5 subagents and two of them asked questions; both subagent transcripts end at the unanswered tool call.

## Root cause

Sculptor pairs an MCP `tools/call` control_request with the agent's `tool_use_id` by expecting the assistant message (which carries the ToolUseBlock) to arrive first — true for the main agent. For **subagents**, the Claude CLI (observed on 2.1.170) emits them in the opposite order: the `tools/call` reaches stdout *before* the sidechain assistant message. The unmatched call was silently dropped without any JSON-RPC response (`mcp_server.py`), so the subagent blocked forever and the Agent tool never returned. Answers submitted in the UI matched no pending call and were discarded as stale.

The same trace exposed two adjacent defects:

- **Stale-cache mis-answer** — if an earlier question in the turn was already answered, the out-of-order `tools/call` was served the *previous* answer from the replay cache, silently answering the subagent's new question with the wrong text.
- **Concurrent mispairing** — the single expected-id slot crossed wires when two subagents asked at the same time, so one subagent's answer resolved the other's request.

## Fix

Three coordinated changes:

1. **MCP server** (`mcp_server.py`): pair `tools/call` requests with assistant ToolUseBlocks by content (tool name + arguments) instead of a single expected-id slot. Calls that arrive before their registration are held in an unmatched-call queue and paired when the assistant stream catches up — never dropped. The answered-question replay cache is additionally guarded by argument equality so a new question is never served the previous question's answer, and concurrent questions each pair with their own registration.
2. **Pending-question queue** (`derived.py`, `message_conversion.py`): task state now tracks every unanswered question, not just the most recent. Answering the visible question surfaces the previous one instead of forgetting it, and a subagent's pending question is reconstructed from its persisted child message on page reload.
3. **Runner gating** (`run_agent/v1.py`): track pending questions by `tool_use_id` instead of a single boolean, so a second answer isn't parked in the queued-messages list forever while the first answer's request is still in flight.

## Tests

TDD: the integration tests were committed first and confirmed failing for the exact buggy behaviors (64ff98ba), then the fix landed (d9d95db7).

- `test_subagent_ask_user_question_completes_turn` — the freeze: a subagent's question answered via the panel routes back and the turn completes.
- `test_subagent_question_not_answered_from_stale_cache` — a subagent's different question is not auto-answered from the replay cache. Failing run showed the subagent receiving `"What language do you prefer?"="Python"` for its *editor* question.
- `test_two_concurrent_subagent_questions_route_answers` — two concurrent subagent questions each receive their own answer.

New fake_claude commands replay the observed subagent event ordering (`tools/call` before the sidechain assistant line) so the tests are deterministic. Unit tests cover the MCP pairing (`mcp_server_test.py`), the pending-question queue and reload reconstruction (`message_conversion_test.py`).

Failing-then-passing evidence:

```
Before (64ff98ba): 3 failed — answer discarded, turn never completes;
  subagent served the stale "Python" answer for the editor question;
  concurrent answers cross-wired then discarded.
After  (d9d95db7): 3 passed in 34.13s
```

Full verification on the final tree: `just format`, `just check` (lint, typecheck, ratchets), `just test-unit`, the new e2e tests, and the full AUQ / plan-mode / subagent integration suites (64 tests) all pass.

## Real-Claude verification

Manually verified end-to-end with real Claude via the headless QA harness: a subagent asked "Which color should the subagent report?", the panel was answered with Blue, the answer routed back, and the main agent completed with "SUBAGENT REPORTED: Blue" — the exact flow that previously froze forever.

## Known limitation

A subagent re-asking a question byte-identical to one already answered in the same turn is served the cached answer without re-prompting — required to preserve the resume-replay cache contract; the argument-equality guard confines the behavior to identical questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
