### PR TITLE
Hold the following pin gap in both directions

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -360,6 +360,72 @@ describe("useAlphaAutoScroll", () => {
     expect(result.current.isEngaged).toBe(true);
   });
 
+  describe("following pin direction", () => {
+    /** Engage `following` by starting a stream while the view sits at the bottom. */
+    const renderFollowing = (el: HTMLDivElement): void => {
+      const ref = { current: el };
+      const virtualizer = createMockVirtualizer();
+      const { result, rerender } = renderHook(
+        ({ isStreaming }) => useAlphaAutoScroll(ref, isStreaming, 10, virtualizer, null, -1, "test-task"),
+        { initialProps: { isStreaming: false } },
+      );
+      act(() => {
+        el.dispatchEvent(new Event("scroll"));
+      });
+      rerender({ isStreaming: true });
+      expect(result.current.isEngaged).toBe(true);
+    };
+
+    it("chases a tail shrink back up to the pin while following", () => {
+      const el = createMockScrollContainer(1300, 2000, 500); // distance=200, at bottom
+      renderFollowing(el);
+
+      // A reflow while following lands on the pin.
+      act(() => {
+        triggerResize();
+      });
+      expectPinnedToBottom(el);
+
+      // The tail shrinks by a text line with scrollTop untouched — the view is
+      // now stranded past the pin. The next reflow must correct back up.
+      setScrollPosition(el, el.scrollTop, 1975);
+      act(() => {
+        triggerResize();
+      });
+      expectPinnedToBottom(el);
+    });
+
+    it("holds a sub-dead-band overshoot instead of chasing measurement wobble", () => {
+      const el = createMockScrollContainer(1300, 2000, 500);
+      renderFollowing(el);
+      act(() => {
+        triggerResize();
+      });
+      const pinnedScrollTop = el.scrollTop;
+
+      // A shrink smaller than the dead-band: within measurement rounding — hold.
+      setScrollPosition(el, pinnedScrollTop, 1995);
+      act(() => {
+        triggerResize();
+      });
+      expect(el.scrollTop).toBe(pinnedScrollTop);
+    });
+
+    it("leaves an overshoot in place when not following (down-only preserved)", () => {
+      // Not streaming, never engaged: the authority is userControlled, and a
+      // position past the pin (inside the tail padding) is legitimate.
+      const el = createMockScrollContainer(1540, 2000, 500); // pin target is 1500
+      const ref = { current: el };
+      const virtualizer = createMockVirtualizer();
+      const { result } = renderHook(() => useAlphaAutoScroll(ref, false, 10, virtualizer, null, -1, "test-task"));
+
+      act(() => {
+        result.current.scrollToBottom();
+      });
+      expect(el.scrollTop).toBe(1540);
+    });
+  });
+
   it("scrolls to bottom when messageCount increases while at bottom (pin-to-bottom)", () => {
     // User is pinned to the bottom (distance=0), not streaming.
     // A new message arrives: messageCount increases and scrollHeight grows by 300px,

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -10,7 +10,12 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExter
 
 import { ChatMessageRole } from "~/api";
 
-import { bottomPinOffset, distanceFromContentBottom, FOOTER_REVEAL_WINDOW_MS } from "../scroll/geometry.ts";
+import {
+  bottomPinOffset,
+  distanceFromContentBottom,
+  FOOTER_REVEAL_WINDOW_MS,
+  PIN_BOTTOM_GAP,
+} from "../scroll/geometry.ts";
 import type { ReadingAnchor } from "../scroll/scrollStateMachine.ts";
 import {
   createScrollStateMachine,
@@ -24,9 +29,19 @@ const BOTTOM_THRESHOLD = 200;
 // essentially the very bottom — not just "near" it — to opt back in.
 const REENGAGE_THRESHOLD = 5;
 // How many px before the viewport edge to transition from filling phase to
-// pin-to-bottom.  The ResizeObserver fires after content grows, so without
-// this buffer the content briefly overshoots the viewport before locking.
-const FILLING_OVERFLOW_BUFFER = 100;
+// pin-to-bottom.  Firing early keeps the growing content from visibly
+// overshooting the viewport while the ResizeObserver lags a beat behind.
+// Must equal the pin gap: the anchored rest position coincides with
+// bottomPinOffset exactly when the tail has filled the viewport to within
+// PIN_BOTTOM_GAP of its bottom edge, so entering `following` is a zero-px
+// handoff — the view is already at the pin. Any larger value starts
+// `following` above the pin, in violation of its invariant, and forces an
+// immediate upward correction.
+const FILLING_OVERFLOW_BUFFER = PIN_BOTTOM_GAP;
+
+// Upward pin corrections chase genuine tail shrinks (a collapsed text line
+// is ~20px+), never sub-line measurement wobble.
+const PIN_UPWARD_DEADBAND = 8;
 
 // Fixed duration for the scroll-to-top animation (ms). Same speed
 // regardless of distance so short and long scrolls feel consistent.
@@ -144,17 +159,23 @@ export const useAlphaAutoScroll = (
 
   // The single "scroll to the bottom" primitive: land the content bottom
   // PIN_BOTTOM_GAP above the viewport bottom, keeping the rest of paddingEnd as
-  // slack below scrollTop (see bottomPinOffset). Down-only — callers reach the
-  // bottom from above, so an upward move would only chase a turn-end shrink,
-  // which we leave in place.
+  // slack below scrollTop (see bottomPinOffset). Downward moves always apply.
+  // Upward moves apply only while `following`, whose per-frame invariant IS the
+  // pin gap: a mid-stream tail shrink (e.g. the standalone streaming cursor
+  // collapsing into the first text line) moves the target back up, and leaving
+  // scrollTop stranded past it shows oversized breathing room below the newest
+  // line until growth overtakes the difference — on slow machines for long
+  // enough that the pin-gap tests fail. In every other phase an upward move
+  // would only chase a turn-end shrink, which we leave in place.
   const pinToBottom = useCallback((): void => {
     const el = scrollContainerRef.current;
     if (!el || messageCount === 0) return;
     const desired = bottomPinOffset(el, virtualizer);
-    if (desired <= el.scrollTop + 1) return;
+    const isUpwardMove = desired <= el.scrollTop + 1;
+    if (isUpwardMove && !(isFollowing() && el.scrollTop - desired > PIN_UPWARD_DEADBAND)) return;
     isProgrammaticScroll.current = true;
     el.scrollTop = desired;
-  }, [scrollContainerRef, virtualizer, messageCount, isProgrammaticScroll]);
+  }, [scrollContainerRef, virtualizer, messageCount, isProgrammaticScroll, isFollowing]);
 
   // Suppress the jump-to-bottom button between message send and response arrival.
   const [isJumpSuppressed, setIsJumpSuppressed] = useState(false);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -35,8 +35,7 @@ const REENGAGE_THRESHOLD = 5;
 // bottomPinOffset exactly when the tail has filled the viewport to within
 // PIN_BOTTOM_GAP of its bottom edge, so entering `following` is a zero-px
 // handoff — the view is already at the pin. Any larger value starts
-// `following` above the pin, in violation of its invariant, and forces an
-// immediate upward correction.
+// `following` above the pin and forces an immediate upward correction.
 const FILLING_OVERFLOW_BUFFER = PIN_BOTTOM_GAP;
 
 // Upward pin corrections chase genuine tail shrinks (a collapsed text line
@@ -164,9 +163,8 @@ export const useAlphaAutoScroll = (
   // pin gap: a mid-stream tail shrink (e.g. the standalone streaming cursor
   // collapsing into the first text line) moves the target back up, and leaving
   // scrollTop stranded past it shows oversized breathing room below the newest
-  // line until growth overtakes the difference — on slow machines for long
-  // enough that the pin-gap tests fail. In every other phase an upward move
-  // would only chase a turn-end shrink, which we leave in place.
+  // line until growth overtakes the difference. In every other phase an upward
+  // move would only chase a turn-end shrink, which we leave in place.
   const pinToBottom = useCallback((): void => {
     const el = scrollContainerRef.current;
     if (!el || messageCount === 0) return;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -171,8 +171,9 @@ export const useAlphaAutoScroll = (
     const el = scrollContainerRef.current;
     if (!el || messageCount === 0) return;
     const desired = bottomPinOffset(el, virtualizer);
-    const isUpwardMove = desired <= el.scrollTop + 1;
-    if (isUpwardMove && !(isFollowing() && el.scrollTop - desired > PIN_UPWARD_DEADBAND)) return;
+    const isBelowTarget = desired > el.scrollTop + 1;
+    const isStrandedPastTarget = isFollowing() && el.scrollTop - desired > PIN_UPWARD_DEADBAND;
+    if (!isBelowTarget && !isStrandedPastTarget) return;
     isProgrammaticScroll.current = true;
     el.scrollTop = desired;
   }, [scrollContainerRef, virtualizer, messageCount, isProgrammaticScroll, isFollowing]);

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -121,11 +121,11 @@ def test_following_keeps_pin_gap_below_last_message(sculptor_instance_: Sculptor
 def test_entering_following_lands_at_the_pin_gap(sculptor_instance_: SculptorInstance) -> None:
     """Entering `following` must already satisfy the pin invariant.
 
-    The anchoring→following handoff pins to the bottom on entry, and the pin is
-    down-only. If the handoff fires while the anchored rest position is still
-    above the pin target, that entry pin silently no-ops and the view parks
-    with the last message floating deeper than the designed gap until the
-    stream grows through the leftover slack — a plateau long enough on CI
+    The anchoring→following handoff pins to the bottom on entry. If that entry
+    pin cannot land on the target — a handoff fired above the pin, or a tail
+    shrink around the handoff that a down-only pin refuses to chase — the view
+    parks with the last message floating deeper than the designed gap until the
+    stream grows through the leftover slack: a plateau long enough on CI
     hardware for the sibling test's stability-polled sample to certify it as
     the resting gap. Sampling the very first window after the phase flips
     checks the entry geometry directly: the max across the window IS the entry

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py
@@ -17,6 +17,7 @@ from playwright.sync_api import expect
 
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_last_turn_footer_viewport_gaps
+from sculptor.testing.elements.alpha_chat_view import get_max_following_tail_gap
 from sculptor.testing.elements.alpha_chat_view import read_scroll_top_sampler
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_to_top
 from sculptor.testing.elements.alpha_chat_view import start_scroll_top_sampler
@@ -39,17 +40,16 @@ _LOREM_STREAM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
 # The visible gap the pin keeps between the last message's bottom and the viewport
 # bottom while following — mirrors PIN_BOTTOM_GAP in chat-alpha/scroll/geometry.ts.
 _PIN_BOTTOM_GAP_PX = 64
-# Slop around the pin gap. At rest the pin lands the tail EXACTLY PIN_BOTTOM_GAP
-# above the viewport bottom (see bottomPinOffset), but this gap is sampled mid-stream
-# while the tail is still growing: the down-only follow pin trails each content reflow
-# by a frame or two, and the virtualizer's measureElement lags the DOM asynchronously,
-# so a mid-growth sample reads a few px off the resting gap. That transient spread is
-# platform-timing-dependent (larger under slower CI rendering), so the band is sized to
-# absorb it while still cleanly separating the two regressions it guards against: hugging
-# the viewport bottom flush (~0px, no breathing room under the newest line) and parking
-# deep in the paddingEnd gap (>= the 128px streaming padding floor, no slack for the
-# turn-end shrink). 64 +/- 40 == [24, 104] stays clear of both (0 and 128).
-_PIN_GAP_TOLERANCE_PX = 40
+# Slop around the pin gap for message margins, sub-pixel rounding, and mid-growth
+# sampling. While `following`, the pin corrects in BOTH directions (see pinToBottom),
+# so the sampled gap stays tight to PIN_BOTTOM_GAP under any runner pacing. The band's
+# upper edge deliberately sits below one text line past the gap (64 + ~21px): a pin
+# stranded past the target by a single collapsed line must read as a failure, not
+# slop. It also separates the two coarser regressions this guards against: hugging
+# the viewport bottom flush (~0px, no breathing room under the newest line) and
+# parking deep in the paddingEnd gap (>= the 128px streaming padding floor, no slack
+# for the turn-end shrink).
+_PIN_GAP_TOLERANCE_PX = 24
 
 # The view must not scroll UP across the turn boundary. A tiny settle for the turn
 # footer is fine; a jump back to an earlier message is a whole-turn (hundreds of px)
@@ -111,6 +111,60 @@ def test_following_keeps_pin_gap_below_last_message(sculptor_instance_: Sculptor
         f"while following, the last message floated {max_gap}px above the viewport bottom "
         + f"(expected <= {_PIN_BOTTOM_GAP_PX + _PIN_GAP_TOLERANCE_PX}px); the pin is parking "
         + "in the paddingEnd gap"
+    )
+
+    # Let the turn finish cleanly before the test ends.
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible(timeout=60_000)
+
+
+@user_story("to have the pin gap in place from the moment the chat starts following the stream")
+def test_entering_following_lands_at_the_pin_gap(sculptor_instance_: SculptorInstance) -> None:
+    """Entering `following` must already satisfy the pin invariant.
+
+    The anchoring→following handoff pins to the bottom on entry, and the pin is
+    down-only. If the handoff fires while the anchored rest position is still
+    above the pin target, that entry pin silently no-ops and the view parks
+    with the last message floating deeper than the designed gap until the
+    stream grows through the leftover slack — a plateau long enough on CI
+    hardware for the sibling test's stability-polled sample to certify it as
+    the resting gap. Sampling the very first window after the phase flips
+    checks the entry geometry directly: the max across the window IS the entry
+    gap even when convergence lands mid-window.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`',
+    )
+    chat_panel = task_page.get_chat_panel()
+    PlaywrightWorkspaceSection(page, "bottom").collapse_section()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    # History so the follow-on user message anchors a genuine new turn whose
+    # streamed reply overflows — the anchoring→following handoff path.
+    send_chat_message(chat_panel, f'fake_claude:text `{{"text": "{_LONG_TEXT}"}}`')
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=4)
+
+    view = get_alpha_chat_view(page)
+    expect(view).to_be_visible()
+
+    send_chat_message(
+        chat_panel,
+        f'fake_claude:stream_text `{{"text": "{_STREAM_TEXT}", "chunk_size": 50, "delay_seconds": 0.1}}`',
+    )
+
+    expect(view).to_have_attribute("data-scroll-phase", "following", timeout=30_000)
+    entry_gap = get_max_following_tail_gap(page)
+
+    assert entry_gap is not None, "alpha chat view or its messages not found at following-entry"
+    # Only the upper bound: a parked-above-the-pin entry is the regression this
+    # guards. Transient growth-lag dips below the gap are erased by the window
+    # max, and the steady-state band is the sibling test's job.
+    assert entry_gap <= _PIN_BOTTOM_GAP_PX + _PIN_GAP_TOLERANCE_PX, (
+        f"entering following left the last message {entry_gap}px above the viewport bottom "
+        + f"(expected <= {_PIN_BOTTOM_GAP_PX + _PIN_GAP_TOLERANCE_PX}px); the anchoring→following "
+        + "handoff parked above the pin instead of landing on it"
     )
 
     # Let the turn finish cleanly before the test ends.


### PR DESCRIPTION
## Original bug

> Failing test on main in CI — failed every run:
> `tests/integration/frontend/test_alpha_scroll_turn_end.py::test_following_keeps_pin_gap_below_last_message`

Every recent `offload integration tests` run on `main` (e.g. on eab82c54) fails with:

```
AssertionError: while following, the last message floated 89px above the viewport bottom
(expected <= 88px); the pin is parking in the paddingEnd gap
assert 89 <= (64 + 24)
```

The test guards the pin-gap contract from SCU-1673 (PR #262): while `following` a streamed
reply, the last message's bottom must sit `PIN_BOTTOM_GAP` (64px, ±24px slop) above the
viewport bottom — stated as a per-frame invariant in
`docs/development/scroll_state_unification.md`.

## Hypotheses considered

1. **Down-only pin strands the view after a mid-stream tail shrink** — REPRODUCED (root
   cause; see below).
2. **Anchoring→following handoff enters above the pin and the entry pin no-ops** —
   CONFIRMED as a secondary instance of the same asymmetry (the handoff buffer was 100px vs
   the 64px pin, so `following` could begin up to 36px above its own invariant); fixed by
   the same change plus the buffer alignment.
3. **Stability sampler races an entry transit** — DISCARDED as a test bug: the sampler
   works as designed; it faithfully reports a real plateau that should not exist.
4. **Standing measurement/DOM offset on Linux (fonts, margins, cursor line height)** —
   DISCARDED: a geometry probe on the CI-equivalent environment shows measurements,
   padding, and content height all consistent during the plateau; only `scrollTop` is off,
   and the gap converges to exactly 64px afterward.

## The bug: a mid-stream tail shrink strands the view past the pin

**Repro steps** (deterministic on CI-class hardware; verified on Offload/Modal, the same
environment CI uses):

1. Start a task with a long `fake_claude:text` reply; close the bottom panel; wait for 2
   completed messages.
2. Send a second long `fake_claude:text` follow-on; wait for 4 completed messages (history
   so the next turn genuinely anchors).
3. Send `fake_claude:stream_text` (~5k chars, 50-char chunks every 0.1s) — the reply
   overflows the anchored turn and the scroll machine hands off `anchoringTurn` →
   `following`.
4. From the moment `data-scroll-phase` flips to `following`, sample the gap between the
   last message's bottom and the viewport bottom (`get_max_following_tail_gap`).

**Expected vs actual**

- Expected: the gap is `PIN_BOTTOM_GAP` (64px) from the first `following` frame.
- Actual: the gap sits at **89px for ~500-700ms**, then converges to 64px. Probe timeline
  on Modal (~100ms windows from the phase flip; identical across runs and retries):

  ```
  before: [89, 89, 89, 89, 89, 64, 64, 64, ... 64]
  ```

  The CI test samples the gap "once stable" (two consecutive ~300ms windows within 8px) —
  on CI hardware the plateau is long enough to be certified as the resting gap → 89 > 88 →
  red. On a fast dev machine text growth usually outruns the plateau, so it passes locally
  — which is how the regression merged green.

**Before** (probe geometry on Modal during the plateau — all quantities consistent except
`scrollTop`, which is exactly one collapsed text line too deep):

```
scrollHeight − last-item DOM end = 128  (= streaming paddingEnd floor, correct)
correct pin scrollTop for DOM end 4646 = 4005
actual scrollTop                       = 4030   (stranded 25px past the pin)
gap                                    = 89     (= 64 + 25)
```

Failing test output (Offload/Modal, pre-fix — same as CI):

```
AssertionError: while following, the last message floated 89px above the viewport bottom
(expected <= 88px); the pin is parking in the paddingEnd gap
```

**Root cause**

`pinToBottom` in `useAlphaAutoScroll.ts` was **down-only** (`if (desired <= scrollTop + 1)
return`). The rule exists so a turn-end shrink (the streaming cursor unmounting) is left
in place rather than chased. But `following` promises a fixed gap every frame, and the
tail can shrink mid-stream: when the reply message first mounts it renders a standalone
blinking-cursor line, and when the first text chunk arrives that cursor collapses into the
text line — the message gets one line (~25px) shorter. The pin target moves up 25px,
down-only refuses to follow, and `scrollTop` is stranded past the pin until stream growth
overtakes the difference. The same asymmetry affected the anchoring→following handoff: it
fired while the natural anchored position was still up to 36px above the pin
(`FILLING_OVERFLOW_BUFFER` 100px vs `PIN_BOTTOM_GAP` 64px), so `following` could begin
already violating its invariant with nothing allowed to correct it.

**Fix**

Two small changes in `useAlphaAutoScroll.ts` that make the code match the one-sentence
spec — *following holds the pin gap, both directions; anchoring hands off exactly at the
pin*:

1. `pinToBottom` now applies upward corrections **only while the authority is
   `following`**, past an 8px dead-band that ignores measurement rounding. Every other pin
   site keeps the down-only rule — and the turn-end shrink stays protected, because the
   machine leaves `following` (on `streamingStopped`) before the cursor-unmount shrink
   lands, so reflows at turn end are never handled by the following pin.
2. `FILLING_OVERFLOW_BUFFER = PIN_BOTTOM_GAP`: the handoff fires exactly when the anchored
   rest position coincides with the pin target, making entry into `following` a zero-px
   event (previously the entry pin was a guaranteed no-op and the first ~36px of every
   followed stream ran above the designed gap).

Alternatives considered: fixing the cursor-collapse shrink at its source (kills this one
instance, but any future tail shrink — a markdown rewrap, a collapsing table — recreates
the class); relaxing the test band (hides a real invariant violation).

**Interplay with 437a29af** ("Harden two scroll tests against slow-runner timing"): that
commit resolved the CI symptom by widening the pin-gap band to ±40px ([24, 104]) — a
ceiling that admits exactly the one-line-stranded geometry (64 + ~25 = 89px) this bug
produces, so the guard could no longer catch its own regression. With the behavioral fix
in place the tight band is deterministically satisfiable again, so this PR restores
`_PIN_GAP_TOLERANCE_PX = 24` (upper edge deliberately below one collapsed line past the
pin). The failing-test commit is red on CI-class hardware by design; the fix commit turns
it green.

**Test**

- Path: `sculptor/tests/integration/frontend/test_alpha_scroll_turn_end.py::test_entering_following_lands_at_the_pin_gap`
- Kind: e2e (integration, Playwright)
- Failing-test commit: 73de7e14
- Fix commit: 094bc378
- Red proof (pre-fix, on Offload/Modal — the environment where the bug manifests; a fast
  dev Mac usually outruns the plateau):

  ```
  AssertionError: entering following left the last message 89px above the viewport bottom
  (expected <= 88px); the anchoring→following handoff parked above the pin instead of
  landing on it
  ```

  (`test_following_keeps_pin_gap_below_last_message` failed at 89px in the same runs —
  the same failure CI shows.)

**After** (post-fix, Offload/Modal):

- Probe timeline from following-entry: **flat `[64 ×40]`** — both attempts, plateau gone.
- All four tests in `test_alpha_scroll_turn_end.py` pass on first attempt (including the
  previously-failing CI test and the new entry-gap test).
- Locally: full frontend unit suite green; the pin-gap tests green.

```
after:  [64, 64, 64, 64, 64, 64, 64, 64, 64, ... 64]
```

## Review notes

The `/code-review-checklist` pass ran over the branch diff; acted-on findings landed as
the two follow-up commits (hook-level unit tests for the pin's direction rules, a clearer
guard structure, a docstring reword, comment trims). Outstanding items a reviewer may
want to weigh in on:

- **No embedded before/after screenshots.** The evidence slots carry the probe
  timelines, the plateau geometry, and the failing→passing test output instead: this
  workflow has no way to host binary images from the CLI (gists reject them), and the
  bug's visible surface — a transient 25px-oversized gap during streaming — is captured
  more faithfully by the numbers. Before/after screenshots from the Modal probe were
  captured and reviewed during the session and can be attached from the web UI if
  wanted.
- **Deliberate behavior change worth eyes:** a view restored at the padded max that
  re-engages `following` mid-stream now aligns to the 64px pin at the next content
  reflow (previously it stayed at the padded max for the whole stream). This is the
  documented `following` invariant; flagging since it touches the restore-adjacent
  behavior SCU-1673 preserved.
- One Offload backend-unit failure during verification was infrastructure (the sandbox
  PyPI mirror returned 500 on a download); 2059/2060 passed and `just check` covers the
  type-check locally.

(Sent by Claude)
