### PR TITLE
Fix flaky wait_for_session_id fast-path test

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/btw_process_manager_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/btw_process_manager_test.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from sculptor.agents.default.claude_code_sdk import btw_process_manager as btw_process_manager_module
 from sculptor.agents.default.claude_code_sdk.btw_process_manager import BtwProcessManager
 from sculptor.agents.default.claude_code_sdk.btw_process_manager import NoBtwSessionAvailable
 from sculptor.agents.default.claude_code_sdk.btw_process_manager import get_btw_claude_command
@@ -143,13 +144,18 @@ def test_read_session_id_returns_none_when_both_missing() -> None:
     assert _manager(env).read_session_id() is None
 
 
-def test_wait_for_session_id_returns_immediately_when_already_present() -> None:
+def test_wait_for_session_id_returns_immediately_when_already_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     env = _make_environment(session_id="session-now")
-    start = time.monotonic()
+    # Assert the behavior directly — no polling — rather than measuring elapsed
+    # wall-clock time, which is flaky under CI load (the fast path does no
+    # sleeping, so any timing threshold is really measuring scheduler jitter).
+    sleep_spy = MagicMock()
+    monkeypatch.setattr(btw_process_manager_module.time, "sleep", sleep_spy)
     result = _manager(env).wait_for_session_id(timeout=1.0)
-    elapsed = time.monotonic() - start
     assert result == "session-now"
-    assert elapsed < 0.2, f"wait took {elapsed:.3f}s — should have returned without polling"
+    sleep_spy.assert_not_called()
 
 
 def test_wait_for_session_id_returns_none_after_timeout() -> None:


### PR DESCRIPTION
## Problem

`test_wait_for_session_id_returns_immediately_when_already_present` flaked in CI ([run](https://github.com/imbue-ai/sculptor/actions/runs/28832138012/job/85508089405)):

```
AssertionError: wait took 0.322s — should have returned without polling
assert 0.3220858489999898 < 0.2
```

## Root cause

The test asserted on **wall-clock elapsed time** (`< 0.2s`). But `wait_for_session_id`'s fast path — when the session id is already on disk — does no sleeping at all: it reads the file once and returns. The 0.2s threshold was therefore measuring scheduler jitter rather than real work, and it tips over when 8 xdist workers share a loaded CI runner (0.322s observed here).

## Fix

Assert the actual intent — that the call returns **without polling** — by spying on `time.sleep` and asserting it is never called. This tests the behavior the test name promises, and is deterministic regardless of CI load.

## Note

The other two `wait_for_session_id` tests in this file (`..._returns_none_after_timeout`, `..._picks_up_late_write`) still drive the real wall clock and sleep for real in the unit suite; the timeout test's `< 1.0` upper bound is the same flake class. Converting the whole trio to a simulated clock would remove the real sleeps and the remaining timing assertions, but is left out of this PR to keep it minimal.

(Sent by Claude)