### PR TITLE
Make the linear-issue plugin tsconfig actually typecheck

### DIFF
--- a/sculptor/frontend/plugins/linear-issue/tsconfig.json
+++ b/sculptor/frontend/plugins/linear-issue/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "isolatedModules": true,
@@ -12,9 +14,11 @@
     "allowSyntheticDefaultImports": true,
     "types": ["vite/client"],
     "paths": {
-      "@sculptor/plugin-sdk": ["../../src/plugins/sdk/index.ts"]
-    },
-    "baseUrl": "."
+      // The rolled-up public SDK contract (generated, freshness-checked in
+      // CI) — NOT the SDK source, whose ~-aliased host imports would drag the
+      // whole host module graph into this standalone project's typecheck.
+      "@sculptor/plugin-sdk": ["../../../sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## What

Papercut #4 from #273's notes: `tsc -p plugins/linear-issue` failed on the deprecated `baseUrl` (TS5101 under the repo's current TypeScript) and on mapping `@sculptor/plugin-sdk` to the SDK *source*, whose `~`-aliased host imports pull the whole host module graph into the standalone project's typecheck.

Fix: same shape as `openhost-preview-switcher`'s tsconfig — drop `baseUrl` (`paths` resolves relative to the tsconfig without it), add `noEmit` + `allowImportingTsExtensions`, and map the SDK to the generated rolled-up `sdk.d.ts` (the public contract, freshness-checked in CI).

The plugin's own code needed no changes — it typechecks clean with the config fixed. One-file diff.

## Testing

`pnpm exec tsc -p plugins/linear-issue` exits 0 (previously failed before reaching the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)