### PR TITLE
Give the auto-qa harness reliable chat-input control

### DIFF
--- a/.claude/skills/auto-qa-changes/SKILL.md
+++ b/.claude/skills/auto-qa-changes/SKILL.md
@@ -87,12 +87,16 @@ loc() { curl -s -X POST http://127.0.0.1:$PORT/execute \
   | python3 -c "import json,sys; e=json.load(sys.stdin).get('elements',[]); print(f\"{e[0]['x']} {e[0]['y']}\" if e else '')"; }
 click() { curl -s -X POST http://127.0.0.1:$PORT/execute -d "{\"action\": \"click\", \"x\": ${1% *}, \"y\": ${1#* }}" >/dev/null; }
 
-for i in $(seq 1 6); do
+for i in $(seq 1 8); do
   [ -n "$(loc ONBOARDING_EMAIL_INPUT)" ] && curl -s -X POST http://127.0.0.1:$PORT/execute \
     -d '{"action": "fill", "id": "ONBOARDING_EMAIL_INPUT", "text": "test@test.com"}' >/dev/null
-  SUBMIT=$(loc ONBOARDING_EMAIL_SUBMIT); [ -n "$SUBMIT" ] && click "$SUBMIT"
-  DONE=$(loc ONBOARDING_COMPLETE_BUTTON)
-  if [ -n "$DONE" ]; then click "$DONE"; echo "Onboarding dismissed"; break; fi
+  CLICKED=0
+  for id in ONBOARDING_EMAIL_SUBMIT ONBOARDING_COMPLETE_BUTTON; do
+    COORD=$(loc $id); [ -n "$COORD" ] && { click "$COORD"; CLICKED=1; }
+  done
+  # No advance button on screen means the modal is gone — the flow has several
+  # steps (email and/or an installation check), so keep going until none remain.
+  [ "$CLICKED" -eq 0 ] && { echo "Onboarding dismissed"; break; }
   sleep 1
 done
 ```

--- a/.claude/skills/auto-qa-changes/SKILL.md
+++ b/.claude/skills/auto-qa-changes/SKILL.md
@@ -76,40 +76,28 @@ done
 
 ### Step 3: Dismiss onboarding (if visible)
 
-A fresh Sculptor instance shows an onboarding modal that blocks the home
-page. Take a screenshot first — if you see the onboarding modal, dismiss it:
+A fresh instance opens an onboarding modal that advances through a few steps —
+an email step and/or an installation check, depending on the build. Loop until
+it's gone: fill the email if shown, click whichever advance button is present,
+and stop after the final complete button:
 
 ```bash
-# Check if onboarding is visible
-RESULT=$(curl -s -X POST http://127.0.0.1:$PORT/execute \
-  -d '{"action": "locate", "selector": "[data-testid=ONBOARDING_WELCOME_STEP]"}')
-ELEMENTS=$(echo "$RESULT" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('elements',[])))")
+loc() { curl -s -X POST http://127.0.0.1:$PORT/execute \
+  -d "{\"action\": \"locate\", \"selector\": \"[data-testid=$1]\"}" \
+  | python3 -c "import json,sys; e=json.load(sys.stdin).get('elements',[]); print(f\"{e[0]['x']} {e[0]['y']}\" if e else '')"; }
+click() { curl -s -X POST http://127.0.0.1:$PORT/execute -d "{\"action\": \"click\", \"x\": ${1% *}, \"y\": ${1#* }}" >/dev/null; }
 
-if [ "$ELEMENTS" -gt 0 ]; then
-  # Click through: email input -> submit -> complete
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "locate", "selector": "[data-testid=ONBOARDING_EMAIL_INPUT]"}'
-  # Click the email input and type a test email
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "click", "x": <x>, "y": <y>}'
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "type", "text": "test@test.com"}'
-  # Locate and click "Get Started"
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "locate", "selector": "[data-testid=ONBOARDING_EMAIL_SUBMIT]"}'
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "click", "x": <x>, "y": <y>}'
-  # Locate and click the final complete button
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "locate", "selector": "[data-testid=ONBOARDING_COMPLETE_BUTTON]"}'
-  curl -s -X POST http://127.0.0.1:$PORT/execute \
-    -d '{"action": "click", "x": <x>, "y": <y>}'
-  echo "Onboarding dismissed"
-fi
+for i in $(seq 1 6); do
+  [ -n "$(loc ONBOARDING_EMAIL_INPUT)" ] && curl -s -X POST http://127.0.0.1:$PORT/execute \
+    -d '{"action": "fill", "id": "ONBOARDING_EMAIL_INPUT", "text": "test@test.com"}' >/dev/null
+  SUBMIT=$(loc ONBOARDING_EMAIL_SUBMIT); [ -n "$SUBMIT" ] && click "$SUBMIT"
+  DONE=$(loc ONBOARDING_COMPLETE_BUTTON)
+  if [ -n "$DONE" ]; then click "$DONE"; echo "Onboarding dismissed"; break; fi
+  sleep 1
+done
 ```
 
-Replace `<x>` and `<y>` with coordinates from each `locate` response.
-If no onboarding modal appears, skip this step.
+If no onboarding modal appears, this loop no-ops — skip to the next step.
 
 ### Step 4: Interact with the browser
 
@@ -197,18 +185,67 @@ curl -s -X POST http://127.0.0.1:$PORT/execute \
 
 ### Type text
 
-Types into whatever element currently has focus:
+Types into whatever element currently has focus. **This does not choose where
+the text goes** — on a workspace page the agent terminal grabs focus on load, so
+a bare `type` (or `click`-then-`type`) can land in the terminal instead of the
+chat box. To type into a specific field, use `fill` (below); to send a chat
+message, use `send_message`.
 
 ```bash
 curl -s -X POST http://127.0.0.1:$PORT/execute \
   -d '{"action": "type", "text": "Hello world"}'
 ```
 
+### Fill a field (focus + type into a named element)
+
+Focuses a named element and types into it, replacing any existing contents.
+This targets the element directly, so it can't miss because another surface
+holds focus or the click landed on a non-editable container. Works for plain
+inputs and for the chat input (a ProseMirror rich editor). Identify the element
+by `id` (data-testid) or `selector`:
+
+```bash
+curl -s -X POST http://127.0.0.1:$PORT/execute \
+  -d '{"action": "fill", "id": "CHAT_INPUT", "text": "Summarize the README"}'
+```
+
+### Send a chat message
+
+Types a prompt into the chat input and submits it. This is the reliable way to
+send a message: it clicks the send button (the real-user path), which sidesteps
+the platform send keybinding — **plain Enter does not send** (it inserts a
+newline; the default send binding is Cmd/Ctrl+Enter), and the send button stays
+disabled until the draft is non-empty. Pass no `text` to submit whatever is
+already in the box.
+
+```bash
+curl -s -X POST http://127.0.0.1:$PORT/execute \
+  -d '{"action": "send_message", "text": "What does this repo do?"}'
+```
+
+### Focus a named element
+
+Moves keyboard focus to an element (by `id` or `selector`) so a subsequent
+`type` lands there. Use `fill`/`send_message` for text fields; reach for bare
+`focus` only when you specifically want `type`/`press` to follow.
+
+```bash
+curl -s -X POST http://127.0.0.1:$PORT/execute \
+  -d '{"action": "focus", "id": "CHAT_INPUT"}'
+```
+
 ### Press a key
+
+Accepts modifier combos joined with `+`. Use `ControlOrMeta` for the platform
+command key (Cmd on macOS, Ctrl elsewhere):
 
 ```bash
 curl -s -X POST http://127.0.0.1:$PORT/execute \
   -d '{"action": "press", "key": "Enter"}'
+
+# Send a chat message via the keybinding instead of the button:
+curl -s -X POST http://127.0.0.1:$PORT/execute \
+  -d '{"action": "press", "key": "ControlOrMeta+Enter"}'
 ```
 
 ### Hover
@@ -623,6 +660,15 @@ By default the server creates a small test git repository. Pass
 `--project-path` to point Sculptor at a real repository instead.
 
 ## Gotchas
+
+- **Typing into the chat input**: On a workspace page, the agent terminal grabs
+  keyboard focus on load, so a bare `type` — or `click`-then-`type` at the chat
+  box's center, which hits the toolbar/padding rather than the editable region —
+  lands in the terminal instead. Use `fill` with `id: CHAT_INPUT` to type into
+  the chat box, and `send_message` to submit. Plain Enter inserts a newline (the
+  default send binding is Cmd/Ctrl+Enter, i.e. `ControlOrMeta+Enter`), and the
+  send button stays disabled until the draft is non-empty — so a send-button
+  click does nothing while the box is empty.
 
 - **Use real Claude, not Fake Claude**: The manual test server passes through
   your local API keys, so real Claude models work out of the box. Use whatever

--- a/sculptor/sculptor/testing/browser_controller.py
+++ b/sculptor/sculptor/testing/browser_controller.py
@@ -125,9 +125,10 @@ class BrowserController:
         if action_type == "focus":
             # Move keyboard focus to a named element. Use this before `type` when
             # another surface (e.g. the agent terminal, which grabs focus on
-            # load) would otherwise capture the keystrokes.
+            # load) would otherwise capture the keystrokes. Uses focus() rather
+            # than a click so it can't accidentally activate a button/checkbox.
             locator = self._resolve_locator(action)
-            locator.click()
+            locator.focus()
             time.sleep(0.3)
             screenshot_path = self._take_screenshot("focus")
             return {"success": True, "screenshot": screenshot_path}
@@ -151,13 +152,20 @@ class BrowserController:
             # the typed draft is non-empty. Pass no `text` to submit the existing
             # draft as-is.
             text = action.get("text")
+            if text is not None and not text.strip():
+                raise ValueError("send_message 'text' is empty — omit 'text' to submit the existing draft")
             chat_input = page.get_by_test_id(_CHAT_INPUT_TEST_ID)
             if text is not None:
                 self._focus_and_replace(chat_input, text)
                 time.sleep(0.2)
             else:
                 chat_input.click()
-            page.get_by_test_id(_SEND_BUTTON_TEST_ID).click()
+            send_button = page.get_by_test_id(_SEND_BUTTON_TEST_ID)
+            # The button disables itself while the draft is empty; report that
+            # plainly instead of letting the click block until it times out.
+            if send_button.is_disabled():
+                raise ValueError("nothing to send — the chat draft is empty")
+            send_button.click()
             time.sleep(0.5)
             screenshot_path = self._take_screenshot("send_message")
             return {"success": True, "screenshot": screenshot_path}

--- a/sculptor/sculptor/testing/browser_controller.py
+++ b/sculptor/sculptor/testing/browser_controller.py
@@ -20,9 +20,17 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
+from playwright.sync_api import Locator
 from playwright.sync_api import Page
 
 from sculptor.testing.manual_test_harness import ManualTestHarness
+
+# The chat message editor and its send button, by data-testid. The editor is a
+# ProseMirror contenteditable (not a plain <textarea>): the test id sits on the
+# editable region itself, so targeting it by id focuses the right element —
+# unlike clicking the container's center, which hits the toolbar/padding.
+_CHAT_INPUT_TEST_ID = "CHAT_INPUT"
+_SEND_BUTTON_TEST_ID = "SEND_BUTTON"
 
 
 class BrowserController:
@@ -34,6 +42,37 @@ class BrowserController:
         self._harness = harness
         self._screenshot_counter = 0
         self._server: HTTPServer | None = None
+
+    def _resolve_locator(self, action: dict[str, Any]) -> Locator:
+        """Resolve an element from an action's ``id`` (data-testid) or ``selector``.
+
+        Prefer this over coordinate clicks for anything you can name: it targets
+        the element directly, so it can't miss because of a focus-stealing panel
+        or a container whose center isn't the interactive part.
+        """
+        test_id = action.get("id")
+        selector = action.get("selector")
+        if test_id:
+            return self._page.get_by_test_id(test_id)
+        if selector:
+            return self._page.locator(selector)
+        raise ValueError("action requires 'id' (data-testid) or 'selector'")
+
+    def _focus_and_replace(self, locator: Locator, text: str) -> None:
+        """Focus an editable element and replace its contents with ``text``.
+
+        Works for plain inputs/textareas and for contenteditable rich editors
+        (TipTap/ProseMirror). Clicks to focus and place the caret, selects any
+        existing content, then types real key events so the editor's own input
+        handling runs — a direct value set would bypass ProseMirror's model.
+        ``ControlOrMeta`` resolves to Cmd on macOS and Ctrl elsewhere, matching
+        the app's own platform handling.
+        """
+        locator.click()
+        locator.press("ControlOrMeta+a")
+        locator.press("Delete")
+        if text:
+            self._page.keyboard.type(text)
 
     def _take_screenshot(self, label: str = "step") -> str:
         """Take a screenshot and return the absolute path."""
@@ -81,6 +120,46 @@ class BrowserController:
             page.keyboard.press(key)
             time.sleep(0.3)
             screenshot_path = self._take_screenshot(f"press_{key}")
+            return {"success": True, "screenshot": screenshot_path}
+
+        if action_type == "focus":
+            # Move keyboard focus to a named element. Use this before `type` when
+            # another surface (e.g. the agent terminal, which grabs focus on
+            # load) would otherwise capture the keystrokes.
+            locator = self._resolve_locator(action)
+            locator.click()
+            time.sleep(0.3)
+            screenshot_path = self._take_screenshot("focus")
+            return {"success": True, "screenshot": screenshot_path}
+
+        if action_type == "fill":
+            # Focus a named editable element and type into it. Prefer this over
+            # click-then-`type` for the chat input and other text fields: it
+            # targets the element directly, so it can't miss because the terminal
+            # panel holds focus or the click landed on a non-editable container.
+            locator = self._resolve_locator(action)
+            self._focus_and_replace(locator, action["text"])
+            time.sleep(0.3)
+            screenshot_path = self._take_screenshot("fill")
+            return {"success": True, "screenshot": screenshot_path}
+
+        if action_type == "send_message":
+            # Type a prompt into the chat input and submit it via the send
+            # button — the reliable real-user path. Clicking the button avoids
+            # the platform-specific send keybinding (Meta+Enter by default; plain
+            # Enter only inserts a newline), and the button enables itself once
+            # the typed draft is non-empty. Pass no `text` to submit the existing
+            # draft as-is.
+            text = action.get("text")
+            chat_input = page.get_by_test_id(_CHAT_INPUT_TEST_ID)
+            if text is not None:
+                self._focus_and_replace(chat_input, text)
+                time.sleep(0.2)
+            else:
+                chat_input.click()
+            page.get_by_test_id(_SEND_BUTTON_TEST_ID).click()
+            time.sleep(0.5)
+            screenshot_path = self._take_screenshot("send_message")
             return {"success": True, "screenshot": screenshot_path}
 
         if action_type == "hover":


### PR DESCRIPTION
## Problem

The `/auto-qa` manual-test harness only offered coordinate clicks and a focus-agnostic `type`, which made driving the chat box unreliable:

- On a workspace page the agent terminal takes keyboard focus on load, so a bare `type` landed in the terminal instead of the chat input.
- The chat box is a ProseMirror rich editor whose editable region — not the container center you'd click — carries the `CHAT_INPUT` test id, so clicking the center hit the toolbar/padding and typing missed.
- Sending was fragile: plain Enter inserts a newline (the send binding defaults to Cmd/Ctrl+Enter) and the send button stays disabled while the draft is empty, so a send-button click did nothing.

This cost several iterations to work around during a real QA session (text had to be nudged into the input's left edge, and only ⌘↵ would send).

## Change

Add element-targeted actions to `BrowserController` so the harness stops coordinate-guessing into a focus-stealing UI:

- **`fill`** (`id`/`selector` + `text`) — focus the named element and replace its contents via real key events; works for plain inputs and the contenteditable chat editor alike.
- **`send_message`** (optional `text`) — fill the chat input, then click the now-enabled send button (the real-user submit path), sidestepping the platform send keybinding.
- **`focus`** (`id`/`selector`) — move focus to a named element before `type`.

The skill doc gains concise entries for the new actions and a gotcha about the terminal grabbing focus. The onboarding-dismissal step now loops until the modal is gone, so it also handles the installation-check step instead of only the email step.

## Verification

Ran the harness live against a real workspace + real Claude:

- Reproduced the friction: on load, `document.activeElement` was the terminal's `xterm-helper-textarea`, and a bare `type` left the chat editor empty.
- `fill id=CHAT_INPUT` → text landed in the ProseMirror editor, focus moved to `CHAT_INPUT`, send button enabled. Filling twice replaced (did not append).
- `send_message` → the prompt appeared in the conversation, the editor cleared, and Claude replied.

`just format`, `just check`, and `just test-unit` all pass.

(Sent by Claude)