### PR TITLE
test: keep width-sensitive integration tests above the mobile breakpoint

### DIFF
--- a/sculptor/sculptor/testing/resources.py
+++ b/sculptor/sculptor/testing/resources.py
@@ -265,7 +265,10 @@ def _get_or_create_shared_instance(
         browser = None
     else:
         electron_frontend = None
-        browser = playwright.chromium.launch()
+        # /dev/shm is tiny in containers (podman defaults to 64MB) and Chromium
+        # uses it for renderer shared memory — without this flag the renderer
+        # crashes on non-trivial pages. Same flag manual_test_harness passes.
+        browser = playwright.chromium.launch(args=["--disable-dev-shm-usage"])
         browser_context = browser.new_context(viewport=DEFAULT_TEST_VIEWPORT, locale=DEFAULT_TEST_LOCALE)
         page = browser_context.new_page()
         configure_page(page, timeout_ms=default_timeout_ms)

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_width_change.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_width_change.py
@@ -43,8 +43,10 @@ from sculptor.testing.user_stories import user_story
 _INITIAL_WIDTH = 1200
 # "Narrow" and "widen" stay in the desktop range so no responsive / mobile /
 # panel-collapse layout kicks in, while clearly reflowing the long paragraph
-# text (narrower => taller content, wider => shorter).
-_NARROW_WIDTH = 560
+# text (narrower => taller content, wider => shorter). "Desktop range" means
+# ABOVE the 768px mobile breakpoint — at or below 767px the mobile shell
+# remounts the whole chat, which resets the scroll state these tests assert on.
+_NARROW_WIDTH = 800
 _WIDE_WIDTH = 1400
 # The height is held constant across every before/after, so only width changes.
 _VIEWPORT_HEIGHT = 800

--- a/sculptor/tests/integration/frontend/test_workspace_peek.py
+++ b/sculptor/tests/integration/frontend/test_workspace_peek.py
@@ -166,9 +166,11 @@ def test_workspace_peek_popover_on_scrolled_tab(
     navigate_to_add_workspace_page(page)
 
     # Shrink viewport to force tab overflow (3 workspace tabs + "Open Workspace"
-    # tab at 200px each = 800px, which won't fit in a 500px-wide viewport).
+    # tab at 200px each = 800px, which won't fit in a 780px-wide viewport).
+    # Must stay ABOVE the 768px mobile breakpoint: below it the mobile shell
+    # replaces the workspace tab strip entirely and there is no tab to hover.
     original_size = page.viewport_size
-    page.set_viewport_size({"width": 500, "height": original_size["height"]})
+    page.set_viewport_size({"width": 780, "height": original_size["height"]})
 
     # "WS 1" is the leftmost tab, which may be scrolled out of view.
     # Scroll it into view and hover to trigger the peek popover.


### PR DESCRIPTION
## Summary

Un-reds the working branch's CI: two integration tests shrink the viewport below the responsive mobile breakpoint (≤767px), which this branch's mobile shell now treats as "switch to the mobile UI" — invalidating what the tests were written to exercise.

- **`test_workspace_peek_popover_on_scrolled_tab`** (fails every run on this branch, incl. on merged PR #274): shrank to 500px to force workspace-tab overflow, but below the breakpoint the mobile shell replaces the tab strip entirely, so the `WORKSPACE_TAB` locator times out. Now 780px — still overflows the ~800px of tabs, stays on the desktop layout.
- **`test_alpha_scroll_width_change`** narrow tests (source of the `test_following_stays_pinned_on_narrow` flake): the 560px "narrow" width predates the mobile shell; crossing the breakpoint remounts the whole chat mid-stream, resetting the scroll state under test. Now 800px — same text-reflow purpose (1200 → 800), desktop range throughout. Comments updated to state the breakpoint constraint explicitly so future width choices don't regress this.

Also passes `--disable-dev-shm-usage` to the integration harness browser (as `manual_test_harness` already does) — containers default `/dev/shm` to 64MB and Chromium's renderer crashes on non-trivial pages without it, which made these tests unrunnable in containerized dev environments.

Noted, not changed: `test_workspace_banner_overflow` shrinks to 280px, where its collapsed-state assertions (`to_have_count(0)`) pass vacuously under the mobile shell. It stays green so it's left alone, but it no longer exercises the desktop progressive-collapse path on this branch.

## Testing

Can't run integration tests in this dev container (that's what the dev-shm fix addresses going forward); validation is CI on this PR. For reference, the base branch's only deterministic integration failure is the peek test fixed here — the pin-gap and hover failures seen on PR #275 flaked-and-recovered on re-run and also flake on main.

(Sent by Claude)