### PR TITLE
feat(background-processes): Storybook design components (SCU-1675)

### DIFF
--- a/sculptor/frontend/src/components/BackgroundProcessWarningDialog.stories.tsx
+++ b/sculptor/frontend/src/components/BackgroundProcessWarningDialog.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+
+import { BackgroundProcessWarningDialog } from "./BackgroundProcessWarningDialog.tsx";
+
+const meta = {
+  title: "BackgroundProcesses/BackgroundProcessWarningDialog",
+  component: BackgroundProcessWarningDialog,
+  globals: { theme: "dark" },
+  args: {
+    isOpen: true,
+    onOpenChange: action("onOpenChange"),
+    onConfirm: action("onConfirm"),
+  },
+} satisfies Meta<typeof BackgroundProcessWarningDialog>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const QuitWithRunning: Story = {
+  args: {
+    action: "quit",
+    runningCount: 3,
+  },
+};
+
+export const DeleteAgentWithRunning: Story = {
+  args: {
+    action: "delete-agent",
+    runningCount: 1,
+    entityName: "fix-auth-bug",
+  },
+};
+
+export const DeleteWorkspaceNoneRunning: Story = {
+  args: {
+    action: "delete-workspace",
+    runningCount: 0,
+  },
+};
+
+export const DeleteWorkspaceWithRunning: Story = {
+  args: {
+    action: "delete-workspace",
+    runningCount: 2,
+  },
+};

--- a/sculptor/frontend/src/components/BackgroundProcessWarningDialog.tsx
+++ b/sculptor/frontend/src/components/BackgroundProcessWarningDialog.tsx
@@ -1,0 +1,112 @@
+// Count-only lifecycle warning shown before an action that would terminate
+// running background processes — quitting Sculptor, or deleting the current
+// agent / workspace. Reuses the DeleteConfirmationDialog AlertDialog pattern:
+// gray-soft Cancel, danger-colored confirm, focus landed on confirm so Enter
+// accepts.
+//
+// Presentational only. The count sentence ("N running background process(es)
+// will be terminated.") is shown ONLY when runningCount > 0 — at zero the
+// dialog is the plain action confirmation.
+import { AlertDialog, Button, Flex } from "@radix-ui/themes";
+import type { ReactElement } from "react";
+import { useRef } from "react";
+
+import { useThemeDangerColor } from "~/common/state/hooks/useThemeBuilder.ts";
+
+import { POPOVER_FRIENDLY_MODAL_ATTRIBUTE } from "./popoverFriendlyModal.ts";
+
+type BackgroundProcessWarningAction = "quit" | "delete-agent" | "delete-workspace";
+
+type BackgroundProcessWarningDialogProps = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  action: BackgroundProcessWarningAction;
+  runningCount: number;
+  entityName?: string;
+  onConfirm: () => void;
+};
+
+// Per-action title + confirm label. The body is assembled below so it can fold
+// in the optional entity name and the conditional count sentence.
+const ACTION_COPY = {
+  quit: {
+    title: "Quit Sculptor?",
+    confirmLabel: "Quit",
+    body: "Quitting Sculptor will close this session.",
+  },
+  "delete-agent": {
+    title: "Delete agent?",
+    confirmLabel: "Delete",
+    body: "This will permanently delete this agent.",
+  },
+  "delete-workspace": {
+    title: "Delete workspace?",
+    confirmLabel: "Delete",
+    body: "This will permanently delete this workspace and all of its agents.",
+  },
+} as const satisfies Record<BackgroundProcessWarningAction, { title: string; confirmLabel: string; body: string }>;
+
+export const BackgroundProcessWarningDialog = ({
+  isOpen,
+  onOpenChange,
+  action,
+  runningCount,
+  entityName,
+  onConfirm,
+}: BackgroundProcessWarningDialogProps): ReactElement => {
+  const dangerColor = useThemeDangerColor();
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  const copy = ACTION_COPY[action];
+  const isDelete = action !== "quit";
+  // When the caller knows the entity name, name it in the body for the delete
+  // actions ("...delete the agent \"fix-auth-bug\"."); otherwise fall back to
+  // the generic body.
+  const body =
+    isDelete && entityName !== undefined
+      ? `This will permanently delete the ${action === "delete-workspace" ? "workspace" : "agent"} "${entityName}"${
+          action === "delete-workspace" ? " and all of its agents" : ""
+        }.`
+      : copy.body;
+
+  const hasRunningProcesses = runningCount > 0;
+  const countSentence = `${runningCount} running background process${
+    runningCount === 1 ? "" : "es"
+  } will be terminated.`;
+
+  // Radix' AlertDialog defaults focus to the first focusable element (Cancel),
+  // which makes Enter dismiss instead of confirming. Land focus on the confirm
+  // button so Enter accepts; Esc / Cancel still close.
+  const handleOpenAutoFocus = (event: Event): void => {
+    event.preventDefault();
+    confirmButtonRef.current?.focus();
+  };
+
+  return (
+    <AlertDialog.Root open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialog.Content
+        maxWidth="400px"
+        {...{ [POPOVER_FRIENDLY_MODAL_ATTRIBUTE]: "true" }}
+        onOpenAutoFocus={handleOpenAutoFocus}
+      >
+        <AlertDialog.Title>{copy.title}</AlertDialog.Title>
+        <AlertDialog.Description>
+          {body}
+          {hasRunningProcesses ? ` ${countSentence}` : ""}
+        </AlertDialog.Description>
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button ref={confirmButtonRef} variant="solid" color={dangerColor} onClick={onConfirm}>
+              {copy.confirmLabel}
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessChip.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessChip.module.scss
@@ -1,0 +1,62 @@
+.chipAnchor {
+  // Let the chip shrink when the chat column is narrow (the parent flex row
+  // would otherwise demand the chip's intrinsic width and overflow). Mirrors
+  // the StatusPill anchor.
+  min-width: 0;
+  pointer-events: none;
+}
+
+// Surface mirrors the StatusPill `.pill` exactly.
+.chip {
+  align-items: center;
+  background: var(--gray-1);
+  border: 1px solid var(--gray-4);
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--font-size-1);
+  gap: var(--space-2);
+  max-width: 100%;
+  min-width: 0;
+  padding: var(--space-1) var(--space-2);
+  pointer-events: auto;
+}
+
+// Gentle opacity pulse for the running dot — mirrors the AlphaExpandedToolRow
+// statusDotPulse keyframes. Status reads from the pulse, never from color.
+@keyframes backgroundProcessChipPulse {
+  0%,
+  100% {
+    opacity: 30%;
+  }
+
+  50% {
+    opacity: 100%;
+  }
+}
+
+.dot {
+  animation: backgroundProcessChipPulse 1s ease-in-out infinite;
+  background: var(--gray-9);
+  border-radius: 50%;
+  flex-shrink: 0;
+  height: 8px; // stylelint-disable-line sculptor/no-hardcoded-values
+  width: 8px; // stylelint-disable-line sculptor/no-hardcoded-values
+}
+
+.label {
+  color: var(--gray-11);
+}
+
+.chevron {
+  align-items: center;
+  color: var(--gray-8);
+  display: inline-flex;
+  flex-shrink: 0;
+  transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessChip.stories.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessChip.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+
+import { BackgroundProcessChipButton } from "./BackgroundProcessChip.tsx";
+
+const meta = {
+  title: "BackgroundProcesses/BackgroundProcessChip",
+  component: BackgroundProcessChipButton,
+  globals: { theme: "dark" },
+} satisfies Meta<typeof BackgroundProcessChipButton>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const OneProcessClosed: Story = {
+  args: { runningCount: 1, isOpen: false },
+};
+
+export const OneProcessOpen: Story = {
+  args: { runningCount: 1, isOpen: true },
+};
+
+export const TwoProcessesClosed: Story = {
+  args: { runningCount: 2, isOpen: false },
+};
+
+export const TwoProcessesOpen: Story = {
+  args: { runningCount: 2, isOpen: true },
+};
+
+export const AllVariants: Story = {
+  args: { runningCount: 1, isOpen: false },
+  render: (): ReactElement => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "flex-start" }}>
+      <BackgroundProcessChipButton runningCount={1} isOpen={false} />
+      <BackgroundProcessChipButton runningCount={1} isOpen={true} />
+      <BackgroundProcessChipButton runningCount={2} isOpen={false} />
+      <BackgroundProcessChipButton runningCount={2} isOpen={true} />
+    </div>
+  ),
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessChip.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessChip.tsx
@@ -1,0 +1,36 @@
+// Presentational chip for the floating bottom bar (just left of the StatusPill),
+// shown while background processes are running. Status is conveyed without
+// color — the dot pulses gently while something runs. Pure props so it renders
+// standalone in Storybook and tests; the live-data container that counts
+// running processes and anchors the details popover lives with the alpha chat
+// wiring. forwardRef so a popover trigger can anchor to the chip's DOM node.
+import { ChevronDown } from "lucide-react";
+import type { ReactElement } from "react";
+import { forwardRef } from "react";
+
+import { mergeClasses, optional } from "~/common/Utils";
+
+import styles from "./BackgroundProcessChip.module.scss";
+
+type BackgroundProcessChipButtonProps = {
+  runningCount: number;
+  isOpen: boolean;
+  onClick?: () => void;
+};
+
+export const BackgroundProcessChipButton = forwardRef<HTMLDivElement, BackgroundProcessChipButtonProps>(
+  ({ runningCount, isOpen, onClick }, ref): ReactElement => {
+    return (
+      <div ref={ref} className={styles.chip} data-testid="background-process-chip" onClick={onClick}>
+        <span className={styles.dot} />
+        <span className={styles.label}>
+          {runningCount} process{runningCount === 1 ? "" : "es"}
+        </span>
+        <span className={mergeClasses(styles.chevron, optional(isOpen, styles.chevronOpen))}>
+          <ChevronDown size={14} />
+        </span>
+      </div>
+    );
+  },
+);
+BackgroundProcessChipButton.displayName = "BackgroundProcessChipButton";

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessOutputBox.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessOutputBox.module.scss
@@ -1,0 +1,78 @@
+// Terminal-style "background box" mirroring the bottom TerminalPanel surface:
+// a dark body, mono font, a slim neutral title bar, and a bounded scrolling
+// tail. Status color never appears in the chrome — the only color allowed is
+// authentic terminal log content inside the body.
+.box {
+  background: var(--terminal-bg);
+  border: 1px solid var(--terminal-border);
+  border-radius: var(--radius-3);
+  overflow: hidden;
+}
+
+// Slim title bar: command on the left, optional "open" affordance on the right.
+// Visually distinct from the body via a lighter surface + a bottom border.
+.titleBar {
+  align-items: center;
+  background: var(--gray-2);
+  border-bottom: 1px solid var(--terminal-border);
+  display: flex;
+  gap: var(--space-2);
+  height: 34px; // stylelint-disable-line sculptor/no-hardcoded-values
+  padding: 0 var(--space-3);
+}
+
+.command {
+  color: var(--gray-9);
+  flex: 1;
+  font-family: var(--code-font-family);
+  font-size: 10.5px; // stylelint-disable-line sculptor/no-hardcoded-values
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// The "open in terminal" affordance is a Radix ghost IconButton; just keep it
+// from stretching and nudge the resting color to match the dim title bar.
+.openButton {
+  color: var(--gray-9);
+  flex-shrink: 0;
+}
+
+// Body: a bounded vertical-scroll tail rendered as mono rows. Default log text
+// is the neutral terminal text color; authentic ANSI-style content is free to
+// override via inline spans the caller passes in (not done here).
+.body {
+  color: var(--terminal-text);
+  font-family: var(--code-font-family);
+  font-size: var(--font-size-1);
+  line-height: 1.65; // stylelint-disable-line sculptor/no-hardcoded-values
+  margin: 0;
+  max-height: 140px; // stylelint-disable-line sculptor/no-hardcoded-values
+  overflow: auto;
+  padding: var(--space-2) var(--space-3);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.line {
+  min-height: 1.65em; // stylelint-disable-line sculptor/no-hardcoded-values
+}
+
+// Blinking block cursor shown at the tail of a running process (neutral, not
+// colored). Mirrors the mock's step-end blink.
+@keyframes backgroundProcessCursorBlink {
+  50% {
+    opacity: 0%;
+  }
+}
+
+.cursor {
+  animation: backgroundProcessCursorBlink 1.1s step-end infinite;
+  background: var(--gray-11);
+  display: inline-block;
+  height: 11px; // stylelint-disable-line sculptor/no-hardcoded-values
+  margin-left: 2px; // stylelint-disable-line sculptor/no-hardcoded-values
+  vertical-align: text-bottom;
+  width: 6px; // stylelint-disable-line sculptor/no-hardcoded-values
+}

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessOutputBox.stories.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessOutputBox.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import { action } from "storybook/actions";
+
+import { BackgroundProcessOutputBox } from "./BackgroundProcessOutputBox.tsx";
+
+const meta = {
+  title: "BackgroundProcesses/BackgroundProcessOutputBox",
+  component: BackgroundProcessOutputBox,
+  globals: { theme: "dark" },
+  // Constrain the width so the bounded box renders at a realistic popover size.
+  decorators: [
+    (Story): ReactElement => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BackgroundProcessOutputBox>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const BASH_BUILD_LINES = [
+  "VITE v5.2.0  ready in 412 ms",
+  "  ➜  Local:   http://localhost:5173/",
+  "2:16:31 [vite] hmr update /src/.../ChatInput.tsx",
+  "2:16:44 [vite] page reload src/main.tsx",
+] as const;
+
+const MONITOR_EVENT_LINES = [
+  "[monitor] watching CI status for HEAD",
+  "[monitor] pipeline #4821 queued",
+  "[monitor] pipeline #4821 running (3 jobs)",
+  "[monitor] job lint passed",
+  "[monitor] job test-unit running…",
+] as const;
+
+const FAILED_RUN_LINES = [
+  "$ npm run build",
+  "> tsc -b && vite build",
+  "src/main.tsx:14:7 - error TS2322: Type 'string' is not assignable to type 'number'.",
+  "Found 1 error.",
+  "exited with code 1",
+] as const;
+
+export const BashBuildLogRunning: Story = {
+  args: {
+    command: "npm run dev",
+    lines: BASH_BUILD_LINES,
+    isRunning: true,
+  },
+};
+
+export const MonitorEventLog: Story = {
+  args: {
+    command: "monitor: CI status",
+    lines: MONITOR_EVENT_LINES,
+    isRunning: true,
+  },
+};
+
+export const FailedRun: Story = {
+  args: {
+    command: "npm run build",
+    lines: FAILED_RUN_LINES,
+    isRunning: false,
+  },
+};
+
+export const WithOpenInTerminal: Story = {
+  args: {
+    command: "npm run dev",
+    lines: BASH_BUILD_LINES,
+    isRunning: true,
+    onOpenInTerminal: action("onOpenInTerminal"),
+  },
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessOutputBox.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessOutputBox.tsx
@@ -1,0 +1,60 @@
+// A terminal-style "background box" mirroring the bottom TerminalPanel surface.
+// Presentational only: it renders a command title bar plus a bounded, scrolling
+// tail of log lines. The only color here is authentic terminal log content
+// (passed in as plain strings) — the chrome stays neutral gray. When the
+// process is running it shows a blinking block cursor at the end of the tail.
+import { IconButton } from "@radix-ui/themes";
+import { ExternalLink } from "lucide-react";
+import type { ReactElement } from "react";
+
+import styles from "./BackgroundProcessOutputBox.module.scss";
+
+type BackgroundProcessOutputBoxProps = {
+  command: string;
+  lines: ReadonlyArray<string>;
+  isRunning?: boolean;
+  onOpenInTerminal?: () => void;
+};
+
+export const BackgroundProcessOutputBox = ({
+  command,
+  lines,
+  isRunning,
+  onOpenInTerminal,
+}: BackgroundProcessOutputBoxProps): ReactElement => {
+  const isProcessRunning = isRunning ?? false;
+
+  return (
+    <div className={styles.box}>
+      <div className={styles.titleBar}>
+        <span className={styles.command} title={command}>
+          {command}
+        </span>
+        {onOpenInTerminal !== undefined ? (
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            className={styles.openButton}
+            onClick={onOpenInTerminal}
+            title="Open in terminal panel"
+            aria-label="Open in terminal panel"
+          >
+            <ExternalLink size={12} />
+          </IconButton>
+        ) : undefined}
+      </div>
+      <pre className={styles.body}>
+        {lines.map((line, index) => (
+          // Log lines are an ordered append-only tail with no stable id; the
+          // index is the natural key for a render-only bounded list.
+          <div key={index} className={styles.line}>
+            {line}
+            {isProcessRunning && index === lines.length - 1 ? <span className={styles.cursor} /> : undefined}
+          </div>
+        ))}
+        {isProcessRunning && lines.length === 0 ? <span className={styles.cursor} /> : undefined}
+      </pre>
+    </div>
+  );
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessPopover.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessPopover.module.scss
@@ -1,0 +1,196 @@
+// Popover surface mirrors the StatusPill tasks popover / AgentTasksPanel:
+// a solid panel, soft shadow, fixed width with a bounded scroll height.
+.popoverContent {
+  background-color: var(--color-panel-solid);
+  border-radius: var(--radius-4);
+  box-shadow: var(--shadow-2);
+  max-height: 400px;
+  overflow: auto;
+  padding: 0;
+  width: 320px;
+}
+
+// Tiny uppercase header, matching the AgentTasksPanel / StatusPill header.
+.header {
+  box-sizing: border-box;
+  color: var(--gray-10);
+  font-size: 10px; // stylelint-disable-line sculptor/no-hardcoded-values
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.8px;
+  padding: var(--space-4) var(--space-4) var(--space-1);
+  text-transform: uppercase;
+  width: 100%;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  // A slight gap so adjacent rows' rounded hover/active highlights (and an
+  // expanded row's output box) never touch the neighbouring row.
+  gap: var(--space-1);
+  // Inset the rows a little from the popover edges so a row's hover/active
+  // highlight (and the expanded output box) read as rounded, padded elements
+  // rather than full-bleed bands.
+  padding: 0 var(--space-2) var(--space-2);
+}
+
+// Each process is a row group: a clickable header line plus an optional
+// expanded output box below it. Rows without output are rendered as plain
+// (non-interactive) divs so there is no focusable affordance without an action.
+.rowGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+// The header line. A button when the row has output to expand, otherwise a
+// plain div — both share these layout styles.
+.row {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  // Rounded so the hover/active highlight is a pill; box-sizing keeps the row
+  // (incl. padding) within the list width so the rightmost Stop/state slot
+  // isn't clipped.
+  border-radius: var(--radius-2);
+  box-sizing: border-box;
+  color: inherit;
+  display: flex;
+  font: inherit;
+  gap: var(--space-2);
+  // Tight vertical padding so the row/highlight feels compact; horizontal
+  // padding aligns the content with the panel header.
+  padding: var(--space-1) var(--space-2);
+  text-align: left;
+  width: 100%;
+}
+
+.rowExpandable {
+  cursor: pointer;
+}
+
+.rowExpandable:hover,
+.rowExpandable:focus-visible {
+  background: var(--gray-a3);
+  outline: none;
+}
+
+// The expanded (active) row keeps a persistent subtle background so it's clear
+// which row is open (only one is open at a time). Neutral gray — no status
+// color. Slightly stronger on hover to stay responsive.
+.rowActive {
+  background: var(--gray-a3);
+}
+
+.rowActive:hover,
+.rowActive:focus-visible {
+  background: var(--gray-a4);
+}
+
+// Ended rows dim — status reads from the dimming + the one-word state, not
+// from color (no status color anywhere).
+.rowEnded {
+  opacity: 55%;
+}
+
+// Gentle opacity pulse for the running row's type icon (status reads from the
+// pulse, not from color). Mirrors the AlphaExpandedToolRow statusDotPulse.
+@keyframes backgroundProcessPulse {
+  0%,
+  100% {
+    opacity: 30%;
+  }
+
+  50% {
+    opacity: 100%;
+  }
+}
+
+.icon {
+  align-items: center;
+  color: var(--gray-9);
+  display: inline-flex;
+  flex-shrink: 0;
+  height: 14px;
+  justify-content: center;
+  width: 14px;
+}
+
+.iconRunning {
+  animation: backgroundProcessPulse 1s ease-in-out infinite;
+}
+
+.name {
+  color: var(--gray-11);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Elapsed time pinned to a fixed right column so the value stays aligned
+// across rows whether the rightmost slot is empty (running) or a state word.
+.elapsed {
+  color: var(--gray-9);
+  flex-shrink: 0;
+  font-family: var(--code-font-family);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+// Rightmost slot: the Stop button for running rows, a one-word state for ended
+// rows. A fixed min-width keeps the elapsed column aligned across rows.
+.slot {
+  align-items: center;
+  color: var(--gray-9);
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+  min-width: 54px; // stylelint-disable-line sculptor/no-hardcoded-values
+  text-align: right;
+}
+
+// Per-process Stop button — always visible on running rows (a Radix Button,
+// soft gray). Neutral gray at rest; turns red ONLY on hover (the sole place
+// red appears in this surface). The icon + label sit on one mono-ish line.
+.stopButton {
+  flex-shrink: 0;
+}
+
+.stopButton:hover,
+.stopButton:focus-visible {
+  // Override the Radix soft-gray hover with a red wash on hover only.
+  background-color: var(--red-a3);
+  color: var(--red-11);
+}
+
+// Trailing expand caret (right side, subagent-pill style), shown only on rows
+// that have output. Points right at rest and rotates to point down when the row
+// is expanded. Neutral gray (no status color).
+.chevron {
+  align-items: center;
+  color: var(--gray-8);
+  display: inline-flex;
+  flex-shrink: 0;
+  transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+// Spacer that occupies the chevron column on rows without output so names stay
+// aligned with rows that do have a chevron.
+.chevronSpacer {
+  flex-shrink: 0;
+  width: 14px; // stylelint-disable-line sculptor/no-hardcoded-values
+}
+
+// Inline expanded output. A slight symmetric x-inset (on top of the list inset)
+// nests the terminal box under its row so it reads as a child of the row above,
+// with a small gap separating them.
+.output {
+  box-sizing: border-box;
+  padding: var(--space-1) var(--space-2);
+  width: 100%;
+}

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessPopover.stories.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessPopover.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+import { action } from "storybook/actions";
+
+import type { BackgroundProcess } from "./BackgroundProcessPopover.tsx";
+import { BackgroundProcessPopover } from "./BackgroundProcessPopover.tsx";
+
+const meta = {
+  title: "BackgroundProcesses/BackgroundProcessPopover",
+  component: BackgroundProcessPopover,
+  globals: { theme: "dark" },
+  args: {
+    onStopProcess: action("onStopProcess"),
+  },
+  // The popover is fixed-width; wrap it so it renders at its real popover size.
+  decorators: [
+    (Story): ReactElement => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BackgroundProcessPopover>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Running processes derive their live elapsed from `startedAt`; anchoring it a
+// fixed number of seconds before "now" keeps the stories readable without being
+// perfectly frozen.
+const startedSecondsAgo = (seconds: number): string => new Date(Date.now() - seconds * 1000).toISOString();
+
+const runningProcess = (inputs: {
+  taskId: string;
+  kind: BackgroundProcess["kind"];
+  name: string;
+  startedSecondsAgo: number;
+}): BackgroundProcess => ({
+  taskId: inputs.taskId,
+  toolUseId: `tool-${inputs.taskId}`,
+  kind: inputs.kind,
+  name: inputs.name,
+  status: "running",
+  startedAt: startedSecondsAgo(inputs.startedSecondsAgo),
+  endedAt: null,
+  summary: "",
+  durationSeconds: null,
+});
+
+const endedProcess = (inputs: {
+  taskId: string;
+  kind: BackgroundProcess["kind"];
+  name: string;
+  status: "completed" | "failed" | "stopped";
+  durationSeconds: number;
+}): BackgroundProcess => ({
+  taskId: inputs.taskId,
+  toolUseId: `tool-${inputs.taskId}`,
+  kind: inputs.kind,
+  name: inputs.name,
+  status: inputs.status,
+  startedAt: startedSecondsAgo(inputs.durationSeconds + 30),
+  endedAt: startedSecondsAgo(30),
+  summary: "",
+  durationSeconds: inputs.durationSeconds,
+});
+
+const DEV_SERVER_OUTPUT = {
+  command: "npm run dev",
+  lines: [
+    "VITE v5.2.0  ready in 412 ms",
+    "  ➜  Local:   http://localhost:5173/",
+    "2:16:31 [vite] hmr update /src/.../ChatInput.tsx",
+    "2:16:44 [vite] page reload src/main.tsx",
+  ],
+} as const;
+
+const MONITOR_OUTPUT = {
+  command: "monitor: CI status",
+  lines: [
+    "[monitor] watching CI status for HEAD",
+    "[monitor] pipeline #4821 running (3 jobs)",
+    "[monitor] job lint passed",
+    "[monitor] job test-unit running…",
+  ],
+} as const;
+
+// In the product every background process has a tailed output file, so every
+// row is expandable and shows the caret. Build a matching output map for a set
+// of processes. The collapsed stories don't render the body (only the caret),
+// so a light per-row entry suffices; RowExpandedWithOutput supplies richer
+// output for the row it opens.
+const outputsFor = (
+  processes: ReadonlyArray<BackgroundProcess>,
+): Record<string, { command: string; lines: ReadonlyArray<string> }> =>
+  Object.fromEntries(processes.map((process) => [process.taskId, { command: process.name, lines: ["…"] }]));
+
+const SINGLE_PROCESSES: ReadonlyArray<BackgroundProcess> = [
+  runningProcess({ taskId: "p1", kind: "bash", name: "dev server", startedSecondsAgo: 134 }),
+];
+
+export const SingleRunningBash: Story = {
+  args: { processes: SINGLE_PROCESSES, outputByTaskId: outputsFor(SINGLE_PROCESSES) },
+};
+
+const BASH_MONITOR_AGENT_PROCESSES: ReadonlyArray<BackgroundProcess> = [
+  runningProcess({ taskId: "p1", kind: "bash", name: "dev server", startedSecondsAgo: 134 }),
+  runningProcess({ taskId: "p2", kind: "monitor", name: "monitor · CI status", startedSecondsAgo: 62 }),
+  runningProcess({ taskId: "p3", kind: "agent", name: "refactor file picker", startedSecondsAgo: 198 }),
+];
+
+export const RunningBashMonitorAgent: Story = {
+  args: { processes: BASH_MONITOR_AGENT_PROCESSES, outputByTaskId: outputsFor(BASH_MONITOR_AGENT_PROCESSES) },
+};
+
+const MIXED_PROCESSES: ReadonlyArray<BackgroundProcess> = [
+  runningProcess({ taskId: "p1", kind: "bash", name: "dev server", startedSecondsAgo: 134 }),
+  runningProcess({ taskId: "p2", kind: "monitor", name: "monitor · CI status", startedSecondsAgo: 62 }),
+  endedProcess({ taskId: "p3", kind: "agent", name: "summarize changelog", status: "completed", durationSeconds: 362 }),
+  endedProcess({ taskId: "p4", kind: "bash", name: "build", status: "failed", durationSeconds: 252 }),
+  endedProcess({ taskId: "p5", kind: "monitor", name: "monitor · deploy", status: "stopped", durationSeconds: 88 }),
+];
+
+export const MixedRunningAndEnded: Story = {
+  args: { processes: MIXED_PROCESSES, outputByTaskId: outputsFor(MIXED_PROCESSES) },
+};
+
+const SCALED_PROCESSES: ReadonlyArray<BackgroundProcess> = [
+  runningProcess({ taskId: "p1", kind: "bash", name: "dev server", startedSecondsAgo: 312 }),
+  runningProcess({ taskId: "p2", kind: "monitor", name: "monitor · CI status", startedSecondsAgo: 281 }),
+  runningProcess({ taskId: "p3", kind: "agent", name: "refactor file picker", startedSecondsAgo: 240 }),
+  runningProcess({ taskId: "p4", kind: "bash", name: "tail server logs", startedSecondsAgo: 190 }),
+  runningProcess({ taskId: "p5", kind: "monitor", name: "monitor · deploy", startedSecondsAgo: 121 }),
+  runningProcess({ taskId: "p6", kind: "agent", name: "write release notes", startedSecondsAgo: 64 }),
+  endedProcess({ taskId: "p7", kind: "bash", name: "npm install", status: "completed", durationSeconds: 73 }),
+  endedProcess({ taskId: "p8", kind: "bash", name: "build", status: "failed", durationSeconds: 252 }),
+  endedProcess({ taskId: "p9", kind: "agent", name: "summarize PR", status: "completed", durationSeconds: 142 }),
+  endedProcess({
+    taskId: "p10",
+    kind: "monitor",
+    name: "monitor · queue depth",
+    status: "stopped",
+    durationSeconds: 410,
+  }),
+];
+
+export const ScaledList: Story = {
+  args: { processes: SCALED_PROCESSES, outputByTaskId: outputsFor(SCALED_PROCESSES) },
+};
+
+const EXPANDED_PROCESSES: ReadonlyArray<BackgroundProcess> = [
+  runningProcess({ taskId: "p1", kind: "bash", name: "dev server", startedSecondsAgo: 134 }),
+  runningProcess({ taskId: "p2", kind: "monitor", name: "monitor · CI status", startedSecondsAgo: 62 }),
+];
+
+export const RowExpandedWithOutput: Story = {
+  args: {
+    processes: EXPANDED_PROCESSES,
+    outputByTaskId: { p1: DEV_SERVER_OUTPUT, p2: MONITOR_OUTPUT },
+    initialExpandedTaskId: "p1",
+  },
+};
+
+export const RunningRowWithStop: Story = {
+  args: { processes: SINGLE_PROCESSES, outputByTaskId: outputsFor(SINGLE_PROCESSES) },
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundProcessPopover.tsx
@@ -1,0 +1,246 @@
+// Details popover opened from the BackgroundProcessChip. One row per
+// background process — running first, then ended (launch order preserved
+// within each group). Status is conveyed without color: running rows pulse
+// their type icon, ended rows dim and show a one-word state.
+//
+// Presentational: the live elapsed time ticks from `startedAt`, but every
+// action is delegated to props — `onStopProcess` for the per-process Stop and
+// `outputByTaskId` to supply the inline terminal-style output box. Rows with
+// output toggle that box open/closed as a single-open accordion.
+import { Button } from "@radix-ui/themes";
+import type { LucideIcon } from "lucide-react";
+import { Activity, Bot, ChevronRightIcon, Terminal } from "lucide-react";
+import type { KeyboardEvent, MouseEvent, ReactElement } from "react";
+import { useEffect, useState } from "react";
+
+import { mergeClasses, optional } from "~/common/Utils";
+
+import { BackgroundProcessOutputBox } from "./BackgroundProcessOutputBox.tsx";
+import styles from "./BackgroundProcessPopover.module.scss";
+
+// Local mirror of the backend `BackgroundProcess` registry model, so this
+// popover and its stories build standalone in Storybook without the generated
+// `~/api` client. Keep this shape in sync with the backend model when wiring
+// the popover to live data.
+export type BackgroundProcess = {
+  taskId: string;
+  toolUseId: string;
+  kind: "bash" | "monitor" | "agent";
+  name: string;
+  status: "running" | "completed" | "failed" | "stopped";
+  startedAt: string;
+  endedAt?: string | null;
+  summary?: string;
+  durationSeconds?: number | null;
+};
+
+type BackgroundProcessKind = BackgroundProcess["kind"];
+type BackgroundProcessStatus = BackgroundProcess["status"];
+
+type ProcessOutput = { command: string; lines: ReadonlyArray<string> };
+
+type BackgroundProcessPopoverProps = {
+  processes: ReadonlyArray<BackgroundProcess>;
+  onStopProcess?: (taskId: string) => void;
+  outputByTaskId?: Readonly<Record<string, ProcessOutput>>;
+  // Which row's output box starts open (single-open accordion). Lets a parent
+  // render the popover with a row already expanded — primarily for stories and
+  // tests; in the app the accordion is driven by user clicks.
+  initialExpandedTaskId?: string;
+};
+
+const KIND_ICONS = {
+  bash: Terminal,
+  monitor: Activity,
+  agent: Bot,
+} as const satisfies Record<BackgroundProcessKind, LucideIcon>;
+
+// One-word state shown in the rightmost slot of an ended row (gray, no color).
+const ENDED_STATE_LABELS = {
+  completed: "done",
+  failed: "failed",
+  stopped: "stopped",
+} as const satisfies Record<Exclude<BackgroundProcessStatus, "running">, string>;
+
+const isRunning = (process: BackgroundProcess): boolean => process.status === "running";
+
+// Format an elapsed duration: sub-minute → one decimal second ("6.2s");
+// otherwise minutes + whole seconds ("2m 14s").
+const formatElapsed = (seconds: number): string => {
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.floor(seconds % 60);
+  return `${minutes}m ${remainder}s`;
+};
+
+// Tick once per second while `isActive`, exposing a `now` timestamp that drives
+// the live elapsed time on running rows. Idle when nothing is running so the
+// popover doesn't re-render needlessly.
+const useNow = (isActive: boolean): number => {
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!isActive) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return (): void => window.clearInterval(id);
+  }, [isActive]);
+
+  return now;
+};
+
+const elapsedSeconds = (process: BackgroundProcess, now: number): number => {
+  if (isRunning(process)) {
+    return Math.max(0, (now - new Date(process.startedAt).getTime()) / 1000);
+  }
+  const { durationSeconds, endedAt } = process;
+
+  if (durationSeconds !== null && durationSeconds !== undefined) {
+    return durationSeconds;
+  }
+
+  if (endedAt !== null && endedAt !== undefined) {
+    return Math.max(0, (new Date(endedAt).getTime() - new Date(process.startedAt).getTime()) / 1000);
+  }
+
+  return 0;
+};
+
+const ProcessRow = ({
+  process,
+  now,
+  output,
+  isExpanded,
+  onToggleExpanded,
+  onStopProcess,
+}: {
+  process: BackgroundProcess;
+  now: number;
+  output?: ProcessOutput;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+  onStopProcess?: (taskId: string) => void;
+}): ReactElement => {
+  const isProcessRunning = isRunning(process);
+  const Icon = KIND_ICONS[process.kind];
+  const elapsed = formatElapsed(elapsedSeconds(process, now));
+  const hasOutput = output !== undefined;
+
+  // The Stop button lives inside the row; stop its click from also toggling the
+  // row's expansion.
+  const handleStop = (event: MouseEvent): void => {
+    event.stopPropagation();
+    onStopProcess?.(process.taskId);
+  };
+
+  // The whole row is a button when it has output. Keep it a div with role/key
+  // handling rather than a Radix Button so the row keeps its plain list-row
+  // layout (a Radix Button would impose button chrome on the full-width row).
+  const handleRowKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onToggleExpanded();
+    }
+  };
+
+  const rowContent = (
+    <>
+      <span className={mergeClasses(styles.icon, optional(isProcessRunning, styles.iconRunning))}>
+        <Icon size={14} />
+      </span>
+      <span className={styles.name}>{process.name}</span>
+      <span className={styles.elapsed}>{elapsed}</span>
+      <span className={styles.slot}>
+        {process.status === "running" ? (
+          <Button
+            size="1"
+            variant="soft"
+            color="gray"
+            className={styles.stopButton}
+            onClick={handleStop}
+            title="Stop this process"
+          >
+            Stop
+          </Button>
+        ) : (
+          ENDED_STATE_LABELS[process.status]
+        )}
+      </span>
+      {/* Expand affordance on the right (subagent-pill style). Rows without
+          output get a same-width spacer so the state/Stop column stays aligned. */}
+      {hasOutput ? (
+        <span className={mergeClasses(styles.chevron, optional(isExpanded, styles.chevronOpen))}>
+          <ChevronRightIcon size={14} />
+        </span>
+      ) : (
+        <span className={styles.chevronSpacer} />
+      )}
+    </>
+  );
+
+  return (
+    <div className={styles.rowGroup} data-testid="background-process-row">
+      {hasOutput ? (
+        <div
+          role="button"
+          tabIndex={0}
+          className={mergeClasses(styles.row, styles.rowExpandable, optional(isExpanded, styles.rowActive))}
+          onClick={onToggleExpanded}
+          onKeyDown={handleRowKeyDown}
+          aria-expanded={isExpanded}
+        >
+          {rowContent}
+        </div>
+      ) : (
+        <div className={styles.row}>{rowContent}</div>
+      )}
+      {hasOutput && isExpanded ? (
+        <div className={styles.output}>
+          <BackgroundProcessOutputBox command={output.command} lines={output.lines} isRunning={isProcessRunning} />
+        </div>
+      ) : undefined}
+    </div>
+  );
+};
+
+export const BackgroundProcessPopover = ({
+  processes,
+  onStopProcess,
+  outputByTaskId,
+  initialExpandedTaskId,
+}: BackgroundProcessPopoverProps): ReactElement => {
+  // Single-open accordion: at most one expanded output box at a time.
+  const [expandedTaskId, setExpandedTaskId] = useState<string | undefined>(initialExpandedTaskId);
+
+  // Running first, then ended; launch order is preserved within each group
+  // because filter keeps the input order.
+  const running = processes.filter(isRunning);
+  const ended = processes.filter((process) => !isRunning(process));
+  const ordered = [...running, ...ended];
+
+  const now = useNow(running.length > 0);
+
+  const handleToggleExpanded = (taskId: string): void => {
+    setExpandedTaskId((current) => (current === taskId ? undefined : taskId));
+  };
+
+  return (
+    <div className={styles.popoverContent} data-testid="background-process-popover">
+      <div className={styles.header}>Background processes</div>
+      <div className={styles.list}>
+        {ordered.map((process) => (
+          <ProcessRow
+            key={process.taskId}
+            process={process}
+            now={now}
+            output={outputByTaskId?.[process.taskId]}
+            isExpanded={expandedTaskId === process.taskId}
+            onToggleExpanded={(): void => handleToggleExpanded(process.taskId)}
+            onStopProcess={onStopProcess}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundSystemLine.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundSystemLine.module.scss
@@ -1,0 +1,47 @@
+// Bare system line — the shared language for every background-process system
+// moment (triggered turns + restart). Mirrors the V2 "sysline" mock and the
+// workspace-intro info-line: dim icon, gray text (name bolded), mono detail,
+// right-aligned mono time. No left rule, no box. Single line that ellipsizes
+// (name/detail truncate, time pinned right). Status is never colored.
+.line {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.icon {
+  color: var(--gray-9);
+  display: flex;
+  flex-shrink: 0;
+}
+
+// Name + detail share one ellipsizing slot; the time stays pinned to the right.
+.label {
+  color: var(--gray-10);
+  flex: 1;
+  font-size: 12.5px; // stylelint-disable-line sculptor/no-hardcoded-values
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.name {
+  color: var(--gray-11);
+  font-weight: var(--font-weight-medium);
+}
+
+.detail {
+  color: var(--gray-10);
+  font-family: var(--code-font-family);
+  font-size: var(--font-size-1);
+}
+
+.time {
+  color: var(--gray-10);
+  flex-shrink: 0;
+  font-family: var(--code-font-family);
+  font-size: var(--font-size-1);
+  font-variant-numeric: tabular-nums;
+}

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundSystemLine.stories.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundSystemLine.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Activity, CircleOff, RotateCcw } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { BackgroundSystemLine } from "./BackgroundSystemLine.tsx";
+
+const meta = {
+  title: "BackgroundProcesses/BackgroundSystemLine",
+  component: BackgroundSystemLine,
+  globals: { theme: "dark" },
+  // Constrain the width to a realistic transcript column so the right-pinned
+  // time and the single-line ellipsis behavior read correctly.
+  decorators: [
+    (Story): ReactElement => (
+      <div style={{ width: 440 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BackgroundSystemLine>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ProcessExit: Story = {
+  args: {
+    icon: CircleOff,
+    name: "Background process exited",
+    detail: "dev server failed (code 1)",
+    time: "4m 12s",
+  },
+};
+
+export const MonitorEvent: Story = {
+  args: {
+    icon: Activity,
+    name: "Monitor event",
+    detail: "CI status: still pending",
+    time: "1m 02s",
+  },
+};
+
+export const Restart: Story = {
+  args: {
+    icon: RotateCcw,
+    name: "Sculptor restarted",
+    detail: "2 background processes terminated  dev server · monitor: CI status",
+    time: "",
+  },
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundSystemLine.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundSystemLine.tsx
@@ -1,0 +1,39 @@
+// The one shared "system line" language used for every background-process
+// system moment in the transcript: triggered turns (monitor events, process
+// exits) and the restart notice all render as the same bare line. Matches the
+// real app's workspace-intro info-line style (AlphaChatIntro): a dim gray icon
+// + gray text (name bolded, detail in mono) + a right-aligned mono time. No
+// left rule, no box; the single line ellipsizes with the time pinned right.
+//
+// Presentational only — the caller supplies the icon, the copy, and the
+// already-formatted time string.
+import type { LucideIcon } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { optional } from "~/common/Utils";
+
+import styles from "./BackgroundSystemLine.module.scss";
+
+type BackgroundSystemLineProps = {
+  icon?: LucideIcon;
+  name: string;
+  detail?: string;
+  time: string;
+};
+
+export const BackgroundSystemLine = ({ icon: Icon, name, detail, time }: BackgroundSystemLineProps): ReactElement => {
+  return (
+    <div className={styles.line}>
+      {Icon !== undefined ? (
+        <span className={styles.icon}>
+          <Icon size={14} aria-hidden="true" />
+        </span>
+      ) : undefined}
+      <span className={styles.label}>
+        <strong className={styles.name}>{name}</strong>
+        {optional(detail !== undefined, <span className={styles.detail}> {detail}</span>)}
+      </span>
+      {optional(time !== "", <span className={styles.time}>{time}</span>)}
+    </div>
+  );
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundToolBlock.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundToolBlock.module.scss
@@ -1,0 +1,117 @@
+// Subagent-style transcript block for a background launch. Mirrors
+// AlphaSubagentPill's gutter + pill metrics (24px gutter, accent-a2 pill,
+// radius-1, 28px row). Status is conveyed without color: the running row
+// pulses gently, ended rows dim. The only color allowed is authentic terminal
+// log content inside the nested BackgroundProcessOutputBox.
+.root {
+  position: relative;
+  width: 100%;
+}
+
+.row {
+  position: relative;
+  width: 100%;
+}
+
+// Ended blocks dim — no status color, just reduced emphasis.
+.rowEnded {
+  opacity: 65%;
+}
+
+// Left gutter icon: spinner while running, corner-return arrow once ended.
+// Position mirrors AlphaSubagentPill so the block lines up with subagent pills.
+.gutterIcon {
+  align-items: center;
+  color: var(--gray-a7);
+  display: inline-flex;
+  height: 28px;
+  justify-content: center;
+  left: calc(-16px - var(--space-2));
+  position: absolute;
+  top: 0;
+  width: 16px;
+}
+
+.pill {
+  align-items: center;
+  background-color: var(--accent-a2);
+  border: 1px solid var(--accent-a3);
+  border-radius: var(--radius-1);
+  color: var(--gray-12);
+  display: flex;
+  font-family: var(--default-font-family);
+  font-size: var(--font-size-2);
+  gap: var(--space-2);
+  height: 28px;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0 var(--space-2);
+  white-space: nowrap;
+  width: 100%;
+}
+
+// Gentle opacity pulse while running — the only "running" signal (no color).
+@keyframes backgroundToolBlockPulse {
+  0%,
+  100% {
+    opacity: 100%;
+  }
+
+  50% {
+    opacity: 65%;
+  }
+}
+
+.pillRunning {
+  animation: backgroundToolBlockPulse 2s ease-in-out infinite;
+}
+
+// Neutral-gray type icon (bash → terminal, monitor → activity). Agent blocks
+// have no type icon, matching the bare subagent pill.
+.typeIcon {
+  color: var(--gray-a10);
+  flex-shrink: 0;
+}
+
+.primary {
+  color: var(--gray-a12);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Command-style kinds (bash/monitor) render the command in mono; agent prompts
+// stay in the default UI font.
+.primaryMono {
+  font-family: var(--code-font-family);
+  font-size: var(--font-size-1);
+}
+
+// Dim mono trailing text — the resolved status word + elapsed time
+// ("background · 2m 14s", "exited · code 1 · 4m 12s"). Gray, never colored.
+.trailing {
+  color: var(--gray-a10);
+  flex-shrink: 0;
+  font-family: var(--code-font-family);
+  font-size: var(--font-size-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.chevron {
+  color: var(--gray-a10);
+  flex-shrink: 0;
+  transition: transform var(--duration-fast) var(--ease-default);
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+// Inline output box sits beneath the row, indented to align with the pill (past
+// the gutter) and with a little breathing room above it.
+.output {
+  margin-top: var(--space-2);
+}

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundToolBlock.stories.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundToolBlock.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+
+import { BackgroundToolBlock } from "./BackgroundToolBlock.tsx";
+
+const meta = {
+  title: "BackgroundProcesses/BackgroundToolBlock",
+  component: BackgroundToolBlock,
+  globals: { theme: "dark" },
+  // Constrain the width to a realistic transcript column, and add left padding
+  // so the negatively-positioned gutter icon (spinner / corner-return) is
+  // visible — it sits in the chat's left gutter, outside the pill.
+  decorators: [
+    (Story): ReactElement => (
+      <div style={{ width: 440, paddingLeft: 28 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof BackgroundToolBlock>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const BASH_BUILD_LINES = [
+  "$ npm run build",
+  "> tsc -b && vite build",
+  "src/main.tsx:14:7 - error TS2322: Type 'string' is not assignable to type 'number'.",
+  "Found 1 error.",
+  "exited with code 1",
+] as const;
+
+const MONITOR_EVENT_LINES = [
+  "[monitor] watching CI status for HEAD",
+  "[monitor] pipeline #4821 queued",
+  "[monitor] pipeline #4821 running (3 jobs)",
+  "[monitor] job lint passed",
+  "[monitor] job test-unit running…",
+] as const;
+
+export const BashRunning: Story = {
+  args: {
+    kind: "bash",
+    name: "dev server",
+    command: "npm run dev",
+    status: "running",
+    trailingText: "background · 2m 14s",
+  },
+};
+
+export const BashExitedExpanded: Story = {
+  args: {
+    kind: "bash",
+    name: "build",
+    command: "npm run build",
+    status: "exited",
+    trailingText: "exited · code 1 · 4m 12s",
+    exitCode: 1,
+    isExpanded: true,
+    output: {
+      command: "npm run build",
+      lines: BASH_BUILD_LINES,
+    },
+  },
+};
+
+export const MonitorRunningExpanded: Story = {
+  args: {
+    kind: "monitor",
+    name: "CI status",
+    command: "monitor: CI status",
+    status: "running",
+    trailingText: "background · 1m 02s",
+    isExpanded: true,
+    output: {
+      command: "monitor: CI status",
+      lines: MONITOR_EVENT_LINES,
+    },
+  },
+};
+
+export const AgentRunning: Story = {
+  args: {
+    kind: "agent",
+    name: "Refactor the auth module and add tests",
+    command: "Refactor the auth module and add tests",
+    status: "running",
+    trailingText: "background · 3m 18s",
+  },
+};
+
+export const AgentDone: Story = {
+  args: {
+    kind: "agent",
+    name: "Refactor the auth module and add tests",
+    command: "Refactor the auth module and add tests",
+    status: "done",
+    trailingText: "done · 6m 02s",
+  },
+};

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundToolBlock.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/BackgroundToolBlock.tsx
@@ -1,0 +1,97 @@
+// A background launch rendered in the chat transcript, mirroring a subagent
+// pill (AlphaSubagentPill). Presentational only: status, trailing text, and
+// expansion are all prop-driven.
+//
+// Status is conveyed WITHOUT color: a spinner in the left gutter while running
+// (→ a corner-return arrow when ended), the running row pulses gently, ended
+// rows dim. The type icon, name/command, and trailing text are all neutral
+// gray; the only color allowed is authentic terminal log content inside the
+// shared BackgroundProcessOutputBox.
+//
+// `kind === 'agent'` mirrors today's AlphaSubagentPill EXACTLY — no extra type
+// icon or label, just the prompt + dim trailing text + chevron. `bash` and
+// `monitor` add a neutral type icon and render the command in mono.
+import type { LucideIcon } from "lucide-react";
+import { Activity, ChevronRight, CornerDownRight, Terminal } from "lucide-react";
+import type { ReactElement } from "react";
+
+import { mergeClasses, optional } from "~/common/Utils";
+
+import { BackgroundProcessOutputBox } from "./BackgroundProcessOutputBox.tsx";
+import styles from "./BackgroundToolBlock.module.scss";
+import { SpinnerAnimation } from "./pill-animations";
+
+type BackgroundToolBlockKind = "bash" | "monitor" | "agent";
+type BackgroundToolBlockStatus = "running" | "exited" | "done";
+
+type BackgroundToolBlockOutput = {
+  command: string;
+  lines: ReadonlyArray<string>;
+};
+
+type BackgroundToolBlockProps = {
+  kind: BackgroundToolBlockKind;
+  name: string;
+  command: string;
+  status: BackgroundToolBlockStatus;
+  // Caller supplies the fully-resolved, dim mono trailing string, e.g.
+  // "background · 2m 14s" or "exited · code 1 · 4m 12s".
+  trailingText: string;
+  exitCode?: number;
+  isExpanded?: boolean;
+  output?: BackgroundToolBlockOutput;
+};
+
+// Neutral type icons for the command-style kinds. Agent intentionally has no
+// entry here — it mirrors the bare subagent pill (no inner type icon/label).
+const COMMAND_KIND_ICONS = {
+  bash: Terminal,
+  monitor: Activity,
+} as const satisfies Record<"bash" | "monitor", LucideIcon>;
+
+export const BackgroundToolBlock = ({
+  kind,
+  name,
+  command,
+  status,
+  trailingText,
+  isExpanded,
+  output,
+}: BackgroundToolBlockProps): ReactElement => {
+  const isRunning = status === "running";
+  const isShowingOutput = (isExpanded ?? false) && output !== undefined;
+
+  // Agent blocks render exactly like the subagent pill: just the prompt, the
+  // dim trailing text, and the chevron — no type icon, no label.
+  const isAgent = kind === "agent";
+  const TypeIcon = isAgent ? undefined : COMMAND_KIND_ICONS[kind];
+
+  // The pill content is the prompt (agent) or the command (bash/monitor). The
+  // name leads agent blocks just like the subagent prompt; bash/monitor lead
+  // with the command in mono.
+  const primaryText = isAgent ? name : command;
+
+  return (
+    <div className={styles.root}>
+      <div className={mergeClasses(styles.row, optional(!isRunning, styles.rowEnded))}>
+        <span className={styles.gutterIcon}>{isRunning ? <SpinnerAnimation /> : <CornerDownRight size={14} />}</span>
+        <div className={mergeClasses(styles.pill, optional(isRunning, styles.pillRunning))}>
+          {TypeIcon !== undefined ? <TypeIcon size={14} className={styles.typeIcon} aria-hidden="true" /> : undefined}
+          <span className={mergeClasses(styles.primary, optional(!isAgent, styles.primaryMono))} title={primaryText}>
+            {primaryText}
+          </span>
+          <span className={styles.trailing}>{trailingText}</span>
+          <ChevronRight
+            size={14}
+            className={mergeClasses(styles.chevron, optional(isExpanded ?? false, styles.chevronOpen))}
+          />
+        </div>
+      </div>
+      {isShowingOutput ? (
+        <div className={styles.output}>
+          <BackgroundProcessOutputBox command={output.command} lines={output.lines} isRunning={isRunning} />
+        </div>
+      ) : undefined}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Frontend-only, self-contained Storybook slice of the **background-processes** UI, for design review. No backend and no runtime wiring — every component is presentational and prop-driven, with stories under the `BackgroundProcesses/*` Storybook title.

### Components

- **BackgroundProcessChip** — bottom-bar chip (just left of the StatusPill) shown while processes run; count + a gently pulsing dot, so status reads without relying on color.
- **BackgroundProcessPopover** — details popover opened from the chip; one row per process (running first, then ended), live elapsed time, a per-row Stop, and a single-open inline-output accordion.
- **BackgroundProcessOutputBox** — inline terminal-style output box mirroring the TerminalPanel surface; a bounded, scrolling log tail with a blinking cursor while running.
- **BackgroundSystemLine** — the one shared "system line" for background-process moments in the transcript (triggered turns, process exits, restart notice), matching the workspace-intro info-line style.
- **BackgroundToolBlock** — a background launch rendered in the transcript, mirroring the subagent pill; the `agent` kind matches the subagent pill exactly, while `bash`/`monitor` add a neutral type icon and render the command in mono.
- **BackgroundProcessWarningDialog** — lifecycle warning shown before an action that would terminate running processes (quit Sculptor / delete agent / delete workspace), reusing the existing AlertDialog confirm pattern.

### Decoupling scope

To keep this slice buildable off `main` with **no backend**, it is decoupled from the generated `~/api` client:

- `BackgroundProcessPopover` defines a local `BackgroundProcess` type (a mirror of the backend registry model, to be kept in sync when wired to live data).
- Test ids are inlined as string literals rather than importing the generated `ElementIds`.
- `BackgroundProcessChip` keeps only the presentational button; the live-data container that counts running processes and anchors the popover lives on the separate background-processes feature branch.

### Verification

- `tsc --noEmit` passes; zero `~/api` imports (the only mention is an explanatory comment).
- `pnpm build-storybook` succeeds; all six `BackgroundProcesses/*` stories render.
- eslint, stylelint, and ratchets are clean.

Part of [SCU-1675](https://linear.app/imbue/issue/SCU-1675/in-turn-messages).

(Sent by Claude)
