### PR TITLE
Keep a visible gap below the pinned chat bottom and round-trip scroll restores (SCU-1673)

### DIFF
--- a/docs/development/scroll_state_unification.md
+++ b/docs/development/scroll_state_unification.md
@@ -340,22 +340,43 @@ as the one `distanceFromContentBottom` primitive.
 
 The same correction governs *pinning* to the bottom, not just *measuring* it. Every
 "scroll to the bottom" site (the `following` pin, the anchoring→following handoff,
-the jump-to-bottom button, the restore-to-bottom) sets `scrollTop` to the inverse of
-that primitive — `contentBottomOffset = scrollHeight − paddingEnd − clientHeight` —
-so the last message's content bottom sits flush with the viewport bottom
-(`distanceFromContentBottom == 0`), leaving `paddingEnd` as empty slack *below*
-`scrollTop`. It deliberately does **not** pin with `virtualizer.scrollToIndex(last,
+the jump-to-bottom button, the restore-to-bottom) sets `scrollTop` to
+`bottomPinOffset = contentBottomOffset + PIN_BOTTOM_GAP` (clamped to the scroll
+range), where `contentBottomOffset = scrollHeight − paddingEnd − clientHeight` is
+the inverse of the distance primitive. `PIN_BOTTOM_GAP` (64px) stays *visible*
+below the last message — breathing room so the newest line neither touches the
+viewport edge nor sits under the absolutely positioned bottom bar.
+
+The `paddingEnd` floor is **streaming-scoped**. While a stream is active (and for
+the settle window after it ends) the floor is `STREAMING_TAIL_PADDING` — gap plus
+`TURN_END_SHRINK_SLACK` — so the remainder below the pinned `scrollTop` is slack.
+At rest it is `IDLE_TAIL_PADDING` (== the gap), so the scroll range ends exactly at
+the pin position: scrolling below the content can reveal the gap and no more, and
+no extra slack is kept when no shrink is pending. The drop back to the idle floor
+happens with the pinned `scrollTop` sitting exactly at the post-drop range end, so
+it never moves the view.
+
+It deliberately does **not** pin with `virtualizer.scrollToIndex(last,
 { align: "end" })`: for the final item TanStack resolves that to
 `getMaxScrollOffset()` — the very bottom of the *padded* scroll range — which parks
-`scrollTop` inside the `paddingEnd` gap with **zero** slack. Two failures followed:
-the last line floated a `paddingEnd`-tall gap above the viewport bottom
-while following, and — the turn-end jump — when a turn ended and its streaming cursor
-was removed, the last message shrank with no slack to absorb it, so the browser
-clamped `scrollTop` down by the shrink and the whole conversation jumped up. Pinning
-to the content bottom leaves the `paddingEnd` slack the shrink is absorbed into. The
-pin is also **down-only**: it follows the live tail's growth toward the bottom but
-never scrolls *up*, so a turn-end shrink is left where it is rather than chased
-(authority has already handed back to `userControlled` by then anyway).
+`scrollTop` at the end of the range with **zero** slack. That caused the turn-end
+jump: when a turn ended and its streaming cursor was removed, the last message
+shrank with no slack to absorb it, so the browser clamped `scrollTop` down by the
+shrink and the whole conversation jumped up. Keeping `TURN_END_SHRINK_SLACK` below
+`scrollTop` is what the shrink is absorbed into. The pin is also **down-only**: it
+follows the live tail's growth toward the bottom but never scrolls *up*, so a
+turn-end shrink is left where it is rather than chased (authority has already
+handed back to `userControlled` by then anyway).
+
+The restore path is the one bottom-lander that does *not* use `bottomPinOffset`:
+a saved position within (or past) the at-bottom threshold re-lands at its **signed**
+saved `distanceFromBottom` relative to the *current* content bottom, clamped to the
+scroll range. Negative distances — the viewport sat inside the tail padding, e.g.
+the anchored-turn rest position or a deliberate max scroll — round-trip exactly
+instead of being clamped to the pin position, while an at-bottom save still follows
+content that grew while the task was in the background. A first visit with no saved
+position lands at `maxScrollOffset`, which for a short last turn *is* the
+anchored-turn rest position the task's owner last saw.
 
 ### 4. Search suppression is a top-level guard
 
@@ -651,7 +672,7 @@ Every painted frame must satisfy the invariant of the active phase:
 
 | Phase | Per-frame invariant |
 | --- | --- |
-| `following` / idle-at-bottom | the last message's bottom is flush with the viewport bottom |
+| `following` / idle-at-bottom | the last message's bottom sits `PIN_BOTTOM_GAP` above the viewport bottom |
 | `userControlled` scrolled-up | the reading-anchor message's top sits at its sampled offset |
 | `anchoringTurn` | the anchored user message's top sits at its sampled offset |
 | `restoring` | the saved-anchor framing |
@@ -707,7 +728,7 @@ Correct to the frame, for four independent reasons:
 - **Ground truth, not lagging arithmetic.** `desired` is anchored to the invariant
   element's measured `start`/`size`, never to `scrollHeight − paddingEnd`. A
   growing or shrinking `paddingEnd` only changes empty space *below* an
-  already-flush anchor — it can never move the anchor — so the `paddingEnd` lag
+  already-placed anchor — it can never move the anchor — so the `paddingEnd` lag
   leaves the correctness path entirely.
 - **Positions are final post-settle-render.** TanStack measures **synchronously**
   inside its `ResizeObserver` (it calls `shouldAdjustScrollPositionOnItemSizeChange`
@@ -725,7 +746,7 @@ Correct to the frame, for four independent reasons:
 unit-testable without a DOM:
 
 ```ts
-// pinBottom  → measuredEnd(last)  − clientHeight
+// pinBottom  → measuredEnd(last)  − clientHeight + PIN_BOTTOM_GAP
 // holdAnchor → measuredStart(i)   − anchor.viewportOffset
 // holdTurn   → measuredStart(idx) − sampledTopOffset
 // ignore     → leave scrollTop alone
@@ -744,8 +765,8 @@ T1  ResizeObserver delivery (after layout, before paint):
       • content RO: detect reflow → dispatch settling("reflow")              [enter settle]
 T1' React flushes the settle render (pre-paint):
       • virtualizer re-renders with final translateYs + final wrapper height
-      • no-deps layout effect → commitInvariant():  scrollTop := lastEnd − clientHeight   ← SOLE write
-T2  ══ PAINT ══   last message flush — invariant holds ✓
+      • no-deps layout effect → commitInvariant():  scrollTop := lastEnd − clientHeight + PIN_BOTTOM_GAP   ← SOLE write
+T2  ══ PAINT ══   pin gap below the last message — invariant holds ✓
 T3  any further pass (e.g. paddingEnd second render): T1'→T2 repeats, each corrected before its paint ✓
 T4  render sees tail sum stable → converged → stable; per-item compensation re-enabled
 ```

--- a/sculptor/frontend/src/common/state/atoms/alphaScroll.ts
+++ b/sculptor/frontend/src/common/state/atoms/alphaScroll.ts
@@ -5,6 +5,9 @@ import { atomFamily } from "jotai/utils";
 export type AlphaScrollPosition = {
   firstVisibleMessageId: string;
   pixelOffset: number;
+  /** Signed distance from the viewport bottom to the content bottom (the
+   *  virtualizer's paddingEnd excluded); negative when the viewport sits past
+   *  the content, inside the tail padding. */
   distanceFromBottom: number;
 };
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
@@ -188,6 +188,7 @@ export const AlphaChatInterface = ({
     scrollMachine,
     introHeight,
     isProgrammaticScrollRef,
+    isStreaming,
   );
 
   const density = useAtomValue(chatToolDensityAtom);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChatMessageRole } from "~/api";
 
+import { PIN_BOTTOM_GAP } from "../../scroll/geometry.ts";
 import { useAlphaAutoScroll } from "../useAlphaAutoScroll.ts";
 
 // Mock ResizeObserver — jsdom doesn't provide one.
@@ -62,12 +63,14 @@ const triggerResize = (): void => {
 };
 
 /**
- * Assert the container is pinned to the content bottom — scrollTop at
- * contentBottomOffset (scrollHeight - paddingEnd - clientHeight), the observable
- * position rather than a virtualizer mock call.
+ * Assert the container is pinned to the bottom — scrollTop at bottomPinOffset
+ * (content bottom plus the visible PIN_BOTTOM_GAP, clamped to the scroll
+ * range), the observable position rather than a virtualizer mock call.
  */
 const expectPinnedToBottom = (el: HTMLDivElement, paddingEnd = 0): void => {
-  expect(el.scrollTop).toBe(Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight));
+  const contentBottom = Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight);
+  const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
+  expect(el.scrollTop).toBe(Math.min(contentBottom + PIN_BOTTOM_GAP, maxScroll));
 };
 
 describe("useAlphaAutoScroll", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -65,12 +65,13 @@ const triggerResize = (): void => {
 /**
  * Assert the container is pinned to the bottom — scrollTop at bottomPinOffset
  * (content bottom plus the visible PIN_BOTTOM_GAP, clamped to the scroll
- * range), the observable position rather than a virtualizer mock call.
+ * range; 0 while the content still fits the viewport), the observable position
+ * rather than a virtualizer mock call.
  */
 const expectPinnedToBottom = (el: HTMLDivElement, paddingEnd = 0): void => {
   const contentBottom = Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight);
   const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
-  expect(el.scrollTop).toBe(Math.min(contentBottom + PIN_BOTTOM_GAP, maxScroll));
+  expect(el.scrollTop).toBe(contentBottom === 0 ? 0 : Math.min(contentBottom + PIN_BOTTOM_GAP, maxScroll));
 };
 
 describe("useAlphaAutoScroll", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
@@ -26,11 +26,14 @@ const createMockVirtualItem = (index: number, start: number, size: number): Virt
   lane: 0,
 });
 
-const createMockVirtualizer = (virtualItems: Array<VirtualItem>): Virtualizer<HTMLDivElement, Element> => {
+const createMockVirtualizer = (
+  virtualItems: Array<VirtualItem>,
+  paddingEnd = 0,
+): Virtualizer<HTMLDivElement, Element> => {
   return {
     getVirtualItems: vi.fn(() => virtualItems),
     scrollToIndex: vi.fn(),
-    options: { paddingEnd: 0 },
+    options: { paddingEnd },
   } as unknown as Virtualizer<HTMLDivElement, Element>;
 };
 
@@ -47,11 +50,14 @@ describe("useAlphaScrollPersistence", () => {
     vi.useRealTimers();
   });
 
-  it("scrolls to bottom on first visit (no saved position)", () => {
+  it("scrolls to the padded max scroll on first visit (no saved position)", () => {
     const el = createMockScrollContainer(0, 2000, 500);
     const ref = { current: el };
     const virtualItems = [createMockVirtualItem(0, 0, 200)];
-    const virtualizer = createMockVirtualizer(virtualItems);
+    // paddingEnd 400 distinguishes the max scroll (1500) from the content
+    // bottom (1100): a first visit lands at the very end of the padded range —
+    // the anchored-turn rest position when the last turn is short.
+    const virtualizer = createMockVirtualizer(virtualItems, 400);
     const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
     const store = createStore();
 
@@ -64,7 +70,7 @@ describe("useAlphaScrollPersistence", () => {
       vi.advanceTimersByTime(16);
     });
 
-    // Restored to the content bottom (scrollHeight 2000 - paddingEnd 0 - clientHeight 500).
+    // Restored to the max scroll offset (scrollHeight 2000 - clientHeight 500).
     expect(el.scrollTop).toBe(1500);
   });
 
@@ -106,7 +112,7 @@ describe("useAlphaScrollPersistence", () => {
     expect(savedPosition?.distanceFromBottom).toBe(1200); // 2000 - 300 - 500
   });
 
-  it("restores to bottom when user was within 200px of bottom", () => {
+  it("restores to the saved distance from the content bottom when near the bottom", () => {
     const el = createMockScrollContainer(0, 2000, 500);
     const ref = { current: el };
     const virtualItems = [createMockVirtualItem(0, 0, 200)];
@@ -129,7 +135,65 @@ describe("useAlphaScrollPersistence", () => {
       vi.advanceTimersByTime(16);
     });
 
-    // Restored to the content bottom (scrollHeight 2000 - paddingEnd 0 - clientHeight 500).
+    // Restored 100px above the content bottom (2000 - paddingEnd 0 - 500 - 100),
+    // relative to the *current* content bottom so content that grew while away
+    // stays in view.
+    expect(el.scrollTop).toBe(1400);
+  });
+
+  it("round-trips a position inside the tail padding (negative distance)", () => {
+    const el = createMockScrollContainer(0, 2000, 500);
+    const ref = { current: el };
+    const virtualItems = [createMockVirtualItem(0, 0, 200)];
+    const virtualizer = createMockVirtualizer(virtualItems, 400);
+    const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+    const store = createStore();
+
+    // Saved while scrolled 300px past the content bottom, into the padding —
+    // e.g. the anchored-turn rest position or a manual max scroll.
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-3",
+      pixelOffset: 0,
+      distanceFromBottom: -300,
+    });
+
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
+      wrapper: wrapperFor(store),
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // Content bottom (2000 - 400 - 500 = 1100) plus the 300px into the padding.
+    expect(el.scrollTop).toBe(1400);
+  });
+
+  it("clamps a padding-deep saved position to the current scroll range", () => {
+    const el = createMockScrollContainer(0, 2000, 500);
+    const ref = { current: el };
+    const virtualItems = [createMockVirtualItem(0, 0, 200)];
+    // paddingEnd shrank since the save (e.g. the tail grew while away): the
+    // saved 600px-into-the-padding position no longer exists.
+    const virtualizer = createMockVirtualizer(virtualItems, 400);
+    const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+    const store = createStore();
+
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-3",
+      pixelOffset: 0,
+      distanceFromBottom: -600,
+    });
+
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
+      wrapper: wrapperFor(store),
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // Content bottom 1100 + 600 = 1700 exceeds the max scroll (1500) — clamped.
     expect(el.scrollTop).toBe(1500);
   });
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaVirtualizer.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaVirtualizer.test.ts
@@ -1,11 +1,16 @@
 import type { VirtualItem, Virtualizer } from "@tanstack/react-virtual";
-import { describe, expect, it } from "vitest";
+import type { RenderHookResult } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { FOOTER_REVEAL_WINDOW_MS, IDLE_TAIL_PADDING, STREAMING_TAIL_PADDING } from "../../scroll/geometry.ts";
+import { createScrollStateMachine } from "../../scroll/scrollStateMachine.ts";
 import {
   buildShouldAdjustScrollPositionOnItemSizeChange,
   shouldAdjustScrollPosition,
   skipNextScrollAdjustForItem,
   touchLRU,
+  useAlphaVirtualizer,
 } from "../useAlphaVirtualizer.ts";
 
 const createMockItem = (start: number, size: number): VirtualItem => ({
@@ -195,5 +200,98 @@ describe("touchLRU", () => {
     ]);
     touchLRU(map, "a", 5);
     expect(map.get("a")).toBe(42);
+  });
+});
+
+describe("streaming paddingEnd floor latch", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  type FloorLatchProps = { taskId: string; isStreaming: boolean };
+
+  // A null scroll container keeps containerHeight/tailContentHeight at 0, so
+  // dynamicPaddingEnd IS the floor — the latch is observable directly through
+  // options.paddingEnd.
+  const renderFloorLatch = (): RenderHookResult<Virtualizer<HTMLDivElement, Element>, FloorLatchProps> => {
+    const machine = createScrollStateMachine();
+    const initialProps: FloorLatchProps = { taskId: "task-1", isStreaming: false };
+    return renderHook(
+      ({ taskId, isStreaming }: FloorLatchProps) =>
+        useAlphaVirtualizer({ current: null }, 0, null, taskId, machine, 64, undefined, isStreaming),
+      { initialProps },
+    );
+  };
+
+  it("uses the idle floor at rest", () => {
+    const { result } = renderFloorLatch();
+    expect(result.current.options.paddingEnd).toBe(IDLE_TAIL_PADDING);
+  });
+
+  it("uses the streaming floor while a stream is active", () => {
+    const { result, rerender } = renderFloorLatch();
+    rerender({ taskId: "task-1", isStreaming: true });
+    expect(result.current.options.paddingEnd).toBe(STREAMING_TAIL_PADDING);
+  });
+
+  it("holds the streaming floor through the settle window, then drops to idle", () => {
+    const { result, rerender } = renderFloorLatch();
+    rerender({ taskId: "task-1", isStreaming: true });
+    rerender({ taskId: "task-1", isStreaming: false });
+
+    // Still held: the turn-end shrink can land within the settle window.
+    expect(result.current.options.paddingEnd).toBe(STREAMING_TAIL_PADDING);
+
+    act(() => {
+      vi.advanceTimersByTime(FOOTER_REVEAL_WINDOW_MS);
+    });
+    expect(result.current.options.paddingEnd).toBe(IDLE_TAIL_PADDING);
+  });
+
+  it("re-arms the hold when a new stream starts inside the settle window", () => {
+    const { result, rerender } = renderFloorLatch();
+    rerender({ taskId: "task-1", isStreaming: true });
+    rerender({ taskId: "task-1", isStreaming: false });
+    act(() => {
+      vi.advanceTimersByTime(FOOTER_REVEAL_WINDOW_MS / 2);
+    });
+
+    rerender({ taskId: "task-1", isStreaming: true });
+    // The pending drop from the previous turn must not fire mid-stream.
+    act(() => {
+      vi.advanceTimersByTime(FOOTER_REVEAL_WINDOW_MS * 2);
+    });
+    expect(result.current.options.paddingEnd).toBe(STREAMING_TAIL_PADDING);
+  });
+
+  it("drops the outgoing task's hold on task switch", () => {
+    const { result, rerender } = renderFloorLatch();
+    rerender({ taskId: "task-1", isStreaming: true });
+    rerender({ taskId: "task-1", isStreaming: false });
+    expect(result.current.options.paddingEnd).toBe(STREAMING_TAIL_PADDING);
+
+    // The incoming idle task gets the idle floor immediately — the outgoing
+    // task's settle window is meaningless for it.
+    rerender({ taskId: "task-2", isStreaming: false });
+    expect(result.current.options.paddingEnd).toBe(IDLE_TAIL_PADDING);
+
+    // Drain the task-switch settle rAF chain so no state updates fire after
+    // the test ends.
+    act(() => {
+      vi.advanceTimersByTime(48);
+    });
   });
 });

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExter
 
 import { ChatMessageRole } from "~/api";
 
-import { contentBottomOffset, distanceFromContentBottom } from "../scroll/geometry.ts";
+import { bottomPinOffset, distanceFromContentBottom } from "../scroll/geometry.ts";
 import type { ReadingAnchor } from "../scroll/scrollStateMachine.ts";
 import {
   createScrollStateMachine,
@@ -39,8 +39,10 @@ const USER_SCROLL_DEBOUNCE_MS = 150;
 
 // How long after a followed turn ends the content observer keeps revealing the
 // tail, so the turn footer (which mounts a beat after the stream stops) is not left
-// below the fold.
-const FOOTER_REVEAL_WINDOW_MS = 1200;
+// below the fold. Exported because useAlphaVirtualizer holds the streaming
+// paddingEnd floor for the same window: both cover the turn-end settle, where
+// late content changes (cursor unmount, footer mount) can still land.
+export const FOOTER_REVEAL_WINDOW_MS = 1200;
 
 /** Cancel any in-progress scroll-to-top transform animation and restore
  *  the virtualizer's scroll-position adjustment callback. */
@@ -147,14 +149,15 @@ export const useAlphaAutoScroll = (
     [virtualizer, machine],
   );
 
-  // The single "scroll to the bottom" primitive: pin the last message's content
-  // bottom flush with the viewport, leaving paddingEnd as slack (see
-  // contentBottomOffset). Down-only — callers reach the bottom from above, so an
-  // upward move would only chase a turn-end shrink, which we leave in place.
-  const pinToContentBottom = useCallback((): void => {
+  // The single "scroll to the bottom" primitive: land the content bottom
+  // PIN_BOTTOM_GAP above the viewport bottom, keeping the rest of paddingEnd as
+  // slack below scrollTop (see bottomPinOffset). Down-only — callers reach the
+  // bottom from above, so an upward move would only chase a turn-end shrink,
+  // which we leave in place.
+  const pinToBottom = useCallback((): void => {
     const el = scrollContainerRef.current;
     if (!el || messageCount === 0) return;
-    const desired = contentBottomOffset(el, virtualizer);
+    const desired = bottomPinOffset(el, virtualizer);
     if (desired <= el.scrollTop + 1) return;
     isProgrammaticScroll.current = true;
     el.scrollTop = desired;
@@ -495,8 +498,8 @@ export const useAlphaAutoScroll = (
     // synchronously — so this never acts on a stale value.
     if (!atBottom()) return;
     if (lastMessageRole === ChatMessageRole.USER) return;
-    pinToContentBottom();
-  }, [messageCount, isAtBottom, isSuppressed, lastMessageRole, atBottom, pinToContentBottom]);
+    pinToBottom();
+  }, [messageCount, isAtBottom, isSuppressed, lastMessageRole, atBottom, pinToBottom]);
 
   // Engage when streaming starts while at bottom; disengage when streaming stops.
   // Reads the live scroll position rather than the isAtBottom state, which can be
@@ -514,12 +517,12 @@ export const useAlphaAutoScroll = (
         }
       }
     } else if (!isStreaming) {
-      // Final settle onto the content bottom before disengaging: the ResizeObserver
+      // Final settle onto the pinned bottom before disengaging: the ResizeObserver
       // disconnects when streaming stops, so later virtualizer re-measurements won't
       // be compensated — pin now, before they land. Skip while anchoring (a short
       // response that never overflowed).
       if (isFollowing() && messageCount > 0) {
-        pinToContentBottom();
+        pinToBottom();
         // The turn footer mounts a beat later and grows the content below the fold;
         // open a short window so the content observer re-pins to reveal it at the
         // bottom, matching where focusing the input lands.
@@ -606,7 +609,7 @@ export const useAlphaAutoScroll = (
             return;
           }
           if (messageCount === 0) return;
-          pinToContentBottom();
+          pinToBottom();
           machine.setGeometryAtBottom(true);
           return;
         }
@@ -628,7 +631,7 @@ export const useAlphaAutoScroll = (
           // occupies the top portion of the viewport.
           if (tailHeight >= el.clientHeight - anchorSize - FILLING_OVERFLOW_BUFFER) {
             machine.dispatch({ kind: "turnAnchored" });
-            pinToContentBottom();
+            pinToBottom();
           }
           return;
         }
@@ -639,7 +642,7 @@ export const useAlphaAutoScroll = (
         }
       }
     },
-    [machine, virtualizer, messageCount, restoreReadingAnchor, pinToContentBottom],
+    [machine, virtualizer, messageCount, restoreReadingAnchor, pinToBottom],
   );
 
   // Unified content-resize observer. One observer, always connected while not
@@ -667,7 +670,7 @@ export const useAlphaAutoScroll = (
         el.scrollHeight > revealFooterBaseHeightRef.current + 1 &&
         `${el.clientWidth}x${el.clientHeight}` === revealFooterViewportRef.current
       ) {
-        pinToContentBottom();
+        pinToBottom();
       }
       applyReflow(el, distance);
     });
@@ -678,7 +681,7 @@ export const useAlphaAutoScroll = (
     // pinBottom, so idle reconnects fall through untouched.
     if (isStreaming && messageCount > 0 && projectReflow(machine.getState()).kind === "pinBottom") {
       if (distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD) {
-        pinToContentBottom();
+        pinToBottom();
       }
     }
 
@@ -687,20 +690,11 @@ export const useAlphaAutoScroll = (
       observer.disconnect();
       cancelAnimationFrame(reflowRestoreRafRef.current);
     };
-  }, [
-    isStreaming,
-    isSuppressed,
-    messageCount,
-    virtualizer,
-    scrollContainerRef,
-    machine,
-    applyReflow,
-    pinToContentBottom,
-  ]);
+  }, [isStreaming, isSuppressed, messageCount, virtualizer, scrollContainerRef, machine, applyReflow, pinToBottom]);
 
   const scrollToBottom = useCallback((): void => {
     if (messageCount === 0) return;
-    pinToContentBottom();
+    pinToBottom();
     // Record at-bottom so the jump-to-bottom button hides immediately even if the
     // resulting scroll event is async or coalesced (a non-streaming jump has no
     // other trigger).
@@ -714,7 +708,7 @@ export const useAlphaAutoScroll = (
       // suppression.
       machine.dispatch({ kind: "userScrolled" });
     }
-  }, [messageCount, isStreaming, machine, pinToContentBottom]);
+  }, [messageCount, isStreaming, machine, pinToBottom]);
 
   const scrollToTop = useCallback((): void => {
     if (messageCount === 0) return;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExter
 
 import { ChatMessageRole } from "~/api";
 
-import { bottomPinOffset, distanceFromContentBottom } from "../scroll/geometry.ts";
+import { bottomPinOffset, distanceFromContentBottom, FOOTER_REVEAL_WINDOW_MS } from "../scroll/geometry.ts";
 import type { ReadingAnchor } from "../scroll/scrollStateMachine.ts";
 import {
   createScrollStateMachine,
@@ -36,13 +36,6 @@ const SCROLL_ANIMATION_EASING = "cubic-bezier(0.33, 1, 0.68, 1)"; // ease-out
 // How long after a wheel/touch/keydown the user is still considered to be
 // actively scrolling, before the user-scroll flag is debounced back off.
 const USER_SCROLL_DEBOUNCE_MS = 150;
-
-// How long after a followed turn ends the content observer keeps revealing the
-// tail, so the turn footer (which mounts a beat after the stream stops) is not left
-// below the fold. Exported because useAlphaVirtualizer holds the streaming
-// paddingEnd floor for the same window: both cover the turn-end settle, where
-// late content changes (cursor unmount, footer mount) can still land.
-export const FOOTER_REVEAL_WINDOW_MS = 1200;
 
 /** Cancel any in-progress scroll-to-top transform animation and restore
  *  the virtualizer's scroll-position adjustment callback. */

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { alphaScrollPositionAtomFamily } from "~/common/state/atoms/alphaScroll.ts";
 
-import { contentBottomOffset, distanceFromContentBottom } from "../scroll/geometry.ts";
+import { contentBottomOffset, distanceFromContentBottom, maxScrollOffset } from "../scroll/geometry.ts";
 import type { ScrollStateMachine } from "../scroll/scrollStateMachine.ts";
 
 /** Cancel all pending rAFs tracked in the set and clear it. */
@@ -56,9 +56,11 @@ export const useAlphaScrollPersistence = (
         setScrollPosition({
           firstVisibleMessageId: message.id,
           pixelOffset: scrollTop - firstVisible.start,
-          // Distance to the real content bottom (paddingEnd excluded), so a user
-          // pinned at the bottom while the virtualizer is padded still restores
-          // to the bottom rather than into the empty tail padding.
+          // Signed distance to the real content bottom (paddingEnd excluded,
+          // negative inside the tail padding). The restore re-lands at this
+          // distance from the then-current content bottom, so an at-bottom
+          // reader follows content that grew while away and a position inside
+          // the padding (the anchored rest / a max scroll) round-trips.
           distanceFromBottom: distanceFromContentBottom(el, virtualizer),
         });
       });
@@ -79,10 +81,26 @@ export const useAlphaScrollPersistence = (
     const el = scrollContainerRef.current;
     if (!el || filteredMessages.length === 0) return;
 
-    if (!scrollPosition || scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
-      // First visit or user was at bottom: restore flush to the content bottom (see
-      // contentBottomOffset — not scrollToIndex, which lands in the tail padding).
-      el.scrollTop = contentBottomOffset(el, virtualizer);
+    if (!scrollPosition) {
+      // First visit: land at the very end of the padded scroll range. For a
+      // task whose last turn is short, the dynamic paddingEnd makes this the
+      // anchored-turn rest position (last user message at the viewport top) —
+      // the view the task's owner last saw.
+      el.scrollTop = maxScrollOffset(el);
+      return;
+    }
+
+    if (scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
+      // At (or past) the bottom: re-land at the saved distance from the
+      // *current* content bottom, not at the saved message anchor — when
+      // content grew while away, an at-bottom reader should see the new
+      // bottom. The distance is signed: negative means the viewport sat
+      // inside the tail padding (a max scroll / the anchored rest), and
+      // honoring it round-trips that position instead of clamping it flush
+      // to the content. Clamp to the scrollable range, since paddingEnd may
+      // have converged differently than when the distance was recorded.
+      const target = contentBottomOffset(el, virtualizer) - scrollPosition.distanceFromBottom;
+      el.scrollTop = Math.min(Math.max(0, target), maxScrollOffset(el));
       return;
     }
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaVirtualizer.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaVirtualizer.ts
@@ -5,7 +5,9 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 
 import { ChatMessageRole } from "~/api";
 
+import { IDLE_TAIL_PADDING, STREAMING_TAIL_PADDING } from "../scroll/geometry.ts";
 import type { ScrollStateMachine } from "../scroll/scrollStateMachine.ts";
+import { FOOTER_REVEAL_WINDOW_MS } from "./useAlphaAutoScroll.ts";
 
 const ESTIMATED_MESSAGE_HEIGHT = 120;
 const OVERSCAN = 5;
@@ -19,15 +21,17 @@ const OVERSCAN = 5;
 const MAX_CACHED_TASKS = 20;
 
 /**
- * Vertical padding around the virtualised list.
+ * Vertical padding above the virtualised list.
  *
- * Using `paddingStart`/`paddingEnd` is the correct TanStack Virtual way to
- * reserve space – CSS padding on the container div is ignored by
+ * Using `paddingStart` (and `paddingEnd` below) is the correct TanStack Virtual
+ * way to reserve space – CSS padding on the container div is ignored by
  * absolutely-positioned virtual items.
  *
  * paddingStart matches var(--space-9) so the first message sits at the same
  * vertical position as subsequent user messages (which get a margin-top of
- * var(--space-9) via the .newCycle class).
+ * var(--space-9) via the .newCycle class). The paddingEnd floor is the
+ * streaming-scoped IDLE_TAIL_PADDING / STREAMING_TAIL_PADDING pair — see the
+ * dynamicPaddingEnd derivation below.
  */
 const VIRTUAL_PADDING = 64;
 
@@ -126,6 +130,9 @@ export const useAlphaVirtualizer = (
   // Set true when an item size change triggers a scrollTop adjustment,
   // so chat-level scroll listeners can distinguish it from a user scroll.
   isProgrammaticScrollRef?: MutableRefObject<boolean>,
+  // Whether the task is streaming — drives the paddingEnd floor (see
+  // dynamicPaddingEnd below).
+  isStreaming: boolean = false,
 ): Virtualizer<HTMLDivElement, Element> => {
   const [containerHeight, setContainerHeight] = useState(0);
   const [tailContentHeight, setTailContentHeight] = useState(0);
@@ -179,6 +186,28 @@ export const useAlphaVirtualizer = (
     return (): void => cancelAnimationFrame(settlingRafRef.current);
   }, []);
 
+  // The paddingEnd floor is streaming-scoped. While a stream is active — and
+  // through the settle window after it ends, while late content changes (the
+  // cursor unmounting, the turn footer mounting) can still land — the floor is
+  // STREAMING_TAIL_PADDING: the pin keeps PIN_BOTTOM_GAP of it visible below
+  // the content and relies on the remainder as slack below scrollTop, so the
+  // turn-end shrink never clamps the scroll position. At rest the floor is
+  // IDLE_TAIL_PADDING (== the pin gap), so the scroll range ends exactly at
+  // the pin position: scrolling below the content reveals the gap and no more.
+  // The drop happens with scrollTop at the post-drop range end, so it never
+  // moves the view.
+  const [isTailSettling, setIsTailSettling] = useState(false);
+  useEffect(() => {
+    if (isStreaming) {
+      setIsTailSettling(true);
+      return;
+    }
+    if (!isTailSettling) return;
+    const timer = setTimeout(() => setIsTailSettling(false), FOOTER_REVEAL_WINDOW_MS);
+    return (): void => clearTimeout(timer);
+  }, [isStreaming, isTailSettling]);
+  const tailPaddingFloor = isStreaming || isTailSettling ? STREAMING_TAIL_PADDING : IDLE_TAIL_PADDING;
+
   // paddingEnd needs to be just large enough for the scroll-to-top target
   // (the last user message) to reach the viewport top.  The required padding
   // = containerHeight - tailContentHeight, where tailContentHeight is the sum
@@ -192,8 +221,8 @@ export const useAlphaVirtualizer = (
   // destabilises scroll positions during view switches and task restoration.
   const dynamicPaddingEnd =
     containerHeight > 0 && tailContentHeight > 0
-      ? Math.max(containerHeight - tailContentHeight, VIRTUAL_PADDING)
-      : VIRTUAL_PADDING;
+      ? Math.max(containerHeight - tailContentHeight, tailPaddingFloor)
+      : tailPaddingFloor;
 
   const virtualizer = useVirtualizer({
     count: messageCount,
@@ -235,6 +264,10 @@ export const useAlphaVirtualizer = (
       // contaminated by the incoming task's ref callbacks.  The outgoing
       // task's correct heights were already saved during its last normal
       // (non-task-switch) render.
+
+      // The outgoing task's settle hold is meaningless for the incoming task;
+      // its own isStreaming re-arms the hold if it is mid-stream.
+      setIsTailSettling(false);
 
       // Restore saved state for the incoming task.
       currentEstimatesRef.current = heightCacheRef.current.get(taskId) ?? [];

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaVirtualizer.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaVirtualizer.ts
@@ -5,9 +5,8 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 
 import { ChatMessageRole } from "~/api";
 
-import { IDLE_TAIL_PADDING, STREAMING_TAIL_PADDING } from "../scroll/geometry.ts";
+import { FOOTER_REVEAL_WINDOW_MS, IDLE_TAIL_PADDING, STREAMING_TAIL_PADDING } from "../scroll/geometry.ts";
 import type { ScrollStateMachine } from "../scroll/scrollStateMachine.ts";
-import { FOOTER_REVEAL_WINDOW_MS } from "./useAlphaAutoScroll.ts";
 
 const ESTIMATED_MESSAGE_HEIGHT = 120;
 const OVERSCAN = 5;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/__tests__/geometry.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/__tests__/geometry.test.ts
@@ -1,0 +1,67 @@
+import type { Virtualizer } from "@tanstack/react-virtual";
+import { describe, expect, it } from "vitest";
+
+import {
+  bottomPinOffset,
+  contentBottomOffset,
+  distanceFromContentBottom,
+  IDLE_TAIL_PADDING,
+  maxScrollOffset,
+  PIN_BOTTOM_GAP,
+  STREAMING_TAIL_PADDING,
+  TURN_END_SHRINK_SLACK,
+} from "../geometry.ts";
+
+const container = (scrollTop: number, scrollHeight: number, clientHeight: number): HTMLElement =>
+  ({ scrollTop, scrollHeight, clientHeight }) as HTMLElement;
+
+const virtualizerWithPadding = (paddingEnd: number): Virtualizer<HTMLDivElement, Element> =>
+  ({ options: { paddingEnd } }) as Virtualizer<HTMLDivElement, Element>;
+
+describe("geometry", () => {
+  it("keeps the streaming paddingEnd floor large enough for the pin gap plus the shrink slack", () => {
+    expect(STREAMING_TAIL_PADDING).toBe(PIN_BOTTOM_GAP + TURN_END_SHRINK_SLACK);
+  });
+
+  it("ends the idle scroll range at the pin position (over-scroll reveals exactly the gap)", () => {
+    expect(IDLE_TAIL_PADDING).toBe(PIN_BOTTOM_GAP);
+  });
+
+  it("measures the signed distance to the content bottom", () => {
+    const el = container(1000, 2000, 500);
+    // Content bottom at 2000 - 400 = 1600; viewport bottom at 1500.
+    expect(distanceFromContentBottom(el, virtualizerWithPadding(400))).toBe(100);
+    // Scrolled 100px past the content bottom, into the padding.
+    el.scrollTop = 1200;
+    expect(distanceFromContentBottom(el, virtualizerWithPadding(400))).toBe(-100);
+  });
+
+  it("pins the content bottom a PIN_BOTTOM_GAP above the viewport bottom", () => {
+    const el = container(0, 2000, 500);
+    expect(contentBottomOffset(el, virtualizerWithPadding(400))).toBe(1100);
+    expect(bottomPinOffset(el, virtualizerWithPadding(400))).toBe(1100 + PIN_BOTTOM_GAP);
+  });
+
+  it("clamps the pin target to the scroll range while paddingEnd has not converged", () => {
+    const el = container(0, 2000, 500);
+    // paddingEnd smaller than the gap: the gap cannot fit, so the pin lands at
+    // the end of the range instead of past it.
+    expect(bottomPinOffset(el, virtualizerWithPadding(PIN_BOTTOM_GAP / 2))).toBe(maxScrollOffset(el));
+  });
+
+  it("never yields a negative offset for content shorter than the viewport", () => {
+    const el = container(0, 300, 500);
+    expect(contentBottomOffset(el, virtualizerWithPadding(100))).toBe(0);
+    expect(bottomPinOffset(el, virtualizerWithPadding(100))).toBe(0);
+    expect(maxScrollOffset(el)).toBe(0);
+  });
+
+  it("does not pin into the padding while the content still fits the viewport", () => {
+    // Content ends at 550 - 128 = 422 < clientHeight 500, but the padding makes
+    // the range scrollable (maxScrollOffset 50). The pin must stay at 0 rather
+    // than scroll the top of the chat out of view to show empty space.
+    const el = container(0, 550, 500);
+    expect(maxScrollOffset(el)).toBe(50);
+    expect(bottomPinOffset(el, virtualizerWithPadding(128))).toBe(0);
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
@@ -1,6 +1,49 @@
 import type { Virtualizer } from "@tanstack/react-virtual";
 
 /**
+ * Visible breathing room kept below the content whenever the chat is
+ * programmatically brought to the bottom (the following pin, the jump button,
+ * the streaming-stop settle, a restore to the bottom). Without it the last
+ * line sits flush against the viewport edge, underneath the absolutely
+ * positioned bottom bar (StatusPill / jump button).
+ */
+export const PIN_BOTTOM_GAP = 64;
+
+/**
+ * Scrollable slack that must remain below `scrollTop` while pinned at
+ * `bottomPinOffset` during a stream. When a turn ends, the removal of the
+ * streaming cursor shrinks the content; if `scrollTop` sat at the very end of
+ * the scroll range the browser would clamp it down by the shrink and the whole
+ * conversation would visibly jump. The slack absorbs that shrink instead.
+ */
+export const TURN_END_SHRINK_SLACK = 64;
+
+/**
+ * Floor for the virtualizer's dynamic `paddingEnd` while the task is idle.
+ * Equal to the pin gap, so at rest the pin position IS the end of the scroll
+ * range: scrolling below the content can reveal exactly the visible gap and no
+ * more — no shrink is pending on an idle task, so no extra slack is kept.
+ */
+export const IDLE_TAIL_PADDING = PIN_BOTTOM_GAP;
+
+/**
+ * Floor for the dynamic `paddingEnd` while a stream is active (or just ended
+ * and still settling). It must fit the visible pin gap plus the shrink slack —
+ * `bottomPinOffset` relies on `paddingEnd >= PIN_BOTTOM_GAP +
+ * TURN_END_SHRINK_SLACK` to provide both while a turn-end shrink can still
+ * land. Once the turn has settled the floor returns to `IDLE_TAIL_PADDING`;
+ * the pinned `scrollTop` sits exactly at the shrunken range's end, so the drop
+ * never clamps the scroll position.
+ */
+export const STREAMING_TAIL_PADDING = PIN_BOTTOM_GAP + TURN_END_SHRINK_SLACK;
+
+/** The largest scrollTop the browser will allow: the very end of the padded
+ *  scroll range. For a chat whose last turn is short, the dynamic `paddingEnd`
+ *  makes this exactly the anchored-turn rest position (last user message at
+ *  the viewport top). */
+export const maxScrollOffset = (el: HTMLElement): number => Math.max(0, el.scrollHeight - el.clientHeight);
+
+/**
  * Pixels from the bottom of the viewport to the bottom of the real content.
  *
  * The virtualizer inflates the scroll container with a dynamic `paddingEnd` so a
@@ -8,6 +51,8 @@ import type { Virtualizer } from "@tanstack/react-virtual";
  * is empty space below the last message, so "at the bottom" means the last
  * message is in view — not that the padded scroll range is exhausted. Because
  * `scrollHeight` includes that padding, the distance subtracts `paddingEnd`.
+ * Negative when the viewport is scrolled past the content bottom, into the
+ * padding.
  */
 export const distanceFromContentBottom = (
   el: HTMLElement,
@@ -21,12 +66,28 @@ export const distanceFromContentBottom = (
  * The `scrollTop` at which the last message's content bottom sits flush with the
  * viewport bottom — i.e. `distanceFromContentBottom === 0` — leaving the dynamic
  * `paddingEnd` as empty slack *below* `scrollTop`.
- *
- * Prefer this to `virtualizer.scrollToIndex(last, { align: "end" })`, which for the
- * final item resolves to `getMaxScrollOffset()` and parks `scrollTop` inside the
- * `paddingEnd` gap — no slack for a turn-end shrink to absorb.
  */
 export const contentBottomOffset = (el: HTMLElement, virtualizer: Virtualizer<HTMLDivElement, Element>): number => {
   const paddingEnd = virtualizer.options.paddingEnd ?? 0;
   return Math.max(0, el.scrollHeight - paddingEnd - el.clientHeight);
+};
+
+/**
+ * The `scrollTop` every "scroll to the bottom" site targets: the content bottom
+ * plus `PIN_BOTTOM_GAP` of visible padding below the last message.
+ *
+ * Prefer this to `virtualizer.scrollToIndex(last, { align: "end" })`, which for
+ * the final item resolves to `getMaxScrollOffset()` and parks `scrollTop` at the
+ * very end of the padded range — flush against the scroll limit, with no slack
+ * for a turn-end shrink to absorb (the padding floor guarantees
+ * `TURN_END_SHRINK_SLACK` remains below this offset). Clamped to the browser's
+ * scroll range for the windows where `paddingEnd` has not converged yet.
+ */
+export const bottomPinOffset = (el: HTMLElement, virtualizer: Virtualizer<HTMLDivElement, Element>): number => {
+  const contentBottom = contentBottomOffset(el, virtualizer);
+  // Content that still fits the viewport needs no gap — the padding can make the
+  // range scrollable before the content overflows, and pinning into it would
+  // only scroll the top of the chat out of view to show empty space.
+  if (contentBottom === 0) return 0;
+  return Math.min(contentBottom + PIN_BOTTOM_GAP, maxScrollOffset(el));
 };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
@@ -37,6 +37,16 @@ export const IDLE_TAIL_PADDING = PIN_BOTTOM_GAP;
  */
 export const STREAMING_TAIL_PADDING = PIN_BOTTOM_GAP + TURN_END_SHRINK_SLACK;
 
+/**
+ * The turn-end settle window: how long after a followed turn ends late content
+ * changes are still expected (the streaming cursor unmounting, the turn footer
+ * mounting a beat after the stream stops). Two mechanisms share it: the content
+ * observer keeps revealing the tail so the footer is not left below the fold
+ * (useAlphaAutoScroll), and the virtualizer holds the streaming paddingEnd
+ * floor so the shrink slack outlives the shrink (useAlphaVirtualizer).
+ */
+export const FOOTER_REVEAL_WINDOW_MS = 1200;
+
 /** The largest scrollTop the browser will allow: the very end of the padded
  *  scroll range. For a chat whose last turn is short, the dynamic `paddingEnd`
  *  makes this exactly the anchored-turn rest position (last user message at

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -225,11 +225,13 @@ def get_max_following_tail_gap(page: Page, frames: int = 18) -> float | None:
     """Over a short ``requestAnimationFrame`` burst, the max gap (px) from the last
     message's bottom edge UP to the viewport bottom.
 
-    A positive gap means the last line is floating above the viewport bottom over
-    empty tail padding; pinned flush to the content bottom is ~0. The max across
-    frames is returned so a transient mid-growth frame (where the streaming tail
-    briefly overflows below the fold, giving a negative gap) does not mask the
-    steady pinned gap. Returns ``None`` if the chat view or its messages are absent.
+    While following, the pin holds this gap at ~PIN_BOTTOM_GAP (64px, see
+    chat-alpha/scroll/geometry.ts): ~0 means the pin is hugging the viewport edge
+    flush, and a full-padding gap (>= the 128px streaming floor) means it is
+    parked at the end of the padded range. The max across frames is returned so a
+    transient mid-growth frame (where the streaming tail briefly overflows below
+    the fold, giving a negative gap) does not mask the steady pinned gap. Returns
+    ``None`` if the chat view or its messages are absent.
     """
     return page.evaluate(
         f"""(frames) => new Promise((resolve) => {{

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -1,3 +1,5 @@
+import time
+
 from playwright.sync_api import Locator
 from playwright.sync_api import Page
 from playwright.sync_api import expect
@@ -260,6 +262,29 @@ def get_max_following_tail_gap(page: Page, frames: int = 18) -> float | None:
     }})""",
         frames,
     )
+
+
+def wait_for_stable_following_tail_gap(
+    page: Page, *, stability_tolerance_px: int = 8, timeout_ms: int = 8_000
+) -> float | None:
+    """The tail gap once the pin has settled at its steady state, while following.
+
+    Entering ``following`` scrolls toward the pin position, so a single
+    ``get_max_following_tail_gap`` window sampled right away can catch that transit
+    instead of the resting gap. This polls successive windows until two consecutive
+    ones agree within ``stability_tolerance_px`` — the pin has landed (at a correct
+    *or* buggy resting position; the caller's assertions judge which) — and returns
+    that stable gap. On timeout the last sample is returned rather than raising, so
+    the caller's assertions report the actual geometry.
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    previous = get_max_following_tail_gap(page)
+    while time.monotonic() < deadline:
+        current = get_max_following_tail_gap(page)
+        if previous is not None and current is not None and abs(current - previous) <= stability_tolerance_px:
+            return current
+        previous = current
+    return previous
 
 
 def scroll_alpha_chat_to_top(page: Page) -> None:

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -2,14 +2,15 @@
 
 The alpha-chat scroll system is an explicit state machine (see
 ``docs/development/scroll_state_unification.md``, SCU-1566). While ``following`` the
-live tail, the design pins the last message's *content* bottom flush with the
-viewport bottom, leaving the dynamic ``paddingEnd`` as empty slack *below*
-``scrollTop`` (``distanceFromContentBottom == 0``) — so a turn-end shrink has slack
-to absorb into and the view does not jump.
+live tail, the design pins the last message's *content* bottom ``PIN_BOTTOM_GAP``
+(64px) above the viewport bottom — visible breathing room below the newest line —
+leaving the rest of the dynamic ``paddingEnd`` as empty slack *below* ``scrollTop``,
+so a turn-end shrink has slack to absorb into and the view does not jump.
 
 These tests send follow-on streaming messages that overflow and pin to the bottom,
-and assert the turn-end behavior: the last message stays flush with the viewport
-bottom, a stale reading anchor is not restored, and the turn footer scrolls into view.
+and assert the turn-end behavior: the last message keeps the pin gap above the
+viewport bottom (neither hugging it flush nor parked deep in the padding), a stale
+reading anchor is not restored, and the turn footer scrolls into view.
 """
 
 from playwright.sync_api import expect
@@ -35,10 +36,15 @@ _STREAM_TEXT = "The quick brown fox jumps over the lazy dog. " * 112
 # Enough Lorem Ipsum to force a scroll (overflow the viewport) while it streams.
 _LOREM_STREAM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor. " * 90
 
-# While following, the last message's bottom may sit a few px above the viewport
-# bottom (message margins, sub-pixel rounding), but never the full ~64px paddingEnd
-# gap of the bug. (Measured: ~64px before the fix, ~0px after.)
-_FLUSH_TOLERANCE_PX = 24
+# The visible gap the pin keeps between the last message's bottom and the viewport
+# bottom while following — mirrors PIN_BOTTOM_GAP in chat-alpha/scroll/geometry.ts.
+_PIN_BOTTOM_GAP_PX = 64
+# Slop around the pin gap for message margins and sub-pixel rounding. The band it
+# defines separates the two regressions this guards against: hugging the viewport
+# bottom flush (~0px, no breathing room under the newest line) and parking deep in
+# the paddingEnd gap (>= the 128px streaming padding floor, no slack for the
+# turn-end shrink).
+_PIN_GAP_TOLERANCE_PX = 24
 
 # The view must not scroll UP across the turn boundary. A tiny settle for the turn
 # footer is fine; a jump back to an earlier message is a whole-turn (hundreds of px)
@@ -47,13 +53,13 @@ _JUMP_BACK_TOLERANCE_PX = 60
 
 # Sub-pixel tolerance for "is this edge inside the viewport".
 _EDGE_TOLERANCE_PX = 6
-# "Close to the bottom" == the footer sits within one standard margin of the viewport
-# bottom (one design-token space above the input box). Generous so it stays rigid.
-_FOOTER_BOTTOM_MARGIN_PX = 72
+# "Close to the bottom" == the footer sits within the deliberate pin gap plus one
+# standard margin of the viewport bottom. Generous so it stays rigid.
+_FOOTER_BOTTOM_MARGIN_PX = _PIN_BOTTOM_GAP_PX + 72
 
 
 @user_story("to not have the chat jump when the agent finishes its turn (req: stable turn-end)")
-def test_following_pins_last_message_flush_to_viewport_bottom(sculptor_instance_: SculptorInstance) -> None:
+def test_following_keeps_pin_gap_below_last_message(sculptor_instance_: SculptorInstance) -> None:
     page = sculptor_instance_.page
 
     task_page = start_task_and_wait_for_ready(
@@ -86,13 +92,20 @@ def test_following_pins_last_message_flush_to_viewport_bottom(sculptor_instance_
 
     max_gap = get_max_following_tail_gap(page)
 
-    # While following, the last message stays flush with the viewport bottom — it is
-    # not parked in the paddingEnd gap (the ~64px regression that produced the
-    # turn-end jump, because there was no slack for the last message to shrink into).
+    # While following, the last message keeps the pin gap above the viewport bottom:
+    # not hugging it flush (no breathing room under the newest line, and the bottom
+    # bar overlays it), and not parked at the full paddingEnd depth (no slack for the
+    # last message to shrink into at turn end — the turn-end jump).
     assert max_gap is not None, "alpha chat view or its messages not found while following"
-    assert max_gap <= _FLUSH_TOLERANCE_PX, (
+    assert max_gap >= _PIN_BOTTOM_GAP_PX - _PIN_GAP_TOLERANCE_PX, (
+        f"while following, the last message sat {max_gap}px above the viewport bottom "
+        + f"(expected >= {_PIN_BOTTOM_GAP_PX - _PIN_GAP_TOLERANCE_PX}px); the pin is hugging "
+        + "the viewport bottom instead of keeping the visible gap"
+    )
+    assert max_gap <= _PIN_BOTTOM_GAP_PX + _PIN_GAP_TOLERANCE_PX, (
         f"while following, the last message floated {max_gap}px above the viewport bottom "
-        + f"(expected <= {_FLUSH_TOLERANCE_PX}px); the pin is parking in the paddingEnd gap"
+        + f"(expected <= {_PIN_BOTTOM_GAP_PX + _PIN_GAP_TOLERANCE_PX}px); the pin is parking "
+        + "in the paddingEnd gap"
     )
 
     # Let the turn finish cleanly before the test ends.
@@ -166,8 +179,8 @@ def test_turn_end_scrolls_turn_footer_into_view_when_following(sculptor_instance
 
     UX contract (rigid, on purpose): after the turn ends, the last turn footer is
     (1) fully IN VIEW inside the chat viewport and (2) CLOSE TO THE BOTTOM — its
-    bottom edge within one standard margin of the viewport's bottom edge (one design
-    space above the input box).
+    bottom edge within the deliberate pin gap plus one standard margin of the
+    viewport's bottom edge.
     """
     page = sculptor_instance_.page
 

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -17,10 +17,10 @@ from playwright.sync_api import expect
 
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_last_turn_footer_viewport_gaps
-from sculptor.testing.elements.alpha_chat_view import get_max_following_tail_gap
 from sculptor.testing.elements.alpha_chat_view import read_scroll_top_sampler
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
 from sculptor.testing.elements.alpha_chat_view import start_scroll_top_sampler
+from sculptor.testing.elements.alpha_chat_view import wait_for_stable_following_tail_gap
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.elements.panels import close_bottom_panel
@@ -84,13 +84,13 @@ def test_following_keeps_pin_gap_below_last_message(sculptor_instance_: Sculptor
         f'fake_claude:stream_text `{{"text": "{_STREAM_TEXT}", "chunk_size": 50, "delay_seconds": 0.1}}`',
     )
 
-    # Wait until we are following the live tail, then let it stream for a span so the
-    # measurement is taken mid-stream (well before the turn ends).
+    # Wait until we are following the live tail, then sample the gap once it has
+    # stabilized: entering `following` scrolls toward the pin, so the first sampling
+    # windows can catch that transit rather than the resting gap. The stream is long
+    # enough (~10s) that the stable sample lands mid-stream, well before the turn ends.
     expect(view).to_have_attribute("data-scroll-phase", "following", timeout=30_000)
-    page.wait_for_timeout(1500)
+    max_gap = wait_for_stable_following_tail_gap(page)
     expect(view).to_have_attribute("data-scroll-phase", "following")
-
-    max_gap = get_max_following_tail_gap(page)
 
     # While following, the last message keeps the pin gap above the viewport bottom:
     # not hugging it flush (no breathing room under the newest line, and the bottom


### PR DESCRIPTION
## Problem

Since the content-bottom pin redesign, every "scroll to the bottom" site (following pin, jump button, streaming-stop settle, footer reveal) landed the last message **flush with the viewport edge** — no breathing room under the newest streamed line, and the turn footer sat underneath the absolutely positioned bottom bar. Scroll restores clamped any position within (or past) the at-bottom threshold flush to the content too, so a view left at the padded max — or at the anchored-turn rest position after a short turn — came back visibly shifted after a tab switch.

## Change

- **Pin gap**: every bottom pin lands at `bottomPinOffset = content bottom + PIN_BOTTOM_GAP (64px)`, restoring the breathing room below the last message while streaming, on jump, and at turn end. The gap only applies once content actually overflows the viewport.
- **Restore fidelity**: restores honor the signed saved `distanceFromBottom`, clamped to the live scroll range. Positions inside the tail padding (padded max, anchored rest) round-trip exactly; an at-bottom save still pulls forward to the new bottom when content grew while the task was in the background, and follow re-engages on a still-streaming task. First visits land at the padded max.
- **Streaming-scoped padding floor**: while a stream is active (plus a ~1.2s settle window after it ends) the `paddingEnd` floor is `STREAMING_TAIL_PADDING` (128px) — the 64px below the pinned `scrollTop` absorbs the turn-end cursor shrink, keeping the turn-end no-jump fix intact. At rest the floor is `IDLE_TAIL_PADDING` (64px), so the scroll range ends exactly at the pin position and manual over-scroll below the content reveals the same 64px filler as before. The drop back to the idle floor happens with the pinned `scrollTop` exactly at the post-drop range end, so it never moves the view.

## Testing

- New `geometry.test.ts` covering the pin/clamp/floor invariants; new persistence round-trip cases (signed distance, clamping, first visit).
- `test_alpha_scroll_turn_end.py` now asserts a **band** around the pin gap while following, separating the two regressions it guards against: hugging the viewport bottom flush, and parking at the full padding depth with no shrink slack. All 3 tests pass in a real browser.
- `just format` / `just check` / `just test-unit` green; full frontend suite (2600+ tests) green.
- Manually verified: streaming gap, jump landing, max-scroll depth, and tab-switch restore round-trips.

Fixes SCU-1673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)