### PR TITLE
Mobile: rename & delete agents and workspaces

### DIFF
--- a/sculptor/frontend/src/pages/workspace/mobile/AgentSheet.module.scss
+++ b/sculptor/frontend/src/pages/workspace/mobile/AgentSheet.module.scss
@@ -64,7 +64,27 @@
   min-height: 48px;
   padding: var(--space-2) var(--space-3);
   text-align: left;
+  // Long-press opens the row menu; suppress the browser's text selection.
+  user-select: none;
   width: 100%;
+}
+
+// Wraps a row + the invisible menu anchor so the long-press menu opens at the
+// row's start rather than tracking the finger.
+.rowWrap {
+  position: relative;
+}
+
+.menuAnchor {
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+// Inline rename field — match the row name's size so the row doesn't shift.
+.renameInput {
+  color: var(--mobile-ink);
+  font-size: var(--font-size-2);
 }
 
 .row:hover,

--- a/sculptor/frontend/src/pages/workspace/mobile/AgentSheet.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/AgentSheet.tsx
@@ -1,17 +1,23 @@
-import { useAtomValue } from "jotai";
-import { Check, Plus } from "lucide-react";
+import { DropdownMenu } from "@radix-ui/themes";
+import { useAtomValue, useSetAtom } from "jotai";
+import { Check, Pencil, Plus, Trash2 } from "lucide-react";
 import type { ReactElement } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
+import { type CodingAgentTaskView, renameWorkspaceAgent } from "~/api";
 import { formatRelativeTime } from "~/common/formatRelativeTime.ts";
 import { useImbueNavigate, useWorkspacePageParams } from "~/common/NavigateUtils.ts";
-import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
+import { tasksArrayAtom, updateTasksAtom } from "~/common/state/atoms/tasks.ts";
+import { useOptimisticTaskDelete } from "~/common/state/hooks/useOptimisticTaskDelete.ts";
 import { useWorkspace } from "~/common/state/hooks/useWorkspace.ts";
+import { DeleteConfirmationDialog } from "~/components/DeleteConfirmationDialog.tsx";
+import { InlineRenameInput } from "~/components/InlineRenameInput.tsx";
 import { AgentStatusDot } from "~/components/statusDot/StatusDot.tsx";
 import { type AgentDotStatus, getAgentDotStatus } from "~/components/statusDot/statusUtils.ts";
 
 import styles from "./AgentSheet.module.scss";
 import { useCreateAgent } from "./useCreateAgent.ts";
+import { useLongPress } from "./useLongPress.ts";
 
 type AgentSheetProps = {
   isOpen: boolean;
@@ -33,12 +39,111 @@ const subLabel = (status: AgentDotStatus, updatedAt: string): string => {
   }
 };
 
+/** One agent row. Tap selects; long-press (or right-click) opens a menu anchored
+ * to the row's start with Rename / Delete. */
+const AgentRow = ({
+  agent,
+  isCurrent,
+  workspaceID,
+  onSelect,
+  onRequestDelete,
+}: {
+  agent: CodingAgentTaskView;
+  isCurrent: boolean;
+  workspaceID: string;
+  onSelect: () => void;
+  onRequestDelete: (agent: CodingAgentTaskView) => void;
+}): ReactElement => {
+  const dotStatus = getAgentDotStatus(agent.status, agent.lastReadAt, agent.updatedAt);
+  const updateTasks = useSetAtom(updateTasksAtom);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { handlers: longPress, consumeClick } = useLongPress(() => setIsMenuOpen(true));
+
+  const handleRenameCommit = async (newName: string): Promise<void> => {
+    setIsRenaming(false);
+    try {
+      const response = await renameWorkspaceAgent({
+        path: { workspace_id: workspaceID, agent_id: agent.id },
+        body: { title: newName },
+      });
+      if (response.data) {
+        updateTasks({ [agent.id]: response.data });
+      }
+    } catch (error) {
+      console.error("Failed to rename agent:", error);
+    }
+  };
+
+  const handleClick = (): void => {
+    if (consumeClick()) return;
+    onSelect();
+  };
+
+  const dot = (
+    <span className={styles.dot}>
+      <AgentStatusDot status={dotStatus} size={8} />
+    </span>
+  );
+
+  if (isRenaming) {
+    return (
+      <div className={`${styles.row} ${isCurrent ? styles.current : ""}`}>
+        {dot}
+        <span className={styles.info}>
+          <InlineRenameInput
+            value={agent.title ?? ""}
+            onCommit={(newName) => void handleRenameCommit(newName)}
+            onCancel={() => setIsRenaming(false)}
+            isEditing={true}
+            className={styles.renameInput}
+          />
+          <span className={styles.sub}>{subLabel(dotStatus, agent.updatedAt)}</span>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.rowWrap}>
+      <DropdownMenu.Root open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+        <DropdownMenu.Trigger>
+          <span className={styles.menuAnchor} aria-hidden="true" />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="start" side="bottom" variant="soft" className="mobileTheme">
+          <DropdownMenu.Item onSelect={() => setIsRenaming(true)}>
+            <Pencil size={16} /> Rename
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item color="red" onSelect={() => onRequestDelete(agent)}>
+            <Trash2 size={16} /> Delete agent
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      <button
+        type="button"
+        className={`${styles.row} ${isCurrent ? styles.current : ""}`}
+        aria-current={isCurrent}
+        onClick={handleClick}
+        {...longPress}
+      >
+        {dot}
+        <span className={styles.info}>
+          <span className={styles.name}>{agent.titleOrSomethingLikeIt?.trim() || "Agent"}</span>
+          <span className={styles.sub}>{subLabel(dotStatus, agent.updatedAt)}</span>
+        </span>
+        {isCurrent ? <Check size={16} className={styles.check} /> : null}
+      </button>
+    </div>
+  );
+};
+
 /**
  * AgentSheet — the bottom drawer half of the agent switcher (Variant D). Lists
  * every agent in the workspace with a status dot + last-activity line, the
  * active one checked, and a "New agent" row at the bottom. The shell owns the
  * dimmed backdrop and the open state (mirrors WorkspaceDrawer); selecting a row
- * closes the sheet and navigates.
+ * closes the sheet and navigates. Long-press a row to rename or delete it.
  */
 export const AgentSheet = ({ isOpen, onClose }: AgentSheetProps): ReactElement => {
   const { workspaceID, agentID } = useWorkspacePageParams();
@@ -57,37 +162,50 @@ export const AgentSheet = ({ isOpen, onClose }: AgentSheetProps): ReactElement =
 
   const workspaceName = workspace?.description?.trim() || "this workspace";
 
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const { execute: executeDelete } = useOptimisticTaskDelete({
+    workspaceId: workspaceID ?? "",
+    onNavigateAfterDelete: (deletedId: string): void => {
+      // If the currently-viewed agent was deleted, hop to another one in the
+      // workspace (deleting any other just drops it from the list).
+      if (deletedId === agentID) {
+        const next = agents.find((a) => a.id !== deletedId);
+        onClose();
+        if (next) {
+          navigateToAgent(workspaceID ?? "", next.id);
+        }
+      }
+    },
+  });
+  const handleRequestDelete = (agent: CodingAgentTaskView): void => {
+    setDeleteTarget({ id: agent.id, name: agent.titleOrSomethingLikeIt?.trim() || "Agent" });
+  };
+
+  const handleDeleteConfirm = (): void => {
+    if (!deleteTarget) return;
+    executeDelete(deleteTarget.id, deleteTarget.name);
+    setDeleteTarget(null);
+  };
+
   return (
     <aside className={`${styles.sheet} ${isOpen ? styles.open : ""}`} aria-hidden={!isOpen}>
       <div className={styles.handle} />
       <div className={styles.title}>Agents in {workspaceName}</div>
 
       <div className={styles.list}>
-        {agents.map((agent) => {
-          const isCurrent = agent.id === agentID;
-          const dotStatus = getAgentDotStatus(agent.status, agent.lastReadAt, agent.updatedAt);
-          return (
-            <button
-              key={agent.id}
-              type="button"
-              className={`${styles.row} ${isCurrent ? styles.current : ""}`}
-              aria-current={isCurrent}
-              onClick={() => {
-                onClose();
-                navigateToAgent(workspaceID, agent.id);
-              }}
-            >
-              <span className={styles.dot}>
-                <AgentStatusDot status={dotStatus} size={8} />
-              </span>
-              <span className={styles.info}>
-                <span className={styles.name}>{agent.titleOrSomethingLikeIt?.trim() || "Agent"}</span>
-                <span className={styles.sub}>{subLabel(dotStatus, agent.updatedAt)}</span>
-              </span>
-              {isCurrent ? <Check size={16} className={styles.check} /> : null}
-            </button>
-          );
-        })}
+        {agents.map((agent) => (
+          <AgentRow
+            key={agent.id}
+            agent={agent}
+            isCurrent={agent.id === agentID}
+            workspaceID={workspaceID ?? ""}
+            onSelect={() => {
+              onClose();
+              navigateToAgent(workspaceID ?? "", agent.id);
+            }}
+            onRequestDelete={handleRequestDelete}
+          />
+        ))}
       </div>
 
       <div className={styles.separator} />
@@ -104,6 +222,16 @@ export const AgentSheet = ({ isOpen, onClose }: AgentSheetProps): ReactElement =
         </span>
         New agent
       </button>
+
+      <DeleteConfirmationDialog
+        isOpen={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        entityType="agent"
+        entityName={deleteTarget?.name ?? ""}
+        onConfirm={handleDeleteConfirm}
+      />
     </aside>
   );
 };

--- a/sculptor/frontend/src/pages/workspace/mobile/MobileWorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/MobileWorkspaceHeader.tsx
@@ -1,7 +1,9 @@
-import { DropdownMenu, IconButton } from "@radix-ui/themes";
-import { Ellipsis, Layers, Plus, Settings, SquareMenu, Terminal } from "lucide-react";
+import { Button, Dialog, DropdownMenu, Flex, IconButton, TextField } from "@radix-ui/themes";
+import { Ellipsis, Layers, Pencil, Plus, Settings, SquareMenu, Terminal } from "lucide-react";
 import type { ReactElement } from "react";
+import { useState } from "react";
 
+import { updateWorkspace } from "~/api";
 import { useImbueNavigate, useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { useWorkspace } from "~/common/state/hooks/useWorkspace.ts";
 
@@ -31,8 +33,26 @@ export const MobileWorkspaceHeader = ({
   const workspace = useWorkspace(workspaceID);
   const { filesChanged } = useMobileChangeSummary(workspaceID);
   const { createAgent } = useCreateAgent();
+  const [isRenameOpen, setIsRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
 
   const workspaceName = workspace?.description?.trim() || "Workspace";
+
+  const openRename = (): void => {
+    setRenameValue(workspace?.description ?? "");
+    setIsRenameOpen(true);
+  };
+
+  const handleRenameSave = async (): Promise<void> => {
+    const trimmed = renameValue.trim();
+    setIsRenameOpen(false);
+    if (!workspaceID || !trimmed || trimmed === workspace?.description) return;
+    try {
+      await updateWorkspace({ path: { workspace_id: workspaceID }, body: { description: trimmed } });
+    } catch (error) {
+      console.error("Failed to rename workspace:", error);
+    }
+  };
 
   return (
     <header className={styles.header}>
@@ -71,11 +91,43 @@ export const MobileWorkspaceHeader = ({
             <Terminal size={16} /> Open terminal
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
+          <DropdownMenu.Item onSelect={openRename}>
+            <Pencil size={16} /> Rename workspace
+          </DropdownMenu.Item>
           <DropdownMenu.Item onSelect={() => navigateToGlobalSettings()}>
             <Settings size={16} /> Workspace settings
           </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Root>
+
+      {/* A dialog (not an inline field) because the header sits next to the chat
+          editor, which would otherwise reclaim the soft keyboard on mobile; a
+          modal traps focus so the rename field keeps it. */}
+      <Dialog.Root open={isRenameOpen} onOpenChange={setIsRenameOpen}>
+        <Dialog.Content maxWidth="400px" className="mobileTheme">
+          <Dialog.Title>Rename workspace</Dialog.Title>
+          <TextField.Root
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleRenameSave();
+              }
+            }}
+            placeholder="Workspace name"
+            aria-label="Workspace name"
+          />
+          <Flex gap="3" mt="4" justify="end">
+            <Dialog.Close>
+              <Button variant="soft" color="gray">
+                Cancel
+              </Button>
+            </Dialog.Close>
+            <Button onClick={() => void handleRenameSave()}>Save</Button>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
     </header>
   );
 };

--- a/sculptor/frontend/src/pages/workspace/mobile/WorkspaceDrawer.module.scss
+++ b/sculptor/frontend/src/pages/workspace/mobile/WorkspaceDrawer.module.scss
@@ -151,7 +151,23 @@
   min-height: 44px;
   padding: var(--space-2) var(--space-3) var(--space-2) calc(var(--space-3) + var(--space-4));
   text-align: left;
+  // Long-press opens the context menu; without this the browser also starts a
+  // text selection on the row label. (The rename input is exempt — inputs stay
+  // editable regardless of an ancestor's user-select.)
+  user-select: none;
   width: 100%;
+}
+
+// Wraps a row + the invisible menu anchor so the long-press menu opens at the
+// row's start rather than tracking the finger.
+.rowWrap {
+  position: relative;
+}
+
+.menuAnchor {
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
 }
 
 .workspaceRow:hover,
@@ -177,6 +193,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+// The inline rename input reuses InlineRenameInput's base look; match the row's
+// name typography so swapping in the field doesn't shift the row.
+.renameInput {
+  color: var(--mobile-ink);
+  font-size: var(--font-size-3);
 }
 
 .workspaceBranch {

--- a/sculptor/frontend/src/pages/workspace/mobile/WorkspaceDrawer.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/WorkspaceDrawer.tsx
@@ -1,18 +1,23 @@
+import { DropdownMenu } from "@radix-ui/themes";
 import { useAtomValue } from "jotai";
-import { ChevronDown, Folder, FolderPlus, House, Plus, Settings } from "lucide-react";
+import { ChevronDown, Folder, FolderPlus, House, Pencil, Plus, Settings, Trash2 } from "lucide-react";
 import type { ReactElement } from "react";
 import { useMemo, useState } from "react";
 
-import type { Workspace } from "~/api";
+import { updateWorkspace, type Workspace } from "~/api";
 import { useImbueLocation, useImbueNavigate } from "~/common/NavigateUtils.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { userEmailAtom } from "~/common/state/atoms/userConfig.ts";
 import { workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
+import { useOptimisticWorkspaceDelete } from "~/common/state/hooks/useOptimisticWorkspaceDelete.ts";
 import { useProject } from "~/common/state/hooks/useProjects.ts";
 import { useWorkspaceBranch } from "~/common/state/hooks/useWorkspaceBranch.ts";
+import { DeleteConfirmationDialog } from "~/components/DeleteConfirmationDialog.tsx";
+import { InlineRenameInput } from "~/components/InlineRenameInput.tsx";
 import { WorkspaceStatusDots } from "~/components/statusDot/StatusDot.tsx";
 import { computeWorkspaceDotStatus } from "~/components/statusDot/statusUtils.ts";
 
+import { useLongPress } from "./useLongPress.ts";
 import styles from "./WorkspaceDrawer.module.scss";
 
 type WorkspaceDrawerProps = {
@@ -30,15 +35,18 @@ function getInitials(email: string | undefined): string {
   return local.slice(0, 2).toUpperCase() || "?";
 }
 
-/** One workspace row — owns its branch lookup + status dot, like the desktop row. */
+/** One workspace row — owns its branch lookup + status dot, like the desktop row.
+ * Long-press (or right-click) opens a context menu to rename or delete. */
 const DrawerWorkspaceRow = ({
   workspace,
   isCurrent,
   onSelect,
+  onRequestDelete,
 }: {
   workspace: Workspace;
   isCurrent: boolean;
   onSelect: () => void;
+  onRequestDelete: (workspace: Workspace) => void;
 }): ReactElement => {
   const tasks = useAtomValue(tasksArrayAtom);
   const branchInfo = useWorkspaceBranch(workspace.objectId);
@@ -47,22 +55,83 @@ const DrawerWorkspaceRow = ({
     [tasks, workspace.objectId],
   );
   const branch = branchInfo?.currentBranch ?? workspace.sourceBranch ?? "";
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { handlers: longPress, consumeClick } = useLongPress(() => setIsMenuOpen(true));
+
+  const handleRenameCommit = async (newName: string): Promise<void> => {
+    setIsRenaming(false);
+    try {
+      await updateWorkspace({ path: { workspace_id: workspace.objectId }, body: { description: newName } });
+    } catch (error) {
+      console.error("Failed to rename workspace:", error);
+    }
+  };
+
+  const handleClick = (): void => {
+    if (consumeClick()) return;
+    onSelect();
+  };
+
+  const dot = (
+    <span className={styles.workspaceDot}>
+      <WorkspaceStatusDots status={dotStatus} size={8} />
+    </span>
+  );
+
+  // While renaming, the row is a plain container (not a button) so the input
+  // owns its own tap/typing without the row's select handler interfering.
+  if (isRenaming) {
+    return (
+      <div className={`${styles.workspaceRow} ${isCurrent ? styles.current : ""}`}>
+        {dot}
+        <span className={styles.workspaceInfo}>
+          <InlineRenameInput
+            value={workspace.description ?? ""}
+            onCommit={(newName) => void handleRenameCommit(newName)}
+            onCancel={() => setIsRenaming(false)}
+            isEditing={true}
+            className={styles.renameInput}
+          />
+          {branch ? <span className={styles.workspaceBranch}>{branch}</span> : null}
+        </span>
+      </div>
+    );
+  }
 
   return (
-    <button
-      type="button"
-      className={`${styles.workspaceRow} ${isCurrent ? styles.current : ""}`}
-      onClick={onSelect}
-      aria-current={isCurrent}
-    >
-      <span className={styles.workspaceDot}>
-        <WorkspaceStatusDots status={dotStatus} size={8} />
-      </span>
-      <span className={styles.workspaceInfo}>
-        <span className={styles.workspaceName}>{workspace.description?.trim() || "Workspace"}</span>
-        {branch ? <span className={styles.workspaceBranch}>{branch}</span> : null}
-      </span>
-    </button>
+    <div className={styles.rowWrap}>
+      {/* Long-press opens this menu anchored to the row's start (not the finger).
+          The trigger is an invisible full-row anchor; opening is driven by the
+          long-press handler on the button below, never by tapping the anchor. */}
+      <DropdownMenu.Root open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+        <DropdownMenu.Trigger>
+          <span className={styles.menuAnchor} aria-hidden="true" />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="start" side="bottom" variant="soft" className="mobileTheme">
+          <DropdownMenu.Item onSelect={() => setIsRenaming(true)}>
+            <Pencil size={16} /> Rename
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item color="red" onSelect={() => onRequestDelete(workspace)}>
+            <Trash2 size={16} /> Delete workspace
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      <button
+        type="button"
+        className={`${styles.workspaceRow} ${isCurrent ? styles.current : ""}`}
+        onClick={handleClick}
+        aria-current={isCurrent}
+        {...longPress}
+      >
+        {dot}
+        <span className={styles.workspaceInfo}>
+          <span className={styles.workspaceName}>{workspace.description?.trim() || "Workspace"}</span>
+          {branch ? <span className={styles.workspaceBranch}>{branch}</span> : null}
+        </span>
+      </button>
+    </div>
   );
 };
 
@@ -72,12 +141,14 @@ const DrawerRepoGroup = ({
   workspaces,
   currentWorkspaceID,
   onSelect,
+  onRequestDelete,
   defaultExpanded,
 }: {
   projectId: string;
   workspaces: ReadonlyArray<Workspace>;
   currentWorkspaceID: string;
   onSelect: (id: string) => void;
+  onRequestDelete: (workspace: Workspace) => void;
   defaultExpanded: boolean;
 }): ReactElement => {
   const project = useProject(projectId);
@@ -103,6 +174,7 @@ const DrawerRepoGroup = ({
               workspace={ws}
               isCurrent={ws.objectId === currentWorkspaceID}
               onSelect={() => onSelect(ws.objectId)}
+              onRequestDelete={onRequestDelete}
             />
           ))
         : null}
@@ -140,6 +212,27 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
   const handleSelect = (id: string): void => {
     onClose();
     navigateToWorkspace(id);
+  };
+
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const { execute: executeDelete } = useOptimisticWorkspaceDelete({
+    onNavigateAfterDelete: (deletedId: string): void => {
+      // Only the currently-viewed workspace's deletion strands the view — send
+      // it home. Deleting any other workspace just drops it from the list.
+      if (deletedId === workspaceID) {
+        onClose();
+        navigateToHome();
+      }
+    },
+  });
+  const handleRequestDelete = (ws: Workspace): void => {
+    setDeleteTarget({ id: ws.objectId, name: ws.description?.trim() || "Workspace" });
+  };
+
+  const handleDeleteConfirm = (): void => {
+    if (!deleteTarget) return;
+    executeDelete(deleteTarget.id, deleteTarget.name);
+    setDeleteTarget(null);
   };
 
   return (
@@ -189,6 +282,7 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
               workspaces={wsList}
               currentWorkspaceID={workspaceID}
               onSelect={handleSelect}
+              onRequestDelete={handleRequestDelete}
               defaultExpanded={wsList.some((ws) => ws.objectId === workspaceID) || groups.length === 1}
             />
           ))
@@ -205,6 +299,16 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
       >
         <Plus size={18} /> New workspace
       </button>
+
+      <DeleteConfirmationDialog
+        isOpen={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        entityType="workspace"
+        entityName={deleteTarget?.name ?? ""}
+        onConfirm={handleDeleteConfirm}
+      />
     </aside>
   );
 };

--- a/sculptor/frontend/src/pages/workspace/mobile/useLongPress.ts
+++ b/sculptor/frontend/src/pages/workspace/mobile/useLongPress.ts
@@ -1,0 +1,82 @@
+import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } from "react";
+import { useCallback, useRef } from "react";
+
+const LONG_PRESS_MS = 450;
+// Ignore tiny finger jitter; a real scroll (> this many px) cancels the press.
+const MOVE_CANCEL_PX = 10;
+
+type LongPressHandlers = {
+  onTouchStart: (e: ReactTouchEvent) => void;
+  onTouchMove: (e: ReactTouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchCancel: () => void;
+  onContextMenu: (e: ReactMouseEvent) => void;
+};
+
+/**
+ * Detect a long-press (touch hold) or right-click and invoke `onLongPress`.
+ * Returns handlers to spread on the target, plus `consumeClick`: the target's
+ * onClick must call it FIRST — it returns true (and resets) when the click is
+ * the tail end of a long-press, so the caller skips its normal tap action.
+ */
+export const useLongPress = (onLongPress: () => void): { handlers: LongPressHandlers; consumeClick: () => boolean } => {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+  const firedRef = useRef(false);
+
+  const cancel = useCallback((): void => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const onTouchStart = useCallback(
+    (e: ReactTouchEvent): void => {
+      firedRef.current = false;
+      const touch = e.touches[0];
+      startPosRef.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+      cancel();
+      timerRef.current = setTimeout(() => {
+        firedRef.current = true;
+        onLongPress();
+      }, LONG_PRESS_MS);
+    },
+    [cancel, onLongPress],
+  );
+
+  const onTouchMove = useCallback(
+    (e: ReactTouchEvent): void => {
+      const touch = e.touches[0];
+      const start = startPosRef.current;
+      if (touch && start && Math.hypot(touch.clientX - start.x, touch.clientY - start.y) > MOVE_CANCEL_PX) {
+        cancel();
+      }
+    },
+    [cancel],
+  );
+
+  const onContextMenu = useCallback(
+    (e: ReactMouseEvent): void => {
+      // Desktop right-click / any browser long-press that still fires contextmenu:
+      // suppress the native menu and open ours instead.
+      e.preventDefault();
+      firedRef.current = true;
+      onLongPress();
+    },
+    [onLongPress],
+  );
+
+  const consumeClick = useCallback((): boolean => {
+    if (firedRef.current) {
+      firedRef.current = false;
+      return true;
+    }
+    return false;
+  }, []);
+
+  return {
+    handlers: { onTouchStart, onTouchMove, onTouchEnd: cancel, onTouchCancel: cancel, onContextMenu },
+    consumeClick,
+  };
+};


### PR DESCRIPTION
## Summary

Adds the ability to **rename and delete agents and workspaces from the mobile UI**.
Desktop does this by double-clicking a tab (`AgentTabs` / `WorkspaceTabs`), but
those aren't rendered in the mobile shell, so mobile had no affordance. This wires
mobile controls to the **existing** backend mutations — no backend changes.

## What's included

**Workspace rename (header)** — the workspace header's ⋮ menu gains **"Rename
workspace"**, which opens a small focus-trapped dialog with a text field. A modal
(rather than an inline field) because the header sits next to the chat editor,
which would otherwise reclaim the soft keyboard on mobile.

**Row menus (workspace drawer + agent sheet)** — **long-press** (or right-click) a
workspace-drawer row or an agent-sheet row to open a menu, anchored to the row's
start, with:
- **Rename** — inline edit in the row.
- **Delete** — a confirmation dialog, then optimistic delete with rollback-on-error.
  Deleting the current workspace navigates Home; deleting the current agent hops to
  another agent in the workspace.

**Shared `useLongPress` hook** — hold detection with a movement threshold (so
scrolling doesn't cancel it) and right-click support, plus a `consumeClick` guard
so the tap that ends a long-press doesn't also select the row. The menu is a
`DropdownMenu` anchored to an invisible full-row element, so it opens at the row's
start instead of tracking the finger.

Reuses `InlineRenameInput`, `updateWorkspace`, `renameWorkspaceAgent`,
`DeleteConfirmationDialog`, `useOptimisticWorkspaceDelete`, and
`useOptimisticTaskDelete`.

## Testing

Type-check, eslint, and stylelint pass. Verified on device via the live mobile
preview: workspace rename (header dialog + drawer), agent rename, workspace/agent
delete, and the long-press menu (anchored, no stray text selection).

(Sent by Claude)
