### PR TITLE
sculpt plugin: renderer base paths + structured error codes

### DIFF
--- a/sculptor/frontend/src/plugins/rendererIdentity.ts
+++ b/sculptor/frontend/src/plugins/rendererIdentity.ts
@@ -39,9 +39,16 @@ export const getRendererId = (): string => {
  * the WebSocket), and `origin` is the page origin — which determines the
  * localStorage domain, so two renderers on different origins can legitimately
  * hold different plugin state.
+ *
+ * `base` is the bundle's compiled base path ("/" normally; "/proxy/<port>/"
+ * when served by an OpenHost preview dev server). Origin alone cannot tell
+ * those windows apart — previews share the deployed app's origin by design —
+ * so the base is what lets `sculpt plugin list` name which bundle a window
+ * is actually running.
  */
 export const getRendererIdentity = (): RendererIdentity => ({
   rendererId: getRendererId(),
   environment: isElectron() ? "electron" : "browser",
   origin: window.location.origin,
+  base: import.meta.env.BASE_URL || "/",
 });

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -895,11 +895,19 @@ class RendererIdentity(SerializableModel):
     from sniffing the WebSocket handshake. ``origin`` is ``window.location``'s
     origin, which determines the localStorage domain — two renderers on
     different origins can legitimately hold different plugin state.
+
+    ``base`` is the bundle's base path within that origin ("/" for the deployed
+    app; the OpenHost preview front serves dev bundles under "/proxy/<port>/").
+    Origin alone cannot distinguish those windows — sharing an origin is exactly
+    what makes the preview setup work — so tooling needs the base to tell a
+    preview window from the deployed app. Optional: bundles built before this
+    field simply don't report it.
     """
 
     renderer_id: str
     environment: Literal["electron", "browser"]
     origin: str
+    base: str | None = None
 
 
 class PluginRegistrations(SerializableModel):

--- a/tools/sculpt/sculpt/commands/data_types.py
+++ b/tools/sculpt/sculpt/commands/data_types.py
@@ -192,3 +192,7 @@ class ErrorOutput(BaseModel):
 
     error: str = Field(description="Error message")
     detail: str = Field(description="Additional detail (may be empty)")
+    code: str | None = Field(
+        default=None,
+        description="Machine-readable error code when the failure has one (e.g. from the backend), else null",
+    )

--- a/tools/sculpt/sculpt/commands/plugin.py
+++ b/tools/sculpt/sculpt/commands/plugin.py
@@ -19,6 +19,7 @@ import os
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
+from typing import NoReturn
 from urllib.parse import urlparse
 
 import httpx
@@ -173,25 +174,49 @@ def _client_or_exit(json_output: bool) -> AuthenticatedClient:
         raise
 
 
-def _check_command_status(response: Any, json_output: bool) -> PluginCommandResponse:
-    """Map a command-endpoint response's status to errors, or return its body.
+def _parse_structured_error(content: bytes) -> tuple[str | None, str | None]:
+    """Extract ``(code, message)`` from a backend error body, if it has them.
 
-    Distinguishes the 403 "agent plugin loading disabled" case so we can point
-    the user at the setting that gates write ops.
+    The backend raises HTTPExceptions with ``detail={"code": ..., "message":
+    ...}``, which FastAPI serializes as ``{"detail": {"code": ..., "message":
+    ...}}``. Returns ``(None, None)`` for anything else, so callers can fall
+    back to the raw body.
+    """
+    try:
+        payload = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, None
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if not isinstance(detail, dict):
+        return None, None
+    code = detail.get("code")
+    message = detail.get("message")
+    return (code if isinstance(code, str) else None, message if isinstance(message, str) else None)
+
+
+def _backend_error(action: str, response: Any, json_output: bool) -> NoReturn:
+    """Report a non-2xx backend response and exit.
+
+    Surfaces the backend's structured ``{code, message}`` when present (as the
+    message plus a machine-readable ``code`` in ``--json`` output) instead of
+    dumping the raw JSON body as an opaque string.
     """
     status = int(response.status_code)
-    if status == HTTPStatus.FORBIDDEN and b"agent_plugin_loading_disabled" in response.content:
-        cli_error(
-            "agent plugin loading is disabled",
-            detail="Enable it in Sculptor under Settings -> Plugins, then try again.",
-            json_output=json_output,
-        )
+    code, message = _parse_structured_error(response.content)
+    if message is not None:
+        cli_error(message, code=code, json_output=json_output)
+    cli_error(
+        f"{action} failed (HTTP {status})",
+        detail=response.content.decode(errors="replace"),
+        json_output=json_output,
+    )
+
+
+def _check_command_status(response: Any, json_output: bool) -> PluginCommandResponse:
+    """Map a command-endpoint response's status to errors, or return its body."""
+    status = int(response.status_code)
     if not (HTTPStatus.OK <= status < HTTPStatus.MULTIPLE_CHOICES):
-        cli_error(
-            f"backend error (HTTP {status})",
-            detail=response.content.decode(errors="replace"),
-            json_output=json_output,
-        )
+        _backend_error("plugin command", response, json_output)
     body = response.parsed
     if not isinstance(body, PluginCommandResponse):
         cli_error(
@@ -225,11 +250,17 @@ def _send_command(
 
 
 def _results_or_exit(response: PluginCommandResponse, json_output: bool) -> list[PluginCommandResult]:
-    """Return the per-renderer results, erroring if no window answered."""
+    """Return the per-renderer results, erroring if no window answered.
+
+    An empty ``results`` and "no windows connected" are the same condition on
+    the wire, so name it with an explicit code rather than leaving ``--json``
+    consumers to guess from an empty array.
+    """
     results = response.results
     if isinstance(results, Unset) or not results:
         cli_error(
             "No Sculptor window responded. Is Sculptor running with frontend plugins enabled?",
+            code="no_windows_connected",
             json_output=json_output,
         )
     return results
@@ -244,10 +275,17 @@ def _preferred_result(results: list[PluginCommandResult]) -> PluginCommandResult
 
 
 def _renderer_label(result: PluginCommandResult) -> str:
-    """A compact ``environment short-id origin`` label for a renderer."""
+    """A compact ``environment short-id origin[base]`` label for a renderer.
+
+    The base is appended only when it isn't the root, so a window running an
+    OpenHost preview bundle reads as ``…example.com/proxy/51042/`` while the
+    deployed app stays ``…example.com`` (they share the origin by design).
+    """
     renderer = result.renderer
     short_id = renderer.renderer_id[:_RENDERER_ID_DISPLAY_LENGTH]
-    return f"{renderer.environment.value} {short_id} {renderer.origin}"
+    base = _opt_str(renderer.base)
+    suffix = base if base is not None and base != "/" else ""
+    return f"{renderer.environment.value} {short_id} {renderer.origin}{suffix}"
 
 
 def _opt_str(value: None | str | Unset) -> str | None:
@@ -312,9 +350,11 @@ def _report_mutation(
     Default: report the preferred (Electron) renderer and note the rest.
     ``--all``: report every renderer and fail if any reports ``ok=False``.
     """
+    # Check for the no-windows case BEFORE emitting: otherwise --json would
+    # print the empty aggregate response AND then a second error document.
+    results = _results_or_exit(response, json_output)
     if json_output:
         _emit_json(response)
-    results = _results_or_exit(response, json_output)
 
     if show_all:
         any_failed = False
@@ -352,10 +392,13 @@ def _report_snapshots(
     show_all: bool,
 ) -> None:
     """Render list/inspect outcomes (read-only; never exits on ok=False)."""
+    # No-windows check first, even for --json: a bare `"results": []` is
+    # indistinguishable from success against zero windows, so name the
+    # condition (and exit non-zero) instead of emitting it.
+    results = _results_or_exit(response, json_output)
     if json_output:
         _emit_json(response)
         return
-    results = _results_or_exit(response, json_output)
 
     if show_all:
         for result in results:
@@ -409,11 +452,7 @@ def load(
             handle_connection_error(json_output)
         install_status = int(install_response.status_code)
         if not (HTTPStatus.OK <= install_status < HTTPStatus.MULTIPLE_CHOICES) or install_response.parsed is None:
-            cli_error(
-                f"upload failed (HTTP {install_status})",
-                detail=install_response.content.decode(errors="replace"),
-                json_output=json_output,
-            )
+            _backend_error("upload", install_response, json_output)
         source = install_response.parsed.manifest_url
 
     response = _send_command(
@@ -492,11 +531,7 @@ def remove(
         handle_connection_error(json_output)
     status = int(remove_response.status_code)
     if not (HTTPStatus.OK <= status < HTTPStatus.MULTIPLE_CHOICES):
-        cli_error(
-            f"remove failed (HTTP {status})",
-            detail=remove_response.content.decode(errors="replace"),
-            json_output=json_output,
-        )
+        _backend_error("remove", remove_response, json_output)
     if json_output:
         typer.echo(json.dumps({"ok": True, "plugin_id": plugin_id}))
     else:
@@ -553,11 +588,7 @@ def dir_command(
         handle_connection_error(json_output)
     status = int(response.status_code)
     if not (HTTPStatus.OK <= status < HTTPStatus.MULTIPLE_CHOICES) or response.parsed is None:
-        cli_error(
-            f"backend error (HTTP {status})",
-            detail=response.content.decode(errors="replace"),
-            json_output=json_output,
-        )
+        _backend_error("plugins directory lookup", response, json_output)
     if json_output:
         typer.echo(json.dumps({"path": response.parsed.path}))
     else:

--- a/tools/sculpt/sculpt/formatting.py
+++ b/tools/sculpt/sculpt/formatting.py
@@ -51,15 +51,16 @@ def truncate(text: str, max_length: int = 50) -> str:
     return text[: max_length - len(_ELLIPSIS)] + _ELLIPSIS
 
 
-def json_error(error: str, detail: str = "") -> str:
+def json_error(error: str, detail: str = "", code: str | None = None) -> str:
     """Return a JSON-formatted error string."""
-    return ErrorOutput(error=error, detail=detail).model_dump_json()
+    return ErrorOutput(error=error, detail=detail, code=code).model_dump_json()
 
 
 def cli_error(
     message: str,
     *,
     detail: str = "",
+    code: str | None = None,
     json_output: bool = False,
     exit_code: int = 1,
 ) -> NoReturn:
@@ -68,11 +69,15 @@ def cli_error(
     When json_output is True, writes structured JSON to stderr.
     Otherwise writes human-readable text to stderr.
 
+    ``code`` carries a machine-readable error code (usually straight from the
+    backend's structured error detail) so ``--json`` consumers can branch on it
+    instead of pattern-matching prose. It appears in the JSON output only.
+
     The exit_code keyword lets specific commands surface category-distinct
     exit codes that an agent's tool harness can pattern-match on.
     """
     if json_output:
-        typer.echo(json_error(message, detail), err=True)
+        typer.echo(json_error(message, detail, code), err=True)
     else:
         typer.echo(f"Error: {message}", err=True)
         if detail:

--- a/tools/sculpt/tests/unit/test_formatting.py
+++ b/tools/sculpt/tests/unit/test_formatting.py
@@ -13,12 +13,12 @@ class TestJsonError:
     def test_returns_valid_json(self) -> None:
         result = json_error("Not found", "No workspace matches prefix 'abc'")
         parsed = json.loads(result)
-        assert parsed == {"error": "Not found", "detail": "No workspace matches prefix 'abc'"}
+        assert parsed == {"error": "Not found", "detail": "No workspace matches prefix 'abc'", "code": None}
 
     def test_empty_detail(self) -> None:
         result = json_error("Server error")
         parsed = json.loads(result)
-        assert parsed == {"error": "Server error", "detail": ""}
+        assert parsed == {"error": "Server error", "detail": "", "code": None}
 
 
 class TestCliError:
@@ -42,7 +42,7 @@ class TestCliError:
         assert exc_info.value.exit_code == 1
         captured = capsys.readouterr()
         parsed = json.loads(captured.err.strip())
-        assert parsed == {"error": "fail", "detail": "extra"}
+        assert parsed == {"error": "fail", "detail": "extra", "code": None}
 
     def test_custom_exit_code(self) -> None:
         with pytest.raises(typer.Exit) as exc_info:
@@ -55,7 +55,7 @@ class TestCliError:
         assert exc_info.value.exit_code == 4
         captured = capsys.readouterr()
         parsed = json.loads(captured.err.strip())
-        assert parsed == {"error": "fail", "detail": ""}
+        assert parsed == {"error": "fail", "detail": "", "code": None}
 
 
 class TestHandleConnectionError:

--- a/tools/sculpt/tests/unit/test_plugin.py
+++ b/tools/sculpt/tests/unit/test_plugin.py
@@ -1,0 +1,84 @@
+"""Unit tests for `sculpt plugin` helpers: error shaping and renderer labels."""
+
+import json
+
+import pytest
+import typer
+
+from sculpt.client.models.plugin_command_result import PluginCommandResult
+from sculpt.client.models.renderer_identity import RendererIdentity
+from sculpt.client.models.renderer_identity_environment import RendererIdentityEnvironment
+from sculpt.client.types import UNSET
+from sculpt.commands.plugin import _parse_structured_error
+from sculpt.commands.plugin import _renderer_label
+from sculpt.formatting import json_error
+
+
+def _result_with_renderer(base: None | str = None, base_unset: bool = False) -> PluginCommandResult:
+    renderer = RendererIdentity(
+        renderer_id="0123456789abcdef",
+        environment=RendererIdentityEnvironment.BROWSER,
+        origin="https://sculptor.example.com",
+        base=UNSET if base_unset else base,
+    )
+    return PluginCommandResult(correlation_id="c", renderer=renderer, op="list", ok=True)
+
+
+class TestParseStructuredError:
+    def test_extracts_code_and_message(self) -> None:
+        body = json.dumps(
+            {"detail": {"code": "agent_plugin_loading_disabled", "message": "Agent plugin loading is disabled."}}
+        ).encode()
+        assert _parse_structured_error(body) == (
+            "agent_plugin_loading_disabled",
+            "Agent plugin loading is disabled.",
+        )
+
+    def test_tolerates_missing_fields(self) -> None:
+        assert _parse_structured_error(json.dumps({"detail": {"message": "just prose"}}).encode()) == (
+            None,
+            "just prose",
+        )
+        assert _parse_structured_error(json.dumps({"detail": {"code": "only_code"}}).encode()) == ("only_code", None)
+
+    def test_rejects_unstructured_bodies(self) -> None:
+        assert _parse_structured_error(b"<html>502</html>") == (None, None)
+        assert _parse_structured_error(json.dumps({"detail": "a plain string"}).encode()) == (None, None)
+        assert _parse_structured_error(json.dumps(["not", "a", "dict"]).encode()) == (None, None)
+        assert _parse_structured_error(b"\xff\xfe") == (None, None)
+
+
+class TestRendererLabel:
+    def test_deployed_app_shows_bare_origin(self) -> None:
+        label = _renderer_label(_result_with_renderer(base="/"))
+        assert label == "browser 01234567 https://sculptor.example.com"
+
+    def test_preview_base_is_appended_to_the_origin(self) -> None:
+        label = _renderer_label(_result_with_renderer(base="/proxy/51042/"))
+        assert label == "browser 01234567 https://sculptor.example.com/proxy/51042/"
+
+    def test_old_bundles_without_base_stay_unchanged(self) -> None:
+        for result in (_result_with_renderer(base=None), _result_with_renderer(base_unset=True)):
+            assert _renderer_label(result) == "browser 01234567 https://sculptor.example.com"
+
+
+class TestJsonErrorCode:
+    def test_code_is_included_when_present(self) -> None:
+        payload = json.loads(json_error("nope", "detail text", "some_code"))
+        assert payload == {"error": "nope", "detail": "detail text", "code": "some_code"}
+
+    def test_code_defaults_to_null(self) -> None:
+        payload = json.loads(json_error("nope"))
+        assert payload == {"error": "nope", "detail": "", "code": None}
+
+
+class TestResultsOrExit:
+    def test_empty_results_error_carries_the_condition_code(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from sculpt.client.models.plugin_command_response import PluginCommandResponse
+        from sculpt.commands.plugin import _results_or_exit
+
+        response = PluginCommandResponse(correlation_id="c", results=[])
+        with pytest.raises(typer.Exit):
+            _results_or_exit(response, json_output=True)
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["code"] == "no_windows_connected"

--- a/tools/sculpt/tests/unit/test_plugin.py
+++ b/tools/sculpt/tests/unit/test_plugin.py
@@ -5,12 +5,14 @@ import json
 import pytest
 import typer
 
+from sculpt.client.models.plugin_command_response import PluginCommandResponse
 from sculpt.client.models.plugin_command_result import PluginCommandResult
 from sculpt.client.models.renderer_identity import RendererIdentity
 from sculpt.client.models.renderer_identity_environment import RendererIdentityEnvironment
 from sculpt.client.types import UNSET
 from sculpt.commands.plugin import _parse_structured_error
 from sculpt.commands.plugin import _renderer_label
+from sculpt.commands.plugin import _results_or_exit
 from sculpt.formatting import json_error
 
 
@@ -74,9 +76,6 @@ class TestJsonErrorCode:
 
 class TestResultsOrExit:
     def test_empty_results_error_carries_the_condition_code(self, capsys: pytest.CaptureFixture[str]) -> None:
-        from sculpt.client.models.plugin_command_response import PluginCommandResponse
-        from sculpt.commands.plugin import _results_or_exit
-
         response = PluginCommandResponse(correlation_id="c", results=[])
         with pytest.raises(typer.Exit):
             _results_or_exit(response, json_output=True)


### PR DESCRIPTION
## What

Two agent-tooling gaps found while testing the OpenHost preview flow (papercuts #1, #2, #3, #6, #7 from #273's notes):

**Renderer identity knows its bundle now.** `RendererIdentity` gains an optional `base` — the bundle's compiled base path (`import.meta.env.BASE_URL`): `/` for the deployed app, `/proxy/<port>/` for an OpenHost preview. Origin alone cannot tell those windows apart (sharing an origin is what makes the preview setup work), so `sculpt plugin list` now labels a preview window as `browser <id> https://host/proxy/51042/`. The field is optional; bundles built before it simply don't report it, and the backend model allows unknown extras, so rollout order doesn't matter.

**Errors are structured end to end.** The backend already raises `{code, message}` details; the CLI now surfaces them instead of flattening:
- `--json` errors carry a machine-readable `code` (e.g. `agent_plugin_loading_disabled`) — no more double-encoded JSON-in-a-string on `load`, and `load`/`reload`/`remove`/`dir` all share one error shape.
- An empty `results` array is named: `no_windows_connected`. Previously it was indistinguishable from success against zero windows — `inspect --json` even printed `{"results": []}` and exited 0.
- `--json` failures emit exactly one JSON document (previously a response dump followed by a separate error object).

## Testing

New unit tests for the structured-error parser, base-aware renderer labels, the `no_windows_connected` code, and `ErrorOutput.code`; full sculpt unit suite passes (283), pyrefly clean, frontend types regenerated + `tsc` clean. Generated client is gitignored and regenerates in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)