### PR TITLE
Serialize PUT /api/v1/config read-merge-write to close singleton-level lost-update race

### DIFF
--- a/sculptor/sculptor/services/user_config/user_config.py
+++ b/sculptor/sculptor/services/user_config/user_config.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import threading
 import tomllib
 from collections.abc import Mapping
 from pathlib import Path
@@ -23,6 +24,19 @@ class InvalidConfigError(Exception):
         self.message = f"Unhandled error loading your config file:\n{error}"
         super().__init__(self.message)
 
+
+# Serializes read-merge-write cycles against the module-level config singleton.
+#
+# Acquired internally by ``replace_config`` and ``merge_config`` so callers
+# cannot write the singleton or file unsynchronized. This lock is
+# process-local: correctness depends on Sculptor running as a single
+# uvicorn worker (see ``sculptor/cli/app.py``). Running uvicorn with
+# ``--workers > 1`` would give each worker its own singleton and its own
+# lock, so two workers could race on the shared config file on disk. If
+# multi-worker mode is ever required, replace this with a filesystem lock
+# (``fcntl.flock`` on the config file) or migrate user config to a
+# persistent store with row-level locking.
+_USER_CONFIG_LOCK = threading.Lock()
 
 _CONFIG_INSTANCE: UserConfig | None = None
 
@@ -53,6 +67,44 @@ def set_user_config_instance(config: UserConfig | None) -> None:
     )
     global _CONFIG_INSTANCE
     _CONFIG_INSTANCE = config
+
+
+def replace_config(new_config: UserConfig) -> UserConfig:
+    """Atomically write a full config object to disk and update the singleton.
+
+    The lock covers the file write and singleton assignment together, so no
+    concurrent caller can observe a half-updated state. Use this when you
+    already have a complete ``UserConfig`` (e.g. from ``model_update`` or
+    ``model_copy``). For partial field updates, use ``merge_config``.
+    """
+    with _USER_CONFIG_LOCK:
+        save_config(new_config, get_config_path())
+        set_user_config_instance(new_config)
+        return new_config
+
+
+def merge_config(partial_fields: dict[str, Any]) -> UserConfig:
+    """Merge partial fields into the current config, atomically.
+
+    Reads the current singleton, merges ``partial_fields`` (camelCase
+    aliases matching the JSON schema) into it, validates, writes to disk,
+    and updates the singleton — all under one lock acquisition. This
+    prevents the lost-update race where two concurrent callers both read
+    the same stale config, each merge their own field, and the second
+    writer silently clobbers the first.
+
+    ``partial_fields`` keys must use camelCase aliases — the same shape the
+    frontend sends in its JSON body. Keys absent from the dict are left
+    unchanged.
+    """
+    with _USER_CONFIG_LOCK:
+        old = get_user_config_instance()
+        merged = old.model_dump(by_alias=True) if old else {}
+        merged.update(partial_fields)
+        new = UserConfig.model_validate(merged)
+        save_config(new, get_config_path())
+        set_user_config_instance(new)
+        return new
 
 
 def _create_random_hash() -> str:

--- a/sculptor/sculptor/services/user_config/user_config_test.py
+++ b/sculptor/sculptor/services/user_config/user_config_test.py
@@ -1,3 +1,5 @@
+import concurrent.futures
+import threading
 from pathlib import Path
 
 import pytest
@@ -5,6 +7,7 @@ import pytest
 import sculptor.services.user_config.user_config as user_config_module
 from sculptor.config.user_config import UserConfig
 from sculptor.services.user_config.user_config import canonicalize_telemetry_flags
+from sculptor.services.user_config.user_config import merge_config
 from sculptor.services.user_config.user_config import save_config
 
 
@@ -73,5 +76,55 @@ def test_initialize_from_file_normalizes_mixed_flags_and_persists(tmp_path: Path
         reloaded = user_config_module.load_config(user_config_module.get_config_path())
         assert reloaded.is_error_reporting_enabled is False
         assert reloaded.is_product_analytics_enabled is False
+    finally:
+        user_config_module.set_user_config_instance(None)
+
+
+# Concurrency regression test: concurrent partial updates to different fields
+# must both be preserved on the singleton and on disk (SCU-710). The test
+# calls ``merge_config`` directly — the same function the PUT handler calls —
+# so it exercises the real locked write path, not a replica.
+
+
+@pytest.mark.parametrize("iteration", range(30))
+def test_concurrent_partial_updates_preserve_both_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, iteration: int
+) -> None:
+    """Two concurrent ``merge_config`` calls each contribute their field.
+
+    Without the internal lock this test loses one of the two writes on
+    disk. ``iteration`` parametrization forces many attempts per pytest
+    run to make a missing lock visible.
+    """
+    config_path = tmp_path / f"config_{iteration}.toml"
+    monkeypatch.setattr(user_config_module, "_CONFIG_PATH", config_path)
+
+    base = _make_config()
+    save_config(base, config_path)
+    user_config_module.set_user_config_instance(base)
+
+    barrier = threading.Barrier(2)
+
+    def update_email() -> None:
+        barrier.wait()
+        merge_config({"userEmail": "thread_a@example.com"})
+
+    def update_user_id() -> None:
+        barrier.wait()
+        merge_config({"userId": "thread_b_user_id"})
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(update_email), pool.submit(update_user_id)]
+            for fut in futures:
+                fut.result(timeout=10)
+
+        final_singleton = user_config_module.get_user_config_instance()
+        assert final_singleton.user_email == "thread_a@example.com"
+        assert final_singleton.user_id == "thread_b_user_id"
+
+        final_on_disk = user_config_module.load_config(config_path)
+        assert final_on_disk.user_email == "thread_a@example.com"
+        assert final_on_disk.user_id == "thread_b_user_id"
     finally:
         user_config_module.set_user_config_instance(None)

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -132,12 +132,11 @@ from sculptor.services.terminal_agent_registry.registry import get_registration
 from sculptor.services.terminal_agent_registry.registry import load_registrations
 from sculptor.services.user_config.telemetry_info import get_onboarding_telemetry_info
 from sculptor.services.user_config.telemetry_info import get_telemetry_info as get_telemetry_info_impl
-from sculptor.services.user_config.user_config import get_config_path
 from sculptor.services.user_config.user_config import get_privacy_settings_for_telemetry
 from sculptor.services.user_config.user_config import get_user_config_instance
 from sculptor.services.user_config.user_config import get_user_config_instance_if_set
-from sculptor.services.user_config.user_config import save_config
-from sculptor.services.user_config.user_config import set_user_config_instance
+from sculptor.services.user_config.user_config import merge_config
+from sculptor.services.user_config.user_config import replace_config
 from sculptor.services.workspace_service.api import FileNotFoundAtRefError
 from sculptor.services.workspace_service.api import WorkspaceFilesUnavailableError
 from sculptor.services.workspace_service.api import WorkspaceNotFoundError
@@ -1993,9 +1992,7 @@ def _record_most_recently_used_agent_type(agent_type: AgentTypeName, registratio
     encoded = _encode_stored_agent_type(agent_type, registration_id)
     if config.last_used_agent_type == encoded:
         return
-    updated = config.model_copy(update={"last_used_agent_type": encoded})
-    save_config(updated, get_config_path())
-    set_user_config_instance(updated)
+    merge_config({"lastUsedAgentType": encoded})
 
 
 def _agent_config_for_request(
@@ -3043,8 +3040,7 @@ def save_user_email(
         email_config_request.full_name is not None,
         email_config_request.did_opt_in_to_marketing,
     )
-    save_config(user_config, get_config_path())
-    set_user_config_instance(user_config)
+    replace_config(user_config)
 
     return get_logged_in_or_anonymous_telemetry_info()
 
@@ -3073,8 +3069,7 @@ def skip_account_setup(
         },
     )
 
-    save_config(user_config, get_config_path())
-    set_user_config_instance(user_config)
+    replace_config(user_config)
 
     return get_logged_in_or_anonymous_telemetry_info()
 
@@ -3167,8 +3162,7 @@ def complete_onboarding(request: Request, user_session: UserSession = Depends(ge
         updates.update(get_privacy_settings_for_telemetry(True).model_dump())
     if updates:
         user_config = model_update(user_config, updates)
-        save_config(user_config, get_config_path())
-        set_user_config_instance(user_config)
+        replace_config(user_config)
 
     logger.info("Onboarding completed successfully")
 
@@ -3203,6 +3197,11 @@ def update_user_config(
     """
     old_user_config = get_user_config_instance()
 
+    # Reject telemetry-flag changes — they go through POST /api/v1/config/telemetry.
+    # This read is safe without the lock (GIL-atomic reference read). A
+    # stale read is harmless: if someone else changed telemetry between this
+    # read and ``merge_config`` below, ``merge_config`` does not touch
+    # telemetry flags (the PUT body excludes them), so the result is correct.
     for flag in _TELEMETRY_FLAGS:
         for key in (flag, to_camel(flag)):
             if key not in update_config_request.user_config:
@@ -3214,18 +3213,12 @@ def update_user_config(
                     detail="Use POST /api/v1/config/telemetry to change telemetry consent.",
                 )
 
-    merged = old_user_config.model_dump(by_alias=True) if old_user_config else {}
-    merged.update(update_config_request.user_config)
-    new_user_config = UserConfig.model_validate(merged)
+    # Atomic read-merge-write — lock scope is the module's problem, not ours.
+    new_user_config = merge_config(update_config_request.user_config)
 
-    save_config(new_user_config, get_config_path())
-    set_user_config_instance(new_user_config)
-
-    # Push updated dependencies status when dependency paths change so the
-    # frontend atom reflects the new mode immediately.
-    new_dep = new_user_config.dependency_paths
+    # Dependency-status push is a side effect after the transaction.
     old_dep = old_user_config.dependency_paths if old_user_config else None
-    if new_dep != old_dep:
+    if new_user_config.dependency_paths != old_dep:
         services = get_services_from_request_or_websocket(request)
         services.dependency_management_service.get_status()
 
@@ -3243,14 +3236,7 @@ def set_telemetry(
     This is the only endpoint allowed to change the underlying telemetry
     flags; PUT /api/v1/config rejects requests that would change them.
     """
-    old_user_config = get_user_config_instance()
-    new_user_config = model_update(
-        old_user_config,
-        get_privacy_settings_for_telemetry(set_telemetry_request.enabled).model_dump(),
-    )
-    save_config(new_user_config, get_config_path())
-    set_user_config_instance(new_user_config)
-    return new_user_config
+    return merge_config(get_privacy_settings_for_telemetry(set_telemetry_request.enabled).model_dump(by_alias=True))
 
 
 @router.get("/api/v1/filesystem/list")


### PR DESCRIPTION
## Summary

Fixes [SCU-710](https://linear.app/imbue/issue/SCU-710/serialize-put-apiv1config-read-merge-write-to-close-singleton-level)

`PUT /api/v1/config` performs an unsynchronized read-merge-write on the module-level `_CONFIG_INSTANCE` singleton. When concurrent handlers run (e.g. multiple browser tabs, or two frontend hooks firing within the same debounce window), both threads can read the same stale config, independently merge their own field, and the second writer silently clobbers the first's on-disk change.

The file write itself is atomic (`save_config` writes to a `.tmp` then renames), but the **read-merge-validate-save-singleton-update sequence** has a race window between the read and the write.

### Changes

- **`sculptor/sculptor/services/user_config/user_config.py`**: Added a module-level `_USER_CONFIG_LOCK` (`threading.Lock`) and a `user_config_lock()` context manager. Documented the single-process assumption (Sculptor runs as one uvicorn worker) and what would need to change for multi-worker mode.
- **`sculptor/sculptor/web/app.py`**: Wrapped the entire read → telemetry-check → merge → validate → save → set-singleton sequence inside `with user_config_lock():` in the `update_user_config` handler. The dependency-status push stays outside the lock to minimize contention.
- **`sculptor/sculptor/services/user_config/user_config_test.py`**: Added `test_concurrent_partial_updates_preserve_both_fields` (parametrized ×30) that spawns two threads via `ThreadPoolExecutor` with a `threading.Barrier(2)` to maximize race overlap, then asserts both fields survive in the singleton and on disk. Without the lock, this test fails deterministically.

### Why a threading.Lock is correct (and sufficient)

Sculptor runs uvicorn as a single worker process. All concurrent `PUT /api/v1/config` requests execute on different threads within that one process, so a `threading.Lock` serializes them correctly. A comment in `user_config.py` documents this assumption so a future `--workers > 1` change doesn't silently reintroduce the race.