### PR TITLE
Make FakeClaude host multiple turns per process and exit on stdin EOF

### DIFF
--- a/sculptor/sculptor/agents/testing/fake_claude.py
+++ b/sculptor/sculptor/agents/testing/fake_claude.py
@@ -249,6 +249,7 @@ def _run_cycle(
     emit_streaming: bool,
     plugin_dir: str | None,
     system_commands: list[str],
+    write_session_file: bool,
 ) -> int | None:
     """Run one full ``init → messages → result`` cycle for a single user frame.
 
@@ -259,6 +260,12 @@ def _run_cycle(
     processor has the session id before any handler blocks (e.g.
     ask_user_question waiting on an MCP response).
 
+    ``write_session_file`` writes the ``--resume`` history file just before the
+    first init. The caller sets it only on the first cycle (and only when
+    session persistence is enabled), so it runs exactly once per invocation and
+    — crucially — never when stdin is already at EOF: an immediate-EOF exit runs
+    no cycle at all and therefore leaves nothing on disk.
+
     ``system_commands`` (directives extracted from ``--append-system-prompt``)
     run before the frame's own directives. The caller passes them only for the
     first cycle, since an appended system prompt is a launch-time input, not a
@@ -267,6 +274,9 @@ def _run_cycle(
     Returns an exit code if the cycle terminates the whole process (an unknown
     command → 1), or ``None`` to signal the caller may run further cycles.
     """
+    if write_session_file:
+        _write_session_file(session_id)
+
     _emit_jsonl([make_init_message(session_id)])
 
     all_messages: list[dict] = []
@@ -326,8 +336,9 @@ def main(argv: list[str] | None = None) -> int:
 
     # `--no-session-persistence` (used by /btw's forked invocation) means we
     # must leave the resumed session file untouched and not write a new one.
-    if not parsed.no_session_persistence:
-        _write_session_file(session_id)
+    # The write itself is deferred into the first cycle (see `_run_cycle`) so an
+    # immediate-EOF exit leaves no orphan session file on disk.
+    persist_session = not parsed.no_session_persistence
 
     # fake_claude: directives embedded in the appended system prompt are a
     # launch-time input, so they run once — on the first cycle only.
@@ -337,7 +348,9 @@ def main(argv: list[str] | None = None) -> int:
     # invocation) — a single cycle, no stdin loop.
     if isinstance(parsed.p_flag, str):
         _maybe_delay_for_compact_indicator(parsed.p_flag, parsed.resume)
-        exit_code = _run_cycle(parsed.p_flag, session_id, cwd, emit_streaming, plugin_dir, system_commands)
+        exit_code = _run_cycle(
+            parsed.p_flag, session_id, cwd, emit_streaming, plugin_dir, system_commands, persist_session
+        )
         return exit_code if exit_code is not None else 0
 
     # Stream-json stdin (the standard main-agent path): one scripted cycle per
@@ -351,7 +364,15 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
             _maybe_delay_for_compact_indicator(prompt, parsed.resume)
             cycle_system_commands = system_commands if is_first_cycle else []
-            exit_code = _run_cycle(prompt, session_id, cwd, emit_streaming, plugin_dir, cycle_system_commands)
+            exit_code = _run_cycle(
+                prompt,
+                session_id,
+                cwd,
+                emit_streaming,
+                plugin_dir,
+                cycle_system_commands,
+                write_session_file=is_first_cycle and persist_session,
+            )
             if exit_code is not None:
                 return exit_code
             is_first_cycle = False
@@ -359,7 +380,7 @@ def main(argv: list[str] | None = None) -> int:
     # Non-stream-json single-shot: a plain piped prompt, or nothing on a tty.
     prompt = html.unescape(sys.stdin.read()).strip() if not sys.stdin.isatty() else ""
     _maybe_delay_for_compact_indicator(prompt, parsed.resume)
-    exit_code = _run_cycle(prompt, session_id, cwd, emit_streaming, plugin_dir, system_commands)
+    exit_code = _run_cycle(prompt, session_id, cwd, emit_streaming, plugin_dir, system_commands, persist_session)
     return exit_code if exit_code is not None else 0
 
 

--- a/sculptor/sculptor/agents/testing/fake_claude.py
+++ b/sculptor/sculptor/agents/testing/fake_claude.py
@@ -180,13 +180,28 @@ def _install_sigterm_handler() -> None:
     signal.signal(signal.SIGTERM, lambda _signum, _frame: sys.exit(AGENT_EXIT_CODE_FROM_SIGTERM))
 
 
-def _read_prompt_from_stream_json_stdin() -> str:
-    """Read a user message from stdin in stream-json format.
+def _read_prompt_from_stream_json_stdin() -> str | None:
+    """Read the next user message from stdin in stream-json format.
 
-    Reads lines from stdin until a JSON object with "type": "user" is found,
-    then extracts and returns the message content. Ignores control_request
-    messages (e.g. interrupts) and other non-user message types.
-    Returns empty string if stdin is closed without a user message.
+    Reads lines until a JSON object with ``"type": "user"`` is found, then
+    returns its (HTML-unescaped, stripped) message content. An empty-content
+    user frame returns ``""`` so the default handler still runs for a
+    genuinely empty prompt.
+
+    Returns ``None`` when stdin closes before another user frame arrives. The
+    caller treats that as EOF and exits cleanly with nothing further emitted,
+    matching the real CLI, which lingers on stdin between turns and exits only
+    on EOF. (Returning ``""`` here instead would spuriously run the default
+    handler for a turn the user never sent.)
+
+    An ``interrupt`` control_request seen while idle between cycles exits with
+    ``AGENT_EXIT_CODE_FROM_SIGTERM``, mirroring the graceful-interrupt exit the
+    in-cycle handlers perform. Other non-user frames (context-usage requests,
+    control responses, etc.) are ignored.
+
+    ``sys.stdin`` is its own iterator, so successive calls resume where the
+    previous one stopped and share one read buffer — reading a sequence of
+    frames across cycles neither drops nor reorders lines.
     """
     for line in sys.stdin:
         line = line.strip()
@@ -198,73 +213,71 @@ def _read_prompt_from_stream_json_stdin() -> str:
             continue
         if not isinstance(data, dict):
             continue
+        if (
+            data.get("type") == "control_request"
+            and isinstance(data.get("request"), dict)
+            and data["request"].get("subtype") == "interrupt"
+        ):
+            sys.exit(AGENT_EXIT_CODE_FROM_SIGTERM)
         if data.get("type") == "user":
             message = data.get("message", {})
             content = message.get("content", "")
             return html.unescape(content).strip() if isinstance(content, str) else ""
-    return ""
+    return None
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Run FakeClaude: read prompt, dispatch command, emit JSONL, write session file."""
-    _install_sigterm_handler()
-    parsed = _parse_args(argv)
+def _maybe_delay_for_compact_indicator(prompt: str, resume_id: str | None) -> None:
+    """Stall a resumed ``/compact`` so tests can observe the Compacting indicator.
 
-    # `-p <question>` carries the prompt on argv (e.g. the /btw forked
-    # invocation). Otherwise read from stdin using the stream-json protocol
-    # (the standard main-agent path).
-    if isinstance(parsed.p_flag, str):
-        prompt = parsed.p_flag
-    elif parsed.input_format == "stream-json":
-        prompt = _read_prompt_from_stream_json_stdin()
-    elif not sys.stdin.isatty():
-        prompt = html.unescape(sys.stdin.read()).strip()
-    else:
-        prompt = ""
-
-    # Add a delay during compact operations so that integration tests can
-    # observe transient UI states like the Compacting indicator.
-    if prompt == "/compact" and parsed.resume:
+    Only the resumed-compact turn stalls; a fresh session never runs /compact.
+    """
+    if prompt == "/compact" and resume_id:
         time.sleep(_COMPACT_INDICATOR_DELAY_SECONDS)
 
-    emit_streaming = parsed.include_partial_messages
-    session_id = _get_session_id(parsed.resume)
-    cwd = os.getcwd()
 
-    # Emit the init message immediately so the output processor gets the
-    # session ID before any handler might block (e.g. ask_user_question
-    # waiting for the kill signal).
+def _run_cycle(
+    prompt: str,
+    session_id: str,
+    cwd: str,
+    emit_streaming: bool,
+    plugin_dir: str | None,
+    system_commands: list[str],
+) -> int | None:
+    """Run one full ``init → messages → result`` cycle for a single user frame.
+
+    Emits the cycle's own ``init`` first — an init per cycle mirrors the real
+    CLI and is the shape Sculptor's output processor expects for every turn —
+    then dispatches the frame's ``fake_claude:`` directives, then the
+    terminating ``result``. Emitting ``init`` up front also means the output
+    processor has the session id before any handler blocks (e.g.
+    ask_user_question waiting on an MCP response).
+
+    ``system_commands`` (directives extracted from ``--append-system-prompt``)
+    run before the frame's own directives. The caller passes them only for the
+    first cycle, since an appended system prompt is a launch-time input, not a
+    per-turn one.
+
+    Returns an exit code if the cycle terminates the whole process (an unknown
+    command → 1), or ``None`` to signal the caller may run further cycles.
+    """
     _emit_jsonl([make_init_message(session_id)])
-    # `--no-session-persistence` (used by /btw's forked invocation) means we
-    # must leave the resumed session file untouched and not write a new one.
-    if not parsed.no_session_persistence:
-        _write_session_file(session_id)
 
     all_messages: list[dict] = []
     end_result = ""
 
-    # FakeClaude handlers only inspect a single plugin_dir for testing. The real
-    # Claude CLI accepts multiple --plugin-dir flags (Sculptor passes one for the
-    # sculptor plugin and one for the sculptor-workflow plugin); we collapse to
-    # the first here since no handler actually reads multiple.
-    plugin_dir = parsed.plugin_dir[0] if parsed.plugin_dir else None
+    # System-prompt directives run first, before the frame's own directives.
+    for system_command in system_commands:
+        try:
+            messages, result = _dispatch_single_prompt(system_command, cwd, emit_streaming, plugin_dir=plugin_dir)
+            all_messages.extend(messages)
+            if result:
+                end_result = result
+        except UnknownFakeClaudeCommandError as e:
+            sys.stderr.write(f"FakeClaude (system prompt): {e}\n")
+            all_messages.append(make_end_message(session_id, is_error=True))
+            _emit_jsonl(all_messages)
+            return 1
 
-    # Execute any fake_claude: commands found in the system prompt first
-    if parsed.append_system_prompt:
-        system_commands = _extract_fake_claude_commands(parsed.append_system_prompt)
-        for system_command in system_commands:
-            try:
-                messages, result = _dispatch_single_prompt(system_command, cwd, emit_streaming, plugin_dir=plugin_dir)
-                all_messages.extend(messages)
-                if result:
-                    end_result = result
-            except UnknownFakeClaudeCommandError as e:
-                sys.stderr.write(f"FakeClaude (system prompt): {e}\n")
-                all_messages.append(make_end_message(session_id, is_error=True))
-                _emit_jsonl(all_messages)
-                return 1
-
-    # Execute the stdin prompt
     try:
         messages, result = _dispatch_single_prompt(prompt, cwd, emit_streaming, plugin_dir=plugin_dir)
         all_messages.extend(messages)
@@ -278,8 +291,69 @@ def main(argv: list[str] | None = None) -> int:
 
     all_messages.append(make_end_message(session_id, result=end_result))
     _emit_jsonl(all_messages)
+    return None
 
-    return 0
+
+def main(argv: list[str] | None = None) -> int:
+    """Run FakeClaude: read prompt(s), dispatch directives, emit JSONL, write session file.
+
+    In ``--input-format stream-json`` mode (the standard main-agent path) one
+    invocation hosts many turns: it runs a full scripted cycle per user frame
+    read from stdin and exits 0 when stdin closes. The other input modes — a
+    ``-p <question>`` argument (e.g. /btw's forked invocation) or a plain piped
+    prompt — run a single cycle. This mirrors the real CLI, which lingers on
+    stdin between turns and exits only on EOF; single-frame usage is the
+    degenerate case where exactly one cycle runs before EOF.
+    """
+    _install_sigterm_handler()
+    parsed = _parse_args(argv)
+
+    emit_streaming = parsed.include_partial_messages
+    cwd = os.getcwd()
+    # FakeClaude handlers only inspect a single plugin_dir for testing. The real
+    # Claude CLI accepts multiple --plugin-dir flags (Sculptor passes one for the
+    # sculptor plugin and one for the sculptor-workflow plugin); we collapse to
+    # the first here since no handler actually reads multiple.
+    plugin_dir = parsed.plugin_dir[0] if parsed.plugin_dir else None
+    session_id = _get_session_id(parsed.resume)
+
+    # `--no-session-persistence` (used by /btw's forked invocation) means we
+    # must leave the resumed session file untouched and not write a new one.
+    if not parsed.no_session_persistence:
+        _write_session_file(session_id)
+
+    # fake_claude: directives embedded in the appended system prompt are a
+    # launch-time input, so they run once — on the first cycle only.
+    system_commands = _extract_fake_claude_commands(parsed.append_system_prompt) if parsed.append_system_prompt else []
+
+    # `-p <question>` carries the prompt on argv (e.g. the /btw forked
+    # invocation) — a single cycle, no stdin loop.
+    if isinstance(parsed.p_flag, str):
+        _maybe_delay_for_compact_indicator(parsed.p_flag, parsed.resume)
+        exit_code = _run_cycle(parsed.p_flag, session_id, cwd, emit_streaming, plugin_dir, system_commands)
+        return exit_code if exit_code is not None else 0
+
+    # Stream-json stdin (the standard main-agent path): one scripted cycle per
+    # user frame, exiting 0 when stdin closes.
+    if parsed.input_format == "stream-json":
+        is_first_cycle = True
+        while True:
+            prompt = _read_prompt_from_stream_json_stdin()
+            if prompt is None:
+                # stdin closed while idle between cycles — exit silently.
+                return 0
+            _maybe_delay_for_compact_indicator(prompt, parsed.resume)
+            cycle_system_commands = system_commands if is_first_cycle else []
+            exit_code = _run_cycle(prompt, session_id, cwd, emit_streaming, plugin_dir, cycle_system_commands)
+            if exit_code is not None:
+                return exit_code
+            is_first_cycle = False
+
+    # Non-stream-json single-shot: a plain piped prompt, or nothing on a tty.
+    prompt = html.unescape(sys.stdin.read()).strip() if not sys.stdin.isatty() else ""
+    _maybe_delay_for_compact_indicator(prompt, parsed.resume)
+    exit_code = _run_cycle(prompt, session_id, cwd, emit_streaming, plugin_dir, system_commands)
+    return exit_code if exit_code is not None else 0
 
 
 if __name__ == "__main__":

--- a/sculptor/sculptor/agents/testing/fake_claude.py
+++ b/sculptor/sculptor/agents/testing/fake_claude.py
@@ -199,9 +199,16 @@ def _read_prompt_from_stream_json_stdin() -> str | None:
     in-cycle handlers perform. Other non-user frames (context-usage requests,
     control responses, etc.) are ignored.
 
-    ``sys.stdin`` is its own iterator, so successive calls resume where the
-    previous one stopped and share one read buffer — reading a sequence of
-    frames across cycles neither drops nor reorders lines.
+    ``sys.stdin`` is its own iterator, so successive *between-cycle* reads
+    resume where the previous one stopped and share one read buffer: frames
+    delivered while FakeClaude is idle between cycles are neither dropped nor
+    reordered. That guarantee is scoped to idle delivery only. A frame written
+    while a cycle's handler is itself polling stdin can be consumed and
+    discarded by that handler before this reader ever sees it — ``_wait_until``
+    drops non-interrupt lines and the raw-fd ``_read_mcp_control_response_text``
+    drops non-matching lines (with the SCU-783 buffering interplay on top) — so
+    tests must not queue a follow-up frame mid-cycle. (Mid-cycle absorption is
+    SCU-1679's concern, not this reader's.)
     """
     for line in sys.stdin:
         line = line.strip()

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -683,9 +683,10 @@ def test_end_to_end_unknown_command_exits_with_error() -> None:
 
 # --- Multi-turn (borrowing-model) FakeClaude, driven directly over stdin ---
 #
-# In production each turn currently spawns a fresh process, so these behaviors
-# are latent capability that the Phase 1 borrowing model will drive; the tests
-# exercise them by feeding stdin directly, the way a lingering CLI is fed.
+# The multi-turn contract is a property of FakeClaude itself, independent of
+# whether a caller sends one frame per process or many. These tests assert it
+# directly by feeding stdin the way a lingering CLI is fed, rather than routing
+# through the process manager.
 
 
 def _user_frame(content: str) -> str:
@@ -784,7 +785,7 @@ def test_stream_json_single_frame_then_eof_runs_exactly_one_cycle() -> None:
 
 def test_stream_json_exits_silently_on_immediate_eof() -> None:
     """With no user frame at all, stdin closing makes FakeClaude exit 0 and emit
-    nothing — no spurious default-handler cycle (the pre-multi-turn behavior)."""
+    nothing, instead of synthesizing a default-handler cycle."""
     result = _run_fake_claude_stream_json("")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -701,12 +701,18 @@ def _user_frame(content: str) -> str:
 
 
 def _run_fake_claude_stream_json(
-    stdin_text: str, *, include_partial: bool = False, timeout: float = 30.0
+    stdin_text: str,
+    *,
+    include_partial: bool = False,
+    append_system_prompt: str | None = None,
+    home: Path | None = None,
+    timeout: float = 30.0,
 ) -> subprocess.CompletedProcess[str]:
     """Run FakeClaude in stream-json input mode, feeding ``stdin_text`` then EOF.
 
     ``subprocess.run(input=...)`` closes stdin after writing, so this exercises
-    the exit-on-EOF path once all frames are consumed.
+    the exit-on-EOF path once all frames are consumed. ``home`` pins ``$HOME``
+    so a test can inspect (or assert the absence of) the on-disk session file.
     """
     argv = [
         sys.executable,
@@ -720,12 +726,16 @@ def _run_fake_claude_stream_json(
     ]
     if include_partial:
         argv.append("--include-partial-messages")
+    if append_system_prompt is not None:
+        argv.extend(["--append-system-prompt", append_system_prompt])
+    env = {**os.environ, "HOME": str(home)} if home is not None else None
     return subprocess.run(
         argv,
         input=stdin_text,
         capture_output=True,
         text=True,
         cwd=str(Path(__file__).parents[3]),
+        env=env,
         timeout=timeout,
     )
 
@@ -789,6 +799,43 @@ def test_stream_json_exits_silently_on_immediate_eof() -> None:
     result = _run_fake_claude_stream_json("")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
+
+
+def test_stream_json_immediate_eof_writes_no_session_file(tmp_path: Path) -> None:
+    """The silent immediate-EOF exit touches no disk: the session history file
+    is deferred until a frame arrives, so a session that emits nothing leaves no
+    orphan file. A single real frame under the same pinned HOME does write one,
+    proving the negative assertion isn't vacuous."""
+    claude_dir = tmp_path / ".claude"
+
+    eof = _run_fake_claude_stream_json("", home=tmp_path)
+    assert eof.returncode == 0, eof.stderr
+    session_files = list(claude_dir.rglob("*.jsonl")) if claude_dir.exists() else []
+    assert session_files == []
+
+    framed = _run_fake_claude_stream_json(_user_frame('fake_claude:text `{"text": "hi"}`'), home=tmp_path)
+    assert framed.returncode == 0, framed.stderr
+    assert list(claude_dir.rglob("*.jsonl"))
+
+
+def test_stream_json_system_prompt_directives_run_once_on_first_cycle() -> None:
+    """fake_claude: directives in --append-system-prompt run on the first cycle
+    only (before that frame's own directives) — an appended system prompt is a
+    launch-time input, not a per-turn one — and do not repeat on later cycles."""
+    frames = [
+        _user_frame('fake_claude:text `{"text": "TURN1"}`'),
+        _user_frame('fake_claude:text `{"text": "TURN2"}`'),
+    ]
+    result = _run_fake_claude_stream_json(
+        "".join(frames),
+        append_system_prompt='fake_claude:text `{"text": "SYSTEM"}`',
+    )
+    assert result.returncode == 0, result.stderr
+
+    events = _top_level_events(result.stdout)
+    assistant_texts = [e["message"]["content"][0]["text"] for e in events if e.get("type") == "assistant"]
+    # SYSTEM runs exactly once, in the first cycle ahead of TURN1; TURN2's cycle has none.
+    assert assistant_texts == ["SYSTEM", "TURN1", "TURN2"]
 
 
 def test_stream_json_interrupt_between_cycles_exits_with_sigterm_code() -> None:

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -1,5 +1,6 @@
 """Unit tests for FakeClaude script."""
 
+import io
 import json
 import os
 import subprocess
@@ -10,6 +11,7 @@ from uuid import uuid4
 import pytest
 
 from sculptor.agents.testing.fake_claude import _parse_prompt
+from sculptor.agents.testing.fake_claude import _read_prompt_from_stream_json_stdin
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_response_text
 from sculptor.agents.testing.fake_claude_commands import handle_ask_user_question
 from sculptor.agents.testing.fake_claude_commands import handle_background_task_notification
@@ -34,6 +36,7 @@ from sculptor.agents.testing.fake_claude_jsonl import make_task_started_message
 from sculptor.agents.testing.fake_claude_jsonl import make_text_block
 from sculptor.agents.testing.fake_claude_jsonl import make_tool_result_message
 from sculptor.agents.testing.fake_claude_jsonl import make_tool_use_block
+from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_FROM_SIGTERM
 from sculptor.state.chat_state import TextBlock
 from sculptor.state.chat_state import ToolUseBlock
 from sculptor.state.claude_state import ParsedAssistantResponse
@@ -676,6 +679,175 @@ def test_end_to_end_unknown_command_exits_with_error() -> None:
         cwd=str(Path(__file__).parents[3]),
     )
     assert result.returncode == 1
+
+
+# --- Multi-turn (borrowing-model) FakeClaude, driven directly over stdin ---
+#
+# In production each turn currently spawns a fresh process, so these behaviors
+# are latent capability that the Phase 1 borrowing model will drive; the tests
+# exercise them by feeding stdin directly, the way a lingering CLI is fed.
+
+
+def _user_frame(content: str) -> str:
+    """Build one stream-json user frame line, matching the wrapper's stdin shape."""
+    message = {
+        "type": "user",
+        "session_id": "",
+        "message": {"role": "user", "content": content},
+        "parent_tool_use_id": None,
+    }
+    return json.dumps(message) + "\n"
+
+
+def _run_fake_claude_stream_json(
+    stdin_text: str, *, include_partial: bool = False, timeout: float = 30.0
+) -> subprocess.CompletedProcess[str]:
+    """Run FakeClaude in stream-json input mode, feeding ``stdin_text`` then EOF.
+
+    ``subprocess.run(input=...)`` closes stdin after writing, so this exercises
+    the exit-on-EOF path once all frames are consumed.
+    """
+    argv = [
+        sys.executable,
+        "-m",
+        "sculptor.agents.testing.fake_claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--input-format",
+        "stream-json",
+    ]
+    if include_partial:
+        argv.append("--include-partial-messages")
+    return subprocess.run(
+        argv,
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[3]),
+        timeout=timeout,
+    )
+
+
+def _top_level_events(stdout: str) -> list[dict]:
+    """Parse stdout JSONL, dropping streaming stream_event lines."""
+    events = [json.loads(line) for line in stdout.splitlines() if line.strip()]
+    return [e for e in events if e.get("type") != "stream_event"]
+
+
+@pytest.mark.parametrize("include_partial", [False, True])
+def test_stream_json_hosts_multiple_turns_in_one_process(include_partial: bool) -> None:
+    """Three user frames on one stdin drive three scripted cycles in one process,
+    each bracketed by its own init/result and honoring its own frame's directive."""
+    frames = [
+        _user_frame('fake_claude:text `{"text": "First turn."}`'),
+        _user_frame('fake_claude:text `{"text": "Second turn."}`'),
+        _user_frame('fake_claude:text `{"text": "Third turn."}`'),
+    ]
+    result = _run_fake_claude_stream_json("".join(frames), include_partial=include_partial)
+    assert result.returncode == 0, result.stderr
+
+    events = _top_level_events(result.stdout)
+    kinds = [(e.get("type"), e.get("subtype", "")) for e in events]
+    # Exactly one init → assistant → result bracket per cycle, three cycles.
+    assert (
+        kinds
+        == [
+            ("system", "init"),
+            ("assistant", ""),
+            ("result", "success"),
+        ]
+        * 3
+    )
+
+    # Each cycle honored its own frame's directive, in order.
+    assistant_texts = [e["message"]["content"][0]["text"] for e in events if e.get("type") == "assistant"]
+    assert assistant_texts == ["First turn.", "Second turn.", "Third turn."]
+
+    # One session per process: every cycle's init reports the same session id.
+    init_session_ids = {e["session_id"] for e in events if e.get("subtype") == "init"}
+    assert len(init_session_ids) == 1
+
+
+def test_stream_json_single_frame_then_eof_runs_exactly_one_cycle() -> None:
+    """A single frame followed by EOF runs one cycle and nothing more — the loop
+    does not synthesize an extra default-handler turn when stdin closes."""
+    result = _run_fake_claude_stream_json(_user_frame('fake_claude:text `{"text": "Only turn."}`'))
+    assert result.returncode == 0, result.stderr
+
+    events = _top_level_events(result.stdout)
+    assert [e.get("subtype") for e in events if e.get("type") == "system"] == ["init"]
+    assert len([e for e in events if e.get("type") == "result"]) == 1
+    assistant_texts = [e["message"]["content"][0]["text"] for e in events if e.get("type") == "assistant"]
+    assert assistant_texts == ["Only turn."]
+
+
+def test_stream_json_exits_silently_on_immediate_eof() -> None:
+    """With no user frame at all, stdin closing makes FakeClaude exit 0 and emit
+    nothing — no spurious default-handler cycle (the pre-multi-turn behavior)."""
+    result = _run_fake_claude_stream_json("")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_stream_json_interrupt_between_cycles_exits_with_sigterm_code() -> None:
+    """An interrupt control_request arriving while idle between cycles tears the
+    process down gracefully (SIGTERM exit code) after the completed cycle."""
+    interrupt = (
+        json.dumps({"type": "control_request", "request_id": "req_x", "request": {"subtype": "interrupt"}}) + "\n"
+    )
+    result = _run_fake_claude_stream_json(_user_frame('fake_claude:text `{"text": "One turn."}`') + interrupt)
+    assert result.returncode == AGENT_EXIT_CODE_FROM_SIGTERM, result.stderr
+
+    events = _top_level_events(result.stdout)
+    # The first cycle completed before the interrupt was read; no second cycle began.
+    assert len([e for e in events if e.get("subtype") == "init"]) == 1
+    assert len([e for e in events if e.get("type") == "result"]) == 1
+
+
+def test_read_prompt_returns_none_on_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+    """EOF (empty stdin) yields None so the caller exits instead of running the
+    default handler for a turn the user never sent."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    assert _read_prompt_from_stream_json_stdin() is None
+
+
+def test_read_prompt_returns_empty_string_for_empty_content_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit empty-content user frame is distinct from EOF: it returns ""
+    so the default handler still runs for a genuinely empty prompt."""
+    frame = json.dumps({"type": "user", "message": {"role": "user", "content": ""}}) + "\n"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(frame))
+    assert _read_prompt_from_stream_json_stdin() == ""
+
+
+def test_read_prompt_returns_content_for_user_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    frame = json.dumps({"type": "user", "message": {"role": "user", "content": "hello there"}}) + "\n"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(frame))
+    assert _read_prompt_from_stream_json_stdin() == "hello there"
+
+
+def test_read_prompt_skips_non_user_frames_until_user_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-user frames (control responses, context-usage requests) are ignored
+    while scanning for the next user frame."""
+    lines = (
+        json.dumps({"type": "control_response", "response": {"request_id": "ctx_1"}})
+        + "\n"
+        + json.dumps({"type": "control_request", "request_id": "c", "request": {"subtype": "get_context_usage"}})
+        + "\n"
+        + json.dumps({"type": "user", "message": {"role": "user", "content": "actual prompt"}})
+        + "\n"
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(lines))
+    assert _read_prompt_from_stream_json_stdin() == "actual prompt"
+
+
+def test_read_prompt_exits_on_idle_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An interrupt control_request read between cycles exits with the SIGTERM code."""
+    frame = json.dumps({"type": "control_request", "request_id": "r", "request": {"subtype": "interrupt"}}) + "\n"
+    monkeypatch.setattr(sys, "stdin", io.StringIO(frame))
+    with pytest.raises(SystemExit) as exc_info:
+        _read_prompt_from_stream_json_stdin()
+    assert exc_info.value.code == AGENT_EXIT_CODE_FROM_SIGTERM
 
 
 def test_determinism_same_output_for_same_input() -> None:


### PR DESCRIPTION
## What

Phase 0 groundwork for the in-turn-messages epic (SCU-1678). FakeClaude previously read one user frame, ran a single `init → … → result` cycle, and exited. The epic's "borrowing model" needs one invocation to host many turns on a lingering stdin, like the real Claude CLI.

## Changes

- **Multi-turn in stream-json mode.** `main()` is restructured around a per-cycle helper. In `--input-format stream-json` mode it now loops: one full scripted `init → messages → result` cycle per user frame read from stdin, each honoring its own frame's `fake_claude:` directives, with a fresh `init` per cycle (the shape Sculptor's output processor already expects per turn). All cycles in one process share one session id.
- **Exit on stdin EOF.** When stdin closes between cycles, FakeClaude exits 0 and emits nothing further. Previously an EOF fell through to the default handler and emitted a spurious response for a turn the user never sent.
- **`-p <arg>` and plain-stdin modes stay single-cycle**, unchanged.
- **`--append-system-prompt` directives run once** (first cycle only), since an appended system prompt is a launch-time input, not a per-turn one.
- **Idle-between-cycles interrupt** now exits gracefully with the SIGTERM exit code (mirroring the in-cycle handlers).

Single-frame usage is the degenerate case (one cycle, then EOF), so existing FakeClaude-based tests are unaffected. In production each turn still spawns a fresh process, so multi-turn is latent capability that Phase 1 will drive; the new tests exercise it by feeding stdin directly.

## Tests

- New direct tests: ≥3 cycles through one process, single-frame-then-EOF, immediate-EOF-silent-exit, idle-interrupt, and `_read_prompt_*` unit cases.
- `just format` / `just check` / `just test-unit` all green (backend 2099 passed, frontend 2671, foundation 129, sculpt 277).
- Integration spot-checks: `test_interrupt_and_continue.py` (6 passed) and `test_alpha_chat_auto_bg_bash.py` + `test_alpha_chat_subagent.py` (3 passed).

Design decisions, and the places this goes slightly beyond the ticket's literal behavior scenarios (e.g. idle-interrupt handling), are documented in the closing comment on SCU-1678 so they flow back to the epic rather than getting buried here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
