### PR TITLE
Add plugin surface for custom tool-call visualizations

### DIFF
--- a/sculptor/frontend/.gitignore
+++ b/sculptor/frontend/.gitignore
@@ -34,10 +34,10 @@ generated-*.ts
 # Lint caches
 .stylelintcache
 
-# Plugin output. Compiled plugins (currently only `linear-issue`) keep their
-# source in `plugins/<id>/` and are built into public/plugins/<id>/ by the host
-# Vite build (see vite-plugins/bundled-plugins.ts); that generated output is
-# ignored.
+# Plugin output. Compiled plugins (see COMPILED_PLUGIN_IDS in
+# vite-plugins/bundled-plugins.ts) keep their source in `plugins/<id>/` and are
+# built into public/plugins/<id>/ by the host Vite build; that generated output
+# is ignored.
 #
 # The no-build example plugins (`sculpty`, `pomodoro`) are the exception: they
 # are hand-authored as a manifest.json + main.js with no build step, so they

--- a/sculptor/frontend/plugins/workflow-viz/manifest.json
+++ b/sculptor/frontend/plugins/workflow-viz/manifest.json
@@ -1,0 +1,7 @@
+{
+  "id": "workflow-viz",
+  "name": "Workflow visualization",
+  "version": "0.1.0",
+  "entry": "main.js",
+  "sdkVersion": "^1.0.0"
+}

--- a/sculptor/frontend/plugins/workflow-viz/src/WorkflowBody.tsx
+++ b/sculptor/frontend/plugins/workflow-viz/src/WorkflowBody.tsx
@@ -1,0 +1,124 @@
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import type { ToolCallView } from "@sculptor/plugin-sdk";
+import { Circle, CircleAlert, CircleCheck } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { parseWorkflowInput, type ParsedWorkflow } from "./parseWorkflow.ts";
+
+/**
+ * The popover body for a `Workflow` tool call. The host renders the plugin's
+ * summary line above this in the popover header, so the body owns everything
+ * below it: the workflow's description, its phase checklist, and — once the
+ * call finishes — the result text.
+ *
+ * While the call is running the phases are shown as a pending checklist. On
+ * completion the result text (the workflow's return value) is shown, tinted for
+ * errors. Input that the parser doesn't recognize (only possible for a
+ * result-only block, since `canRender` gates the rest) still renders the result.
+ */
+export const WorkflowBody = ({ call }: { call: ToolCallView }): ReactElement => {
+  const parsed = parseWorkflowInput(call.input);
+  const isRunning = call.status === "running";
+
+  return (
+    <Flex direction="column" gap="3" p="1">
+      {parsed !== null && <WorkflowDetails workflow={parsed} isRunning={isRunning} />}
+      {call.result !== null && <WorkflowResult text={call.result.text} isError={call.result.isError} />}
+    </Flex>
+  );
+};
+
+/** The static description + phase checklist recovered from the workflow input. */
+const WorkflowDetails = ({ workflow, isRunning }: { workflow: ParsedWorkflow; isRunning: boolean }): ReactElement => (
+  <Flex direction="column" gap="3">
+    {workflow.description !== undefined && (
+      <Text size="2" color="gray">
+        {workflow.description}
+      </Text>
+    )}
+
+    {workflow.source === "scriptPath" && (
+      <Text size="1" color="gray" style={{ fontFamily: "var(--code-font-family)" }}>
+        {workflow.scriptPath}
+      </Text>
+    )}
+
+    {workflow.phases.length > 0 && (
+      <Flex direction="column" gap="1" asChild>
+        <ol style={{ margin: 0, padding: 0, listStyle: "none" }}>
+          {workflow.phases.map((phase, index) => (
+            <PhaseRow key={index} title={phase.title} detail={phase.detail} isRunning={isRunning} />
+          ))}
+        </ol>
+      </Flex>
+    )}
+  </Flex>
+);
+
+/**
+ * One phase of the checklist. Phases carry no per-phase progress from the tool,
+ * so a running workflow shows every phase as pending and a finished one shows
+ * them settled; the row is intentionally status-agnostic beyond that.
+ */
+const PhaseRow = ({
+  title,
+  detail,
+  isRunning,
+}: {
+  title: string;
+  detail: string | undefined;
+  isRunning: boolean;
+}): ReactElement => (
+  <Flex asChild align="start" gap="2" py="1">
+    <li>
+      <Box style={{ color: "var(--gray-9)", lineHeight: 0, paddingTop: "var(--space-1)" }}>
+        {isRunning ? <Circle size={14} /> : <CircleCheck size={14} />}
+      </Box>
+      <Flex direction="column" gap="1">
+        <Text size="2">{title}</Text>
+        {detail !== undefined && (
+          <Text size="1" color="gray">
+            {detail}
+          </Text>
+        )}
+      </Flex>
+    </li>
+  </Flex>
+);
+
+/** The workflow's return value, tinted red when the run reported an error. */
+const WorkflowResult = ({ text, isError }: { text: string; isError: boolean }): ReactElement => (
+  <Flex direction="column" gap="2">
+    <Flex align="center" gap="2">
+      {isError ? (
+        <CircleAlert size={14} style={{ color: "var(--red-11)" }} />
+      ) : (
+        <CircleCheck size={14} style={{ color: "var(--green-11)" }} />
+      )}
+      <Badge size="1" color={isError ? "red" : "green"} variant="soft">
+        {isError ? "Failed" : "Result"}
+      </Badge>
+    </Flex>
+    <Box
+      style={{
+        maxHeight: "20rem",
+        overflow: "auto",
+        borderRadius: "var(--radius-2)",
+        padding: "var(--space-2)",
+        backgroundColor: isError ? "var(--red-a2)" : "var(--gray-a2)",
+      }}
+    >
+      <Text
+        size="1"
+        style={{
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          fontFamily: "var(--code-font-family)",
+          color: isError ? "var(--red-11)" : "var(--gray-12)",
+        }}
+      >
+        {text}
+      </Text>
+    </Box>
+  </Flex>
+);

--- a/sculptor/frontend/plugins/workflow-viz/src/index.tsx
+++ b/sculptor/frontend/plugins/workflow-viz/src/index.tsx
@@ -1,0 +1,40 @@
+import type { PluginHostApi, ToolCallView } from "@sculptor/plugin-sdk";
+import { GitFork } from "lucide-react";
+
+import { parseWorkflowInput } from "./parseWorkflow.ts";
+import { WorkflowBody } from "./WorkflowBody.tsx";
+
+/**
+ * A reference tool visualization: it replaces the generic rendering of Claude
+ * Code's `Workflow` tool with the workflow's name, a phase checklist, and its
+ * result. It is the worked example other tool-visualization plugins copy.
+ */
+
+/** The `meta` line for a running or completed call — a phase count or the run status. */
+const summaryMeta = (call: ToolCallView, phaseCount: number): string => {
+  if (call.result !== null) return call.result.isError ? "failed" : "done";
+  if (call.status === "running") return "running";
+  if (phaseCount > 0) return `${phaseCount} ${phaseCount === 1 ? "phase" : "phases"}`;
+  return "workflow";
+};
+
+export default function activate(api: PluginHostApi): () => void {
+  return api.registerToolVisualization({
+    id: "workflow-viz",
+    toolNames: ["Workflow"],
+    agentTypes: ["claude"],
+    // A result-only block (`input === null`) still renders — the body shows the
+    // result. Otherwise only claim inputs the parser recognizes as a workflow,
+    // so unrecognized shapes fall through to stock rendering.
+    canRender: (call) => call.input === null || parseWorkflowInput(call.input) !== null,
+    icon: GitFork,
+    summary: (call) => {
+      const parsed = parseWorkflowInput(call.input);
+      return {
+        title: parsed?.name ?? "workflow",
+        meta: summaryMeta(call, parsed?.phases.length ?? 0),
+      };
+    },
+    body: WorkflowBody,
+  });
+}

--- a/sculptor/frontend/plugins/workflow-viz/src/parseWorkflow.test.ts
+++ b/sculptor/frontend/plugins/workflow-viz/src/parseWorkflow.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWorkflowInput } from "./parseWorkflow.ts";
+
+describe("parseWorkflowInput", () => {
+  it("extracts name, description, and phases from a meta literal", () => {
+    const script = `
+      export const meta = {
+        name: "Deploy service",
+        description: "Ship the current branch to staging",
+        phases: [
+          { title: "Build", detail: "Compile and bundle" },
+          { title: "Test" },
+          { title: "Release", detail: "Promote to staging" },
+        ],
+      };
+      export default async function run() {}
+    `;
+    expect(parseWorkflowInput({ script })).toEqual({
+      source: "script",
+      name: "Deploy service",
+      description: "Ship the current branch to staging",
+      phases: [
+        { title: "Build", detail: "Compile and bundle" },
+        { title: "Test" },
+        { title: "Release", detail: "Promote to staging" },
+      ],
+    });
+  });
+
+  it("handles single quotes and a brace inside a string value", () => {
+    const script = `export const meta = { name: 'Format { and } braces', phases: [{ title: 'One' }] };`;
+    expect(parseWorkflowInput({ script })).toEqual({
+      source: "script",
+      name: "Format { and } braces",
+      phases: [{ title: "One" }],
+    });
+  });
+
+  it("reads a phases array of bare strings", () => {
+    const script = `export const meta = { name: "Bare", phases: ["Alpha", "Beta"] };`;
+    expect(parseWorkflowInput({ script })).toEqual({
+      source: "script",
+      name: "Bare",
+      phases: [{ title: "Alpha" }, { title: "Beta" }],
+    });
+  });
+
+  it("falls back to phase() call sites when meta has no phases", () => {
+    const script = `
+      export const meta = { name: "Imperative" };
+      export default async function run(ctx) {
+        await phase("Gather inputs");
+        await phase('Do the work');
+      }
+    `;
+    expect(parseWorkflowInput({ script })).toEqual({
+      source: "script",
+      name: "Imperative",
+      phases: [{ title: "Gather inputs" }, { title: "Do the work" }],
+    });
+  });
+
+  it("recovers phases from phase() calls even without a meta literal", () => {
+    const script = `export default async function run() { await phase("Only phase"); }`;
+    expect(parseWorkflowInput({ script })).toEqual({
+      source: "script",
+      phases: [{ title: "Only phase" }],
+    });
+  });
+
+  it("returns a script parse with empty phases when meta exists but has none", () => {
+    const script = `export const meta = { name: "Nameless phases" };`;
+    expect(parseWorkflowInput({ script })).toEqual({
+      source: "script",
+      name: "Nameless phases",
+      phases: [],
+    });
+  });
+
+  it("returns null for a script with neither a meta literal nor phase() calls", () => {
+    expect(parseWorkflowInput({ script: "const x = 1; console.log(x);" })).toBeNull();
+  });
+
+  it("handles the scriptPath input shape", () => {
+    expect(parseWorkflowInput({ scriptPath: "/workflows/deploy.ts" })).toEqual({
+      source: "scriptPath",
+      scriptPath: "/workflows/deploy.ts",
+      phases: [],
+    });
+  });
+
+  it("handles the named-workflow input shape", () => {
+    expect(parseWorkflowInput({ name: "nightly-sync" })).toEqual({
+      source: "name",
+      name: "nightly-sync",
+      phases: [],
+    });
+  });
+
+  it("prefers script over scriptPath and name when several are present", () => {
+    const input = { script: `export const meta = { name: "Wins", phases: [] };`, scriptPath: "/x.ts", name: "y" };
+    expect(parseWorkflowInput(input)?.source).toBe("script");
+  });
+
+  it("returns null for null input and for an unrecognized shape", () => {
+    expect(parseWorkflowInput(null)).toBeNull();
+    expect(parseWorkflowInput({ other: "value" })).toBeNull();
+    expect(parseWorkflowInput({ script: "" })).toBeNull();
+  });
+
+  it("returns null when the meta literal never closes its brace", () => {
+    // An unterminated literal yields no meta fields and no phases, so the parse
+    // has nothing recognizable to show and declines.
+    expect(parseWorkflowInput({ script: `export const meta = { name: "Broken", phases: [` })).toBeNull();
+  });
+});

--- a/sculptor/frontend/plugins/workflow-viz/src/parseWorkflow.ts
+++ b/sculptor/frontend/plugins/workflow-viz/src/parseWorkflow.ts
@@ -1,0 +1,193 @@
+/**
+ * Parses the input of Claude Code's `Workflow` tool into a small, display-ready
+ * shape. The tool's input arrives in one of three forms:
+ *
+ * - `{ script: "<js source>" }` — an inline workflow script whose first
+ *   statement is `export const meta = { name, description, phases: [...] }`.
+ * - `{ scriptPath: "<path>" }` — a reference to a script file on disk; the
+ *   source text is not available to the renderer, so only the path is shown.
+ * - `{ name: "<saved workflow name>" }` — a workflow saved under a name.
+ *
+ * The script is parsed with lenient string extraction (regex + bracket
+ * matching), never `eval`/`new Function`/dynamic import: agent-authored code
+ * must never execute in the renderer. Extraction is best-effort — a field it
+ * cannot recover is simply omitted rather than failing the whole parse.
+ *
+ * `parseWorkflowInput` returns `null` for any input shape it does not
+ * understand, which is what the plugin's `canRender` keys off to decline the
+ * call and fall back to stock rendering.
+ */
+
+/** One phase of a workflow, as recovered from the script. */
+export type WorkflowPhase = {
+  title: string;
+  detail?: string;
+};
+
+/** The three input shapes discriminated by which field is present. */
+export type WorkflowSource = "script" | "scriptPath" | "name";
+
+/** A parsed `Workflow` tool input, ready to render. */
+export type ParsedWorkflow = {
+  source: WorkflowSource;
+  /** The workflow's display name, when recoverable (script `meta.name` or the saved name). */
+  name?: string;
+  /** The workflow's description from `meta.description`, when present. */
+  description?: string;
+  /** Phases in declaration order. Empty when none could be recovered. */
+  phases: ReadonlyArray<WorkflowPhase>;
+  /** The referenced file path, for the `scriptPath` shape. */
+  scriptPath?: string;
+};
+
+/**
+ * Returns the substring of `source` for the object/array literal that opens at
+ * `openIndex` (which must point at `{` or `[`), balancing brackets while
+ * skipping over string and template literals so a brace inside a string does
+ * not end the match early. Returns `null` if the literal never closes.
+ */
+const matchBalanced = (source: string, openIndex: number): string | null => {
+  const open = source[openIndex];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = openIndex; i < source.length; i++) {
+    const char = source[i];
+    if (quote !== null) {
+      if (char === "\\") {
+        i++; // skip the escaped character
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === open) depth++;
+    else if (char === close) {
+      depth--;
+      if (depth === 0) return source.slice(openIndex, i + 1);
+    }
+  }
+  return null;
+};
+
+/**
+ * Reads a single-line string value for `key` out of an object-literal body,
+ * e.g. `name: "Deploy"` → `Deploy`. Handles single, double, and backtick
+ * quotes but only flat (non-interpolated) values, which covers the metadata a
+ * workflow's `meta` literal carries.
+ */
+const extractStringField = (body: string, key: string): string | undefined => {
+  const pattern = new RegExp(`${key}\\s*:\\s*(['"\`])((?:\\\\.|(?!\\1).)*)\\1`);
+  const match = body.match(pattern);
+  if (!match) return undefined;
+  // Un-escape the common escapes; leave everything else verbatim.
+  return match[2].replace(/\\(['"`\\])/g, "$1");
+};
+
+/**
+ * Extracts phases from a `phases: [ ... ]` array literal. Each entry is either
+ * an object with a `title` (and optional `detail`) or a bare string. Entries
+ * whose title cannot be recovered are dropped.
+ */
+const extractPhasesFromMeta = (body: string): ReadonlyArray<WorkflowPhase> => {
+  const arrayStart = body.search(/phases\s*:\s*\[/);
+  if (arrayStart === -1) return [];
+  const bracketIndex = body.indexOf("[", arrayStart);
+  const literal = matchBalanced(body, bracketIndex);
+  if (literal === null) return [];
+
+  const phases: Array<WorkflowPhase> = [];
+  // Walk each top-level object entry `{ ... }` inside the array.
+  for (let i = 0; i < literal.length; i++) {
+    if (literal[i] !== "{") continue;
+    const objectLiteral = matchBalanced(literal, i);
+    if (objectLiteral === null) break;
+    i += objectLiteral.length - 1;
+    const title = extractStringField(objectLiteral, "title");
+    if (title === undefined) continue;
+    const detail = extractStringField(objectLiteral, "detail");
+    phases.push(detail === undefined ? { title } : { title, detail });
+  }
+  if (phases.length > 0) return phases;
+
+  // No object entries — fall back to treating the array as bare strings.
+  const stringEntries = literal.matchAll(/(['"`])((?:\\.|(?!\1).)*)\1/g);
+  for (const entry of stringEntries) {
+    phases.push({ title: entry[2].replace(/\\(['"`\\])/g, "$1") });
+  }
+  return phases;
+};
+
+/**
+ * Recovers phases from `phase('…')` call sites in the script body, the fallback
+ * for scripts that drive their phases imperatively instead of declaring them in
+ * `meta.phases`.
+ */
+const extractPhasesFromCalls = (script: string): ReadonlyArray<WorkflowPhase> => {
+  const phases: Array<WorkflowPhase> = [];
+  const calls = script.matchAll(/\bphase\s*\(\s*(['"`])((?:\\.|(?!\1).)*)\1/g);
+  for (const call of calls) {
+    phases.push({ title: call[2].replace(/\\(['"`\\])/g, "$1") });
+  }
+  return phases;
+};
+
+/**
+ * Parses a workflow script's leading `export const meta = { ... }` literal for
+ * name/description/phases, falling back to `phase('…')` call sites for phases
+ * when `meta.phases` is absent. Returns `null` when nothing recognizable was
+ * recovered (no name, no description, no phases), so a plain non-workflow string
+ * declines rather than rendering empty.
+ */
+const parseScript = (script: string): ParsedWorkflow | null => {
+  const metaStart = script.search(/export\s+const\s+meta\s*=\s*\{/);
+  let name: string | undefined;
+  let description: string | undefined;
+  let phases: ReadonlyArray<WorkflowPhase> = [];
+
+  if (metaStart !== -1) {
+    const braceIndex = script.indexOf("{", metaStart);
+    const metaBody = matchBalanced(script, braceIndex);
+    if (metaBody !== null) {
+      name = extractStringField(metaBody, "name");
+      description = extractStringField(metaBody, "description");
+      phases = extractPhasesFromMeta(metaBody);
+    }
+  }
+
+  if (phases.length === 0) {
+    phases = extractPhasesFromCalls(script);
+  }
+
+  // Nothing recognizable was recovered (no meta fields, no phases) — decline so
+  // stock rendering handles the call. This also covers a `meta` literal whose
+  // brace never closes, which yields no fields.
+  if (name === undefined && description === undefined && phases.length === 0) return null;
+
+  const parsed: ParsedWorkflow = { source: "script", phases };
+  if (name !== undefined) parsed.name = name;
+  if (description !== undefined) parsed.description = description;
+  return parsed;
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+export const parseWorkflowInput = (input: Readonly<Record<string, unknown>> | null): ParsedWorkflow | null => {
+  if (input === null) return null;
+
+  const script = asString(input.script);
+  if (script !== undefined) return parseScript(script);
+
+  const scriptPath = asString(input.scriptPath);
+  if (scriptPath !== undefined) return { source: "scriptPath", scriptPath, phases: [] };
+
+  const name = asString(input.name);
+  if (name !== undefined) return { source: "name", name, phases: [] };
+
+  return null;
+};

--- a/sculptor/frontend/plugins/workflow-viz/tsconfig.json
+++ b/sculptor/frontend/plugins/workflow-viz/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["vite/client"],
+    "paths": {
+      "@sculptor/plugin-sdk": ["../../src/plugins/sdk/index.ts"]
+    },
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaExpandedToolRow.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaExpandedToolRow.tsx
@@ -7,6 +7,7 @@ import { ElementIds } from "~/api";
 import styles from "./AlphaExpandedToolRow.module.scss";
 import { ToolEntryContent, type ToolEntryShell } from "./AlphaToolPopover.tsx";
 import { formatDuration } from "./durationUtils.ts";
+import { safeSummary, usePluginToolVisualization } from "./pluginToolViz.ts";
 import type { PillData } from "./toolPill.types.ts";
 import { getToolIcon } from "./toolPillIcons.tsx";
 import { useElapsedTime } from "./useElapsedTime.ts";
@@ -42,8 +43,16 @@ const AlphaExpandedToolRowImpl = forwardRef<HTMLDivElement, AlphaExpandedToolRow
     // a row layout, popover, and pulsing status dot while executing.
     const isCommandStyleTool = label === "Bash" || label === "Monitor";
     const isExecuting = state === "initializing";
-    const Icon = getToolIcon(label);
-    const isShowingStatusDot = isCommandStyleTool && isExecuting;
+
+    const block = pillData.blocks[0] ?? null;
+    const result = pillData.results[0] ?? null;
+    // A matched tool-visualization plugin overrides the icon and the row's
+    // inline summary; its body never renders inline (matching built-ins). This
+    // wins over the command-style branch, so a plugin can claim Bash/Monitor.
+    const { visualization, call } = usePluginToolVisualization({ block, result, pillState: state });
+
+    const Icon = visualization?.definition.icon ?? getToolIcon(label);
+    const isShowingStatusDot = isCommandStyleTool && isExecuting && visualization === null;
 
     const handleKeyDown = useCallback(
       (e: KeyboardEvent<HTMLDivElement>): void => {
@@ -58,9 +67,6 @@ const AlphaExpandedToolRowImpl = forwardRef<HTMLDivElement, AlphaExpandedToolRow
     const classNames = [styles.row];
     if (isOpen) classNames.push(styles.rowOpen);
     if (state === "error") classNames.push(styles.rowError);
-
-    const block = pillData.blocks[0] ?? null;
-    const result = pillData.results[0] ?? null;
 
     // Expanded rows deliberately drop the per-tool action buttons (copy
     // path, open in editor, etc.). The whole row is a click target that
@@ -81,6 +87,32 @@ const AlphaExpandedToolRowImpl = forwardRef<HTMLDivElement, AlphaExpandedToolRow
     // Bash keeps its dedicated testID so the existing integration tests stay
     // anchored to it; Monitor and everything else share the generic pill ID.
     const testId = label === "Bash" ? ElementIds.ALPHA_CHAT_BASH_BLOCK : ElementIds.ALPHA_CHAT_TOOL_PILL;
+
+    let rowContent: ReactElement;
+    if (visualization !== null) {
+      // A plugin owns the inline summary: its `{title, meta}` only (the body
+      // stays in the popover). The host default title covers an omitted or
+      // throwing `summary`.
+      const summary = safeSummary(visualization.definition, call);
+      rowContent = rowShell({
+        title: summary?.title ?? call.invocation ?? call.toolName,
+        meta: summary?.meta,
+        bodyText: "",
+      });
+    } else if (isCommandStyleTool) {
+      rowContent = <CommandRowContent block={block} result={result} isExecuting={isExecuting} shell={rowShell} />;
+    } else {
+      rowContent = (
+        <ToolEntryContent
+          toolName={label}
+          block={block}
+          result={result}
+          workspaceCodePath={workspaceCodePath}
+          pillState={state}
+          renderShell={rowShell}
+        />
+      );
+    }
 
     return (
       <div
@@ -108,17 +140,7 @@ const AlphaExpandedToolRowImpl = forwardRef<HTMLDivElement, AlphaExpandedToolRow
             ·
           </span>
         </span>
-        {isCommandStyleTool ? (
-          <CommandRowContent block={block} result={result} isExecuting={isExecuting} shell={rowShell} />
-        ) : (
-          <ToolEntryContent
-            toolName={label}
-            block={block}
-            result={result}
-            workspaceCodePath={workspaceCodePath}
-            renderShell={rowShell}
-          />
-        )}
+        {rowContent}
       </div>
     );
   },

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPill.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPill.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from "react";
 import { ElementIds } from "~/api";
 
 import styles from "./AlphaToolPill.module.scss";
+import { usePluginToolVisualization } from "./pluginToolViz.ts";
 import type { PillData } from "./toolPill.types.ts";
 import { getToolIcon } from "./toolPillIcons.tsx";
 
@@ -23,7 +24,13 @@ export const AlphaToolPill = forwardRef<HTMLButtonElement, AlphaToolPillProps>(
     // duration is meaningful enough to surface visually.
     const isCommandStyleTool = label === "Bash" || label === "Monitor";
     const isExecuting = state === "initializing";
-    const Icon = getToolIcon(label);
+    const block = pillData.blocks[0] ?? null;
+    const result = pillData.results[0] ?? null;
+    // A matched tool-visualization plugin overrides the icon; its presence also
+    // suppresses the command-style executing dot so the plugin's icon shows,
+    // matching the expanded row.
+    const { visualization } = usePluginToolVisualization({ block, result, pillState: state });
+    const Icon = visualization?.definition.icon ?? getToolIcon(label);
 
     const classNames = [styles.pill];
     if (isOpen) classNames.push(styles.pillOpen);
@@ -37,7 +44,7 @@ export const AlphaToolPill = forwardRef<HTMLButtonElement, AlphaToolPillProps>(
     // a pulsing status dot. Once it finishes (completed or error) the Lucide
     // icon comes back. The dot's margin matches the icon's width so the
     // label position is identical across the swap.
-    const isShowingStatusDot = isCommandStyleTool && isExecuting;
+    const isShowingStatusDot = isCommandStyleTool && isExecuting && visualization === null;
 
     return (
       <button

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPillRow.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPillRow.tsx
@@ -17,6 +17,7 @@ import { AlphaToolPopover } from "./AlphaToolPopover.tsx";
 import { chatToolDensityAtom } from "./atoms.ts";
 import { useCloseOnChatScroll } from "./hooks/useChatScroll.tsx";
 import { usePillHoverDelay } from "./hooks/usePillHoverDelay.ts";
+import { usePluginToolVisualization } from "./pluginToolViz.ts";
 import { useToolNavigation } from "./ToolNavigationContext.tsx";
 import type { PillData } from "./toolPill.types.ts";
 import { buildPillData } from "./toolPillUtils.ts";
@@ -253,22 +254,6 @@ export const AlphaToolPillRow = ({
 
   if (pillDataList.length === 0) return null;
 
-  const renderPopoverContent = (pill: PillData): ReactElement => {
-    if (pill.label === "Bash" || pill.label === "Monitor") {
-      const block = pill.blocks[0];
-      const result = pill.results[0];
-      return (
-        <AlphaCommandPopover
-          toolName={pill.label}
-          block={block}
-          result={result}
-          isExecuting={pill.state === "initializing"}
-        />
-      );
-    }
-    return <AlphaToolPopover pillData={pill} workspaceCodePath={workspaceCodePath} />;
-  };
-
   return (
     <Popover.Root
       open={isPopoverOpen}
@@ -351,10 +336,43 @@ export const AlphaToolPillRow = ({
             onMouseEnter={handlePopoverMouseEnter}
             onMouseLeave={handlePopoverMouseLeave}
           >
-            {renderPopoverContent(openPill)}
+            <PillPopoverContent pill={openPill} workspaceCodePath={workspaceCodePath} />
           </div>
         )}
       </Popover.Content>
     </Popover.Root>
   );
+};
+
+/**
+ * The popover body for one pill in default density. Consults the plugin
+ * tool-visualization registry first so a matching plugin overrides even the
+ * dedicated Bash/Monitor command popover (which otherwise bypasses the shared
+ * per-entry dispatch). With no plugin match, single-call Bash/Monitor pills use
+ * the command popover; everything else falls to the shared multi-entry tool
+ * popover — whose per-entry `ToolEntryContent` runs the same registry check, so
+ * a plugin hit renders through it there too.
+ */
+const PillPopoverContent = ({
+  pill,
+  workspaceCodePath,
+}: {
+  pill: PillData;
+  workspaceCodePath: string | null;
+}): ReactElement => {
+  const block = pill.blocks[0] ?? null;
+  const result = pill.results[0] ?? null;
+  const { visualization } = usePluginToolVisualization({ block, result, pillState: pill.state });
+
+  if (visualization === null && (pill.label === "Bash" || pill.label === "Monitor")) {
+    return (
+      <AlphaCommandPopover
+        toolName={pill.label}
+        block={block ?? undefined}
+        result={result ?? undefined}
+        isExecuting={pill.state === "initializing"}
+      />
+    );
+  }
+  return <AlphaToolPopover pillData={pill} workspaceCodePath={workspaceCodePath} />;
 };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.tsx
@@ -8,12 +8,15 @@ import type { ToolResultBlock, ToolUseBlock } from "~/api";
 import { isGenericToolContent } from "~/common/Guards.ts";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { openFileViewTabAtom } from "~/pages/workspace/components/diffPanel/atoms.ts";
+import type { PluginToolVisualization } from "~/plugins/pluginRegistry.ts";
+import type { ToolCallView } from "~/plugins/types.ts";
 
 import styles from "./AlphaToolPopover.module.scss";
 import { OutsideWorkspaceIcon } from "./OutsideWorkspaceIcon.tsx";
+import { safeSummary, usePluginToolVisualization } from "./pluginToolViz.ts";
 import headerStyles from "./PopoverHeader.module.scss";
 import { PopoverHeader } from "./PopoverHeader.tsx";
-import type { PillData } from "./toolPill.types.ts";
+import type { PillData, PillState } from "./toolPill.types.ts";
 import { makeRelative } from "./toolPillUtils.ts";
 
 export type ToolEntryShellArgs = {
@@ -259,16 +262,25 @@ type ToolEntryContentProps = {
   block: ToolUseBlock | null;
   result: ToolResultBlock | null;
   workspaceCodePath: string | null;
+  /**
+   * The owning pill's lifecycle state, when the caller has it (the expanded row
+   * and the pill-level popover branch). The multi-entry popover renders one
+   * entry per call with no single pill state, so it omits this and the status is
+   * derived from the entry's own result.
+   */
+  pillState?: PillState;
   /** Defaults to the popover-entry layout (header + body). */
   renderShell?: ToolEntryShell;
 };
 
 /**
- * Render a single tool call's per-tool entry. The `renderShell` prop
- * controls layout — popover-entry chrome by default; AlphaToolPillRow
- * passes a row-layout shell for expanded density.
+ * The host's built-in per-tool entry: the specialized renderer for a known tool
+ * name, falling back to `DefaultEntry` (invocation string + `<pre>` dump).
+ * `ToolEntryContent` wraps this with a plugin-registry check; a plugin body's
+ * error boundary falls back to this rendering, so a broken visualizer is never
+ * less readable than stock.
  */
-export const ToolEntryContent = ({
+const BuiltinToolEntry = ({
   toolName,
   block,
   result,
@@ -294,6 +306,80 @@ export const ToolEntryContent = ({
     default:
       return <DefaultEntry {...props} />;
   }
+};
+
+/**
+ * A matched tool-visualization plugin's entry.
+ *
+ * In the popover (no `renderShell`), it renders the plugin summary as the header
+ * and the plugin body below — the body wrapped so a crash degrades to `builtin`
+ * rather than a generic plugin-error card. In the expanded row (a `renderShell`
+ * that drops the body), it renders only the plugin `{title, meta}` through the
+ * shell and never mounts the body — matching built-in row behavior.
+ */
+const PluginToolEntry = ({
+  visualization,
+  call,
+  builtin,
+  renderShell,
+}: {
+  visualization: PluginToolVisualization;
+  call: ToolCallView;
+  /** The stock rendering for this call — the popover body's crash fallback. */
+  builtin: ReactElement;
+  renderShell?: ToolEntryShell;
+}): ReactElement => {
+  const summary = safeSummary(visualization.definition, call);
+
+  if (renderShell) {
+    return renderShell({
+      // The host's default title (invocation string / tool name) covers a plugin
+      // that omits (or throws from) `summary`.
+      title: summary?.title ?? call.invocation ?? call.toolName,
+      meta: summary?.meta,
+      bodyText: "",
+    });
+  }
+
+  const PluginBody = visualization.wrappedBody;
+  return (
+    <div className={styles.entry}>
+      <PopoverHeader title={summary?.title ?? call.invocation ?? call.toolName} meta={summary?.meta} />
+      <PluginBody call={call} fallback={builtin} />
+    </div>
+  );
+};
+
+/**
+ * Render a single tool call's per-tool entry. Consults the plugin
+ * tool-visualization registry first: a matching plugin overrides the built-in
+ * renderer (summary + body in the popover, summary-only in the expanded row).
+ * With no match — or for a call whose pill data isn't available here — the
+ * host's built-in per-tool entry renders. The `renderShell` prop controls
+ * layout: popover-entry chrome by default; AlphaExpandedToolRow passes a
+ * row-layout shell for expanded density.
+ */
+export const ToolEntryContent = ({
+  toolName,
+  block,
+  result,
+  workspaceCodePath,
+  pillState,
+  renderShell,
+}: ToolEntryContentProps): ReactElement => {
+  const derivedState: PillState = result ? (result.isError ? "error" : "completed") : "initializing";
+  const { visualization, call } = usePluginToolVisualization({ block, result, pillState: pillState ?? derivedState });
+  const builtin = (
+    <BuiltinToolEntry
+      toolName={toolName}
+      block={block}
+      result={result}
+      workspaceCodePath={workspaceCodePath}
+      renderShell={renderShell}
+    />
+  );
+  if (!visualization) return builtin;
+  return <PluginToolEntry visualization={visualization} call={call} builtin={builtin} renderShell={renderShell} />;
 };
 
 type AlphaToolPopoverProps = {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/ToolEntryContent.dispatch.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/ToolEntryContent.dispatch.test.tsx
@@ -1,0 +1,102 @@
+import { Theme } from "@radix-ui/themes";
+import { cleanup, render as rtlRender, screen } from "@testing-library/react";
+import type { ComponentType, ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ToolResultBlock, ToolUseBlock } from "~/api";
+import { PluginErrorBoundary } from "~/plugins/PluginErrorBoundary.tsx";
+import type { PluginToolVisualization } from "~/plugins/pluginRegistry.ts";
+import type { ToolCallView } from "~/plugins/types.ts";
+
+import type * as PluginToolViz from "./pluginToolViz.ts";
+
+// The registry dispatch reads the current workspace/task; stub it so the entry
+// renders without the full app/router/jotai context. The visualization the
+// dispatch returns is controlled per-test via the mock below.
+vi.mock("~/common/NavigateUtils.ts", () => ({
+  useWorkspacePageParams: (): { workspaceID: string; agentID: string } => ({ workspaceID: "ws-1", agentID: "a-1" }),
+}));
+
+const dispatch = vi.hoisted(() => ({ visualization: null as PluginToolVisualization | null }));
+
+vi.mock("./pluginToolViz.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof PluginToolViz>();
+  return {
+    ...actual,
+    usePluginToolVisualization: (inputs: {
+      block: ToolUseBlock | null;
+      result: ToolResultBlock | null;
+    }): { visualization: PluginToolVisualization | null; call: ToolCallView } => ({
+      visualization: dispatch.visualization,
+      call: actual.buildToolCallView({ ...inputs, pillState: "completed", agentType: "claude" }),
+    }),
+  };
+});
+
+// Imported after the mocks so the component picks up the stubbed dispatch.
+const { ToolEntryContent } = await import("./AlphaToolPopover.tsx");
+
+const ThemeWrapper = ({ children }: { children: ReactNode }): ReactElement => <Theme>{children}</Theme>;
+const render = (ui: ReactElement): ReturnType<typeof rtlRender> => rtlRender(ui, { wrapper: ThemeWrapper });
+
+const makeVisualization = (body: ComponentType<{ call: ToolCallView }>): PluginToolVisualization => ({
+  definition: {
+    id: "viz",
+    toolNames: ["Workflow"],
+    body,
+    summary: () => ({ title: "Plugin summary" }),
+  },
+  // The wrapped body the chat actually mounts renders the plugin body inside the
+  // real error boundary, so a body crash degrades to the host-supplied
+  // `fallback` — mirroring the loader's wrap.
+  wrappedBody: ({ call, fallback }): ReactElement => {
+    const Body = body;
+    return (
+      <PluginErrorBoundary pluginId="plugin-viz" pluginName="viz" fallback={fallback}>
+        <Body call={call} />
+      </PluginErrorBoundary>
+    );
+  },
+  pluginId: "plugin-viz",
+});
+
+const block: ToolUseBlock = { type: "tool_use", id: "t-1", name: "Workflow", input: { script: "s" } };
+const result: ToolResultBlock = {
+  type: "tool_result",
+  toolUseId: "t-1",
+  toolName: "Workflow",
+  invocationString: "Workflow(...)",
+  content: { contentType: "generic", text: "stock body text" },
+};
+
+afterEach(() => {
+  dispatch.visualization = null;
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe("ToolEntryContent plugin dispatch", () => {
+  it("renders the built-in DefaultEntry when no plugin matches", () => {
+    dispatch.visualization = null;
+    render(<ToolEntryContent toolName="Workflow" block={block} result={result} workspaceCodePath={null} />);
+    expect(screen.getByText("stock body text")).toBeTruthy();
+    expect(screen.queryByText("Plugin summary")).toBeNull();
+  });
+
+  it("renders the plugin summary and body when a visualization matches", () => {
+    dispatch.visualization = makeVisualization(() => <div>plugin body</div>);
+    render(<ToolEntryContent toolName="Workflow" block={block} result={result} workspaceCodePath={null} />);
+    expect(screen.getByText("Plugin summary")).toBeTruthy();
+    expect(screen.getByText("plugin body")).toBeTruthy();
+  });
+
+  it("degrades a crashing plugin body to the stock rendering", () => {
+    dispatch.visualization = makeVisualization(() => {
+      throw new Error("body crash");
+    });
+    render(<ToolEntryContent toolName="Workflow" block={block} result={result} workspaceCodePath={null} />);
+    // The summary header still renders; the body falls back to the stock entry.
+    expect(screen.getByText("Plugin summary")).toBeTruthy();
+    expect(screen.getByText("stock body text")).toBeTruthy();
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/__tests__/AlphaToolPill.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/__tests__/AlphaToolPill.test.tsx
@@ -2,8 +2,29 @@ import { Theme } from "@radix-ui/themes";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ToolCallView } from "~/plugins/types.ts";
+
 import { AlphaToolPill } from "../AlphaToolPill.tsx";
 import type { PillData } from "../toolPill.types.ts";
+
+// The pill consults the tool-visualization registry (which reads the workspace
+// route + task atoms). Stub the dispatch to "no plugin" so the pill renders in
+// isolation without the app/router context, exercising its built-in icon path.
+vi.mock("../pluginToolViz.ts", () => ({
+  usePluginToolVisualization: (): { visualization: null; call: ToolCallView } => ({
+    visualization: null,
+    call: {
+      id: "",
+      toolName: "",
+      agentType: null,
+      input: null,
+      status: "success",
+      invocation: null,
+      result: null,
+      durationSeconds: null,
+    },
+  }),
+}));
 
 const createPillData = (overrides: Partial<PillData> = {}): PillData => ({
   id: "pill-1",

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/pluginToolViz.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/pluginToolViz.test.ts
@@ -1,0 +1,160 @@
+import type { ComponentType } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { ToolResultBlock, ToolUseBlock } from "~/api";
+import type { PluginToolVisualization } from "~/plugins/pluginRegistry.ts";
+import type { ToolCallView, ToolVisualizationDefinition } from "~/plugins/types.ts";
+
+import { buildToolCallView, selectToolVisualization } from "./pluginToolViz.ts";
+import type { PillState } from "./toolPill.types.ts";
+
+const NoopBody: ComponentType<{ call: ToolCallView }> = () => null;
+
+/** A registry entry wrapping a definition — only the definition is read by dispatch. */
+const entry = (definition: Partial<ToolVisualizationDefinition> & { id: string }): PluginToolVisualization => ({
+  definition: { toolNames: ["Workflow"], body: NoopBody, ...definition },
+  wrappedBody: () => null,
+  pluginId: `plugin-${definition.id}`,
+});
+
+const callFor = (overrides: Partial<ToolCallView> = {}): ToolCallView => ({
+  id: "call-1",
+  toolName: "Workflow",
+  agentType: "claude",
+  input: {},
+  status: "success",
+  invocation: null,
+  result: null,
+  durationSeconds: null,
+  ...overrides,
+});
+
+describe("selectToolVisualization", () => {
+  it("matches only registrations whose toolNames contain the call's tool name (exact)", () => {
+    const defs = [entry({ id: "a", toolNames: ["Read"] }), entry({ id: "b", toolNames: ["Workflow"] })];
+    expect(selectToolVisualization(defs, callFor({ toolName: "Workflow" }))?.definition.id).toBe("b");
+    expect(selectToolVisualization(defs, callFor({ toolName: "Workflo" }))).toBeNull();
+    expect(selectToolVisualization(defs, callFor({ toolName: "mcp__srv__Workflow" }))).toBeNull();
+  });
+
+  it("does not match a scoped registration against a null agentType", () => {
+    const defs = [entry({ id: "a", agentTypes: ["claude"] })];
+    expect(selectToolVisualization(defs, callFor({ agentType: null }))).toBeNull();
+  });
+
+  it("matches an unscoped registration against a null agentType", () => {
+    const defs = [entry({ id: "a" })];
+    expect(selectToolVisualization(defs, callFor({ agentType: null }))?.definition.id).toBe("a");
+  });
+
+  it("filters by agentTypes when scoped", () => {
+    const defs = [entry({ id: "a", agentTypes: ["pi", "registered:my-tool"] })];
+    expect(selectToolVisualization(defs, callFor({ agentType: "claude" }))).toBeNull();
+    expect(selectToolVisualization(defs, callFor({ agentType: "pi" }))?.definition.id).toBe("a");
+    expect(selectToolVisualization(defs, callFor({ agentType: "registered:my-tool" }))?.definition.id).toBe("a");
+  });
+
+  it("skips a candidate whose canRender returns false and falls through to the next", () => {
+    const defs = [
+      entry({ id: "keep", toolNames: ["Workflow"] }),
+      entry({ id: "decline", toolNames: ["Workflow"], canRender: () => false }),
+    ];
+    // "decline" is later (last-wins) but declines, so the earlier "keep" survives.
+    expect(selectToolVisualization(defs, callFor())?.definition.id).toBe("keep");
+  });
+
+  it("treats a throwing canRender as declined rather than fatal", () => {
+    const defs = [
+      entry({ id: "keep", toolNames: ["Workflow"] }),
+      entry({
+        id: "throws",
+        toolNames: ["Workflow"],
+        canRender: () => {
+          throw new Error("boom");
+        },
+      }),
+    ];
+    expect(() => selectToolVisualization(defs, callFor())).not.toThrow();
+    expect(selectToolVisualization(defs, callFor())?.definition.id).toBe("keep");
+  });
+
+  it("returns null when every candidate declines", () => {
+    const defs = [entry({ id: "a", canRender: () => false })];
+    expect(selectToolVisualization(defs, callFor())).toBeNull();
+  });
+
+  it("lets the last-registered survivor win among eligible candidates", () => {
+    const defs = [entry({ id: "first", toolNames: ["Workflow"] }), entry({ id: "second", toolNames: ["Workflow"] })];
+    expect(selectToolVisualization(defs, callFor())?.definition.id).toBe("second");
+  });
+});
+
+const useBlock = (overrides: Partial<ToolUseBlock> = {}): ToolUseBlock => ({
+  type: "tool_use",
+  id: "tool-1",
+  name: "Workflow",
+  input: { script: "x" },
+  ...overrides,
+});
+
+const resultBlock = (overrides: Partial<ToolResultBlock> = {}): ToolResultBlock => ({
+  type: "tool_result",
+  toolUseId: "tool-1",
+  toolName: "Workflow",
+  invocationString: "Workflow(...)",
+  content: { contentType: "generic", text: "done" },
+  ...overrides,
+});
+
+describe("buildToolCallView", () => {
+  const build = (block: ToolUseBlock | null, result: ToolResultBlock | null, pillState: PillState): ToolCallView =>
+    buildToolCallView({ block, result, pillState, agentType: "claude" });
+
+  it("maps pill state to status (initializing → running, error → error, else success)", () => {
+    expect(build(useBlock(), null, "initializing").status).toBe("running");
+    expect(build(useBlock(), resultBlock({ isError: true }), "error").status).toBe("error");
+    expect(build(useBlock(), resultBlock(), "completed").status).toBe("success");
+  });
+
+  it("carries block input and id/toolName from the block when present", () => {
+    const call = build(useBlock({ input: { script: "hi" } }), null, "initializing");
+    expect(call.id).toBe("tool-1");
+    expect(call.toolName).toBe("Workflow");
+    expect(call.input).toEqual({ script: "hi" });
+  });
+
+  it("builds a result-only call: null input, id/toolName from the result", () => {
+    const call = build(null, resultBlock({ toolUseId: "res-9", toolName: "Workflow" }), "completed");
+    expect(call.input).toBeNull();
+    expect(call.id).toBe("res-9");
+    expect(call.toolName).toBe("Workflow");
+  });
+
+  it("extracts result text from GenericToolContent and flags errors", () => {
+    const ok = build(useBlock(), resultBlock({ content: { contentType: "generic", text: "output" } }), "completed");
+    expect(ok.result).toEqual({ text: "output", isError: false });
+
+    const errored = build(
+      useBlock(),
+      resultBlock({ isError: true, content: { contentType: "generic", text: "nope" } }),
+      "error",
+    );
+    expect(errored.result).toEqual({ text: "nope", isError: true });
+  });
+
+  it("leaves result null while the call is still running", () => {
+    expect(build(useBlock(), null, "initializing").result).toBeNull();
+  });
+
+  it("reports null duration when the result carries none", () => {
+    expect(build(useBlock(), resultBlock({ durationSeconds: null }), "completed").durationSeconds).toBeNull();
+    expect(build(useBlock(), resultBlock({ durationSeconds: 2.5 }), "completed").durationSeconds).toBe(2.5);
+  });
+
+  it("prefers the block invocation string, falling back to the result's", () => {
+    expect(build(useBlock({ invocationString: "from-block" }), resultBlock(), "completed").invocation).toBe(
+      "from-block",
+    );
+    expect(build(null, resultBlock({ invocationString: "from-result" }), "completed").invocation).toBe("from-result");
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/pluginToolViz.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/pluginToolViz.ts
@@ -1,0 +1,153 @@
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
+
+import type { ToolResultBlock, ToolUseBlock } from "~/api";
+import { isGenericToolContent } from "~/common/Guards.ts";
+import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
+import { encodeRegisteredAgentType } from "~/common/state/atoms/agentTabs.ts";
+import { taskAtomFamily } from "~/common/state/atoms/tasks.ts";
+import type { PluginToolVisualization } from "~/plugins/pluginRegistry.ts";
+import { pluginToolVisualizationsAtom } from "~/plugins/pluginRegistry.ts";
+import type { ToolCallStatus, ToolCallView, ToolVisualizationDefinition } from "~/plugins/types.ts";
+
+import type { PillState } from "./toolPill.types.ts";
+
+/** Map a pill's lifecycle state to the plugin-facing tool-call status. */
+const statusFromPillState = (state: PillState): ToolCallStatus => {
+  if (state === "initializing") return "running";
+  if (state === "error") return "error";
+  return "success";
+};
+
+// The extractor DefaultEntry uses to stringify a tool result — GenericToolContent
+// carries the text; a DiffToolContent (diff tools are routed to the chip row well
+// before pills) has none, so it stringifies to empty.
+const resultText = (result: ToolResultBlock | null): string => {
+  if (!result) return "";
+  if (isGenericToolContent(result.content)) return result.content.text;
+  return "";
+};
+
+/**
+ * Build the curated {@link ToolCallView} a plugin visualizer sees from a paired
+ * tool_use block / result. `block` is null for result-only pills (input is then
+ * null); `result` is null while the call is still running. `agentType` is the
+ * stored encoding of the owning task's harness, or null when unknown.
+ */
+export const buildToolCallView = (inputs: {
+  block: ToolUseBlock | null;
+  result: ToolResultBlock | null;
+  pillState: PillState;
+  agentType: string | null;
+}): ToolCallView => {
+  const { block, result, pillState, agentType } = inputs;
+  const id = block?.id ?? result?.toolUseId ?? "";
+  const toolName = block?.name ?? result?.toolName ?? "";
+  const invocation = (block?.invocationString as string | undefined) ?? result?.invocationString ?? null;
+  return {
+    id,
+    toolName,
+    agentType,
+    input: block?.input ?? null,
+    status: statusFromPillState(pillState),
+    invocation,
+    result: result ? { text: resultText(result), isError: result.isError ?? false } : null,
+    durationSeconds: result?.durationSeconds ?? null,
+  };
+};
+
+/**
+ * Pick the tool-visualization registration that should render `call`, or null
+ * for none. Candidates are registrations whose `toolNames` contains the call's
+ * tool name (exact match). They are then filtered by `agentTypes` (a scoped
+ * registration never matches a null/unknown `agentType`; an unscoped one always
+ * does) and by `canRender` (missing = eligible; a throw is treated as declined).
+ * Among survivors, the last-registered wins — so the array is scanned in
+ * reverse, consistent with replace-by-id semantics elsewhere.
+ */
+export const selectToolVisualization = (
+  defs: ReadonlyArray<PluginToolVisualization>,
+  call: ToolCallView,
+): PluginToolVisualization | null => {
+  for (let i = defs.length - 1; i >= 0; i--) {
+    const candidate = defs[i];
+    const { definition } = candidate;
+    if (!definition.toolNames.includes(call.toolName)) continue;
+    if (definition.agentTypes !== undefined) {
+      if (call.agentType === null) continue;
+      if (!definition.agentTypes.includes(call.agentType)) continue;
+    }
+
+    if (definition.canRender) {
+      let isAllowed: boolean;
+      try {
+        isAllowed = definition.canRender(call);
+      } catch {
+        // `canRender` is untrusted: a throw declines this candidate rather than
+        // taking down the row, so the next candidate (or built-in) still renders.
+        continue;
+      }
+      if (!isAllowed) continue;
+    }
+    return candidate;
+  }
+  return null;
+};
+
+/**
+ * The summary a visualizer contributes for `call`, or null to fall back to the
+ * host's default title. `summary` is untrusted: a throw is treated as declined
+ * (null), so a broken summarizer never takes down the row — it just reverts to
+ * the stock title/meta.
+ */
+export const safeSummary = (
+  definition: ToolVisualizationDefinition,
+  call: ToolCallView,
+): { title: string; meta?: string } | null => {
+  if (!definition.summary) return null;
+  try {
+    return definition.summary(call);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The stored agent-type encoding for the workspace's current task
+ * (`registered:<id>` for registered agents), or null when the task or its agent
+ * type is unknown. Drives the `agentTypes` filter in tool-visualization dispatch.
+ */
+export const useCurrentTaskAgentType = (): string | null => {
+  const { agentID } = useWorkspacePageParams();
+  const task = useAtomValue(taskAtomFamily(agentID ?? ""));
+  if (!task || task.agentType == null) return null;
+  if (task.agentType === "registered") {
+    // A registered agent with no registration id can't be addressed distinctly,
+    // so it stays unknown rather than matching a bare "registered" scope.
+    return task.registrationId ? encodeRegisteredAgentType(task.registrationId) : null;
+  }
+  return task.agentType;
+};
+
+/**
+ * The tool-visualization registration that should render this tool call, or
+ * null. Reads the plugin registry and the current task's agent type, builds the
+ * curated {@link ToolCallView}, and dispatches. Memoized so the (hot) chat
+ * render path doesn't re-scan the registry unless its inputs change.
+ */
+export const usePluginToolVisualization = (inputs: {
+  block: ToolUseBlock | null;
+  result: ToolResultBlock | null;
+  pillState: PillState;
+}): { visualization: PluginToolVisualization | null; call: ToolCallView } => {
+  const { block, result, pillState } = inputs;
+  const defs = useAtomValue(pluginToolVisualizationsAtom);
+  const agentType = useCurrentTaskAgentType();
+
+  const call = useMemo(
+    () => buildToolCallView({ block, result, pillState, agentType }),
+    [block, result, pillState, agentType],
+  );
+  const visualization = useMemo(() => selectToolVisualization(defs, call), [defs, call]);
+  return { visualization, call };
+};

--- a/sculptor/frontend/src/plugins/PluginErrorBoundary.tsx
+++ b/sculptor/frontend/src/plugins/PluginErrorBoundary.tsx
@@ -5,6 +5,14 @@ type Props = {
   pluginId: string;
   pluginName: string;
   children: ReactNode;
+  /**
+   * What to render instead of the default "stopped responding" panel when the
+   * wrapped component crashes. Used where a broken plugin must degrade to the
+   * host's own rendering rather than an error card — e.g. a tool-visualization
+   * body falling back to the stock tool-call entry, so a crash never makes a
+   * call less readable than without the plugin.
+   */
+  fallback?: ReactNode;
 };
 
 type State = { error: Error | null };
@@ -29,6 +37,7 @@ export class PluginErrorBoundary extends Component<Props, State> {
 
   render(): ReactNode {
     if (this.state.error) {
+      if (this.props.fallback !== undefined) return this.props.fallback;
       return (
         <Flex direction="column" gap="2" p="3">
           <Text size="2" weight="medium">

--- a/sculptor/frontend/src/plugins/pluginManager.tsx
+++ b/sculptor/frontend/src/plugins/pluginManager.tsx
@@ -1,5 +1,5 @@
 import type { createStore } from "jotai";
-import type { ComponentType, ReactElement } from "react";
+import type { ComponentType, ReactElement, ReactNode } from "react";
 
 import {
   getLocalPlugins,
@@ -28,6 +28,7 @@ import {
   pluginSourcesAtom,
   type PluginSourceState,
   pluginSourceStatesAtom,
+  pluginToolVisualizationsAtom,
   pluginWorkspaceWidgetsAtom,
 } from "./pluginRegistry.ts";
 import { getRendererIdentity } from "./rendererIdentity.ts";
@@ -39,6 +40,8 @@ import type {
   PluginLoadError,
   PluginManifest,
   PluginModule,
+  ToolCallView,
+  ToolVisualizationDefinition,
   WorkspaceWidgetDefinition,
 } from "./types.ts";
 import { WorkspacePluginContext } from "./WorkspaceContext.tsx";
@@ -109,6 +112,7 @@ const BUILTIN_SOURCES: ReadonlyArray<BuiltinSource> = [
   { path: "/plugins/sculpty", disabledByDefault: true },
   { path: "/plugins/pomodoro", disabledByDefault: true },
   { path: "/plugins/linear-issue" },
+  { path: "/plugins/workflow-viz" },
 ];
 
 /**
@@ -950,6 +954,43 @@ export class PluginManager {
         store.set(pluginHomeViewsAtom, (prev) => [...prev.filter((v) => v.id !== view.id), entry]);
         const undo = (): void => {
           store.set(pluginHomeViewsAtom, (prev) => prev.filter((v) => v !== entry));
+        };
+        loadDisposers.push(undo);
+        return undo;
+      },
+      registerToolVisualization: (definition: ToolVisualizationDefinition): (() => void) => {
+        // The chat is workspace-scoped, so wrap the body like a panel: error
+        // boundary + PluginContext + a per-render WorkspacePluginContext read
+        // fresh from the route. The `call` prop is forwarded from the chat's
+        // dispatch layer, which owns building the ToolCallView.
+        const PluginBody = definition.body;
+        // `fallback` is a host-supplied detail, not part of the plugin's body
+        // contract: the chat passes the stock tool-call rendering so a body
+        // crash degrades to it instead of the generic plugin-error card.
+        const WrappedBody = ({ call, fallback }: { call: ToolCallView; fallback?: ReactNode }): ReactElement | null => {
+          const { workspaceID } = useWorkspacePageParams();
+          if (!workspaceID) return null;
+          return (
+            <PluginErrorBoundary pluginId={manifest.id} pluginName={manifest.name} fallback={fallback}>
+              <PluginContext.Provider value={{ pluginId: manifest.id }}>
+                <WorkspacePluginContext.Provider value={{ workspaceId: workspaceID }}>
+                  <PluginBody call={call} />
+                </WorkspacePluginContext.Provider>
+              </PluginContext.Provider>
+            </PluginErrorBoundary>
+          );
+        };
+        WrappedBody.displayName = `PluginToolVisualization(${definition.id})`;
+        const entry = { definition, wrappedBody: WrappedBody, pluginId: manifest.id };
+
+        // Replace-by-id; undo by instance (see the panel undo above). Order is
+        // preserved so the chat's "last registered wins" is a reverse scan.
+        store.set(pluginToolVisualizationsAtom, (prev) => [
+          ...prev.filter((v) => v.definition.id !== definition.id),
+          entry,
+        ]);
+        const undo = (): void => {
+          store.set(pluginToolVisualizationsAtom, (prev) => prev.filter((v) => v !== entry));
         };
         loadDisposers.push(undo);
         return undo;

--- a/sculptor/frontend/src/plugins/pluginRegistry.ts
+++ b/sculptor/frontend/src/plugins/pluginRegistry.ts
@@ -1,10 +1,10 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 
 import type { PanelDefinition } from "~/components/panels/types.ts";
 
-import type { PluginManifest } from "./types.ts";
+import type { PluginManifest, ToolVisualizationDefinition } from "./types.ts";
 
 /**
  * Panels contributed by loaded plugins, ready to be merged into the host's
@@ -50,6 +50,47 @@ export const pluginWorkspaceWidgetsAtom = atom<
 export const pluginHomeViewsAtom = atom<
   ReadonlyArray<{ id: string; title: string; icon?: ComponentType; component: ComponentType }>
 >([]);
+
+/**
+ * One registered tool-call visualization: the plugin's `definition` plus the
+ * error-boundary-wrapped `body` the chat renders, attributed to its owning
+ * plugin (`pluginId` is the manifest id, so `inspect` can list a plugin's
+ * visualizations). The entry keeps `wrappedBody` separate from
+ * `definition.body` so dispatch reads the raw definition (names, agent types,
+ * `canRender`, `summary`, `icon`) while the chat mounts the wrapped component.
+ */
+export type PluginToolVisualization = {
+  definition: ToolVisualizationDefinition;
+  /**
+   * The chat-rendered body: the plugin's `definition.body` wrapped by the loader
+   * in an error boundary, PluginContext, and WorkspacePluginContext. Takes the
+   * same `call` the definition's body does, plus a host-supplied `fallback` the
+   * error boundary renders on a body crash (the stock tool-call rendering) so a
+   * broken visualizer degrades to it rather than a generic plugin-error card.
+   */
+  wrappedBody: ComponentType<{ call: ToolVisualizationCall; fallback?: ReactNode }>;
+  pluginId: string;
+};
+
+/**
+ * The `call` prop the wrapped body receives. Structurally the SDK's
+ * `ToolCallView`, restated here (rather than imported) so the registry module
+ * doesn't depend on the SDK barrel; the dispatch layer owns the mapping.
+ */
+export type ToolVisualizationCall = ToolVisualizationDefinition extends {
+  body: ComponentType<{ call: infer TCall }>;
+}
+  ? TCall
+  : never;
+
+/**
+ * Tool-call visualizations contributed by plugins via
+ * `registerToolVisualization`. Ordered by registration, so dispatch's
+ * "last registered wins" is a reverse scan. Replace-by-id within the same
+ * definition id. Each entry's `wrappedBody` is already wrapped by the loader in
+ * an error boundary, the plugin's PluginContext, and the WorkspacePluginContext.
+ */
+export const pluginToolVisualizationsAtom = atom<ReadonlyArray<PluginToolVisualization>>([]);
 
 /**
  * User-added plugin sources, persisted to localStorage. A source is a URL or

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -23,6 +23,10 @@ export type {
   OverlayDefinition,
   PluginHostApi,
   PluginManifest,
+  ToolCallStatus,
+  ToolCallView,
+  ToolVisualizationDefinition,
+  ToolVisualizationSummary,
   WorkspaceWidgetDefinition,
 } from "../types.ts";
 export type { PanelDefinition } from "~/components/panels/types.ts";

--- a/sculptor/frontend/src/plugins/types.ts
+++ b/sculptor/frontend/src/plugins/types.ts
@@ -1,3 +1,4 @@
+import type { LucideIcon } from "lucide-react";
 import type { ComponentType } from "react";
 
 import type { PanelDefinition } from "~/components/panels/types.ts";
@@ -101,6 +102,86 @@ export type HomeViewDefinition = {
   component: ComponentType;
 };
 
+/** Lifecycle of a single tool call, as a plugin visualizer sees it. */
+export type ToolCallStatus = "running" | "success" | "error";
+
+/**
+ * Curated view of one tool call handed to a tool-visualization plugin.
+ * Deliberately NOT the generated `ToolUseBlock`/`ToolResultBlock` — plugins
+ * must not couple to backend block shapes (same precedent as `WorkspaceView`
+ * in `sdk/hooks.ts`).
+ */
+export type ToolCallView = {
+  /** The tool_use id (a result-only block's `toolUseId`). */
+  id: string;
+  /** Full tool name, including an `mcp__server__tool` for MCP tools. */
+  toolName: string;
+  /**
+   * The owning agent's stored type encoding: `"claude" | "pi" | "terminal" |
+   * "registered:<registrationId>"`, or `null` when the host can't tell which
+   * harness owns the transcript.
+   */
+  agentType: string | null;
+  /**
+   * The tool's input. Complete once visible (never partial — tool input is
+   * revealed as a whole unit), and `null` for result-only blocks that carry no
+   * input.
+   */
+  input: Readonly<Record<string, unknown>> | null;
+  status: ToolCallStatus;
+  /** The host's invocation string, available once a result exists; else `null`. */
+  invocation: string | null;
+  /** The tool's result, or `null` while the call is still running. */
+  result: { text: string; isError: boolean } | null;
+  durationSeconds: number | null;
+};
+
+/** The header line a visualizer contributes for a tool call. */
+export type ToolVisualizationSummary = {
+  title: string;
+  meta?: string;
+};
+
+/**
+ * A plugin contribution that replaces how a matching tool call is rendered in
+ * the chat — its pill/row icon, its summary line, and its popover body.
+ */
+export type ToolVisualizationDefinition = {
+  /** Stable id; registering twice with the same id replaces the previous one. */
+  id: string;
+  /** Tool names this visualizer claims. Exact matches only (no predicates). */
+  toolNames: ReadonlyArray<string>;
+  /**
+   * Restrict the visualizer to calls from these agent types (the stored
+   * encoding, `registered:<id>` for registered agents). Omitted matches every
+   * agent. A scoped registration does NOT match a call whose `agentType` is
+   * `null`/unknown; an unscoped one does.
+   */
+  agentTypes?: ReadonlyArray<string>;
+  /**
+   * Runtime discard, run at dispatch time before the host commits to this
+   * visualizer. Must be pure and cheap. Returning `false` (or throwing —
+   * treated as declined) falls through to the next candidate, then to the
+   * host's built-in/default rendering.
+   */
+  canRender?: (call: ToolCallView) => boolean;
+  /** Pill/row icon override; falls back to the host's `getToolIcon` when omitted. */
+  icon?: LucideIcon;
+  /**
+   * The header line in the popover AND the inline text of the expanded-density
+   * row. Strings only — the expanded row is a `role="button"` click target, so
+   * JSX is not allowed there. When omitted, the host's default title
+   * (invocation string / tool name) is used; a throw falls back the same way.
+   */
+  summary?: (call: ToolCallView) => ToolVisualizationSummary;
+  /**
+   * The popover body, rendered in both densities. Never rendered inline in the
+   * expanded-density row (matching built-in behavior). A crash here falls back
+   * to the host's stock rendering for that call, not a plugin-error panel.
+   */
+  body: ComponentType<{ call: ToolCallView }>;
+};
+
 export type PluginHostApi = {
   registerPanel: (panel: PanelDefinition) => () => void;
   /**
@@ -131,6 +212,14 @@ export type PluginHostApi = {
    * disposer.
    */
   registerHomeView: (view: HomeViewDefinition) => () => void;
+  /**
+   * Registers a custom renderer for a matching tool call in the chat — its
+   * pill/row icon, summary line, and popover body. The `body` is wrapped, like
+   * a panel, in a per-plugin error boundary, the host's PluginContext, and the
+   * WorkspacePluginContext for the workspace the chat is shown in; a body crash
+   * falls back to the host's stock rendering for that call. Returns a disposer.
+   */
+  registerToolVisualization: (definition: ToolVisualizationDefinition) => () => void;
 };
 
 export type PluginActivate = (api: PluginHostApi) => void | (() => void) | Promise<void | (() => void)>;

--- a/sculptor/frontend/src/stories/custom/WorkspacePeekPopover.stories.tsx
+++ b/sculptor/frontend/src/stories/custom/WorkspacePeekPopover.stories.tsx
@@ -65,6 +65,8 @@ function makeTask(overrides: Partial<CodingAgentTaskView> & { id: string }): Cod
     taskStatus: "RUNNING" as TaskState,
     isAutoCompacting: false,
     acceptsAutomatedPrompts: false,
+    agentType: null,
+    registrationId: null,
     artifactNames: [],
     updatedAt: "2026-03-05T01:30:00Z",
     initialPrompt: "Do something",

--- a/sculptor/frontend/vite-plugins/bundled-plugins.ts
+++ b/sculptor/frontend/vite-plugins/bundled-plugins.ts
@@ -11,8 +11,9 @@ import { RUNTIME_MODULE_SPECIFIERS } from "./plugin-runtime-stubs.ts";
  * compiling) as part of the host build, emitting each bundle into
  * `public/plugins/<id>/` — the same tree the no-build, pure-JS plugins live in.
  *
- * `linear-issue` is the only such plugin today; pure-JS plugins need no build
- * (their source is committed directly under `public/plugins/<id>/`). Wiring the
+ * The compiled plugins are listed in `COMPILED_PLUGIN_IDS`; pure-JS plugins need
+ * no build (their source is committed directly under `public/plugins/<id>/`).
+ * Wiring the
  * compile into the host build means `npm run build` and the dev server produce
  * the bundle — there's no separate `cd plugins/<id> && npm run build` step, and
  * no second toolchain: the plugin reuses the host's Vite, React, and TypeScript.
@@ -24,7 +25,7 @@ import { RUNTIME_MODULE_SPECIFIERS } from "./plugin-runtime-stubs.ts";
  */
 
 /** Plugins built from TS/TSX source at `plugins/<id>/src/index.tsx`. */
-const COMPILED_PLUGIN_IDS: ReadonlyArray<string> = ["linear-issue"];
+const COMPILED_PLUGIN_IDS: ReadonlyArray<string> = ["linear-issue", "workflow-viz"];
 
 const buildCompiledPlugin = async (frontendRoot: string, id: string): Promise<void> => {
   const sourceDir = path.join(frontendRoot, "plugins", id);

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -86,7 +86,6 @@ from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import ModelOption
 from sculptor.state.messages import ResponseBlockAgentMessage
 
-
 _PROMPT_ID = "prompt-1"
 
 

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -36,13 +36,16 @@ from sculptor.foundation.pydantic_serialization import build_discriminator
 from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingDoneAgentMessage
+from sculptor.interfaces.agents.agent import ClaudeCodeSDKAgentConfig
 from sculptor.interfaces.agents.agent import EnvironmentAcquiredRunnerMessage
 from sculptor.interfaces.agents.agent import EnvironmentReleasedRunnerMessage
 from sculptor.interfaces.agents.agent import PersistentRequestCompleteAgentMessage
+from sculptor.interfaces.agents.agent import PiAgentConfig
 from sculptor.interfaces.agents.agent import RegisteredTerminalAgentConfig
 from sculptor.interfaces.agents.agent import RemoveQueuedMessageAgentMessage
 from sculptor.interfaces.agents.agent import RequestFailureAgentMessage
 from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
+from sculptor.interfaces.agents.agent import TerminalAgentConfig
 from sculptor.interfaces.agents.agent import TerminalAgentSignalRunnerMessage
 from sculptor.interfaces.agents.agent import TerminalStatusSignal
 from sculptor.interfaces.agents.agent import UpdatedArtifactAgentMessage
@@ -70,6 +73,7 @@ from sculptor.state.messages import Message
 from sculptor.state.messages import ModelOption
 from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.utils.functional import first
+from sculptor.web.data_types import AgentTypeName
 from sculptor.web.data_types import PrApproval  # noqa: F401 — re-exported for existing import sites
 from sculptor.web.data_types import PrComment  # noqa: F401 — re-exported for existing import sites
 from sculptor.web.data_types import PrStatusInfo  # noqa: F401 — re-exported for existing import sites
@@ -458,6 +462,35 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
         # the terminal-input endpoint.
         agent_config = self.task_input.agent_config
         return isinstance(agent_config, RegisteredTerminalAgentConfig) and agent_config.accepts_automated_prompts
+
+    @computed_field
+    @property
+    def agent_type(self) -> AgentTypeName | None:
+        """The harness the task was created with, derived from the persisted
+        `agent_config` subtype. None for configs with no user-facing agent type
+        (e.g. the internal hello harness) or a shape a future config adds before
+        this mapping is extended — the frontend treats null as "unknown" and
+        skips agent-scoped tool visualizations rather than guessing."""
+        agent_config = self.task_input.agent_config
+        if isinstance(agent_config, ClaudeCodeSDKAgentConfig):
+            return AgentTypeName.CLAUDE
+        if isinstance(agent_config, PiAgentConfig):
+            return AgentTypeName.PI
+        if isinstance(agent_config, RegisteredTerminalAgentConfig):
+            return AgentTypeName.REGISTERED
+        if isinstance(agent_config, TerminalAgentConfig):
+            return AgentTypeName.TERMINAL
+        return None
+
+    @computed_field
+    @property
+    def registration_id(self) -> str | None:
+        """The registered-terminal registration this task was stamped from, or
+        None for every non-registered agent type."""
+        agent_config = self.task_input.agent_config
+        if isinstance(agent_config, RegisteredTerminalAgentConfig):
+            return agent_config.registration_id
+        return None
 
     @computed_field
     @property

--- a/sculptor/sculptor/web/derived_agent_type_test.py
+++ b/sculptor/sculptor/web/derived_agent_type_test.py
@@ -1,0 +1,93 @@
+"""Tests for CodingAgentTaskView.agent_type / registration_id.
+
+Both are derived from the persisted `agent_config` subtype on the task's
+input_data, so the frontend can tell which harness owns a transcript.
+"""
+
+from sculptor.config.settings import SculptorSettings
+from sculptor.database.models import AgentTaskInputsV2
+from sculptor.database.models import AgentTaskStateV2
+from sculptor.database.models import Task
+from sculptor.database.models import TaskID
+from sculptor.interfaces.agents.agent import AgentConfigTypes
+from sculptor.interfaces.agents.agent import ClaudeCodeSDKAgentConfig
+from sculptor.interfaces.agents.agent import HelloAgentConfig
+from sculptor.interfaces.agents.agent import PiAgentConfig
+from sculptor.interfaces.agents.agent import RegisteredTerminalAgentConfig
+from sculptor.interfaces.agents.agent import TerminalAgentConfig
+from sculptor.interfaces.agents.tasks import TaskState
+from sculptor.primitives.ids import OrganizationReference
+from sculptor.primitives.ids import ProjectID
+from sculptor.primitives.ids import UserReference
+from sculptor.primitives.ids import WorkspaceID
+from sculptor.web.data_types import AgentTypeName
+from sculptor.web.derived import CodingAgentTaskView
+from sculptor.web.derived import create_initial_task_view
+
+
+def _make_task_view(agent_config: AgentConfigTypes) -> CodingAgentTaskView:
+    task = Task(
+        object_id=TaskID(),
+        user_reference=UserReference("test-user"),
+        organization_reference=OrganizationReference("test-org"),
+        project_id=ProjectID(),
+        input_data=AgentTaskInputsV2(
+            agent_config=agent_config,
+            git_hash="abc123",
+            system_prompt=None,
+        ),
+        current_state=AgentTaskStateV2(workspace_id=WorkspaceID()),
+        outcome=TaskState.RUNNING,
+    )
+    view = create_initial_task_view(task, SculptorSettings())
+    assert isinstance(view, CodingAgentTaskView)
+    view.update_task(task)
+    return view
+
+
+def _registered_config() -> RegisteredTerminalAgentConfig:
+    return RegisteredTerminalAgentConfig(
+        registration_id="my-tool",
+        display_name="My Tool",
+        launch_command="my-tool",
+    )
+
+
+def test_claude_agent_type() -> None:
+    view = _make_task_view(ClaudeCodeSDKAgentConfig())
+    assert view.agent_type == AgentTypeName.CLAUDE
+    assert view.registration_id is None
+
+
+def test_pi_agent_type() -> None:
+    view = _make_task_view(PiAgentConfig())
+    assert view.agent_type == AgentTypeName.PI
+    assert view.registration_id is None
+
+
+def test_terminal_agent_type() -> None:
+    view = _make_task_view(TerminalAgentConfig())
+    assert view.agent_type == AgentTypeName.TERMINAL
+    assert view.registration_id is None
+
+
+def test_registered_agent_type_carries_registration_id() -> None:
+    view = _make_task_view(_registered_config())
+    assert view.agent_type == AgentTypeName.REGISTERED
+    assert view.registration_id == "my-tool"
+
+
+def test_hello_config_has_no_agent_type() -> None:
+    # The internal hello harness maps to no user-facing agent type, so the view
+    # reports null rather than guessing.
+    view = _make_task_view(HelloAgentConfig())
+    assert view.agent_type is None
+    assert view.registration_id is None
+
+
+def test_agent_type_and_registration_id_serialize_on_the_view() -> None:
+    # The frontend reads these off the serialized CodingAgentTaskView, so the
+    # computed fields must appear in the dumped payload.
+    dumped = _make_task_view(_registered_config()).model_dump(by_alias=True)
+    assert dumped["agentType"] == AgentTypeName.REGISTERED
+    assert dumped["registrationId"] == "my-tool"


### PR DESCRIPTION
## What

A new plugin contribution point, `registerToolVisualization`, that lets a frontend plugin replace how a tool call renders in the chat — the pill/row icon, the summary line, and the popover body — plus a reference plugin, `workflow-viz`, that visualizes Claude Code's `Workflow` tool as a phase checklist instead of a raw `<pre>` dump.

## Design

- **Curated contract.** Plugins receive a `ToolCallView` (id, tool name, agent type, input, status, result, duration) rather than the generated transcript block types, so the SDK stays decoupled from backend shapes — same precedent as `WorkspaceView`.
- **Multi-harness safety.** Tool names are only namespaced by convention, and different harnesses can ship same-named tools. Definitions can scope to specific harnesses (`agentTypes`, using the stored `registered:<id>` encoding) and decline individual calls at runtime (`canRender`, e.g. when the input doesn't parse as the expected shape). A scoped registration never matches a call whose harness is unknown. To support this, `CodingAgentTaskView` now exposes `agent_type`/`registration_id`, derived from the persisted `agent_config` subtype.
- **Density-toggle compatible.** `summary()` returns plain strings because the expanded chat density inlines it into a `role="button"` row; the `body` component renders only in the popover, in both densities.
- **Fail-open rendering.** The body mounts inside the plugin error boundary with the stock tool entry as fallback — a crashing visualizer degrades to default rendering, never an error card. `canRender`/`summary` throwing counts as declining.
- **Dispatch.** Exact tool-name match, last-registered-wins, plugins win over built-in specialized renderers. Out of scope (host-owned): diff-tool chips, plan-mode tool lines, subagent pills, interactive tools.
- The reference plugin parses the workflow script with an eval-free bracket-matching extractor — agent-authored code must never execute in the renderer.

## Tests

- Backend: `derived_agent_type_test.py` (agent-type derivation per config subtype).
- Dispatch: `pluginToolViz.test.ts` (matching, agent scoping incl. unknown-harness rule, canRender discard/throw, last-wins) and `ToolEntryContent.dispatch.test.tsx` (plugin renders instead of default; crashing body falls back to stock rendering).
- Plugin: `parseWorkflow.test.ts` (12 cases: meta/phases extraction, `phase()` fallback, scriptPath/name shapes, malformed input).

## Known quirks (from manual QA, follow-ups)

- Nested scrollbars can appear in the popover body.
- The workflow body still shows the run-start message content in the tool output after the workflow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)