### PR TITLE
Streamline the sculpt CLI for agent/orchestrator use (SCU-1766)

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,8 +149,8 @@ format:
     {{ _quiet_by_default_fn }}
     _do_format() {
       echo "Formatting Python files..."
-      uv run ruff check --select UP006,UP007,I,F401 --fix --force-exclude --config pyproject.toml sculptor/
-      uv run ruff format --force-exclude --config pyproject.toml sculptor/
+      uv run ruff check --select UP006,UP007,I,F401 --fix --force-exclude --config pyproject.toml sculptor/ tools/sculpt/
+      uv run ruff format --force-exclude --config pyproject.toml sculptor/ tools/sculpt/
       echo "Formatting JS/TS files..."
       {{ nvm_use }}
       cd "{{justfile_directory()}}/sculptor/frontend" && pnpm run format .
@@ -167,9 +167,9 @@ lint:
     {{ _quiet_by_default_fn }}
     _do_lint() {
       echo "Checking Python formatting..."
-      uv run ruff format --check --force-exclude --config pyproject.toml sculptor/
+      uv run ruff format --check --force-exclude --config pyproject.toml sculptor/ tools/sculpt/
       echo "Linting Python files..."
-      uv run ruff check --force-exclude --config pyproject.toml sculptor/
+      uv run ruff check --force-exclude --config pyproject.toml sculptor/ tools/sculpt/
       echo "Linting JS/TS files..."
       {{ nvm_use }}
       cd "{{justfile_directory()}}/sculptor/frontend" && pnpm run lint .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ exclude = [
   "**/quarantine/**",
   "test_data/**",
   "**/*.ipynb",
+  # Machine-generated OpenAPI client (rebuilt by `just generate-sculpt-client`).
+  "tools/sculpt/sculpt/client/**",
 ]
 
 [tool.ruff.format]

--- a/sculptor/sculptor-plugin/skills/sculpt-cli/SKILL.md
+++ b/sculptor/sculptor-plugin/skills/sculpt-cli/SKILL.md
@@ -59,8 +59,8 @@ sculpt agent send <agent-id> "And what about Y?" -f
 ```
 
 Exit codes for `--follow`: `0` = turn completed, `2` = the agent stopped to
-ask a question (WAITING). For bounded polling instead, use
-`sculpt agent status <id> --json` (single shot) or `status -f --timeout <s>`.
+ask a question (WAITING). For polling instead, call the single-shot
+`sculpt agent status <id> --json` in your own loop.
 
 ## Models
 

--- a/sculptor/sculptor-plugin/skills/sculpt-cli/SKILL.md
+++ b/sculptor/sculptor-plugin/skills/sculpt-cli/SKILL.md
@@ -11,22 +11,94 @@ description: |
 
 CLI for interacting with the Sculptor API. Use `sculpt --help` for full documentation.
 
-## JSON output
+## Identity: who am I?
 
-All commands support `--json` for machine-readable output. To discover the exact
-shape of the JSON each command returns, use the `schema` subcommand:
+Every Sculptor agent shell exports three env vars identifying the shell's own
+context:
+
+| variable             | meaning                          |
+|----------------------|----------------------------------|
+| `SCULPT_AGENT_ID`    | this shell's own agent (task) ID |
+| `SCULPT_WORKSPACE_ID`| this shell's workspace ID        |
+| `SCULPT_PROJECT_ID`  | the repo/project ID              |
+
+Commands default to them where it makes sense:
 
 ```bash
-# List all available schemas
-sculpt schema
-
-# Show the JSON schema for a specific command's output
-sculpt schema workspace.list
-sculpt schema agent.show
-sculpt schema run
+sculpt agent show        # no argument: shows THIS shell's agent
+sculpt agent status      # ditto
+sculpt workspace show    # no argument: shows THIS shell's workspace
 ```
 
-The schema output is valid JSON Schema and can be used with `jq` for scripting:
+`sculpt agent list` / `sculpt workspace list` mark your own row with `*`, and
+their `--json` output includes an `is_self` field. Before reasoning about
+*other* agents, check your own identity first — don't infer it from branch
+names or workspace titles.
+
+## Addressing agents in other workspaces
+
+Full agent IDs (and unambiguous prefixes) work from anywhere: `send`,
+`interrupt`, `rename`, and `delete` resolve them across all workspaces.
+`SCULPT_WORKSPACE_ID` only narrows ambiguous prefixes; when the agent lives
+elsewhere a stderr note tells you which workspace it is in. An explicit
+`--workspace` is authoritative — if the agent is not in that workspace, the
+command errors instead of silently redirecting.
+
+## Delegate-and-await: the core orchestration pattern
+
+`--follow` on `run` and `agent send` streams the reply and **exits when the
+turn ends**, so it is a synchronous request/response primitive — prefer it
+over polling:
+
+```bash
+# Create a workspace + agent, stream until its first turn finishes
+sculpt run --model haiku --strategy clone --name "Experiment" "Try X and report" -f
+
+# Send a follow-up and wait for the answer
+sculpt agent send <agent-id> "And what about Y?" -f
+```
+
+Exit codes for `--follow`: `0` = turn completed, `2` = the agent stopped to
+ask a question (WAITING). For bounded polling instead, use
+`sculpt agent status <id> --json` (single shot) or `status -f --timeout <s>`.
+
+## Models
+
+`agent send` **keeps the agent's current model** unless you pass `--model` —
+passing it switches the agent's model persistently for subsequent turns.
+`run` / `agent create` default to opus; pick `--model haiku`/`sonnet` for
+cheap disposable agents.
+
+## Agents waiting on a question
+
+When an agent calls AskUserQuestion its status becomes `WAITING`, and
+`sculpt agent status` shows the question and its options:
+
+```
+Status: WAITING
+Waiting: Which color?
+Options: Red | Blue
+```
+
+(`--json`: `waiting_detail` + `waiting_options`.) **Answering is reserved for
+the human user in the Sculptor UI** — there is deliberately no CLI answer
+command. If you are orchestrating and must unblock the agent yourself,
+`sculpt agent interrupt <id>` abandons the question, after which `send` works
+again.
+
+## JSON output
+
+All commands support `--json` for machine-readable output. JSON goes to
+stdout, informational notes to stderr, and with `--json` errors are emitted to
+stderr as `{"error": ..., "detail": ...}`. Discover each command's exact output
+shape with the `schema` subcommand:
+
+```bash
+sculpt schema                   # list all available schemas
+sculpt schema agent.status      # JSON Schema for `sculpt agent status --json`
+```
+
+Examples:
 
 ```bash
 # Get workspace IDs
@@ -36,7 +108,7 @@ sculpt workspace list --all --json | jq '.[].id'
 sculpt agent list --all --json | jq '[.[] | select(.status == "RUNNING")]'
 
 # Get agent progress
-sculpt agent status <id> --json | jq '{status, progress: "\(.todo_completed)/\(.todo_total)"}'
+sculpt agent status <id> --json | jq '{status, progress: "\(.task_completed)/\(.task_total)"}'
 ```
 
 ## Examples
@@ -56,11 +128,12 @@ sculpt run --model opus --name "Fix bug" "Fix the login bug" --json
 sculpt workspace show <id> --json
 sculpt agent show <id> --json
 
-# Check agent status
-sculpt agent status <id> --json
+# Send a message to an agent (any workspace; keeps the agent's model)
+sculpt agent send <agent-id> "Please also update the tests" --json
 
-# Send a message to an agent
-sculpt agent send <id> "Please also update the tests" -w <workspace_id> --json
+# Clean up (both prompt unless -y)
+sculpt agent delete <agent-id> -y
+sculpt workspace delete <workspace-id> -y
 ```
 
 ## Conceptual model
@@ -79,42 +152,41 @@ A working environment derived from a repo. The **initialization strategy**
 is fixed at creation and determines how the workspace's checkout relates to
 the user's repo:
 
-| strategy   | working directory                       | git relationship to user's repo                                            |
-|------------|-----------------------------------------|----------------------------------------------------------------------------|
-| `clone`    | `~/.sculptor/workspaces/<wsid>/code/`   | Separate clone with shared git object store; remotes mirrored. Isolated.   |
-| `worktree` | `~/.sculptor/workspaces/<wsid>/code/`   | Real `git worktree`; `.git` shared. Commits land in user's repo instantly. |
-| `in_place` | The user's repo path itself             | None — agent edits the user's actual checkout.                             |
+| strategy   | git relationship to user's repo                                            | good for                                    |
+|------------|-----------------------------------------------------------------------------|---------------------------------------------|
+| `clone`    | Separate clone with shared git object store; remotes mirrored. Isolated.    | disposable experiments, risky changes        |
+| `worktree` | Real `git worktree`; `.git` shared. Commits land in user's repo instantly.  | normal feature work (the default)            |
+| `in_place` | None — agent edits the user's actual checkout.                              | coordination tasks on the live checkout      |
+
+### Finding a workspace's files
+
+Workspace directories on disk are named by opaque internal IDs that do NOT
+match the `ws_...` API ID — never guess paths. Use the fields reported by
+`workspace show`/`list --json`:
+
+- `working_directory` — the checkout directory (`.../code` for clone/worktree,
+  the repo path itself for in_place)
+- `current_branch` — the branch checked out there right now
+- `repo_path` — the user's original repo
 
 ### Agent
 
 A single coding agent running inside a workspace. Each agent has its own
 conversation, status, todos, state, and artifacts — but shares the
-workspace's `code/` directory with every other agent in the same workspace.
-
-### Filesystem layout (clone / worktree)
-
-```
-~/.sculptor/workspaces/<workspace-id>/
-├── code/                              # the checkout — SHARED across all agents
-├── state/tasks/<agent-id>/            # per-agent private state
-├── artifacts/tasks/<agent-id>/        # per-agent diffs, logs, etc.
-└── attachments/                       # workspace-wide attachments
-```
-
-For `in_place`, the working directory is the user's repo path; the workspace
-dir holds only per-agent state and artifacts.
+workspace's checkout with every other agent in the same workspace.
 
 ### What multiple agents in one workspace share
 
-**Shared**:
+**Shared**: every tracked and untracked file in the checkout, and git state
+(HEAD, branches, working tree, index). There is **no file locking** between
+sibling agents.
 
-- Every tracked and untracked file in `code/`
-- Git state: HEAD, branches, working tree, index
+**Private to each agent**: conversation history; TODOs, status, current
+activity; per-agent state and artifact directories.
 
-There is **no file locking** between sibling agents.
+## Using sculpt from outside a Sculptor shell
 
-**Private to each agent**:
-
-- Conversation history
-- TODOs, status, current activity
-- `state/tasks/<agent-id>/` and `artifacts/tasks/<agent-id>/`
+`sculpt` talks to the local Sculptor app, defaulting to
+`http://localhost:5050`. If the app serves a different port (it exports
+`SCULPT_API_PORT` into its own shells), set that variable or pass
+`--base-url` explicitly.

--- a/sculptor/sculptor/services/data_model_service/data_types.py
+++ b/sculptor/sculptor/services/data_model_service/data_types.py
@@ -42,10 +42,15 @@ class WorkspaceListingRow(FrozenModel):
     description: str
     initialization_strategy: WorkspaceInitializationStrategy
     source_branch: str | None
+    environment_id: str | None
     is_deleted: bool
     is_open: bool
     created_at: datetime.datetime
     project_name: str
+    # The project's user_git_repo_url (a file:// URL when set), denormalized so
+    # the web layer can derive the workspace's working directory without a
+    # per-row project lookup.
+    project_git_repo_url: str | None
     agent_count: int
     last_activity_at: datetime.datetime
 

--- a/sculptor/sculptor/services/data_model_service/sql_implementation.py
+++ b/sculptor/sculptor/services/data_model_service/sql_implementation.py
@@ -324,10 +324,12 @@ class SQLTransaction(BaseDataModelTransaction):
                     w.description,
                     w.initialization_strategy,
                     w.source_branch,
+                    w.environment_id,
                     w.is_deleted,
                     w.is_open,
                     w.created_at,
                     p.name AS project_name,
+                    p.user_git_repo_url AS project_git_repo_url,
                     COUNT(CASE
                         WHEN t.is_deleted = 0
                          AND json_extract(t.current_state, '$.workspace_id') = w.object_id

--- a/sculptor/sculptor/services/workspace_service/api.py
+++ b/sculptor/sculptor/services/workspace_service/api.py
@@ -149,6 +149,15 @@ class WorkspaceService(Service, ABC):
     def remove_observer(self, queue: "Queue[StreamingUpdateSourceTypes]") -> None:
         """Unsubscribe a queue previously passed to ``add_observer``."""
 
+    @abstractmethod
+    def get_cached_current_branch(self, workspace_id: WorkspaceID) -> str | None:
+        """Return the branch scanner's cached current branch for a workspace.
+
+        A pure cache read — never forks git, resumes an environment, or starts
+        the scanning machinery. Returns None when the branch is unknown (the
+        workspace hasn't been scanned yet, or the scanner isn't running).
+        """
+
     # Workspace Operations
 
     @abstractmethod

--- a/sculptor/sculptor/services/workspace_service/branch_poller.py
+++ b/sculptor/sculptor/services/workspace_service/branch_poller.py
@@ -127,6 +127,12 @@ class WorkspaceBranchPoller:
         with self._observer_lock:
             self._observers = [observer for observer in self._observers if observer is not queue]
 
+    def get_current_branch(self, workspace_id: WorkspaceID) -> str | None:
+        """Return the last-scanned current branch for a workspace, or None if not yet scanned."""
+        with self._observer_lock:
+            info = self._branch_info_by_workspace.get(workspace_id)
+        return info.current_branch if info is not None else None
+
     def _publish_branch_info(self, info: WorkspaceBranchInfo) -> None:
         """Atomically record and fan out a branch update under ``_observer_lock``."""
         with self._observer_lock:

--- a/sculptor/sculptor/services/workspace_service/branch_poller_test.py
+++ b/sculptor/sculptor/services/workspace_service/branch_poller_test.py
@@ -145,6 +145,22 @@ def test_target_falls_back_to_local_excluding_own_branch(
     assert "wsbranch" not in target_infos[0].target_branches
 
 
+def test_get_current_branch_returns_cached_value_and_none_for_unknown(
+    base_repo: Path, tmp_path: Path, test_root_concurrency_group: ConcurrencyGroup
+) -> None:
+    worktree = tmp_path / "ws"
+    _add_worktree(base_repo, worktree, "wsbranch")
+    workspace = _FakeWorkspace(WorkspaceID(), ProjectID())
+    poller = _build_poller([workspace], {workspace.object_id: worktree}, test_root_concurrency_group)
+
+    assert poller.get_current_branch(workspace.object_id) is None  # Nothing scanned yet.
+
+    poller._scan_once()
+
+    assert poller.get_current_branch(workspace.object_id) == "wsbranch"
+    assert poller.get_current_branch(WorkspaceID()) is None
+
+
 def test_branch_change_emits_and_refreshes_diff(
     base_repo: Path, tmp_path: Path, test_root_concurrency_group: ConcurrencyGroup
 ) -> None:

--- a/sculptor/sculptor/services/workspace_service/default_implementation.py
+++ b/sculptor/sculptor/services/workspace_service/default_implementation.py
@@ -156,6 +156,16 @@ class DefaultWorkspaceService(WorkspaceService):
     def remove_observer(self, queue: Queue[StreamingUpdateSourceTypes]) -> None:
         self._branch_poller.remove_observer(queue)
 
+    def get_cached_current_branch(self, workspace_id: WorkspaceID) -> str | None:
+        # Read the instance directly instead of going through the lazy
+        # ``_branch_poller`` property: a pure cache read must not construct the
+        # polling machinery.
+        with self._branch_poller_lock:
+            poller = self._branch_poller_instance
+        if poller is None:
+            return None
+        return poller.get_current_branch(workspace_id)
+
     def reconcile_setup_state(self) -> None:
         """Bring persisted setup state into a coherent state on app startup.
 

--- a/sculptor/sculptor/services/workspace_service/workspace_service_test.py
+++ b/sculptor/sculptor/services/workspace_service/workspace_service_test.py
@@ -1190,3 +1190,27 @@ class TestExpandNumstatRenamePath:
 
     def test_no_rename(self) -> None:
         assert DefaultWorkspaceService._expand_numstat_rename_path("src/file.py") == "src/file.py"
+
+
+def test_get_cached_current_branch_does_not_create_the_branch_poller(
+    test_service_collection: CompleteServiceCollection,
+    test_root_concurrency_group: ConcurrencyGroup,
+) -> None:
+    """The accessor is a pure cache read: on a service whose poller has never
+    been built it must return None WITHOUT constructing the polling machinery."""
+    fresh_service = DefaultWorkspaceService.build(
+        concurrency_group=test_root_concurrency_group,
+        settings=test_service_collection.settings,
+        data_model_service=test_service_collection.data_model_service,
+        project_service=test_service_collection.project_service,
+        dependency_management_service=test_service_collection.dependency_management_service,
+    )
+
+    assert fresh_service.get_cached_current_branch(WorkspaceID()) is None
+    assert fresh_service._branch_poller_instance is None
+
+
+def test_get_cached_current_branch_returns_none_for_unknown_workspace(
+    test_service_collection: CompleteServiceCollection,
+) -> None:
+    assert test_service_collection.workspace_service.get_cached_current_branch(WorkspaceID()) is None

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -353,7 +353,45 @@ def validate_workspace_id(workspace_id: str) -> WorkspaceID:
         ) from e
 
 
-def _workspace_to_response(workspace: Workspace, workspace_setup_command: str | None = None) -> WorkspaceResponse:
+def _project_path_from_git_repo_url(user_git_repo_url: str | None) -> str | None:
+    """Convert a project's file:// repo URL to a local filesystem path.
+
+    Mirrors ``Project.get_local_user_path`` for callers that only have the raw
+    URL (e.g. denormalized listing rows), but returns None instead of asserting
+    when the URL is missing or not file://-schemed.
+    """
+    if user_git_repo_url is None or not user_git_repo_url.startswith("file://"):
+        return None
+    return str(Path(user_git_repo_url.removeprefix("file://")))
+
+
+def _workspace_working_directory(
+    strategy: WorkspaceInitializationStrategy,
+    environment_id: str | None,
+    project_path: str | None,
+) -> str | None:
+    """Resolve the directory holding a workspace's checkout.
+
+    Mirrors ``LocalEnvironment.get_working_directory`` without resuming the
+    environment (resume has side effects and is too heavy for list endpoints):
+    clone/worktree checkouts live at ``<environment_id>/code`` (environment_id
+    is the absolute workspace directory path), while in-place workspaces work
+    directly in the project's local repo. None when the environment hasn't been
+    initialized yet.
+    """
+    if strategy == WorkspaceInitializationStrategy.IN_PLACE:
+        return project_path
+    if environment_id is None:
+        return None
+    return str(Path(environment_id) / "code")
+
+
+def _workspace_to_response(
+    workspace: Workspace,
+    workspace_setup_command: str | None = None,
+    project_path: str | None = None,
+    current_branch: str | None = None,
+) -> WorkspaceResponse:
     """Convert a Workspace model to a WorkspaceResponse."""
     setup_snapshot = _build_setup_snapshot(workspace)
     return WorkspaceResponse(
@@ -370,6 +408,10 @@ def _workspace_to_response(workspace: Workspace, workspace_setup_command: str | 
         created_at=workspace.created_at,
         workspace_setup_command=workspace_setup_command,
         setup=setup_snapshot,
+        working_directory=_workspace_working_directory(
+            workspace.initialization_strategy, workspace.environment_id, project_path
+        ),
+        current_branch=current_branch,
     )
 
 
@@ -764,7 +806,12 @@ def create_workspace_v2(
             in (WorkspaceInitializationStrategy.CLONE, WorkspaceInitializationStrategy.WORKTREE)
             else None
         )
-        return _workspace_to_response(workspace, workspace_setup_command=setup_command)
+        return _workspace_to_response(
+            workspace,
+            workspace_setup_command=setup_command,
+            project_path=_project_path_from_git_repo_url(project.user_git_repo_url),
+            current_branch=services.workspace_service.get_cached_current_branch(workspace.object_id),
+        )
 
 
 _PREVIEW_BRANCH_NAME_GIT_TIMEOUT = 5.0
@@ -939,6 +986,12 @@ def list_recent_workspaces(
             agent_count=row.agent_count,
             is_open=row.is_open,
             last_activity_at=row.last_activity_at,
+            working_directory=_workspace_working_directory(
+                row.initialization_strategy,
+                row.environment_id,
+                _project_path_from_git_repo_url(row.project_git_repo_url),
+            ),
+            current_branch=services.workspace_service.get_cached_current_branch(row.object_id),
         )
         for row in workspace_rows
     ]
@@ -969,13 +1022,18 @@ def update_workspace(
         except WorkspaceNotFoundError as e:
             raise HTTPException(status_code=404, detail=f"Workspace {workspace_id} not found") from e
         logger.info("Updated workspace {}", workspace_id)
+        project = transaction.get_project(updated_workspace.project_id)
 
     # Refresh diffs after the transaction commits so the frontend picks up the
     # new target-branch diff via the diffUpdatedAt reactivity.
     if update_request.target_branch is not None:
         services.workspace_service.refresh_workspace_diff(validated_workspace_id, include_target_branch_diff=True)
 
-    return _workspace_to_response(updated_workspace)
+    return _workspace_to_response(
+        updated_workspace,
+        project_path=_project_path_from_git_repo_url(project.user_git_repo_url) if project is not None else None,
+        current_branch=services.workspace_service.get_cached_current_branch(updated_workspace.object_id),
+    )
 
 
 @router.post("/api/v1/workspaces/batch-update-open-state")
@@ -1015,7 +1073,12 @@ def get_workspace(
         workspace = transaction.get_workspace(validated_workspace_id)
         if workspace is None or workspace.is_deleted:
             raise HTTPException(status_code=404, detail=f"Workspace {workspace_id} not found")
-        return _workspace_to_response(workspace)
+        project = transaction.get_project(workspace.project_id)
+        return _workspace_to_response(
+            workspace,
+            project_path=_project_path_from_git_repo_url(project.user_git_repo_url) if project is not None else None,
+            current_branch=services.workspace_service.get_cached_current_branch(workspace.object_id),
+        )
 
 
 @router.get("/api/v1/projects/{project_id}/workspaces")
@@ -1030,7 +1093,16 @@ def list_workspaces(
 
     with user_session.open_transaction(services) as transaction:
         workspaces = transaction.get_workspaces(project_id=validated_project_id)
-        return [_workspace_to_response(w) for w in workspaces]
+        project = transaction.get_project(validated_project_id)
+        project_path = _project_path_from_git_repo_url(project.user_git_repo_url) if project is not None else None
+        return [
+            _workspace_to_response(
+                w,
+                project_path=project_path,
+                current_branch=services.workspace_service.get_cached_current_branch(w.object_id),
+            )
+            for w in workspaces
+        ]
 
 
 @router.delete("/api/v1/workspaces/{workspace_id}")

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -48,6 +48,7 @@ from sculptor.state.messages import LLMModel
 from sculptor.state.messages import ModelOption
 from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.web.app import _agent_config_for_request
+from sculptor.web.app import _workspace_working_directory
 from sculptor.web.auth import SESSION_TOKEN_HEADER_NAME
 from sculptor.web.auth import UserSession
 from sculptor.web.auth import authenticate_anonymous
@@ -259,6 +260,41 @@ def test_create_worktree_workspace_accepts_valid_branch_name(
 ) -> None:
     response = _post_create_worktree_workspace(client, test_project, "imbue/board-demo-workspace")
     assert response.status_code == 200, response.text
+
+
+def test_workspace_working_directory_resolves_per_strategy() -> None:
+    # Clone and worktree checkouts live at <environment_id>/code.
+    assert _workspace_working_directory(WorkspaceInitializationStrategy.CLONE, "/tmp/ws1", "/repo") == "/tmp/ws1/code"
+    assert (
+        _workspace_working_directory(WorkspaceInitializationStrategy.WORKTREE, "/tmp/ws2", "/repo") == "/tmp/ws2/code"
+    )
+    # In-place workspaces work directly in the project's local repo.
+    assert _workspace_working_directory(WorkspaceInitializationStrategy.IN_PLACE, None, "/repo") == "/repo"
+    # No environment yet for an isolated checkout: unknown.
+    assert _workspace_working_directory(WorkspaceInitializationStrategy.CLONE, None, "/repo") is None
+
+
+def test_workspace_endpoints_report_working_directory_and_current_branch(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        workspace = _create_workspace(transaction, test_services, test_project)
+
+    response = client.get("/api/v1/workspaces/recent")
+    assert response.status_code == 200, response.text
+    rows_by_id = {row["objectId"]: row for row in response.json()["workspaces"]}
+    row = rows_by_id[str(workspace.object_id)]
+    # IN_PLACE workspaces work directly in the project's local repo.
+    assert row["workingDirectory"] == str(test_project.get_local_user_path())
+    # The branch scan cache may not have run yet, so only presence is guaranteed.
+    assert "currentBranch" in row
+
+    response = client.get(f"/api/v1/workspaces/{workspace.object_id}")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["workingDirectory"] == str(test_project.get_local_user_path())
+    assert "currentBranch" in body
 
 
 def _validate_new_branch_name(client: TestClient, project: Project, name: str) -> dict:

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -237,6 +237,13 @@ class WorkspaceResponse(SerializableModel):
     created_at: datetime.datetime
     workspace_setup_command: str | None = None
     setup: "WorkspaceSetupSnapshot | None" = None
+    # Absolute path of the workspace's checkout: `<environment_id>/code` for
+    # clone/worktree workspaces, the project's local repo path for in-place ones.
+    # None when the environment hasn't been initialized yet.
+    working_directory: str | None = None
+    # Branch currently checked out in that directory, from the workspace
+    # service's branch scan cache. None when not yet scanned.
+    current_branch: str | None = None
 
 
 class PreviewBranchNameResponse(SerializableModel):
@@ -343,6 +350,13 @@ class RecentWorkspaceResponse(SerializableModel):
     agent_count: int
     is_open: bool
     last_activity_at: datetime.datetime
+    # Absolute path of the workspace's checkout: `<environment_id>/code` for
+    # clone/worktree workspaces, the project's local repo path for in-place ones.
+    # None when the environment hasn't been initialized yet.
+    working_directory: str | None = None
+    # Branch currently checked out in that directory, from the workspace
+    # service's branch scan cache. None when not yet scanned.
+    current_branch: str | None = None
 
 
 class ListWorkspacesResponse(SerializableModel):

--- a/sculptor/tests/integration/frontend/test_sculpt_cli.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_cli.py
@@ -271,10 +271,12 @@ def _assert_subset(expected: dict[str, Any], actual: dict[str, Any]) -> None:
 
 WORKSPACE_CREATE_KEYS = {"id", "repo_id", "description", "strategy", "source_branch"}
 
-WORKSPACE_LIST_ALL_KEYS = {
+WORKSPACE_SHOW_KEYS = {
     "id",
     "repo_id",
     "repo_path",
+    "working_directory",
+    "current_branch",
     "description",
     "strategy",
     "source_branch",
@@ -284,11 +286,13 @@ WORKSPACE_LIST_ALL_KEYS = {
     "last_activity_at",
 }
 
+WORKSPACE_LIST_ALL_KEYS = WORKSPACE_SHOW_KEYS | {"is_self"}
+
 REPO_KEYS = {"id", "name", "path", "accessible", "created_at"}
 
 AGENT_CREATE_KEYS = {"id", "title", "status", "model", "workspace_id", "created_at"}
 
-AGENT_LIST_KEYS = {"id", "title", "status", "model", "workspace_id", "created_at"}
+AGENT_LIST_KEYS = {"id", "title", "status", "model", "workspace_id", "created_at", "is_self"}
 
 AGENT_SHOW_KEYS = {
     "id",
@@ -308,6 +312,7 @@ AGENT_SHOW_KEYS = {
     "task_total",
     "current_task_subject",
     "waiting_detail",
+    "waiting_options",
     "error_detail",
 }
 
@@ -318,6 +323,7 @@ AGENT_STATUS_KEYS = {
     "current_activity",
     "last_activity",
     "waiting_detail",
+    "waiting_options",
     "error_detail",
     "task_completed",
     "task_total",
@@ -378,7 +384,7 @@ def test_workspace_show_via_cli(sculptor_instance_: SculptorInstance) -> None:
     assert exit_code == 0, f"workspace show failed: {output}"
     detail = json.loads(output)
 
-    assert set(detail.keys()) == WORKSPACE_LIST_ALL_KEYS
+    assert set(detail.keys()) == WORKSPACE_SHOW_KEYS
     _assert_subset(
         {
             "id": ws_id,
@@ -811,7 +817,7 @@ def test_agent_delete_via_cli(sculptor_instance_: SculptorInstance) -> None:
     assert exit_code == 0
     agent_id = json.loads(output)["id"]
 
-    exit_code, output = _run_sculpt(sculptor_instance_, ["agent", "delete", agent_id, "--workspace", ws_id])
+    exit_code, output = _run_sculpt(sculptor_instance_, ["agent", "delete", agent_id, "--workspace", ws_id, "--yes"])
     assert exit_code == 0, f"agent delete failed: {output}"
     deleted = json.loads(output)
     assert deleted == {"deleted": True, "id": agent_id}
@@ -1129,6 +1135,7 @@ def _expected_status_event(agent_id: str) -> dict[str, Any]:
             "current_activity": ANY_STR_OR_NONE,
             "last_activity": ANY_STR_OR_NONE,
             "waiting_detail": None,
+            "waiting_options": None,
             "error_detail": None,
             "task_completed": 0,
             "task_total": 0,

--- a/tools/sculpt/sculpt/auth.py
+++ b/tools/sculpt/sculpt/auth.py
@@ -3,11 +3,11 @@
 import os
 
 import httpx
-import typer
 
 from sculpt.client import Client
 from sculpt.client.models import LLMModel
-from sculpt.formatting import CONNECTION_HINT
+from sculpt.formatting import cli_error
+from sculpt.formatting import handle_connection_error
 from sculpt.session import SessionTokenError
 from sculpt.session import get_session_token
 
@@ -40,16 +40,13 @@ MODEL_MAPPING: dict[str, LLMModel] = {
 }
 
 
-def get_authenticated_client(base_url: str) -> Client:
+def get_authenticated_client(base_url: str, json_output: bool = False) -> Client:
     """Create an authenticated client for the Sculptor API."""
     client = build_client(base_url)
     try:
         session_token = get_session_token(client)
     except SessionTokenError as e:
-        typer.echo(f"Error: {e}", err=True)
-        raise typer.Exit(code=1) from None
+        cli_error(str(e), json_output=json_output)
     except (httpx.ConnectError, httpx.ConnectTimeout):
-        typer.echo(f"Error: Could not connect to Sculptor server at {base_url}", err=True)
-        typer.echo(CONNECTION_HINT, err=True)
-        raise typer.Exit(code=1) from None
+        handle_connection_error(json_output, base_url=base_url)
     return client.with_headers({"x-session-token": session_token})

--- a/tools/sculpt/sculpt/auth.py
+++ b/tools/sculpt/sculpt/auth.py
@@ -7,6 +7,7 @@ import typer
 
 from sculpt.client import Client
 from sculpt.client.models import LLMModel
+from sculpt.formatting import CONNECTION_HINT
 from sculpt.session import SessionTokenError
 from sculpt.session import get_session_token
 
@@ -49,5 +50,6 @@ def get_authenticated_client(base_url: str) -> Client:
         raise typer.Exit(code=1) from None
     except (httpx.ConnectError, httpx.ConnectTimeout):
         typer.echo(f"Error: Could not connect to Sculptor server at {base_url}", err=True)
+        typer.echo(CONNECTION_HINT, err=True)
         raise typer.Exit(code=1) from None
     return client.with_headers({"x-session-token": session_token})

--- a/tools/sculpt/sculpt/commands/_follow_helpers.py
+++ b/tools/sculpt/sculpt/commands/_follow_helpers.py
@@ -10,6 +10,7 @@ import typer
 from sculpt.auth import build_client
 from sculpt.commands.data_types import AgentStatusOutput
 from sculpt.formatting import cli_error
+from sculpt.formatting import handle_connection_error
 from sculpt.message_formatting import format_message
 from sculpt.session import SessionTokenError
 from sculpt.session import get_session_token
@@ -25,7 +26,7 @@ def get_session_token_safe(base_url: str, json_output: bool) -> str:
     except SessionTokenError as e:
         cli_error(str(e), json_output=json_output)
     except (httpx.ConnectError, httpx.ConnectTimeout):
-        cli_error(f"Could not connect to Sculptor server at {base_url}", json_output=json_output)
+        handle_connection_error(json_output, base_url=base_url)
 
 
 def handle_exit_reason(reason: ExitReason, json_output: bool) -> None:
@@ -55,6 +56,7 @@ def on_status_json(snapshot: AgentSnapshot) -> None:
         current_activity=snapshot.current_activity,
         last_activity=snapshot.last_activity,
         waiting_detail=snapshot.waiting_detail,
+        waiting_options=snapshot.waiting_options,
         error_detail=snapshot.error_detail,
         task_completed=snapshot.task_completed,
         task_total=snapshot.task_total,

--- a/tools/sculpt/sculpt/commands/_follow_helpers.py
+++ b/tools/sculpt/sculpt/commands/_follow_helpers.py
@@ -151,7 +151,5 @@ def follow_and_stream_messages(base_url: str, agent_id: str, *, json_output: boo
         messages_cb = on_messages_text
         reconnect_cb = on_reconnect_separator
 
-    exit_reason = follow_agent(
-        base_url, session_token, agent_id, status_cb, messages_cb, reconnect_cb
-    )
+    exit_reason = follow_agent(base_url, session_token, agent_id, status_cb, messages_cb, reconnect_cb)
     handle_exit_reason(exit_reason, json_output)

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -59,6 +59,7 @@ from sculpt.formatting import overwrite_lines
 from sculpt.formatting import truncate
 from sculpt.message_formatting import format_message
 from sculpt.resolve import find_prefix_matches
+from sculpt.resolve import find_workspace_id
 from sculpt.resolve import resolve_agent_id
 from sculpt.resolve import resolve_by_prefix
 from sculpt.resolve import resolve_project
@@ -376,8 +377,13 @@ def _resolve_agent_for_action(
         return agent.id, workspace_id, _model_identifier(agent.model)
 
     env_workspace = os.environ.get("SCULPT_WORKSPACE_ID")
-    if env_workspace:
-        workspace_id = resolve_workspace_id(client, env_workspace, json_output)
+    # Resolve the env scope leniently: a stale SCULPT_WORKSPACE_ID (workspace
+    # deleted after this shell started) means "no scope", not a hard failure —
+    # otherwise full IDs would stop working from exactly the shells that most
+    # need the global fallback.
+    env_workspace_id = find_workspace_id(client, env_workspace, json_output) if env_workspace else None
+    if env_workspace_id is not None:
+        workspace_id = env_workspace_id
         agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
         matches = find_prefix_matches(agent_id_arg, agents, lambda a: a.id)
         if len(matches) == 1:
@@ -543,6 +549,11 @@ def delete(
     resolved_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     if not yes:
+        # An interactive prompt would corrupt the JSON stream (typer.confirm
+        # writes to stdout) and EOF-abort with plain text in scripts; fail
+        # with the structured error contract instead.
+        if json_output:
+            cli_error("Confirmation required: pass --yes/-y to delete", json_output=True)
         typer.confirm(f"Delete agent {resolved_id}?", abort=True)
 
     try:

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -159,11 +159,7 @@ def create(
     llm_model = MODEL_MAPPING[model_lower]
 
     selection = resolve_harness_selection(harness, client, json_output)
-    if (
-        prompt
-        and selection is not None
-        and selection.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED)
-    ):
+    if prompt and selection is not None and selection.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
         cli_error("Terminal agents do not take an initial prompt (--prompt)", json_output=json_output)
 
     request = CreateAgentRequest(
@@ -174,9 +170,7 @@ def create(
         sent_via="sculpt",
         agent_type=selection.agent_type if selection is not None else UNSET,
         registration_id=(
-            selection.registration_id
-            if selection is not None and selection.registration_id is not None
-            else UNSET
+            selection.registration_id if selection is not None and selection.registration_id is not None else UNSET
         ),
     )
 
@@ -212,7 +206,9 @@ def create(
 @agent_app.command("list")
 def list_cmd(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace ID (or set SCULPT_WORKSPACE_ID)"),
-    status: str | None = typer.Option(None, "--status", "-s", help="Filter by status (BUILDING, ERROR, READY, RUNNING)"),
+    status: str | None = typer.Option(
+        None, "--status", "-s", help="Filter by status (BUILDING, ERROR, READY, RUNNING)"
+    ),
     show_all: bool = typer.Option(False, "--all", help="List agents across all workspaces"),
     repo: str | None = typer.Option(None, "--repo", help="Path to the repository"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -225,7 +221,9 @@ def list_cmd(
     if status is not None:
         status = status.upper()
         if status not in valid_statuses:
-            cli_error(f"Invalid status '{status}'. Valid options: {', '.join(valid_statuses)}", json_output=json_output)
+            cli_error(
+                f"Invalid status '{status}'. Valid options: {', '.join(valid_statuses)}", json_output=json_output
+            )
 
     session_token = get_session_token_safe(base_url, json_output)
 
@@ -297,9 +295,7 @@ def list_cmd(
         typer.echo("* = this agent (SCULPT_AGENT_ID)", err=True)
 
 
-def _fetch_agents_for_workspace(
-    client: Client, workspace_id: str, json_output: bool
-) -> list[CodingAgentTaskView]:
+def _fetch_agents_for_workspace(client: Client, workspace_id: str, json_output: bool) -> list[CodingAgentTaskView]:
     try:
         result = list_workspace_agents.sync(workspace_id=workspace_id, client=client)
     except httpx.ConnectError:
@@ -508,9 +504,7 @@ def rename(
     """Rename an agent."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(
-        base_url, client, agent_id, workspace, json_output
-    )
+    resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     request = RenameAgentRequest(title=title)
 
@@ -546,9 +540,7 @@ def delete(
     """Delete an agent."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    resolved_id, workspace_id, _ = _resolve_agent_for_action(
-        base_url, client, agent_id, workspace, json_output
-    )
+    resolved_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     if not yes:
         typer.confirm(f"Delete agent {resolved_id}?", abort=True)
@@ -628,9 +620,7 @@ def send(
         return
 
     if json_output:
-        output = AgentSendOutput(
-            sent=True, agent_id=resolved_agent_id, message=message[:_MESSAGE_PREVIEW_MAX_LENGTH]
-        )
+        output = AgentSendOutput(sent=True, agent_id=resolved_agent_id, message=message[:_MESSAGE_PREVIEW_MAX_LENGTH])
         typer.echo(output.model_dump_json())
         return
 
@@ -866,14 +856,10 @@ def interrupt(
     """Interrupt a running agent."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(
-        base_url, client, agent_id, workspace, json_output
-    )
+    resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     try:
-        interrupt_workspace_agent.sync(
-            workspace_id=workspace_id, agent_id=resolved_agent_id, client=client
-        )
+        interrupt_workspace_agent.sync(workspace_id=workspace_id, agent_id=resolved_agent_id, client=client)
     except httpx.ConnectError:
         handle_connection_error(json_output, base_url=base_url)
 

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -24,6 +24,7 @@ from sculpt.client.models.agent_type_name import AgentTypeName
 from sculpt.client.models.coding_agent_task_view import CodingAgentTaskView
 from sculpt.client.models.create_agent_request import CreateAgentRequest
 from sculpt.client.models.http_validation_error import HTTPValidationError
+from sculpt.client.models.llm_model import LLMModel
 from sculpt.client.models.rename_agent_request import RenameAgentRequest
 from sculpt.client.models.send_message_request import SendMessageRequest
 from sculpt.client.models.task_status import TaskStatus
@@ -57,6 +58,7 @@ from sculpt.formatting import is_tty
 from sculpt.formatting import overwrite_lines
 from sculpt.formatting import truncate
 from sculpt.message_formatting import format_message
+from sculpt.resolve import find_prefix_matches
 from sculpt.resolve import resolve_agent_id
 from sculpt.resolve import resolve_by_prefix
 from sculpt.resolve import resolve_project
@@ -237,7 +239,7 @@ def list_cmd(
         scope = f"workspace:{resolved_ws_id}"
     else:
         client = get_authenticated_client(base_url)
-        project_id = resolve_project(repo, client)
+        project_id = resolve_project(repo, client, json_output)
         scope = f"project:{project_id}"
 
     try:
@@ -256,6 +258,8 @@ def list_cmd(
 
     agents.sort(key=lambda t: t.created_at, reverse=True)
 
+    self_agent_id = os.environ.get("SCULPT_AGENT_ID")
+
     if json_output:
         items = [
             AgentListItem(
@@ -265,6 +269,7 @@ def list_cmd(
                 model=t.model,
                 workspace_id=t.workspace_id,
                 created_at=t.created_at,
+                is_self=t.task_id == self_agent_id,
             )
             for t in agents
         ]
@@ -278,7 +283,7 @@ def list_cmd(
     headers = ["ID", "STATUS", "MODEL", "WORKSPACE", "CREATED", "TITLE"]
     rows = [
         [
-            t.task_id[:_ID_DISPLAY_PREFIX_LENGTH],
+            t.task_id[:_ID_DISPLAY_PREFIX_LENGTH] + (" *" if t.task_id == self_agent_id else ""),
             t.status,
             _format_model_name(t.model),
             t.workspace_id[:_ID_DISPLAY_PREFIX_LENGTH],
@@ -288,6 +293,8 @@ def list_cmd(
         for t in agents
     ]
     typer.echo(format_table(headers, rows))
+    if any(t.task_id == self_agent_id for t in agents):
+        typer.echo("* = this agent (SCULPT_AGENT_ID)", err=True)
 
 
 def _fetch_agents_for_workspace(
@@ -307,17 +314,128 @@ def _fetch_agents_for_workspace(
     return [a for a in result if isinstance(a, CodingAgentTaskView)]
 
 
+def _model_identifier(model: LLMModel | str | None) -> str | None:
+    """The agent's model as its wire string.
+
+    The generated client parses an unknown model value (from a newer server)
+    as the raw string rather than an ``LLMModel``, so ``.value`` is not safe.
+    """
+    if model is None:
+        return None
+    if isinstance(model, LLMModel):
+        return model.value
+    return str(model)
+
+
+def _fetch_agents_across_workspaces(base_url: str, json_output: bool) -> list[AgentSnapshot]:
+    """Fetch live agent snapshots across all workspaces."""
+    session_token = get_session_token_safe(base_url, json_output)
+    try:
+        snapshots = fetch_all_agents(base_url, session_token, scope="all")
+    except (OSError, websockets.exceptions.WebSocketException):
+        handle_connection_error(json_output, base_url=base_url)
+    return [s for s in snapshots if not s.is_deleted]
+
+
+def _resolve_agent_for_action(
+    base_url: str,
+    client: Client,
+    agent_id_arg: str,
+    workspace_option: str | None,
+    json_output: bool,
+) -> tuple[str, str, str | None]:
+    """Resolve an agent reference for a workspace-scoped endpoint call.
+
+    Returns ``(agent_id, workspace_id, current_model)``. An explicit
+    ``--workspace`` is authoritative: the agent must be inside it, and an ID
+    that lives in a different workspace is an error rather than a silent
+    redirect. Without the flag, ``SCULPT_WORKSPACE_ID`` (set in every Sculptor
+    agent shell) is only a disambiguation scope — an agent with no match there
+    is looked up across all workspaces, so full IDs work from any shell.
+    """
+    if workspace_option is not None:
+        workspace_id = resolve_workspace_id(client, workspace_option, json_output)
+        agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
+        if not find_prefix_matches(agent_id_arg, agents, lambda a: a.id):
+            elsewhere = find_prefix_matches(
+                agent_id_arg,
+                _fetch_agents_across_workspaces(base_url, json_output),
+                lambda s: s.task_id,
+            )
+            if len(elsewhere) == 1:
+                cli_error(
+                    f"Agent {elsewhere[0].task_id} is in workspace {elsewhere[0].workspace_id},"
+                    + f" not {workspace_id}",
+                    json_output=json_output,
+                )
+        agent = resolve_by_prefix(
+            agent_id_arg,
+            agents,
+            lambda a: a.id,
+            resource_noun="agent",
+            json_output=json_output,
+            label_getter=_get_task_title,
+            scope_description=f"workspace {workspace_id}",
+        )
+        return agent.id, workspace_id, _model_identifier(agent.model)
+
+    env_workspace = os.environ.get("SCULPT_WORKSPACE_ID")
+    if env_workspace:
+        workspace_id = resolve_workspace_id(client, env_workspace, json_output)
+        agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
+        matches = find_prefix_matches(agent_id_arg, agents, lambda a: a.id)
+        if len(matches) == 1:
+            agent = matches[0]
+            return agent.id, workspace_id, _model_identifier(agent.model)
+        if len(matches) > 1:
+            resolve_by_prefix(
+                agent_id_arg,
+                agents,
+                lambda a: a.id,
+                resource_noun="agent",
+                json_output=json_output,
+                label_getter=_get_task_title,
+                scope_description=f"workspace {workspace_id} (from SCULPT_WORKSPACE_ID)",
+            )
+        # No match in the shell's own workspace — widen to all workspaces.
+
+    snapshots = _fetch_agents_across_workspaces(base_url, json_output)
+    snapshot = resolve_by_prefix(
+        agent_id_arg,
+        snapshots,
+        lambda s: s.task_id,
+        resource_noun="agent",
+        json_output=json_output,
+        label_getter=lambda s: s.title,
+    )
+    if env_workspace:
+        # The agent resolved outside the shell's own workspace; say where it
+        # actually lives so a cross-workspace action is never silent.
+        typer.echo(f"Agent {snapshot.task_id} is in workspace {snapshot.workspace_id}", err=True)
+    return snapshot.task_id, snapshot.workspace_id, snapshot.model
+
+
+def _agent_id_or_env(agent_id: str | None, json_output: bool) -> str:
+    """Default an omitted AGENT_ID argument to the shell's own agent."""
+    if agent_id:
+        return agent_id
+    env_value = os.environ.get("SCULPT_AGENT_ID")
+    if env_value:
+        typer.echo("Using agent from SCULPT_AGENT_ID", err=True)
+        return env_value
+    cli_error("AGENT_ID is required (or set SCULPT_AGENT_ID)", json_output=json_output)
+
 
 @agent_app.command("show")
 def show(
-    agent_id: str = typer.Argument(..., help="Agent ID or prefix"),
+    agent_id: str | None = typer.Argument(None, help="Agent ID or prefix (defaults to SCULPT_AGENT_ID)"),
     timeout: float = typer.Option(30.0, "--timeout", help="Timeout in seconds for WebSocket connection"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
     base_url: str | None = typer.Option(None, "--base-url", "-u", help="The Sculptor server URL"),
 ) -> None:
-    """Show details of an agent."""
+    """Show details of an agent (with no argument: this shell's own agent)."""
     base_url = base_url or get_default_base_url()
-    full_agent_id = resolve_agent_id(base_url, agent_id, json_output)
+    full_agent_id = resolve_agent_id(base_url, _agent_id_or_env(agent_id, json_output), json_output)
     snapshot = _fetch_snapshot(base_url, full_agent_id, timeout, json_output)
 
     if json_output:
@@ -339,6 +457,7 @@ def show(
             task_total=snapshot.task_total,
             current_task_subject=snapshot.current_task_subject,
             waiting_detail=snapshot.waiting_detail,
+            waiting_options=snapshot.waiting_options,
             error_detail=snapshot.error_detail,
         )
         typer.echo(output.model_dump_json(indent=2))
@@ -369,6 +488,8 @@ def show(
         lines.append(progress)
     if snapshot.waiting_detail:
         lines.append(f"Waiting: {snapshot.waiting_detail}")
+    if snapshot.waiting_options:
+        lines.append(f"Options: {' | '.join(snapshot.waiting_options)}")
     if snapshot.error_detail:
         lines.append(f"Error: {snapshot.error_detail}")
     if snapshot.artifact_names:
@@ -387,19 +508,18 @@ def rename(
     """Rename an agent."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    workspace_id = resolve_workspace(workspace, client, json_output)
-
-    agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
-    agent = resolve_by_prefix(agent_id, agents, lambda a: a.id)
+    resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(
+        base_url, client, agent_id, workspace, json_output
+    )
 
     request = RenameAgentRequest(title=title)
 
     try:
         result = rename_workspace_agent.sync(
-            workspace_id=workspace_id, agent_id=agent.id, client=client, body=request
+            workspace_id=workspace_id, agent_id=resolved_agent_id, client=client, body=request
         )
     except httpx.ConnectError:
-        handle_connection_error(json_output)
+        handle_connection_error(json_output, base_url=base_url)
 
     if result is None:
         cli_error("Failed to rename agent", detail="No response from server", json_output=json_output)
@@ -408,33 +528,35 @@ def rename(
         cli_error("Validation error", detail=str(result), json_output=json_output)
 
     if json_output:
-        output = AgentRenameOutput(id=agent.id, title=title)
+        output = AgentRenameOutput(id=resolved_agent_id, title=title)
         typer.echo(output.model_dump_json())
         return
 
-    typer.echo(f"Agent {agent.id} renamed to '{title}'.")
+    typer.echo(f"Agent {resolved_agent_id} renamed to '{title}'.")
 
 
 @agent_app.command("delete")
 def delete(
     agent_id: str = typer.Argument(..., help="Agent ID or prefix"),
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace ID (or set SCULPT_WORKSPACE_ID)"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
     base_url: str | None = typer.Option(None, "--base-url", "-u", help="The Sculptor server URL"),
 ) -> None:
     """Delete an agent."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    workspace_id = resolve_workspace(workspace, client, json_output)
+    resolved_id, workspace_id, _ = _resolve_agent_for_action(
+        base_url, client, agent_id, workspace, json_output
+    )
 
-    agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
-    agent = resolve_by_prefix(agent_id, agents, lambda a: a.id)
-    resolved_id = agent.id
+    if not yes:
+        typer.confirm(f"Delete agent {resolved_id}?", abort=True)
 
     try:
         delete_workspace_agent.sync(workspace_id=workspace_id, agent_id=resolved_id, client=client)
     except httpx.ConnectError:
-        handle_connection_error(json_output)
+        handle_connection_error(json_output, base_url=base_url)
 
     if json_output:
         output = AgentDeleteOutput(deleted=True, id=resolved_id)
@@ -449,8 +571,14 @@ def send(
     agent_id: str = typer.Argument(..., help="Agent ID or prefix"),
     message: str = typer.Argument(..., help="Message to send"),
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace ID (or set SCULPT_WORKSPACE_ID)"),
-    model: str = typer.Option(
-        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)"
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help=(
+            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)."
+            + " Defaults to the agent's current model."
+        ),
     ),
     file: list[str] | None = typer.Option(None, "--file", help="Files to include (repeatable)"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Stream the agent's response after sending"),
@@ -460,17 +588,12 @@ def send(
     """Send a message to an agent."""
     base_url = base_url or get_default_base_url()
 
-    model_lower = model.lower()
-    if model_lower not in MODEL_MAPPING:
-        valid = ", ".join(MODEL_MAPPING.keys())
-        cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
-
-    llm_model = MODEL_MAPPING[model_lower]
     client = get_authenticated_client(base_url)
-    workspace_id = resolve_workspace(workspace, client, json_output)
+    resolved_agent_id, workspace_id, current_model = _resolve_agent_for_action(
+        base_url, client, agent_id, workspace, json_output
+    )
 
-    agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
-    agent = resolve_by_prefix(agent_id, agents, lambda a: a.id)
+    llm_model = _resolve_send_model(model, current_model, json_output)
 
     request = SendMessageRequest(
         message=message,
@@ -481,10 +604,10 @@ def send(
 
     try:
         response = send_workspace_agent_messages.sync_detailed(
-            workspace_id=workspace_id, agent_id=agent.id, client=client, body=request
+            workspace_id=workspace_id, agent_id=resolved_agent_id, client=client, body=request
         )
     except httpx.ConnectError:
-        handle_connection_error(json_output)
+        handle_connection_error(json_output, base_url=base_url)
 
     if response.status_code.value >= 400:
         detail = ""
@@ -500,29 +623,57 @@ def send(
         )
 
     if follow:
-        typer.echo(f"Message sent to agent {agent.id}. Following response...", err=True)
-        follow_and_stream_messages(base_url, agent.id, json_output=json_output)
+        typer.echo(f"Message sent to agent {resolved_agent_id}. Following response...", err=True)
+        follow_and_stream_messages(base_url, resolved_agent_id, json_output=json_output)
         return
 
     if json_output:
-        output = AgentSendOutput(sent=True, agent_id=agent.id, message=message[:_MESSAGE_PREVIEW_MAX_LENGTH])
+        output = AgentSendOutput(
+            sent=True, agent_id=resolved_agent_id, message=message[:_MESSAGE_PREVIEW_MAX_LENGTH]
+        )
         typer.echo(output.model_dump_json())
         return
 
-    typer.echo(f"Message sent to agent {agent.id}.")
+    typer.echo(f"Message sent to agent {resolved_agent_id}.")
+
+
+def _resolve_send_model(model_option: str | None, current_model: str | None, json_output: bool) -> LLMModel:
+    """Pick the model for an outgoing message.
+
+    An explicit ``--model`` wins. Otherwise reuse the agent's current model, so
+    a plain follow-up never switches the agent to a different model. Terminal
+    agents carry no model; the request field still needs a value, and the
+    server ignores it for them.
+    """
+    if model_option is not None:
+        model_lower = model_option.lower()
+        if model_lower not in MODEL_MAPPING:
+            valid = ", ".join(MODEL_MAPPING.keys())
+            cli_error(f"Invalid model '{model_option}'. Valid options: {valid}", json_output=json_output)
+        return MODEL_MAPPING[model_lower]
+    if current_model:
+        try:
+            return LLMModel(current_model)
+        except ValueError:
+            cli_error(
+                f"The agent's current model '{current_model}' is not recognized by this sculpt"
+                + " version; pass --model explicitly",
+                json_output=json_output,
+            )
+    return MODEL_MAPPING["opus"]
 
 
 @agent_app.command("status")
 def status(
-    agent_id: str = typer.Argument(..., help="Agent ID or prefix"),
+    agent_id: str | None = typer.Argument(None, help="Agent ID or prefix (defaults to SCULPT_AGENT_ID)"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Stream status updates in real-time"),
     timeout: float = typer.Option(10.0, "--timeout", help="Timeout in seconds for WebSocket connection"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
     base_url: str | None = typer.Option(None, "--base-url", "-u", help="The Sculptor server URL"),
 ) -> None:
-    """Show lightweight status of an agent."""
+    """Show lightweight status of an agent (with no argument: this shell's own agent)."""
     base_url = base_url or get_default_base_url()
-    agent_id = resolve_agent_id(base_url, agent_id, json_output)
+    agent_id = resolve_agent_id(base_url, _agent_id_or_env(agent_id, json_output), json_output)
 
     if follow:
         session_token = get_session_token_safe(base_url, json_output)
@@ -559,7 +710,7 @@ def status(
 
 @agent_app.command("messages")
 def messages(
-    agent_id: str = typer.Argument(..., help="Agent ID or prefix"),
+    agent_id: str | None = typer.Argument(None, help="Agent ID or prefix (defaults to SCULPT_AGENT_ID)"),
     limit: int | None = typer.Option(None, "--limit", help="Show only the last N messages"),
     tail: int | None = typer.Option(None, "--tail", help="Alias for --limit"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Stream messages in real-time"),
@@ -567,9 +718,9 @@ def messages(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
     base_url: str | None = typer.Option(None, "--base-url", "-u", help="The Sculptor server URL"),
 ) -> None:
-    """Show conversation history for an agent."""
+    """Show conversation history for an agent (with no argument: this shell's own agent)."""
     base_url = base_url or get_default_base_url()
-    agent_id = resolve_agent_id(base_url, agent_id, json_output)
+    agent_id = resolve_agent_id(base_url, _agent_id_or_env(agent_id, json_output), json_output)
 
     effective_limit = limit or tail
 
@@ -660,6 +811,7 @@ def _status_output(snapshot: AgentSnapshot) -> AgentStatusOutput:
         current_activity=snapshot.current_activity,
         last_activity=snapshot.last_activity,
         waiting_detail=snapshot.waiting_detail,
+        waiting_options=snapshot.waiting_options,
         error_detail=snapshot.error_detail,
         task_completed=snapshot.task_completed,
         task_total=snapshot.task_total,
@@ -679,6 +831,8 @@ def _format_status_text(snapshot: AgentSnapshot) -> str:
         lines.append(f"Last Activity: {snapshot.last_activity}")
     if snapshot.waiting_detail:
         lines.append(f"Waiting: {snapshot.waiting_detail}")
+    if snapshot.waiting_options:
+        lines.append(f"Options: {' | '.join(snapshot.waiting_options)}")
     if snapshot.error_detail:
         lines.append(f"Error: {snapshot.error_detail}")
     if snapshot.task_total > 0:
@@ -712,21 +866,20 @@ def interrupt(
     """Interrupt a running agent."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    workspace_id = resolve_workspace(workspace, client, json_output)
-
-    agents = _fetch_agents_for_workspace(client, workspace_id, json_output)
-    agent = resolve_by_prefix(agent_id, agents, lambda a: a.id)
+    resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(
+        base_url, client, agent_id, workspace, json_output
+    )
 
     try:
         interrupt_workspace_agent.sync(
-            workspace_id=workspace_id, agent_id=agent.id, client=client
+            workspace_id=workspace_id, agent_id=resolved_agent_id, client=client
         )
     except httpx.ConnectError:
-        handle_connection_error(json_output)
+        handle_connection_error(json_output, base_url=base_url)
 
     if json_output:
-        output = AgentInterruptOutput(interrupted=True, id=agent.id)
+        output = AgentInterruptOutput(interrupted=True, id=resolved_agent_id)
         typer.echo(output.model_dump_json())
         return
 
-    typer.echo(f"Agent {agent.id} interrupted.")
+    typer.echo(f"Agent {resolved_agent_id} interrupted.")

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -148,7 +148,7 @@ def create(
     if not prompt and model != "opus":
         cli_error("--model has no effect without --prompt", json_output=json_output)
 
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     workspace_id = resolve_workspace(workspace, client, json_output)
 
     model_lower = model.lower()
@@ -232,11 +232,11 @@ def list_cmd(
     if show_all:
         scope = "all"
     elif ws_id:
-        client = get_authenticated_client(base_url)
+        client = get_authenticated_client(base_url, json_output)
         resolved_ws_id = resolve_workspace_id(client, ws_id, json_output)
         scope = f"workspace:{resolved_ws_id}"
     else:
-        client = get_authenticated_client(base_url)
+        client = get_authenticated_client(base_url, json_output)
         project_id = resolve_project(repo, client, json_output)
         scope = f"project:{project_id}"
 
@@ -503,7 +503,7 @@ def rename(
 ) -> None:
     """Rename an agent."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     request = RenameAgentRequest(title=title)
@@ -539,7 +539,7 @@ def delete(
 ) -> None:
     """Delete an agent."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     resolved_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     if not yes:
@@ -580,7 +580,7 @@ def send(
     """Send a message to an agent."""
     base_url = base_url or get_default_base_url()
 
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     resolved_agent_id, workspace_id, current_model = _resolve_agent_for_action(
         base_url, client, agent_id, workspace, json_output
     )
@@ -855,7 +855,7 @@ def interrupt(
 ) -> None:
     """Interrupt a running agent."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     resolved_agent_id, workspace_id, _ = _resolve_agent_for_action(base_url, client, agent_id, workspace, json_output)
 
     try:

--- a/tools/sculpt/sculpt/commands/data_types.py
+++ b/tools/sculpt/sculpt/commands/data_types.py
@@ -25,6 +25,13 @@ class WorkspaceListItem(BaseModel):
     id: str = Field(description="Unique workspace ID")
     repo_id: str = Field(description="Associated repo/project ID")
     repo_path: str = Field(description="Local filesystem path of the repo")
+    working_directory: str | None = Field(
+        default=None,
+        description="The workspace's checkout directory on disk (null until its environment exists)",
+    )
+    current_branch: str | None = Field(
+        default=None, description="Branch currently checked out in the workspace (null when unknown)"
+    )
     description: str | None = Field(description="User-provided description")
     strategy: str = Field(description="Workspace initialization strategy")
     source_branch: str | None = Field(description="Source branch name")
@@ -32,6 +39,10 @@ class WorkspaceListItem(BaseModel):
     is_open: bool = Field(description="Whether the workspace is open")
     created_at: str = Field(description="ISO 8601 datetime of creation")
     last_activity_at: str = Field(description="ISO 8601 datetime of last activity")
+    is_self: bool = Field(
+        default=False,
+        description="Whether this is the calling shell's own workspace (matches SCULPT_WORKSPACE_ID)",
+    )
 
 
 class WorkspaceListProjectItem(BaseModel):
@@ -39,6 +50,13 @@ class WorkspaceListProjectItem(BaseModel):
 
     id: str = Field(description="Unique workspace ID")
     repo_id: str = Field(description="Associated repo/project ID")
+    working_directory: str | None = Field(
+        default=None,
+        description="The workspace's checkout directory on disk (null until its environment exists)",
+    )
+    current_branch: str | None = Field(
+        default=None, description="Branch currently checked out in the workspace (null when unknown)"
+    )
     description: str | None = Field(description="User-provided description")
     strategy: str = Field(description="Workspace initialization strategy")
     source_branch: str | None = Field(description="Source branch the workspace was cut from")
@@ -47,6 +65,10 @@ class WorkspaceListProjectItem(BaseModel):
     )
     requested_branch_name: str | None = Field(description="The workspace's own working branch name")
     is_deleted: bool = Field(description="Whether the workspace has been deleted")
+    is_self: bool = Field(
+        default=False,
+        description="Whether this is the calling shell's own workspace (matches SCULPT_WORKSPACE_ID)",
+    )
 
 
 class WorkspaceShowOutput(BaseModel):
@@ -55,6 +77,13 @@ class WorkspaceShowOutput(BaseModel):
     id: str = Field(description="Unique workspace ID")
     repo_id: str = Field(description="Associated repo/project ID")
     repo_path: str = Field(description="Local filesystem path of the repo")
+    working_directory: str | None = Field(
+        default=None,
+        description="The workspace's checkout directory on disk (null until its environment exists)",
+    )
+    current_branch: str | None = Field(
+        default=None, description="Branch currently checked out in the workspace (null when unknown)"
+    )
     description: str | None = Field(description="User-provided description")
     strategy: str = Field(description="Workspace initialization strategy")
     source_branch: str | None = Field(description="Source branch name")
@@ -108,6 +137,10 @@ class AgentListItem(BaseModel):
     model: str | None = Field(description="LLM model identifier (null for terminal agents)")
     workspace_id: str = Field(description="Parent workspace ID")
     created_at: str = Field(description="ISO 8601 datetime of creation")
+    is_self: bool = Field(
+        default=False,
+        description="Whether this is the calling shell's own agent (matches SCULPT_AGENT_ID)",
+    )
 
 
 class AgentShowOutput(BaseModel):
@@ -130,6 +163,9 @@ class AgentShowOutput(BaseModel):
     task_total: int = Field(description="Total number of tasks")
     current_task_subject: str | None = Field(description="Subject of the in-progress task")
     waiting_detail: str | None = Field(description="Detail about what the agent is waiting for")
+    waiting_options: list[str] | None = Field(
+        description="Answer options of the pending question the agent is waiting on (user-only to answer)"
+    )
     error_detail: str | None = Field(description="Error detail if agent is in error state")
 
 
@@ -164,6 +200,9 @@ class AgentStatusOutput(BaseModel):
     current_activity: str | None = Field(description="What the agent is currently doing")
     last_activity: str | None = Field(description="Last recorded activity")
     waiting_detail: str | None = Field(description="Detail about what the agent is waiting for")
+    waiting_options: list[str] | None = Field(
+        description="Answer options of the pending question the agent is waiting on (user-only to answer)"
+    )
     error_detail: str | None = Field(description="Error detail if agent is in error state")
     task_completed: int = Field(description="Number of completed tasks")
     task_total: int = Field(description="Total number of tasks")

--- a/tools/sculpt/sculpt/commands/debug.py
+++ b/tools/sculpt/sculpt/commands/debug.py
@@ -64,7 +64,9 @@ def heap(
         help="Start tracemalloc in the backend (captures allocation sites from now on). Reproduce growth, then re-run plain.",
     ),
     stop_trace: bool = typer.Option(False, "--stop-trace", help="Stop tracemalloc in the backend."),
-    trace_frames: int = typer.Option(10, "--trace-frames", help="Frames per allocation captured when starting tracemalloc."),
+    trace_frames: int = typer.Option(
+        10, "--trace-frames", help="Frames per allocation captured when starting tracemalloc."
+    ),
     top: int = typer.Option(30, "--top", help="How many types / allocation sites to show."),
     limit: int = typer.Option(
         5_000_000,

--- a/tools/sculpt/sculpt/commands/repo.py
+++ b/tools/sculpt/sculpt/commands/repo.py
@@ -45,7 +45,7 @@ def list_cmd(
     """List all known repos."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    projects = fetch_projects(client)
+    projects = fetch_projects(client, json_output)
 
     if json_output:
         items = [_repo_item_from_project(p) for p in projects]
@@ -78,9 +78,16 @@ def show(
     """Show details of a repo."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    projects = fetch_projects(client)
+    projects = fetch_projects(client, json_output)
 
-    project = resolve_by_prefix(repo_id, projects, lambda p: p.object_id)
+    project = resolve_by_prefix(
+        repo_id,
+        projects,
+        lambda p: p.object_id,
+        resource_noun="repo",
+        json_output=json_output,
+        label_getter=lambda p: p.name,
+    )
 
     if json_output:
         typer.echo(_repo_item_from_project(project).model_dump_json(indent=2))

--- a/tools/sculpt/sculpt/commands/repo.py
+++ b/tools/sculpt/sculpt/commands/repo.py
@@ -25,9 +25,7 @@ repo_app = typer.Typer(
 
 def _repo_item_from_project(project: Project) -> RepoItem:
     """Build the JSON output model for a single repo from a project."""
-    created_at = (
-        project.created_at.isoformat() if isinstance(project.created_at, datetime.datetime) else None
-    )
+    created_at = project.created_at.isoformat() if isinstance(project.created_at, datetime.datetime) else None
     return RepoItem(
         id=project.object_id,
         name=project.name,

--- a/tools/sculpt/sculpt/commands/repo.py
+++ b/tools/sculpt/sculpt/commands/repo.py
@@ -42,7 +42,7 @@ def list_cmd(
 ) -> None:
     """List all known repos."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     projects = fetch_projects(client, json_output)
 
     if json_output:
@@ -75,7 +75,7 @@ def show(
 ) -> None:
     """Show details of a repo."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     projects = fetch_projects(client, json_output)
 
     project = resolve_by_prefix(

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -91,7 +91,7 @@ def run_cmd(
             json_output=json_output,
         )
 
-    project_id = resolve_project(repo, client)
+    project_id = resolve_project(repo, client, json_output)
 
     strategy_enum = resolve_strategy(strategy, json_output=json_output)
 

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -77,7 +77,7 @@ def run_cmd(
         cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
 
     llm_model = MODEL_MAPPING[model_lower]
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
 
     # Resolve the harness up front so a bad or terminal choice fails before we
     # create a workspace. `run` always sends a prompt, so terminal harnesses

--- a/tools/sculpt/sculpt/commands/signal.py
+++ b/tools/sculpt/sculpt/commands/signal.py
@@ -78,7 +78,11 @@ def _post_event(
     """POST one signal event; 204 is silent success, anything else exits 1."""
     agent_id = _resolve_agent_id(agent, json_output)
     client = get_authenticated_client(get_default_base_url())
-    body = SignalEventRequest(event=event) if session_id is None else SignalEventRequest(event=event, session_id=session_id)
+    body = (
+        SignalEventRequest(event=event)
+        if session_id is None
+        else SignalEventRequest(event=event, session_id=session_id)
+    )
     response = _post_signal_with_retries(client, agent_id, body, max_attempts)
     if response is None:
         handle_connection_error(json_output)

--- a/tools/sculpt/sculpt/commands/workspace.py
+++ b/tools/sculpt/sculpt/commands/workspace.py
@@ -85,7 +85,7 @@ def create(
 ) -> None:
     """Create a new workspace."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     project_id = resolve_project(repo, client, json_output)
 
     strategy_enum = resolve_strategy(strategy, json_output=json_output)
@@ -148,7 +148,7 @@ def list_cmd(
 ) -> None:
     """List workspaces."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
 
     if show_all:
         _list_all(client, json_output)
@@ -282,7 +282,7 @@ def show(
 ) -> None:
     """Show details of a workspace (with no argument: this shell's own workspace)."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
 
     if workspace_id is None:
         env_value = os.environ.get("SCULPT_WORKSPACE_ID")
@@ -352,7 +352,7 @@ def rename(
 ) -> None:
     """Rename a workspace (update its description)."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
 
     workspaces = _fetch_recent_workspaces(client, json_output)
     ws = resolve_by_prefix(
@@ -395,7 +395,7 @@ def delete(
 ) -> None:
     """Delete a workspace and all its agents."""
     base_url = base_url or get_default_base_url()
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
 
     workspaces = _fetch_recent_workspaces(client, json_output)
     ws = resolve_by_prefix(

--- a/tools/sculpt/sculpt/commands/workspace.py
+++ b/tools/sculpt/sculpt/commands/workspace.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import httpx
 import typer
@@ -15,6 +16,7 @@ from sculpt.client.models.create_workspace_request_v2 import CreateWorkspaceRequ
 from sculpt.client.models.http_validation_error import HTTPValidationError
 from sculpt.client.models.recent_workspace_response import RecentWorkspaceResponse
 from sculpt.client.models.update_workspace_request import UpdateWorkspaceRequest
+from sculpt.client.types import Unset
 from sculpt.commands._workspace_helpers import STRATEGY_MAPPING
 from sculpt.commands._workspace_helpers import resolve_requested_branch_name
 from sculpt.commands._workspace_helpers import resolve_strategy
@@ -43,6 +45,11 @@ workspace_app = typer.Typer(
 _RECENT_REPO_DISPLAY_MAX_LENGTH = 30
 _RECENT_DESCRIPTION_DISPLAY_MAX_LENGTH = 30
 _PROJECT_DESCRIPTION_DISPLAY_MAX_LENGTH = 40
+
+
+def _optional_str(value: None | str | Unset) -> str | None:
+    """Collapse the generated client's UNSET (field absent on older servers) to None."""
+    return value if isinstance(value, str) else None
 
 
 @workspace_app.command("create")
@@ -79,7 +86,7 @@ def create(
     """Create a new workspace."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
-    project_id = resolve_project(repo, client)
+    project_id = resolve_project(repo, client, json_output)
 
     strategy_enum = resolve_strategy(strategy, json_output=json_output)
 
@@ -146,13 +153,14 @@ def list_cmd(
     if show_all:
         _list_all(client, json_output)
     else:
-        project_id = resolve_project(repo, client)
+        project_id = resolve_project(repo, client, json_output)
         _list_for_project(client, project_id, json_output)
 
 
 def _list_all(client: Client, json_output: bool) -> None:
     workspaces = _fetch_recent_workspaces(client, json_output)
     repo_lookup = fetch_repo_path_lookup(client)  # type: ignore[arg-type]
+    self_workspace_id = os.environ.get("SCULPT_WORKSPACE_ID")
 
     if json_output:
         items = [
@@ -160,6 +168,8 @@ def _list_all(client: Client, json_output: bool) -> None:
                 id=w.object_id,
                 repo_id=w.project_id,
                 repo_path=repo_lookup.get(w.project_id, w.project_name),
+                working_directory=_optional_str(w.working_directory),
+                current_branch=_optional_str(w.current_branch),
                 description=w.description,
                 strategy=w.initialization_strategy.value,
                 source_branch=w.source_branch,
@@ -167,6 +177,7 @@ def _list_all(client: Client, json_output: bool) -> None:
                 is_open=w.is_open,
                 created_at=w.created_at.isoformat(),
                 last_activity_at=w.last_activity_at.isoformat(),
+                is_self=w.object_id == self_workspace_id,
             )
             for w in workspaces
         ]
@@ -180,16 +191,20 @@ def _list_all(client: Client, json_output: bool) -> None:
     headers = ["ID", "REPO", "STRATEGY", "BRANCH", "AGENTS", "DESCRIPTION"]
     rows = [
         [
-            w.object_id,
+            w.object_id + (" *" if w.object_id == self_workspace_id else ""),
             truncate(repo_lookup.get(w.project_id, w.project_name), _RECENT_REPO_DISPLAY_MAX_LENGTH),
             w.initialization_strategy.value,
-            w.source_branch or "-",
+            # Prefer the live checked-out branch; fall back to the source branch
+            # for workspaces whose checkout hasn't been scanned (or built) yet.
+            _optional_str(w.current_branch) or w.source_branch or "-",
             str(w.agent_count),
             truncate(w.description, _RECENT_DESCRIPTION_DISPLAY_MAX_LENGTH),
         ]
         for w in workspaces
     ]
     typer.echo(format_table(headers, rows))
+    if any(w.object_id == self_workspace_id for w in workspaces):
+        typer.echo("* = this workspace (SCULPT_WORKSPACE_ID)", err=True)
 
 
 def _fetch_recent_workspaces(client: Client, json_output: bool) -> list[RecentWorkspaceResponse]:
@@ -216,17 +231,22 @@ def _list_for_project(client: Client, project_id: str, json_output: bool) -> Non
     if isinstance(result, HTTPValidationError):
         cli_error("Validation error", detail=str(result), json_output=json_output)
 
+    self_workspace_id = os.environ.get("SCULPT_WORKSPACE_ID")
+
     if json_output:
         items = [
             WorkspaceListProjectItem(
                 id=w.object_id,
                 repo_id=w.project_id,
+                working_directory=_optional_str(w.working_directory),
+                current_branch=_optional_str(w.current_branch),
                 description=w.description,
                 strategy=w.initialization_strategy.value,
                 source_branch=w.source_branch,
                 target_branch=w.target_branch,
                 requested_branch_name=w.requested_branch_name,
                 is_deleted=w.is_deleted,
+                is_self=w.object_id == self_workspace_id,
             )
             for w in result
         ]
@@ -240,28 +260,48 @@ def _list_for_project(client: Client, project_id: str, json_output: bool) -> Non
     headers = ["ID", "STRATEGY", "BRANCH", "DESCRIPTION"]
     rows = [
         [
-            w.object_id,
+            w.object_id + (" *" if w.object_id == self_workspace_id else ""),
             w.initialization_strategy.value,
-            w.source_branch or "-",
+            # Prefer the live checked-out branch, then the workspace's own branch
+            # name, then the branch it was cut from.
+            _optional_str(w.current_branch) or w.requested_branch_name or w.source_branch or "-",
             truncate(w.description, _PROJECT_DESCRIPTION_DISPLAY_MAX_LENGTH),
         ]
         for w in result
     ]
     typer.echo(format_table(headers, rows))
+    if any(w.object_id == self_workspace_id for w in result):
+        typer.echo("* = this workspace (SCULPT_WORKSPACE_ID)", err=True)
 
 
 @workspace_app.command("show")
 def show(
-    workspace_id: str = typer.Argument(..., help="Workspace ID or prefix"),
+    workspace_id: str | None = typer.Argument(
+        None, help="Workspace ID or prefix (defaults to SCULPT_WORKSPACE_ID)"
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
     base_url: str | None = typer.Option(None, "--base-url", "-u", help="The Sculptor server URL"),
 ) -> None:
-    """Show details of a workspace."""
+    """Show details of a workspace (with no argument: this shell's own workspace)."""
     base_url = base_url or get_default_base_url()
     client = get_authenticated_client(base_url)
 
+    if workspace_id is None:
+        env_value = os.environ.get("SCULPT_WORKSPACE_ID")
+        if not env_value:
+            cli_error("WORKSPACE_ID is required (or set SCULPT_WORKSPACE_ID)", json_output=json_output)
+        typer.echo("Using workspace from SCULPT_WORKSPACE_ID", err=True)
+        workspace_id = env_value
+
     workspaces = _fetch_recent_workspaces(client, json_output)
-    ws = resolve_by_prefix(workspace_id, workspaces, lambda w: w.object_id)
+    ws = resolve_by_prefix(
+        workspace_id,
+        workspaces,
+        lambda w: w.object_id,
+        resource_noun="workspace",
+        json_output=json_output,
+        label_getter=lambda w: w.description,
+    )
 
     repo_lookup = fetch_repo_path_lookup(client)  # type: ignore[arg-type]
     repo_path = repo_lookup.get(ws.project_id, ws.project_name)
@@ -271,6 +311,8 @@ def show(
             id=ws.object_id,
             repo_id=ws.project_id,
             repo_path=repo_path,
+            working_directory=_optional_str(ws.working_directory),
+            current_branch=_optional_str(ws.current_branch),
             description=ws.description,
             strategy=ws.initialization_strategy.value,
             source_branch=ws.source_branch,
@@ -286,7 +328,15 @@ def show(
         f"Workspace: {ws.object_id}",
         f"Repo: {repo_path} ({ws.project_id})",
         f"Strategy: {ws.initialization_strategy.value}",
-        f"Branch: {ws.source_branch or '-'}",
+    ]
+    working_directory = _optional_str(ws.working_directory)
+    if working_directory:
+        lines.append(f"Path: {working_directory}")
+    current_branch = _optional_str(ws.current_branch)
+    if current_branch:
+        lines.append(f"Current Branch: {current_branch}")
+    lines += [
+        f"Source Branch: {ws.source_branch or '-'}",
         f"Description: {ws.description}",
         f"Created: {format_datetime(ws.created_at)}",
         f"Agents: {ws.agent_count}",
@@ -307,7 +357,14 @@ def rename(
     client = get_authenticated_client(base_url)
 
     workspaces = _fetch_recent_workspaces(client, json_output)
-    ws = resolve_by_prefix(workspace_id, workspaces, lambda w: w.object_id)
+    ws = resolve_by_prefix(
+        workspace_id,
+        workspaces,
+        lambda w: w.object_id,
+        resource_noun="workspace",
+        json_output=json_output,
+        label_getter=lambda w: w.description,
+    )
     resolved_id = ws.object_id
 
     request = UpdateWorkspaceRequest(description=description)
@@ -343,7 +400,14 @@ def delete(
     client = get_authenticated_client(base_url)
 
     workspaces = _fetch_recent_workspaces(client, json_output)
-    ws = resolve_by_prefix(workspace_id, workspaces, lambda w: w.object_id)
+    ws = resolve_by_prefix(
+        workspace_id,
+        workspaces,
+        lambda w: w.object_id,
+        resource_noun="workspace",
+        json_output=json_output,
+        label_getter=lambda w: w.description,
+    )
     resolved_id = ws.object_id
 
     if not yes:

--- a/tools/sculpt/sculpt/commands/workspace.py
+++ b/tools/sculpt/sculpt/commands/workspace.py
@@ -276,9 +276,7 @@ def _list_for_project(client: Client, project_id: str, json_output: bool) -> Non
 
 @workspace_app.command("show")
 def show(
-    workspace_id: str | None = typer.Argument(
-        None, help="Workspace ID or prefix (defaults to SCULPT_WORKSPACE_ID)"
-    ),
+    workspace_id: str | None = typer.Argument(None, help="Workspace ID or prefix (defaults to SCULPT_WORKSPACE_ID)"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
     base_url: str | None = typer.Option(None, "--base-url", "-u", help="The Sculptor server URL"),
 ) -> None:

--- a/tools/sculpt/sculpt/commands/workspace.py
+++ b/tools/sculpt/sculpt/commands/workspace.py
@@ -409,6 +409,11 @@ def delete(
     resolved_id = ws.object_id
 
     if not yes:
+        # An interactive prompt would corrupt the JSON stream (typer.confirm
+        # writes to stdout) and EOF-abort with plain text in scripts; fail
+        # with the structured error contract instead.
+        if json_output:
+            cli_error("Confirmation required: pass --yes/-y to delete", json_output=True)
         typer.confirm(f"Delete workspace {resolved_id}?", abort=True)
 
     try:

--- a/tools/sculpt/sculpt/formatting.py
+++ b/tools/sculpt/sculpt/formatting.py
@@ -85,9 +85,26 @@ def cli_error(
     raise typer.Exit(code=exit_code)
 
 
-def handle_connection_error(json_output: bool = False, *, exit_code: int = 1) -> NoReturn:
+# Guidance for connection failures: the server is the local Sculptor app, and
+# a wrong port (the app picks a free one and exports SCULPT_API_PORT into its
+# agent shells) is the usual cause outside those shells.
+CONNECTION_HINT = (
+    "Is the Sculptor app running? If it serves a non-default port, set"
+    + " SCULPT_API_PORT or pass --base-url."
+)
+
+
+def handle_connection_error(
+    json_output: bool = False, *, base_url: str | None = None, exit_code: int = 1
+) -> NoReturn:
     """Handle a connection error to the Sculptor server."""
-    cli_error("Could not connect to Sculptor server", json_output=json_output, exit_code=exit_code)
+    target = f" at {base_url}" if base_url else ""
+    cli_error(
+        f"Could not connect to Sculptor server{target}",
+        detail=CONNECTION_HINT,
+        json_output=json_output,
+        exit_code=exit_code,
+    )
 
 
 def is_tty() -> bool:

--- a/tools/sculpt/sculpt/formatting.py
+++ b/tools/sculpt/sculpt/formatting.py
@@ -1,7 +1,6 @@
 """Output formatting utilities for the sculpt CLI."""
 
 import datetime
-import json
 import sys
 from collections.abc import Sequence
 from typing import NoReturn
@@ -89,14 +88,11 @@ def cli_error(
 # a wrong port (the app picks a free one and exports SCULPT_API_PORT into its
 # agent shells) is the usual cause outside those shells.
 CONNECTION_HINT = (
-    "Is the Sculptor app running? If it serves a non-default port, set"
-    + " SCULPT_API_PORT or pass --base-url."
+    "Is the Sculptor app running? If it serves a non-default port, set" + " SCULPT_API_PORT or pass --base-url."
 )
 
 
-def handle_connection_error(
-    json_output: bool = False, *, base_url: str | None = None, exit_code: int = 1
-) -> NoReturn:
+def handle_connection_error(json_output: bool = False, *, base_url: str | None = None, exit_code: int = 1) -> NoReturn:
     """Handle a connection error to the Sculptor server."""
     target = f" at {base_url}" if base_url else ""
     cli_error(

--- a/tools/sculpt/sculpt/main.py
+++ b/tools/sculpt/sculpt/main.py
@@ -13,6 +13,13 @@ from sculpt.commands.workspace import workspace_app
 app = typer.Typer(
     name="sculpt",
     help="CLI client for the Sculptor API",
+    epilog=(
+        "Every Sculptor agent shell exports SCULPT_AGENT_ID, SCULPT_WORKSPACE_ID, and"
+        + " SCULPT_PROJECT_ID identifying that shell's own agent, workspace, and repo."
+        + " Commands use them as defaults where noted (e.g. `sculpt agent show` with no"
+        + " argument shows your own agent). Outside a Sculptor shell, set SCULPT_API_PORT"
+        + " or pass --base-url if the app serves a non-default port."
+    ),
 )
 
 app.add_typer(workspace_app, name="workspace")

--- a/tools/sculpt/sculpt/resolve.py
+++ b/tools/sculpt/sculpt/resolve.py
@@ -22,6 +22,7 @@ from sculpt.client.models.project import Project
 from sculpt.client.models.project_initialization_request import ProjectInitializationRequest
 from sculpt.formatting import cli_error
 from sculpt.formatting import handle_connection_error
+from sculpt.formatting import truncate
 
 T = TypeVar("T")
 
@@ -56,7 +57,11 @@ def resolve_agent_id(base_url: str, prefix_or_id: str, json_output: bool) -> str
     except httpx.ConnectError:
         handle_connection_error(json_output)
     if response.status_code == HTTPStatus.NOT_FOUND:
-        cli_error(f"Agent not found for '{prefix_or_id}'", json_output=json_output)
+        cli_error(
+            f"Agent not found for '{prefix_or_id}'",
+            detail=wrong_id_kind_detail(prefix_or_id, "agent"),
+            json_output=json_output,
+        )
     if response.status_code == HTTPStatus.CONFLICT:
         # The server's detail string includes the matching ids; surface the full
         # message verbatim so the user can pick a longer prefix.
@@ -86,43 +91,42 @@ def fetch_repo_path_lookup(client: Client) -> dict[str, str]:
     return {p.object_id: repo_path_from_url(p.user_git_repo_url) for p in projects}
 
 
-def fetch_projects(client: Client) -> list[Project]:
+def fetch_projects(client: Client, json_output: bool = False) -> list[Project]:
     """Fetch all projects from the API."""
     try:
         result = list_projects.sync(client=client)  # type: ignore[arg-type]
     except httpx.ConnectError:
-        typer.echo("Error: Could not connect to Sculptor server", err=True)
-        raise typer.Exit(code=1) from None
+        handle_connection_error(json_output)
 
     if result is None:
-        typer.echo("Error: Failed to list repos (no response)", err=True)
-        raise typer.Exit(code=1)
+        cli_error("Failed to list repos", detail="No response from server", json_output=json_output)
 
     return result
 
 
-def resolve_project(repo: str | None, client: Client) -> str:
+def resolve_project(repo: str | None, client: Client, json_output: bool = False) -> str:
     """Resolve a project ID through the priority chain: --repo > env var > cwd.
 
     Args:
         repo: Explicit repo path from --repo flag, or None.
         client: An authenticated API client.
+        json_output: Whether to format errors as JSON.
 
     Returns:
         The resolved project ID string.
     """
     if repo is not None:
-        return _resolve_from_repo(repo, client)
+        return _resolve_from_repo(repo, client, json_output)
 
     project_id = os.environ.get("SCULPT_PROJECT_ID")
     if project_id is not None:
         typer.echo("Using repo from SCULPT_PROJECT_ID", err=True)
         return project_id
 
-    return _resolve_from_cwd(client)
+    return _resolve_from_cwd(client, json_output)
 
 
-def _resolve_from_repo(repo: str, client: Client) -> str:
+def _resolve_from_repo(repo: str, client: Client, json_output: bool = False) -> str:
     absolute_path = os.path.abspath(repo)
     request = ProjectInitializationRequest(project_path=absolute_path)
 
@@ -132,8 +136,7 @@ def _resolve_from_repo(repo: str, client: Client) -> str:
             body=request,
         )
     except httpx.ConnectError:
-        typer.echo("Error: Could not connect to Sculptor server", err=True)
-        raise typer.Exit(code=1) from None
+        handle_connection_error(json_output)
 
     if response.status_code == HTTPStatus.OK:
         parsed = response.parsed
@@ -158,17 +161,11 @@ def _resolve_from_repo(repo: str, client: Client) -> str:
 
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         parsed = response.parsed
-        typer.echo(f"Error: Validation error - {parsed}", err=True)
-        raise typer.Exit(code=1)
+        cli_error("Validation error", detail=str(parsed), json_output=json_output)
 
     if detail is not None:
-        typer.echo(f"Error: {detail}", err=True)
-    else:
-        typer.echo(
-            f"Error: Failed to initialize repo (status {response.status_code})",
-            err=True,
-        )
-    raise typer.Exit(code=1)
+        cli_error(detail, json_output=json_output)
+    cli_error(f"Failed to initialize repo (status {response.status_code})", json_output=json_output)
 
 
 def _find_existing_project_for_path(client: Client, absolute_path: str) -> str | None:
@@ -227,62 +224,123 @@ def _git_canonical_repo_path(path: str) -> str | None:
     return str(resolved)
 
 
-def _resolve_from_cwd(client: Client) -> str:
+def _resolve_from_cwd(client: Client, json_output: bool = False) -> str:
     cwd = os.getcwd()
     cwd_uri = f"file:///{cwd.lstrip('/')}"
 
-    try:
-        projects = list_projects.sync(client=client)  # type: ignore[arg-type]
-    except httpx.ConnectError:
-        typer.echo("Error: Could not connect to Sculptor server", err=True)
-        raise typer.Exit(code=1) from None
-
-    if projects is None:
-        typer.echo("Error: Failed to list repos (no response)", err=True)
-        raise typer.Exit(code=1)
+    projects = fetch_projects(client, json_output)
 
     for project in projects:
         if project.user_git_repo_url == cwd_uri:
             typer.echo(f"Using repo from current directory: {cwd}", err=True)
             return project.object_id
 
-    typer.echo(
-        f"No repo found for {cwd}. Use --repo to create one, or set"
-        + " SCULPT_PROJECT_ID to an existing project id.",
-        err=True,
+    cli_error(
+        f"No repo found for {cwd}",
+        detail="Use --repo to create one, or set SCULPT_PROJECT_ID to an existing project id.",
+        json_output=json_output,
     )
-    raise typer.Exit(code=1)
 
 
-def resolve_by_prefix(prefix: str, candidates: list[T], id_getter: Callable[[T], str]) -> T:
-    """Find a unique candidate matching the given ID prefix.
+def find_prefix_matches(prefix: str, candidates: list[T], id_getter: Callable[[T], str]) -> list[T]:
+    """Return the candidates whose ID starts with ``prefix``.
 
-    Args:
-        prefix: The user-provided ID prefix.
-        candidates: List of candidate objects to search.
-        id_getter: Callable that extracts the ID string from a candidate.
-
-    Returns:
-        The unique matching candidate.
+    An exact ID match wins outright (returns just that candidate), so a full ID
+    is never reported as ambiguous even when it is a prefix of another ID.
     """
     matches: list[T] = []
     for candidate in candidates:
         candidate_id = id_getter(candidate)
         if candidate_id == prefix:
-            return candidate
+            return [candidate]
         if candidate_id.startswith(prefix):
             matches.append(candidate)
+    return matches
 
-    if len(matches) == 0:
-        typer.echo(f"No resource matches prefix '{prefix}'", err=True)
-        raise typer.Exit(code=1)
 
-    if len(matches) > 1:
-        match_ids = "\n  ".join(id_getter(m) for m in matches)
-        typer.echo(f"Ambiguous prefix '{prefix}'. Matches:\n  {match_ids}", err=True)
-        raise typer.Exit(code=1)
+# ID-type prefixes and the resource noun + CLI command group each belongs to,
+# used to catch e.g. a workspace ID passed where an agent ID is expected.
+_ID_KIND_BY_PREFIX = {
+    "tsk_": ("agent", "sculpt agent"),
+    "ws_": ("workspace", "sculpt workspace"),
+    "prj_": ("repo", "sculpt repo"),
+}
 
-    return matches[0]
+# Ambiguous-prefix errors list at most this many matches before eliding.
+_MAX_AMBIGUOUS_MATCHES_SHOWN = 10
+
+_AMBIGUOUS_LABEL_MAX_LENGTH = 40
+
+
+def wrong_id_kind_detail(prefix: str, resource_noun: str) -> str:
+    """A redirect hint when ``prefix`` carries another resource kind's ID prefix.
+
+    Returns an empty string when the prefix doesn't look like a known ID kind,
+    or already matches the expected kind (a plain not-found, not a mix-up).
+    """
+    for id_prefix, (noun, command_group) in _ID_KIND_BY_PREFIX.items():
+        if prefix.startswith(id_prefix) and noun != resource_noun:
+            article = "an" if noun[0] in "aeiou" else "a"
+            return f"'{prefix}' looks like {article} {noun} ID — try `{command_group} show {prefix}`"
+    return ""
+
+
+def resolve_by_prefix(
+    prefix: str,
+    candidates: list[T],
+    id_getter: Callable[[T], str],
+    *,
+    resource_noun: str = "resource",
+    json_output: bool = False,
+    label_getter: Callable[[T], str | None] | None = None,
+    scope_description: str = "",
+) -> T:
+    """Find a unique candidate matching the given ID prefix, or exit with an error.
+
+    Args:
+        prefix: The user-provided ID prefix.
+        candidates: List of candidate objects to search.
+        id_getter: Callable that extracts the ID string from a candidate.
+        resource_noun: What the candidates are ("agent", "workspace", ...), for
+            error messages.
+        json_output: Whether to format errors as JSON.
+        label_getter: Optional callable extracting a human label (title,
+            description) shown next to each ID in ambiguity errors.
+        scope_description: Where the search looked (e.g. "workspace ws_123"),
+            appended to the not-found message so a scoped miss is
+            distinguishable from the resource not existing at all.
+
+    Returns:
+        The unique matching candidate.
+    """
+    matches = find_prefix_matches(prefix, candidates, id_getter)
+
+    if len(matches) == 1:
+        return matches[0]
+
+    if not matches:
+        scope_suffix = f" in {scope_description}" if scope_description else ""
+        cli_error(
+            f"No {resource_noun} matches '{prefix}'{scope_suffix}",
+            detail=wrong_id_kind_detail(prefix, resource_noun),
+            json_output=json_output,
+        )
+
+    lines = []
+    for match in matches[:_MAX_AMBIGUOUS_MATCHES_SHOWN]:
+        label = label_getter(match) if label_getter is not None else None
+        if label:
+            lines.append(f"  {id_getter(match)}  {truncate(label, _AMBIGUOUS_LABEL_MAX_LENGTH)}")
+        else:
+            lines.append(f"  {id_getter(match)}")
+    elided = len(matches) - _MAX_AMBIGUOUS_MATCHES_SHOWN
+    if elided > 0:
+        lines.append(f"  ... and {elided} more")
+    cli_error(
+        f"Ambiguous prefix '{prefix}' matches {len(matches)} {resource_noun}s",
+        detail="\n".join(lines),
+        json_output=json_output,
+    )
 
 
 def resolve_workspace_id(client: Client, workspace_id_or_prefix: str, json_output: bool = False) -> str:
@@ -306,5 +364,12 @@ def resolve_workspace_id(client: Client, workspace_id_or_prefix: str, json_outpu
     if result is None:
         cli_error("Failed to list workspaces", detail="No response from server", json_output=json_output)
 
-    ws = resolve_by_prefix(workspace_id_or_prefix, result.workspaces, lambda w: w.object_id)
+    ws = resolve_by_prefix(
+        workspace_id_or_prefix,
+        result.workspaces,
+        lambda w: w.object_id,
+        resource_noun="workspace",
+        json_output=json_output,
+        label_getter=lambda w: w.description,
+    )
     return ws.object_id

--- a/tools/sculpt/sculpt/resolve.py
+++ b/tools/sculpt/sculpt/resolve.py
@@ -55,7 +55,7 @@ def resolve_agent_id(base_url: str, prefix_or_id: str, json_output: bool) -> str
     try:
         response = resolve_agent_by_prefix.sync_detailed(prefix=prefix_or_id, client=client)
     except httpx.ConnectError:
-        handle_connection_error(json_output)
+        handle_connection_error(json_output, base_url=base_url)
     if response.status_code == HTTPStatus.NOT_FOUND:
         cli_error(
             f"Agent not found for '{prefix_or_id}'",
@@ -341,6 +341,27 @@ def resolve_by_prefix(
         detail="\n".join(lines),
         json_output=json_output,
     )
+
+
+def find_workspace_id(client: Client, workspace_id_or_prefix: str, json_output: bool = False) -> str | None:
+    """Resolve a workspace ID prefix leniently: None on a miss instead of exiting.
+
+    For scope hints like ``SCULPT_WORKSPACE_ID``, where a stale value (the
+    workspace was deleted after the shell started) should mean "no scope"
+    rather than a hard failure. Connection errors still exit.
+    """
+    try:
+        result = list_recent_workspaces.sync(client=client)  # type: ignore[arg-type]
+    except httpx.ConnectError:
+        handle_connection_error(json_output)
+
+    if result is None:
+        return None
+
+    matches = find_prefix_matches(workspace_id_or_prefix, result.workspaces, lambda w: w.object_id)
+    if len(matches) == 1:
+        return matches[0].object_id
+    return None
 
 
 def resolve_workspace_id(client: Client, workspace_id_or_prefix: str, json_output: bool = False) -> str:

--- a/tools/sculpt/sculpt/resolve.py
+++ b/tools/sculpt/sculpt/resolve.py
@@ -51,7 +51,7 @@ def resolve_agent_id(base_url: str, prefix_or_id: str, json_output: bool) -> str
         # doesn't match the typed route and falls through to the SPA static
         # handler (returns HTML 200). Short-circuit before the HTTP call.
         cli_error(f"Agent not found for '{prefix_or_id}'", json_output=json_output)
-    client = get_authenticated_client(base_url)
+    client = get_authenticated_client(base_url, json_output)
     try:
         response = resolve_agent_by_prefix.sync_detailed(prefix=prefix_or_id, client=client)
     except httpx.ConnectError:

--- a/tools/sculpt/sculpt/resolve.py
+++ b/tools/sculpt/sculpt/resolve.py
@@ -79,7 +79,7 @@ def repo_path_from_url(url: str | None) -> str:
     if url is None:
         return ""
     if url.startswith("file:///"):
-        return url[len("file://"):]
+        return url[len("file://") :]
     return url
 
 

--- a/tools/sculpt/sculpt/ws_client.py
+++ b/tools/sculpt/sculpt/ws_client.py
@@ -37,6 +37,10 @@ class AgentSnapshot(pydantic.BaseModel):
     task_total: int
     current_task_subject: str | None
     waiting_detail: str | None
+    # Answer options of the pending AskUserQuestion, from the task update's
+    # server-maintained pendingUserQuestion (None when the agent isn't blocked
+    # on one, or when the connection scope carries no task update).
+    waiting_options: list[str] | None = None
     error_detail: str | None
     updated_at: str
     title: str | None
@@ -108,10 +112,32 @@ def _is_waiting_state(snapshot: AgentSnapshot) -> bool:
     return snapshot.status == "WAITING"
 
 
+def _options_from_pending_question(update: dict[str, Any] | None) -> list[str] | None:
+    """Option labels of the pending AskUserQuestion carried by a task update.
+
+    The server maintains ``pendingUserQuestion`` (set when the agent asks,
+    cleared when the user answers), so its presence is authoritative — no
+    message-history scanning needed. Returns the first question's option
+    labels, or None when nothing is pending.
+    """
+    if not update:
+        return None
+    pending = update.get("pendingUserQuestion")
+    if not isinstance(pending, dict):
+        return None
+    questions = pending.get("questions") or []
+    if not questions or not isinstance(questions[0], dict):
+        return None
+    options = questions[0].get("options") or []
+    labels = [o.get("label") for o in options if isinstance(o, dict) and o.get("label")]
+    return labels or None
+
+
 def _snapshot_from_view(
-    task_id: str, view: dict[str, Any], messages: list[dict[str, Any]] | None = None
+    task_id: str, view: dict[str, Any], update: dict[str, Any] | None = None
 ) -> AgentSnapshot:
-    """Build an AgentSnapshot from a single task view dict."""
+    """Build an AgentSnapshot from a task view dict plus its optional task update."""
+    update = update or {}
     return AgentSnapshot(
         task_id=view.get("id", task_id),
         status=view.get("status", "UNKNOWN"),
@@ -122,6 +148,7 @@ def _snapshot_from_view(
         task_total=view.get("taskTotal", 0),
         current_task_subject=view.get("currentTaskSubject"),
         waiting_detail=view.get("waitingDetail"),
+        waiting_options=_options_from_pending_question(update),
         error_detail=view.get("errorDetail"),
         updated_at=view.get("updatedAt", ""),
         title=view.get("title"),
@@ -132,7 +159,7 @@ def _snapshot_from_view(
         created_at=view.get("createdAt", ""),
         is_deleted=view.get("isDeleted", False),
         artifact_names=view.get("artifactNames", []),
-        messages=messages or [],
+        messages=update.get("chatMessages", []),
     )
 
 
@@ -143,9 +170,8 @@ def _extract_snapshot(task_id: str, dump: dict[str, Any]) -> AgentSnapshot:
 
     view = task_views[task_id]
     update = task_updates.get(task_id, {})
-    messages = update.get("chatMessages", [])
 
-    return _snapshot_from_view(task_id, view, messages)
+    return _snapshot_from_view(task_id, view, update)
 
 
 async def _receive_initial_dump(ws: Any, timeout: float = 30.0) -> dict[str, Any]:
@@ -186,7 +212,11 @@ async def _fetch_all_agents_async(ws_url: str, timeout: float) -> list[AgentSnap
         async with websockets.connect(ws_url, max_size=None) as ws:
             dump = await _receive_initial_dump(ws, timeout=timeout)
             task_views = dump.get("taskViewsByTaskId", {})
-            return [_snapshot_from_view(task_id, view) for task_id, view in task_views.items()]
+            task_updates = dump.get("taskUpdateByTaskId", {})
+            return [
+                _snapshot_from_view(task_id, view, task_updates.get(task_id))
+                for task_id, view in task_views.items()
+            ]
     except websockets.exceptions.InvalidStatus as e:
         raise _wrap_invalid_status(e) from e
 
@@ -224,6 +254,7 @@ def _status_signature(snapshot: AgentSnapshot) -> tuple[Any, ...]:
         snapshot.task_total,
         snapshot.current_task_subject,
         snapshot.waiting_detail,
+        tuple(snapshot.waiting_options) if snapshot.waiting_options is not None else None,
         snapshot.error_detail,
         snapshot.is_deleted,
     )
@@ -245,6 +276,7 @@ async def _follow_loop(
     on_partial: Callable[[dict[str, Any] | None], None],
     last_status_sig: list[tuple[Any, ...]],
     last_partial_sig: list[tuple[Any, ...]],
+    last_waiting_options: list[list[str] | None],
 ) -> ExitReason:
     """Process incremental WebSocket updates until a terminal/waiting state."""
     while True:
@@ -255,9 +287,17 @@ async def _follow_loop(
 
         exit_reason: ExitReason | None = None
 
+        # A frame may carry the view without the update; remember the latest
+        # pending-question state so such view-only snapshots still render it.
+        task_updates = dump.get("taskUpdateByTaskId", {})
+        if task_id in task_updates:
+            last_waiting_options[0] = _options_from_pending_question(task_updates[task_id])
+
         task_views = dump.get("taskViewsByTaskId", {})
         if task_id in task_views:
-            snapshot = _snapshot_from_view(task_id, task_views[task_id])
+            snapshot = _snapshot_from_view(task_id, task_views[task_id]).model_copy(
+                update={"waiting_options": last_waiting_options[0]}
+            )
             sig = _status_signature(snapshot)
             if sig != last_status_sig[0]:
                 last_status_sig[0] = sig
@@ -267,7 +307,6 @@ async def _follow_loop(
             elif _is_waiting_state(snapshot):
                 exit_reason = ExitReason.WAITING
 
-        task_updates = dump.get("taskUpdateByTaskId", {})
         if task_id in task_updates:
             update = task_updates[task_id]
             all_messages = update.get("chatMessages", [])
@@ -308,6 +347,7 @@ async def _follow_agent_async(
     task_id = agent_id
     last_status_sig: list[tuple[Any, ...]] = [()]
     last_partial_sig: list[tuple[Any, ...]] = [()]
+    last_waiting_options: list[list[str] | None] = [None]
     on_partial_cb: Callable[[dict[str, Any] | None], None] = on_partial or (lambda _p: None)
 
     while True:
@@ -320,6 +360,7 @@ async def _follow_agent_async(
                     raise AgentNotFoundError(f"Agent {task_id} not found in scoped frame")
 
                 snapshot = _extract_snapshot(task_id, dump)
+                last_waiting_options[0] = snapshot.waiting_options
 
                 is_reconnect = retry_count > 0
                 if is_reconnect and on_reconnect is not None:
@@ -352,6 +393,7 @@ async def _follow_agent_async(
                     on_partial_cb,
                     last_status_sig,
                     last_partial_sig,
+                    last_waiting_options,
                 )
                 return result
 

--- a/tools/sculpt/sculpt/ws_client.py
+++ b/tools/sculpt/sculpt/ws_client.py
@@ -133,9 +133,7 @@ def _options_from_pending_question(update: dict[str, Any] | None) -> list[str] |
     return labels or None
 
 
-def _snapshot_from_view(
-    task_id: str, view: dict[str, Any], update: dict[str, Any] | None = None
-) -> AgentSnapshot:
+def _snapshot_from_view(task_id: str, view: dict[str, Any], update: dict[str, Any] | None = None) -> AgentSnapshot:
     """Build an AgentSnapshot from a task view dict plus its optional task update."""
     update = update or {}
     return AgentSnapshot(
@@ -214,8 +212,7 @@ async def _fetch_all_agents_async(ws_url: str, timeout: float) -> list[AgentSnap
             task_views = dump.get("taskViewsByTaskId", {})
             task_updates = dump.get("taskUpdateByTaskId", {})
             return [
-                _snapshot_from_view(task_id, view, task_updates.get(task_id))
-                for task_id, view in task_views.items()
+                _snapshot_from_view(task_id, view, task_updates.get(task_id)) for task_id, view in task_views.items()
             ]
     except websockets.exceptions.InvalidStatus as e:
         raise _wrap_invalid_status(e) from e

--- a/tools/sculpt/sculpt/ws_client.py
+++ b/tools/sculpt/sculpt/ws_client.py
@@ -125,10 +125,12 @@ def _options_from_pending_question(update: dict[str, Any] | None) -> list[str] |
     pending = update.get("pendingUserQuestion")
     if not isinstance(pending, dict):
         return None
-    questions = pending.get("questions") or []
-    if not questions or not isinstance(questions[0], dict):
+    questions = pending.get("questions")
+    if not isinstance(questions, list) or not questions or not isinstance(questions[0], dict):
         return None
-    options = questions[0].get("options") or []
+    options = questions[0].get("options")
+    if not isinstance(options, list):
+        return None
     labels = [o.get("label") for o in options if isinstance(o, dict) and o.get("label")]
     return labels or None
 

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -1443,9 +1443,7 @@ class TestAgentCrossWorkspaceResolution:
         monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_env123")
         _mock_session()
         _mock_workspaces("ws_env123")
-        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(
-            return_value=Response(200, json=[])
-        )
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(return_value=Response(200, json=[]))
         mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
         route = respx.post(
             "http://localhost:5050/api/v1/workspaces/ws_actual456/agents/tsk_abc123def456/messages"
@@ -1471,9 +1469,9 @@ class TestAgentCrossWorkspaceResolution:
         respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(
             return_value=Response(200, json=[_task_response_dict(workspace_id="ws_env123")])
         )
-        route = respx.post(
-            "http://localhost:5050/api/v1/workspaces/ws_env123/agents/tsk_abc123def456/messages"
-        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_env123/agents/tsk_abc123def456/messages").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
+        )
 
         result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello"])
 
@@ -1484,9 +1482,7 @@ class TestAgentCrossWorkspaceResolution:
 
     @patch("sculpt.commands.agent.fetch_all_agents")
     @respx.mock
-    def test_send_explicit_workspace_mismatch_is_an_error(
-        self, mock_fetch: Any, runner: CliRunner
-    ) -> None:
+    def test_send_explicit_workspace_mismatch_is_an_error(self, mock_fetch: Any, runner: CliRunner) -> None:
         _mock_session()
         _mock_workspaces("ws_other789")
         respx.get("http://localhost:5050/api/v1/workspaces/ws_other789/agents").mock(
@@ -1507,9 +1503,7 @@ class TestAgentCrossWorkspaceResolution:
         monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_env123")
         _mock_session()
         _mock_workspaces("ws_env123")
-        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(
-            return_value=Response(200, json=[])
-        )
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(return_value=Response(200, json=[]))
         mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
         route = respx.post(
             "http://localhost:5050/api/v1/workspaces/ws_actual456/agents/tsk_abc123def456/interrupt"
@@ -1523,9 +1517,7 @@ class TestAgentCrossWorkspaceResolution:
 
     @patch("sculpt.commands.agent.fetch_all_agents")
     @respx.mock
-    def test_send_without_workspace_context_resolves_globally(
-        self, mock_fetch: Any, runner: CliRunner
-    ) -> None:
+    def test_send_without_workspace_context_resolves_globally(self, mock_fetch: Any, runner: CliRunner) -> None:
         _mock_session()
         mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
         route = respx.post(
@@ -1552,9 +1544,9 @@ class TestAgentSendModelDefault:
         respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
             return_value=Response(200, json=[_task_response_dict(model="CLAUDE-4-HAIKU")])
         )
-        route = respx.post(
-            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages"
-        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
+        )
 
         result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123"])
 
@@ -1569,13 +1561,11 @@ class TestAgentSendModelDefault:
         respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
             return_value=Response(200, json=[_task_response_dict(model="CLAUDE-4-HAIKU")])
         )
-        route = respx.post(
-            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages"
-        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
-
-        result = runner.invoke(
-            app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123", "-m", "opus"]
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
         )
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123", "-m", "opus"])
 
         assert result.exit_code == 0, result.output + (result.stderr or "")
         body = json.loads(route.calls.last.request.content)
@@ -1589,9 +1579,9 @@ class TestAgentSendModelDefault:
         respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
             return_value=Response(200, json=[_task_response_dict(model=None)])
         )
-        route = respx.post(
-            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages"
-        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
+        )
 
         result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123"])
 
@@ -1625,9 +1615,9 @@ class TestAgentDeleteConfirmation:
         respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
             return_value=Response(200, json=[_task_response_dict()])
         )
-        route = respx.delete(
-            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456"
-        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+        route = respx.delete("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
+        )
 
         result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123"], input="n\n")
 
@@ -1641,9 +1631,9 @@ class TestAgentDeleteConfirmation:
         respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
             return_value=Response(200, json=[_task_response_dict()])
         )
-        route = respx.delete(
-            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456"
-        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+        route = respx.delete("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
+        )
 
         result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123"], input="y\n")
 

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -1460,6 +1460,27 @@ class TestAgentCrossWorkspaceResolution:
 
     @patch("sculpt.commands.agent.fetch_all_agents")
     @respx.mock
+    def test_send_with_stale_env_workspace_still_resolves_globally(
+        self, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SCULPT_WORKSPACE_ID points at a workspace that no longer exists (it
+        # was deleted after the shell started); the stale scope must degrade
+        # to a global lookup rather than a hard failure.
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_gone999")
+        _mock_session()
+        _mock_workspaces("ws_other111")
+        mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_actual456/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert route.called
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @respx.mock
     def test_send_agent_in_env_workspace_stays_local(
         self, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1623,6 +1644,24 @@ class TestAgentDeleteConfirmation:
 
         assert result.exit_code != 0
         assert not route.called
+
+    @respx.mock
+    def test_delete_json_without_yes_fails_with_structured_error(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict()])
+        )
+        route = respx.delete("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456").mock(
+            return_value=Response(200, text="null", headers={"content-type": "application/json"})
+        )
+
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123", "--json"])
+
+        assert result.exit_code != 0
+        assert not route.called
+        error = json.loads(result.stderr.strip().splitlines()[-1])
+        assert "--yes" in error["error"]
 
     @respx.mock
     def test_delete_prompt_accepted_sends_delete(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -8,8 +8,11 @@ from unittest.mock import patch
 
 import pytest
 import respx
+import typer
 from httpx import ConnectError
 from httpx import Response
+from sculpt.auth import MODEL_MAPPING
+from sculpt.commands.agent import _resolve_send_model
 from sculpt.main import app
 from sculpt.ws_client import AgentNotFoundError
 from sculpt.ws_client import AgentSnapshot
@@ -45,7 +48,7 @@ def _task_response_dict(
     workspace_id: str = "ws_test123",
     title: str = "Test task",
     status: str = "RUNNING",
-    model: str = "CLAUDE-4-SONNET",
+    model: str | None = "CLAUDE-4-SONNET",
 ) -> dict[str, Any]:
     return {
         "id": task_id,
@@ -524,7 +527,7 @@ class TestAgentDelete:
             return_value=Response(200, text="null", headers={"content-type": "application/json"})
         )
 
-        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123"])
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123", "-y"])
 
         assert result.exit_code == 0
         assert "deleted" in result.output
@@ -540,7 +543,7 @@ class TestAgentDelete:
             return_value=Response(200, text="null", headers={"content-type": "application/json"})
         )
 
-        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123", "--json"])
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123", "--json", "-y"])
 
         assert result.exit_code == 0
         data = json.loads(result.stdout)
@@ -558,7 +561,7 @@ class TestAgentDelete:
             return_value=Response(200, text="null", headers={"content-type": "application/json"})
         )
 
-        result = runner.invoke(app, ["agent", "delete", "tsk_abc", "-w", "ws_test123"])
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc", "-w", "ws_test123", "-y"])
 
         assert result.exit_code == 0
 
@@ -803,6 +806,7 @@ def _make_snapshot(
     current_activity: str | None = None,
     last_activity: str | None = None,
     waiting_detail: str | None = None,
+    waiting_options: list[str] | None = None,
     error_detail: str | None = None,
     task_completed: int = 0,
     task_total: int = 0,
@@ -822,6 +826,7 @@ def _make_snapshot(
         task_total=task_total,
         current_task_subject=current_task_subject,
         waiting_detail=waiting_detail,
+        waiting_options=waiting_options,
         error_detail=error_detail,
         updated_at="2026-01-15T10:35:00Z",
         title="Test task",
@@ -1366,7 +1371,7 @@ class TestWorkspacePrefixResolution:
             return_value=Response(200, text="null", headers={"content-type": "application/json"})
         )
 
-        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123"])
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123", "-y"])
 
         assert result.exit_code == 0
 
@@ -1419,3 +1424,399 @@ class TestWorkspacePrefixResolution:
 
         assert result.exit_code == 0
         assert "tsk_abc123d" in result.output
+
+
+class TestAgentCrossWorkspaceResolution:
+    """Workspace scoping for agent actions (send/interrupt/rename/delete).
+
+    An explicit --workspace is authoritative: an agent living elsewhere is an
+    error. SCULPT_WORKSPACE_ID is only a disambiguation scope: an agent with no
+    match there is looked up across all workspaces, so full IDs work from any
+    Sculptor agent shell.
+    """
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @respx.mock
+    def test_send_env_workspace_miss_falls_back_to_actual_workspace(
+        self, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_env123")
+        _mock_session()
+        _mock_workspaces("ws_env123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(
+            return_value=Response(200, json=[])
+        )
+        mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_actual456/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert route.called
+        # The widened lookup goes across all workspaces...
+        assert mock_fetch.call_args.kwargs.get("scope") == "all"
+        # ...and the cross-workspace action is never silent.
+        assert "Agent tsk_abc123def456 is in workspace ws_actual456" in result.stderr
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @respx.mock
+    def test_send_agent_in_env_workspace_stays_local(
+        self, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_env123")
+        _mock_session()
+        _mock_workspaces("ws_env123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict(workspace_id="ws_env123")])
+        )
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_env123/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert route.called
+        mock_fetch.assert_not_called()
+        assert "is in workspace" not in result.stderr
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @respx.mock
+    def test_send_explicit_workspace_mismatch_is_an_error(
+        self, mock_fetch: Any, runner: CliRunner
+    ) -> None:
+        _mock_session()
+        _mock_workspaces("ws_other789")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_other789/agents").mock(
+            return_value=Response(200, json=[])
+        )
+        mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_other789"])
+
+        assert result.exit_code == 1
+        assert "Agent tsk_abc123def456 is in workspace ws_actual456, not ws_other789" in result.stderr
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @respx.mock
+    def test_interrupt_env_workspace_miss_hits_actual_workspace(
+        self, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_env123")
+        _mock_session()
+        _mock_workspaces("ws_env123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_env123/agents").mock(
+            return_value=Response(200, json=[])
+        )
+        mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_actual456/agents/tsk_abc123def456/interrupt"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "interrupt", "tsk_abc123def456"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert route.called
+        assert "Agent tsk_abc123def456 is in workspace ws_actual456" in result.stderr
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @respx.mock
+    def test_send_without_workspace_context_resolves_globally(
+        self, mock_fetch: Any, runner: CliRunner
+    ) -> None:
+        _mock_session()
+        mock_fetch.return_value = [_make_snapshot(workspace_id="ws_actual456")]
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_actual456/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        # A prefix (not just a full id) resolves through the global snapshot list.
+        result = runner.invoke(app, ["agent", "send", "tsk_abc", "hello"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert route.called
+        # Without an env workspace there is nothing to contrast against — no note.
+        assert "is in workspace" not in result.stderr
+
+
+class TestAgentSendModelDefault:
+    """`send` without --model reuses the agent's current model, so a plain
+    follow-up never switches the agent to a different model."""
+
+    @respx.mock
+    def test_send_defaults_to_agents_current_model(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict(model="CLAUDE-4-HAIKU")])
+        )
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        body = json.loads(route.calls.last.request.content)
+        assert body["model"] == "CLAUDE-4-HAIKU"
+
+    @respx.mock
+    def test_send_explicit_model_overrides_current(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict(model="CLAUDE-4-HAIKU")])
+        )
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(
+            app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123", "-m", "opus"]
+        )
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        body = json.loads(route.calls.last.request.content)
+        assert body["model"] == MODEL_MAPPING["opus"].value
+
+    @respx.mock
+    def test_send_null_current_model_falls_back_to_opus(self, runner: CliRunner) -> None:
+        """Terminal agents carry no model; the request field still needs a value."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict(model=None)])
+        )
+        route = respx.post(
+            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        body = json.loads(route.calls.last.request.content)
+        assert body["model"] == MODEL_MAPPING["opus"].value
+
+    def test_resolve_send_model_unrecognized_current_model_requires_flag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A current model this sculpt version doesn't know must not be silently
+        swapped for a different one — the user has to pass --model."""
+        with pytest.raises(typer.Exit):
+            _resolve_send_model(None, "CLAUDE-99-FUTURE", False)
+        captured = capsys.readouterr()
+        assert "not recognized" in captured.err
+        assert "--model" in captured.err
+
+    def test_resolve_send_model_explicit_wins_over_current(self) -> None:
+        assert _resolve_send_model("haiku", "CLAUDE-4-SONNET", False) == MODEL_MAPPING["haiku"]
+
+    def test_resolve_send_model_no_flag_no_current_defaults_to_opus(self) -> None:
+        assert _resolve_send_model(None, None, False) == MODEL_MAPPING["opus"]
+
+
+class TestAgentDeleteConfirmation:
+    @respx.mock
+    def test_delete_prompt_declined_sends_no_request(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict()])
+        )
+        route = respx.delete(
+            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123"], input="n\n")
+
+        assert result.exit_code != 0
+        assert not route.called
+
+    @respx.mock
+    def test_delete_prompt_accepted_sends_delete(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict()])
+        )
+        route = respx.delete(
+            "http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456"
+        ).mock(return_value=Response(200, text="null", headers={"content-type": "application/json"}))
+
+        result = runner.invoke(app, ["agent", "delete", "tsk_abc123def456", "-w", "ws_test123"], input="y\n")
+
+        assert result.exit_code == 0
+        assert route.called
+        assert "deleted" in result.output
+
+
+class TestAgentIdentityDefaults:
+    """show/status/messages with no AGENT_ID argument target the shell's own agent."""
+
+    @pytest.mark.parametrize("command", ["show", "status", "messages"])
+    @patch("sculpt.commands.agent.fetch_agent_state")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_no_arg_defaults_to_env_agent(
+        self,
+        _mock_token: Any,
+        mock_fetch: Any,
+        command: str,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SCULPT_AGENT_ID", "tsk_abc123def456")
+        mock_fetch.return_value = _make_snapshot()
+
+        result = runner.invoke(app, ["agent", command])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert "Using agent from SCULPT_AGENT_ID" in result.stderr
+        assert mock_fetch.call_args[0][2] == "tsk_abc123def456"
+
+    @pytest.mark.parametrize("command", ["show", "status", "messages"])
+    def test_no_arg_without_env_errors(self, command: str, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["agent", command])
+
+        assert result.exit_code == 1
+        assert "SCULPT_AGENT_ID" in result.stderr
+
+
+class TestAgentSelfMarker:
+    """`agent list` flags the calling shell's own agent (SCULPT_AGENT_ID)."""
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_list_json_flags_only_own_agent(
+        self, _mock_token: Any, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_AGENT_ID", "tsk_abc123def456")
+        mock_fetch.return_value = [
+            _make_snapshot(task_id="tsk_abc123def456"),
+            _make_snapshot(task_id="tsk_zzz999xyz888"),
+        ]
+
+        result = runner.invoke(app, ["agent", "list", "--all", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        flags = {item["id"]: item["is_self"] for item in data}
+        assert flags == {"tsk_abc123def456": True, "tsk_zzz999xyz888": False}
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_list_table_marks_own_agent_with_legend(
+        self, _mock_token: Any, mock_fetch: Any, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_AGENT_ID", "tsk_abc123def456")
+        mock_fetch.return_value = [
+            _make_snapshot(task_id="tsk_abc123def456"),
+            _make_snapshot(task_id="tsk_zzz999xyz888"),
+        ]
+
+        result = runner.invoke(app, ["agent", "list", "--all"])
+
+        assert result.exit_code == 0
+        assert "tsk_abc123d *" in result.output
+        assert "tsk_zzz999x *" not in result.output
+        assert "* = this agent (SCULPT_AGENT_ID)" in result.stderr
+
+    @patch("sculpt.commands.agent.fetch_all_agents")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_list_without_env_has_no_marker_or_legend(
+        self, _mock_token: Any, mock_fetch: Any, runner: CliRunner
+    ) -> None:
+        mock_fetch.return_value = [_make_snapshot()]
+
+        result = runner.invoke(app, ["agent", "list", "--all"])
+
+        assert result.exit_code == 0
+        assert "*" not in result.output
+        assert "* = this agent" not in result.stderr
+
+
+class TestAgentWaitingOptions:
+    """A pending AskUserQuestion's answer options surface in status/show output."""
+
+    @patch("sculpt.commands.agent.fetch_agent_state")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_status_text_renders_options(self, _mock_token: Any, mock_fetch: Any, runner: CliRunner) -> None:
+        mock_fetch.return_value = _make_snapshot(
+            status="WAITING", waiting_detail="Choose a color", waiting_options=["Red", "Blue"]
+        )
+
+        result = runner.invoke(app, ["agent", "status", "tsk_abc123def456"])
+
+        assert result.exit_code == 0
+        assert "Options: Red | Blue" in result.output
+
+    @patch("sculpt.commands.agent.fetch_agent_state")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_status_json_includes_options(self, _mock_token: Any, mock_fetch: Any, runner: CliRunner) -> None:
+        mock_fetch.return_value = _make_snapshot(
+            status="WAITING", waiting_detail="Choose a color", waiting_options=["Red", "Blue"]
+        )
+
+        result = runner.invoke(app, ["agent", "status", "tsk_abc123def456", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["waiting_options"] == ["Red", "Blue"]
+
+    @patch("sculpt.commands.agent.fetch_agent_state")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_status_without_pending_question_omits_options(
+        self, _mock_token: Any, mock_fetch: Any, runner: CliRunner
+    ) -> None:
+        mock_fetch.return_value = _make_snapshot()
+
+        result = runner.invoke(app, ["agent", "status", "tsk_abc123def456"])
+
+        assert result.exit_code == 0
+        assert "Options:" not in result.output
+
+    @patch("sculpt.commands.agent.fetch_agent_state")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_show_text_renders_options(self, _mock_token: Any, mock_fetch: Any, runner: CliRunner) -> None:
+        mock_fetch.return_value = _make_snapshot(
+            status="WAITING", waiting_detail="Choose a color", waiting_options=["Red", "Blue"]
+        )
+
+        result = runner.invoke(app, ["agent", "show", "tsk_abc123def456"])
+
+        assert result.exit_code == 0
+        assert "Options: Red | Blue" in result.output
+
+    @patch("sculpt.commands.agent.fetch_agent_state")
+    @patch("sculpt.commands._follow_helpers.get_session_token", return_value="test-token")
+    def test_show_json_includes_options(self, _mock_token: Any, mock_fetch: Any, runner: CliRunner) -> None:
+        mock_fetch.return_value = _make_snapshot(
+            status="WAITING", waiting_detail="Choose a color", waiting_options=["Red", "Blue"]
+        )
+
+        result = runner.invoke(app, ["agent", "show", "tsk_abc123def456", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["waiting_options"] == ["Red", "Blue"]
+
+
+class TestConnectionErrorHint:
+    @respx.mock
+    def test_send_connection_error_mentions_base_url_and_port_hint(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        respx.get("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=[_task_response_dict()])
+        )
+        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents/tsk_abc123def456/messages").mock(
+            side_effect=ConnectError("Connection refused")
+        )
+
+        result = runner.invoke(app, ["agent", "send", "tsk_abc123def456", "hello", "-w", "ws_test123"])
+
+        assert result.exit_code == 1
+        assert "http://localhost:5050" in result.stderr
+        assert "SCULPT_API_PORT" in result.stderr
+        assert "--base-url" in result.stderr

--- a/tools/sculpt/tests/unit/test_extension.py
+++ b/tools/sculpt/tests/unit/test_extension.py
@@ -4,7 +4,6 @@ import json
 
 import pytest
 import typer
-
 from sculpt.client.models.extension_command_response import ExtensionCommandResponse
 from sculpt.client.models.extension_command_result import ExtensionCommandResult
 from sculpt.client.models.renderer_identity import RendererIdentity

--- a/tools/sculpt/tests/unit/test_repo.py
+++ b/tools/sculpt/tests/unit/test_repo.py
@@ -76,9 +76,7 @@ class TestRepoList:
     @respx.mock
     def test_list_empty(self, runner: CliRunner) -> None:
         _mock_session()
-        respx.get("http://localhost:5050/api/v1/projects").mock(
-            return_value=Response(200, json=[])
-        )
+        respx.get("http://localhost:5050/api/v1/projects").mock(return_value=Response(200, json=[]))
 
         result = runner.invoke(app, ["repo", "list"])
 
@@ -88,9 +86,7 @@ class TestRepoList:
     @respx.mock
     def test_list_connection_error(self, runner: CliRunner) -> None:
         _mock_session()
-        respx.get("http://localhost:5050/api/v1/projects").mock(
-            side_effect=ConnectError("Connection refused")
-        )
+        respx.get("http://localhost:5050/api/v1/projects").mock(side_effect=ConnectError("Connection refused"))
 
         result = runner.invoke(app, ["repo", "list"])
 

--- a/tools/sculpt/tests/unit/test_resolve.py
+++ b/tools/sculpt/tests/unit/test_resolve.py
@@ -313,7 +313,7 @@ class TestWrongIdKindDetail:
 
     def test_agent_id_where_workspace_expected(self) -> None:
         detail = wrong_id_kind_detail("tsk_abc123", "workspace")
-        assert "looks like a agent ID" in detail or "looks like an agent ID" in detail
+        assert "looks like an agent ID" in detail
         assert "sculpt agent show tsk_abc123" in detail
 
     def test_matching_kind_yields_no_hint(self) -> None:

--- a/tools/sculpt/tests/unit/test_resolve.py
+++ b/tools/sculpt/tests/unit/test_resolve.py
@@ -11,6 +11,7 @@ from httpx import ConnectError
 from httpx import Response
 from sculpt.client import Client
 from sculpt.resolve import find_prefix_matches
+from sculpt.resolve import find_workspace_id
 from sculpt.resolve import resolve_by_prefix
 from sculpt.resolve import resolve_project
 from sculpt.resolve import resolve_workspace_id
@@ -449,6 +450,37 @@ def _make_workspace_response(
 
 def _mock_workspaces_response(*object_ids: str) -> dict[str, Any]:
     return {"workspaces": [_make_workspace_response(oid) for oid in object_ids]}
+
+
+class TestFindWorkspaceId:
+    """The lenient variant: a miss means "no scope" (None), never an exit."""
+
+    @respx.mock
+    def test_unique_match_returns_id(self) -> None:
+        client = _make_client()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(200, json=_mock_workspaces_response("ws_abc123full", "ws_def456full"))
+        )
+
+        assert find_workspace_id(client, "ws_abc123full") == "ws_abc123full"
+
+    @respx.mock
+    def test_stale_id_returns_none(self) -> None:
+        client = _make_client()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(200, json=_mock_workspaces_response("ws_abc123full"))
+        )
+
+        assert find_workspace_id(client, "ws_gone999") is None
+
+    @respx.mock
+    def test_ambiguous_prefix_returns_none(self) -> None:
+        client = _make_client()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(200, json=_mock_workspaces_response("ws_abc123", "ws_abc456"))
+        )
+
+        assert find_workspace_id(client, "ws_abc") is None
 
 
 class TestResolveWorkspaceId:

--- a/tools/sculpt/tests/unit/test_resolve.py
+++ b/tools/sculpt/tests/unit/test_resolve.py
@@ -1,5 +1,6 @@
 """Unit tests for project resolution and prefix matching."""
 
+import json
 import os
 from typing import Any
 
@@ -9,9 +10,11 @@ import typer
 from httpx import ConnectError
 from httpx import Response
 from sculpt.client import Client
+from sculpt.resolve import find_prefix_matches
 from sculpt.resolve import resolve_by_prefix
 from sculpt.resolve import resolve_project
 from sculpt.resolve import resolve_workspace_id
+from sculpt.resolve import wrong_id_kind_detail
 
 
 def _make_client(base_url: str = "http://localhost:5050") -> Client:
@@ -300,6 +303,139 @@ class TestResolveByPrefix:
         items = ["abc", "abcdef"]
         result = resolve_by_prefix("abc", items, lambda x: x)
         assert result == "abc"
+
+    def test_full_id_wins_over_longer_id_prefix_collision(self) -> None:
+        """A full ID that is also a prefix of a longer ID must resolve, not be ambiguous."""
+        items = ["tsk_abc123", "tsk_abc123def456"]
+        result = resolve_by_prefix("tsk_abc123", items, lambda x: x)
+        assert result == "tsk_abc123"
+
+
+class TestFindPrefixMatches:
+    def test_exact_match_short_circuits_prefix_collisions(self) -> None:
+        items = ["tsk_abc123", "tsk_abc123def456", "tsk_abc123def789"]
+        assert find_prefix_matches("tsk_abc123", items, lambda x: x) == ["tsk_abc123"]
+
+    def test_returns_all_prefix_matches_in_order(self) -> None:
+        items = ["tsk_abc1", "tsk_xyz", "tsk_abc2"]
+        assert find_prefix_matches("tsk_abc", items, lambda x: x) == ["tsk_abc1", "tsk_abc2"]
+
+    def test_no_match_returns_empty(self) -> None:
+        assert find_prefix_matches("tsk_zzz", ["tsk_abc"], lambda x: x) == []
+
+
+class TestWrongIdKindDetail:
+    def test_workspace_id_where_agent_expected(self) -> None:
+        detail = wrong_id_kind_detail("ws_abc123", "agent")
+        assert "looks like a workspace ID" in detail
+        assert "sculpt workspace show ws_abc123" in detail
+
+    def test_agent_id_where_workspace_expected(self) -> None:
+        detail = wrong_id_kind_detail("tsk_abc123", "workspace")
+        assert "looks like a agent ID" in detail or "looks like an agent ID" in detail
+        assert "sculpt agent show tsk_abc123" in detail
+
+    def test_matching_kind_yields_no_hint(self) -> None:
+        assert wrong_id_kind_detail("tsk_abc123", "agent") == ""
+
+    def test_unknown_prefix_yields_no_hint(self) -> None:
+        assert wrong_id_kind_detail("bogus123", "agent") == ""
+
+
+class TestResolveByPrefixErrors:
+    def test_not_found_mentions_noun_and_scope(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix(
+                "tsk_zzz",
+                ["tsk_abc123"],
+                lambda x: x,
+                resource_noun="agent",
+                scope_description="workspace ws_test123",
+            )
+        captured = capsys.readouterr()
+        assert "No agent matches 'tsk_zzz' in workspace ws_test123" in captured.err
+
+    def test_not_found_without_scope_omits_scope_suffix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix("tsk_zzz", ["tsk_abc123"], lambda x: x, resource_noun="agent")
+        captured = capsys.readouterr()
+        assert "No agent matches 'tsk_zzz'" in captured.err
+        assert " in " not in captured.err
+
+    def test_not_found_wrong_kind_hint(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A ws_ ID passed where an agent is expected gets redirected, not a bare not-found."""
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix("ws_abc123", ["tsk_abc123"], lambda x: x, resource_noun="agent")
+        captured = capsys.readouterr()
+        assert "looks like a workspace ID" in captured.err
+        assert "sculpt workspace show ws_abc123" in captured.err
+
+    def test_ambiguous_lists_ids_with_labels(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [
+            {"id": "tsk_aaa111", "title": "First task"},
+            {"id": "tsk_aaa222", "title": "Second task"},
+        ]
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix(
+                "tsk_aaa",
+                items,
+                lambda x: x["id"],
+                resource_noun="agent",
+                label_getter=lambda x: x["title"],
+            )
+        captured = capsys.readouterr()
+        assert "Ambiguous prefix 'tsk_aaa' matches 2 agents" in captured.err
+        assert "tsk_aaa111  First task" in captured.err
+        assert "tsk_aaa222  Second task" in captured.err
+
+    def test_ambiguous_without_label_getter_lists_bare_ids(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix("tsk_aaa", ["tsk_aaa111", "tsk_aaa222"], lambda x: x, resource_noun="agent")
+        captured = capsys.readouterr()
+        assert "tsk_aaa111" in captured.err
+        assert "tsk_aaa222" in captured.err
+
+    def test_ambiguous_truncates_long_labels(self, capsys: pytest.CaptureFixture[str]) -> None:
+        long_title = "x" * 60
+        items = [
+            {"id": "tsk_aaa111", "title": long_title},
+            {"id": "tsk_aaa222", "title": "Short"},
+        ]
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix(
+                "tsk_aaa",
+                items,
+                lambda x: x["id"],
+                resource_noun="agent",
+                label_getter=lambda x: x["title"],
+            )
+        captured = capsys.readouterr()
+        assert long_title not in captured.err
+        assert "x" * 37 + "..." in captured.err
+
+    def test_ambiguous_caps_listing_at_ten_and_elides_rest(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [f"tsk_aaa{i:02d}" for i in range(13)]
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix("tsk_aaa", items, lambda x: x, resource_noun="agent")
+        captured = capsys.readouterr()
+        assert "Ambiguous prefix 'tsk_aaa' matches 13 agents" in captured.err
+        assert "tsk_aaa09" in captured.err
+        assert "tsk_aaa10" not in captured.err
+        assert "... and 3 more" in captured.err
+
+    def test_json_output_emits_structured_error_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(typer.Exit):
+            resolve_by_prefix(
+                "ws_abc123",
+                ["tsk_abc123"],
+                lambda x: x,
+                resource_noun="agent",
+                json_output=True,
+            )
+        captured = capsys.readouterr()
+        data = json.loads(captured.err)
+        assert data["error"] == "No agent matches 'ws_abc123'"
+        assert "looks like a workspace ID" in data["detail"]
 
 
 def _make_workspace_response(

--- a/tools/sculpt/tests/unit/test_resolve.py
+++ b/tools/sculpt/tests/unit/test_resolve.py
@@ -49,9 +49,7 @@ class TestResolveProject:
     @respx.mock
     def test_repo_provided_server_error(self) -> None:
         client = _make_client()
-        respx.post("http://localhost:5050/api/v1/projects/initialize").mock(
-            return_value=Response(500)
-        )
+        respx.post("http://localhost:5050/api/v1/projects/initialize").mock(return_value=Response(500))
 
         with pytest.raises(typer.Exit):
             resolve_project(repo="/tmp/my-repo", client=client)
@@ -67,9 +65,7 @@ class TestResolveProject:
             resolve_project(repo="/tmp/my-repo", client=client)
 
     @respx.mock
-    def test_repo_provided_already_added_returns_existing_project(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_repo_provided_already_added_returns_existing_project(self, capsys: pytest.CaptureFixture[str]) -> None:
         """SCU-1309: When --repo points at a path the server already has registered, the
         server returns 409 'This repository is already added to Sculptor.' Previously
         the CLI printed 'Failed to initialize repo (no response)' and exited 1. With
@@ -102,9 +98,7 @@ class TestResolveProject:
         assert "no response" not in captured.err
 
     @respx.mock
-    def test_repo_provided_already_added_no_match_surfaces_detail(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_repo_provided_already_added_no_match_surfaces_detail(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Defensive: if the server says 409 'already added' but no project matches the
         path in list_projects, surface the server's detail rather than the misleading
         'no response' message — the user gets something actionable to debug."""
@@ -126,9 +120,7 @@ class TestResolveProject:
         assert "no response" not in captured.err
 
     @respx.mock
-    def test_repo_provided_400_not_git_repo_surfaces_detail(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_repo_provided_400_not_git_repo_surfaces_detail(self, capsys: pytest.CaptureFixture[str]) -> None:
         """4xx errors from /projects/initialize must surface the server's detail
         instead of the misleading 'no response' (SCU-1309)."""
         client = _make_client()
@@ -151,9 +143,7 @@ class TestResolveProject:
         assert "no response" not in captured.err
 
     @respx.mock
-    def test_repo_provided_404_path_missing_surfaces_detail(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_repo_provided_404_path_missing_surfaces_detail(self, capsys: pytest.CaptureFixture[str]) -> None:
         """404 'Project path does not exist' must surface the detail (SCU-1309)."""
         client = _make_client()
         respx.post("http://localhost:5050/api/v1/projects/initialize").mock(
@@ -170,9 +160,7 @@ class TestResolveProject:
         assert "no response" not in captured.err
 
     @respx.mock
-    def test_repo_provided_409_no_commits_surfaces_detail(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_repo_provided_409_no_commits_surfaces_detail(self, capsys: pytest.CaptureFixture[str]) -> None:
         """The other 409 path ('no commits') is a real error and must surface the
         detail, not be mistakenly funneled through the idempotent 'already added'
         branch."""
@@ -181,10 +169,7 @@ class TestResolveProject:
             return_value=Response(
                 409,
                 json={
-                    "detail": (
-                        "Selected git repository has no commits."
-                        + " Please create an initial commit first."
-                    )
+                    "detail": ("Selected git repository has no commits." + " Please create an initial commit first.")
                 },
             )
         )
@@ -247,17 +232,13 @@ class TestResolveProject:
     @respx.mock
     def test_cwd_fallback_empty_project_list(self) -> None:
         client = _make_client()
-        respx.get("http://localhost:5050/api/v1/projects").mock(
-            return_value=Response(200, json=[])
-        )
+        respx.get("http://localhost:5050/api/v1/projects").mock(return_value=Response(200, json=[]))
 
         with pytest.raises(typer.Exit):
             resolve_project(repo=None, client=client)
 
     @respx.mock
-    def test_cwd_no_match_error_mentions_env_var(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_cwd_no_match_error_mentions_env_var(self, capsys: pytest.CaptureFixture[str]) -> None:
         """SCU-1309: When _resolve_from_cwd can't match the current directory to any
         registered project, the error message must also mention SCULPT_PROJECT_ID.
         Otherwise agents (and humans) are funneled into `--repo`, which then 409s
@@ -526,9 +507,7 @@ class TestResolveWorkspaceId:
     @respx.mock
     def test_no_response(self) -> None:
         client = _make_client()
-        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
-            return_value=Response(500)
-        )
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(return_value=Response(500))
 
         with pytest.raises(typer.Exit):
             resolve_workspace_id(client, "ws_abc")

--- a/tools/sculpt/tests/unit/test_trace.py
+++ b/tools/sculpt/tests/unit/test_trace.py
@@ -26,7 +26,9 @@ def _mock_session(base_url: str = _BASE_URL) -> None:
 def test_trace_start_prints_output_path(runner: CliRunner) -> None:
     _mock_session()
     route = respx.post(f"{_BASE_URL}/api/v1/trace/start").mock(
-        return_value=Response(200, json={"enabled": True, "outputPath": "/logs/traces/t.json", "bufferedExternalEvents": 0})
+        return_value=Response(
+            200, json={"enabled": True, "outputPath": "/logs/traces/t.json", "bufferedExternalEvents": 0}
+        )
     )
 
     result = runner.invoke(app, ["debug", "trace", "start"])

--- a/tools/sculpt/tests/unit/test_ui.py
+++ b/tools/sculpt/tests/unit/test_ui.py
@@ -60,22 +60,16 @@ class TestUiOpenFile:
         assert result.exit_code == 2
 
     def test_invalid_mode_returns_2(self, runner: CliRunner) -> None:
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123", "--mode", "bogus"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123", "--mode", "bogus"])
         assert result.exit_code == 2
 
     @respx.mock
     def test_success_exits_0(self, runner: CliRunner) -> None:
         _mock_session()
         _mock_workspaces("ws_test123")
-        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/ui/open-file").mock(
-            return_value=Response(204)
-        )
+        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/ui/open-file").mock(return_value=Response(204))
 
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"])
         assert result.exit_code == 0
 
     @respx.mock
@@ -94,9 +88,7 @@ class TestUiOpenFile:
             )
         )
 
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"])
         assert result.exit_code == 3
         assert "is not open" in result.stderr
 
@@ -116,9 +108,7 @@ class TestUiOpenFile:
             )
         )
 
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/nope.txt", "-w", "ws_test123"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/nope.txt", "-w", "ws_test123"])
         assert result.exit_code == 4
 
     @respx.mock
@@ -129,9 +119,7 @@ class TestUiOpenFile:
             return_value=Response(500, text="Internal Server Error")
         )
 
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"])
         assert result.exit_code == 5
 
     @respx.mock
@@ -142,15 +130,11 @@ class TestUiOpenFile:
             side_effect=ConnectError("Connection refused")
         )
 
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123"])
         assert result.exit_code == 5
 
     @respx.mock
-    def test_relative_path_is_resolved_to_absolute(
-        self, runner: CliRunner, tmp_path: Any
-    ) -> None:
+    def test_relative_path_is_resolved_to_absolute(self, runner: CliRunner, tmp_path: Any) -> None:
         _mock_session()
         _mock_workspaces("ws_test123")
 
@@ -160,16 +144,12 @@ class TestUiOpenFile:
             captured["body"] = json.loads(request.content)
             return Response(204)
 
-        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/ui/open-file").mock(
-            side_effect=_capture
-        )
+        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/ui/open-file").mock(side_effect=_capture)
 
         cwd = os.getcwd()
         try:
             os.chdir(str(tmp_path))
-            result = runner.invoke(
-                app, ["ui", "open-file", "relative.txt", "-w", "ws_test123"]
-            )
+            result = runner.invoke(app, ["ui", "open-file", "relative.txt", "-w", "ws_test123"])
         finally:
             os.chdir(cwd)
 
@@ -190,13 +170,9 @@ class TestUiOpenFile:
             captured["body"] = json.loads(request.content)
             return Response(204)
 
-        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/ui/open-file").mock(
-            side_effect=_capture
-        )
+        respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/ui/open-file").mock(side_effect=_capture)
 
-        result = runner.invoke(
-            app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123", "--mode", "diff"]
-        )
+        result = runner.invoke(app, ["ui", "open-file", "/tmp/x.txt", "-w", "ws_test123", "--mode", "diff"])
         assert result.exit_code == 0
         assert captured["body"]["mode"] == "diff"
 

--- a/tools/sculpt/tests/unit/test_workspace.py
+++ b/tools/sculpt/tests/unit/test_workspace.py
@@ -157,9 +157,7 @@ class TestWorkspaceCreate:
             return_value=Response(200, json=_workspace_response_dict(strategy="IN_PLACE"))
         )
 
-        result = runner.invoke(
-            app, ["workspace", "create", "--repo", "/tmp/test", "--strategy", "in-place"]
-        )
+        result = runner.invoke(app, ["workspace", "create", "--repo", "/tmp/test", "--strategy", "in-place"])
 
         assert result.exit_code == 0
 
@@ -168,9 +166,9 @@ class TestWorkspaceCreate:
         """When --branch-name is supplied, the CLI sends it through unchanged and skips the preview call."""
         _mock_session()
         _mock_initialize_project()
-        preview_route = respx.get(
-            "http://localhost:5050/api/v1/workspaces/preview-branch-name"
-        ).mock(return_value=Response(200, json={"branchName": "should-not-be-used"}))
+        preview_route = respx.get("http://localhost:5050/api/v1/workspaces/preview-branch-name").mock(
+            return_value=Response(200, json={"branchName": "should-not-be-used"})
+        )
         create_route = respx.post("http://localhost:5050/api/v1/workspaces").mock(
             return_value=Response(200, json=_workspace_response_dict(strategy="WORKTREE"))
         )
@@ -207,9 +205,9 @@ class TestWorkspaceCreate:
         """When --branch-name is omitted for worktree, the CLI auto-fills it via preview-branch-name."""
         _mock_session()
         _mock_initialize_project()
-        preview_route = respx.get(
-            "http://localhost:5050/api/v1/workspaces/preview-branch-name"
-        ).mock(return_value=Response(200, json={"branchName": "dev/auto-generated"}))
+        preview_route = respx.get("http://localhost:5050/api/v1/workspaces/preview-branch-name").mock(
+            return_value=Response(200, json={"branchName": "dev/auto-generated"})
+        )
         create_route = respx.post("http://localhost:5050/api/v1/workspaces").mock(
             return_value=Response(200, json=_workspace_response_dict(strategy="WORKTREE"))
         )
@@ -271,9 +269,7 @@ class TestWorkspaceCreate:
         _mock_session()
         _mock_initialize_project()
 
-        result = runner.invoke(
-            app, ["workspace", "create", "--repo", "/tmp/test", "--strategy", "bogus"]
-        )
+        result = runner.invoke(app, ["workspace", "create", "--repo", "/tmp/test", "--strategy", "bogus"])
 
         assert result.exit_code == 1
         assert "Invalid strategy 'bogus'" in (result.stderr or result.output)
@@ -282,9 +278,7 @@ class TestWorkspaceCreate:
     def test_create_connection_error(self, runner: CliRunner) -> None:
         _mock_session()
         _mock_initialize_project()
-        respx.post("http://localhost:5050/api/v1/workspaces").mock(
-            side_effect=ConnectError("Connection refused")
-        )
+        respx.post("http://localhost:5050/api/v1/workspaces").mock(side_effect=ConnectError("Connection refused"))
 
         result = runner.invoke(app, ["workspace", "create", "--repo", "/tmp/test"])
 
@@ -483,9 +477,7 @@ class TestWorkspaceShowDefault:
     """`workspace show` with no argument targets the shell's own workspace."""
 
     @respx.mock
-    def test_show_no_arg_uses_env_workspace(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_show_no_arg_uses_env_workspace(self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
         _mock_session()
         _mock_projects_list()
@@ -649,9 +641,7 @@ class TestWorkspaceSelfMarker:
     """`workspace list` flags the calling shell's own workspace (SCULPT_WORKSPACE_ID)."""
 
     @respx.mock
-    def test_list_all_json_flags_only_own_workspace(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_list_all_json_flags_only_own_workspace(self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
         _mock_session()
         _mock_projects_list()
@@ -786,9 +776,7 @@ class TestWorkspaceRename:
             return_value=Response(200, json={"workspaces": [_recent_workspace_dict()]})
         )
         respx.patch("http://localhost:5050/api/v1/workspaces/ws_test123").mock(
-            return_value=Response(
-                200, json=_workspace_response_dict(description="New description")
-            )
+            return_value=Response(200, json=_workspace_response_dict(description="New description"))
         )
 
         result = runner.invoke(app, ["workspace", "rename", "ws_test123", "New description"])
@@ -804,9 +792,7 @@ class TestWorkspaceRename:
             return_value=Response(200, json={"workspaces": [_recent_workspace_dict()]})
         )
         respx.patch("http://localhost:5050/api/v1/workspaces/ws_test123").mock(
-            return_value=Response(
-                200, json=_workspace_response_dict(description="New description")
-            )
+            return_value=Response(200, json=_workspace_response_dict(description="New description"))
         )
 
         result = runner.invoke(app, ["workspace", "rename", "ws_test123", "New description", "--json"])
@@ -823,9 +809,7 @@ class TestWorkspaceRename:
             return_value=Response(200, json={"workspaces": [_recent_workspace_dict()]})
         )
         respx.patch("http://localhost:5050/api/v1/workspaces/ws_test123").mock(
-            return_value=Response(
-                200, json=_workspace_response_dict(description="Updated")
-            )
+            return_value=Response(200, json=_workspace_response_dict(description="Updated"))
         )
 
         result = runner.invoke(app, ["workspace", "rename", "ws_test", "Updated"])

--- a/tools/sculpt/tests/unit/test_workspace.py
+++ b/tools/sculpt/tests/unit/test_workspace.py
@@ -579,19 +579,20 @@ class TestWorkspacePathAndBranch:
     def test_list_all_prefers_current_branch_over_source(self, runner: CliRunner) -> None:
         _mock_session()
         _mock_projects_list()
+        # A distinctive source-branch value, so the table-wide negative below
+        # can't collide with unrelated columns (paths, descriptions).
+        workspace = _recent_workspace_dict(current_branch="dev/live-branch")
+        workspace["sourceBranch"] = "distinctive-source-branch"
         respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
-            return_value=Response(
-                200,
-                json={"workspaces": [_recent_workspace_dict(current_branch="dev/live-branch")]},
-            )
+            return_value=Response(200, json={"workspaces": [workspace]})
         )
 
         result = runner.invoke(app, ["workspace", "list", "--all"])
 
         assert result.exit_code == 0
         assert "dev/live-branch" in result.output
-        # The source branch ("main") is only the fallback when no live branch is known.
-        assert "main" not in result.output
+        # The source branch is only the fallback when no live branch is known.
+        assert "distinctive-source-branch" not in result.output
 
     @respx.mock
     def test_list_all_json_includes_path_and_branch(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_workspace.py
+++ b/tools/sculpt/tests/unit/test_workspace.py
@@ -92,8 +92,10 @@ def _recent_workspace_dict(
     project_id: str = "prj_test123",
     description: str = "Test workspace",
     project_name: str = "test-project",
+    working_directory: str | None = None,
+    current_branch: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    response = {
         "objectId": object_id,
         "projectId": project_id,
         "description": description,
@@ -106,6 +108,13 @@ def _recent_workspace_dict(
         "isOpen": True,
         "lastActivityAt": "2024-01-15T11:00:00Z",
     }
+    # Older servers omit these fields entirely (the client sees UNSET); only
+    # include them when a test explicitly provides values.
+    if working_directory is not None:
+        response["workingDirectory"] = working_directory
+    if current_branch is not None:
+        response["currentBranch"] = current_branch
+    return response
 
 
 class TestWorkspaceCreate:
@@ -468,6 +477,305 @@ class TestWorkspaceShow:
         result = runner.invoke(app, ["workspace", "show", "nonexistent"])
 
         assert result.exit_code == 1
+
+
+class TestWorkspaceShowDefault:
+    """`workspace show` with no argument targets the shell's own workspace."""
+
+    @respx.mock
+    def test_show_no_arg_uses_env_workspace(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(200, json={"workspaces": [_recent_workspace_dict()]})
+        )
+
+        result = runner.invoke(app, ["workspace", "show"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        assert "ws_test123" in result.output
+        assert "Using workspace from SCULPT_WORKSPACE_ID" in result.stderr
+
+    @respx.mock
+    def test_show_no_arg_without_env_errors(self, runner: CliRunner) -> None:
+        # Client auth happens before the env check, so the session endpoint
+        # must respond for the test to reach the WORKSPACE_ID error.
+        _mock_session()
+
+        result = runner.invoke(app, ["workspace", "show"])
+
+        assert result.exit_code == 1
+        assert "SCULPT_WORKSPACE_ID" in result.stderr
+
+
+class TestWorkspacePathAndBranch:
+    """show/list surface the live checkout location and branch when the server provides them."""
+
+    @respx.mock
+    def test_show_renders_path_and_current_branch(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(
+                200,
+                json={
+                    "workspaces": [
+                        _recent_workspace_dict(
+                            working_directory="/tmp/worktrees/foo",
+                            current_branch="dev/feature-x",
+                        )
+                    ]
+                },
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "show", "ws_test123"])
+
+        assert result.exit_code == 0
+        assert "Path: /tmp/worktrees/foo" in result.output
+        assert "Current Branch: dev/feature-x" in result.output
+
+    @respx.mock
+    def test_show_json_includes_path_and_branch(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(
+                200,
+                json={
+                    "workspaces": [
+                        _recent_workspace_dict(
+                            working_directory="/tmp/worktrees/foo",
+                            current_branch="dev/feature-x",
+                        )
+                    ]
+                },
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "show", "ws_test123", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["working_directory"] == "/tmp/worktrees/foo"
+        assert data["current_branch"] == "dev/feature-x"
+
+    @respx.mock
+    def test_show_tolerates_older_server_without_fields(self, runner: CliRunner) -> None:
+        """A server that doesn't send workingDirectory/currentBranch yields nulls, not a crash."""
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(200, json={"workspaces": [_recent_workspace_dict()]})
+        )
+
+        result = runner.invoke(app, ["workspace", "show", "ws_test123", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["working_directory"] is None
+        assert data["current_branch"] is None
+
+        result = runner.invoke(app, ["workspace", "show", "ws_test123"])
+        assert result.exit_code == 0
+        assert "Path:" not in result.output
+
+    @respx.mock
+    def test_list_all_prefers_current_branch_over_source(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(
+                200,
+                json={"workspaces": [_recent_workspace_dict(current_branch="dev/live-branch")]},
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--all"])
+
+        assert result.exit_code == 0
+        assert "dev/live-branch" in result.output
+        # The source branch ("main") is only the fallback when no live branch is known.
+        assert "main" not in result.output
+
+    @respx.mock
+    def test_list_all_json_includes_path_and_branch(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(
+                200,
+                json={
+                    "workspaces": [
+                        _recent_workspace_dict(
+                            working_directory="/tmp/worktrees/foo",
+                            current_branch="dev/feature-x",
+                        )
+                    ]
+                },
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--all", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data[0]["working_directory"] == "/tmp/worktrees/foo"
+        assert data[0]["current_branch"] == "dev/feature-x"
+
+    @respx.mock
+    def test_list_project_json_includes_path_and_branch(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_initialize_project()
+        workspace = _workspace_response_dict()
+        workspace["workingDirectory"] = "/tmp/worktrees/foo"
+        workspace["currentBranch"] = "dev/feature-x"
+        respx.get("http://localhost:5050/api/v1/projects/prj_test123/workspaces").mock(
+            return_value=Response(200, json=[workspace])
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--repo", "/tmp/test", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data[0]["working_directory"] == "/tmp/worktrees/foo"
+        assert data[0]["current_branch"] == "dev/feature-x"
+
+
+class TestWorkspaceSelfMarker:
+    """`workspace list` flags the calling shell's own workspace (SCULPT_WORKSPACE_ID)."""
+
+    @respx.mock
+    def test_list_all_json_flags_only_own_workspace(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(
+                200,
+                json={
+                    "workspaces": [
+                        _recent_workspace_dict(object_id="ws_test123"),
+                        _recent_workspace_dict(object_id="ws_other456"),
+                    ]
+                },
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--all", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        flags = {item["id"]: item["is_self"] for item in data}
+        assert flags == {"ws_test123": True, "ws_other456": False}
+
+    @respx.mock
+    def test_list_all_table_marks_own_workspace_with_legend(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(
+                200,
+                json={
+                    "workspaces": [
+                        _recent_workspace_dict(object_id="ws_test123"),
+                        _recent_workspace_dict(object_id="ws_other456"),
+                    ]
+                },
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--all"])
+
+        assert result.exit_code == 0
+        assert "ws_test123 *" in result.output
+        assert "ws_other456 *" not in result.output
+        assert "* = this workspace (SCULPT_WORKSPACE_ID)" in result.stderr
+
+    @respx.mock
+    def test_list_project_json_flags_only_own_workspace(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
+        _mock_session()
+        _mock_initialize_project()
+        respx.get("http://localhost:5050/api/v1/projects/prj_test123/workspaces").mock(
+            return_value=Response(
+                200,
+                json=[
+                    _workspace_response_dict(object_id="ws_test123"),
+                    _workspace_response_dict(object_id="ws_other456"),
+                ],
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--repo", "/tmp/test", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        flags = {item["id"]: item["is_self"] for item in data}
+        assert flags == {"ws_test123": True, "ws_other456": False}
+
+    @respx.mock
+    def test_list_project_table_marks_own_workspace_with_legend(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_test123")
+        _mock_session()
+        _mock_initialize_project()
+        respx.get("http://localhost:5050/api/v1/projects/prj_test123/workspaces").mock(
+            return_value=Response(
+                200,
+                json=[
+                    _workspace_response_dict(object_id="ws_test123"),
+                    _workspace_response_dict(object_id="ws_other456"),
+                ],
+            )
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--repo", "/tmp/test"])
+
+        assert result.exit_code == 0
+        assert "ws_test123 *" in result.output
+        assert "ws_other456 *" not in result.output
+        assert "* = this workspace (SCULPT_WORKSPACE_ID)" in result.stderr
+
+    @respx.mock
+    def test_list_all_without_env_has_no_marker_or_legend(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_projects_list()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            return_value=Response(200, json={"workspaces": [_recent_workspace_dict()]})
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--all"])
+
+        assert result.exit_code == 0
+        assert "*" not in result.output
+        assert "* = this workspace" not in result.stderr
+
+
+class TestWorkspaceConnectionErrorHint:
+    @respx.mock
+    def test_list_connection_error_mentions_port_hint(self, runner: CliRunner) -> None:
+        _mock_session()
+        respx.get("http://localhost:5050/api/v1/workspaces/recent").mock(
+            side_effect=ConnectError("Connection refused")
+        )
+
+        result = runner.invoke(app, ["workspace", "list", "--all"])
+
+        assert result.exit_code == 1
+        assert "SCULPT_API_PORT" in result.stderr
+        assert "--base-url" in result.stderr
 
 
 class TestWorkspaceRename:

--- a/tools/sculpt/tests/unit/test_ws_client.py
+++ b/tools/sculpt/tests/unit/test_ws_client.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 import pytest
 import websockets
 import websockets.server
-
 from sculpt.ws_client import AgentNotFoundError
 from sculpt.ws_client import AgentSnapshot
 from sculpt.ws_client import ExitReason
@@ -22,9 +21,7 @@ from sculpt.ws_client import fetch_all_agents
 from sculpt.ws_client import follow_agent
 
 
-def _pending_question_update(
-    *labels: str, chat_messages: list[dict[str, Any]] | None = None
-) -> dict[str, Any]:
+def _pending_question_update(*labels: str, chat_messages: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     """A task update dict carrying a pendingUserQuestion with the given option labels."""
     return {
         "chatMessages": chat_messages or [],
@@ -162,9 +159,7 @@ def _make_dump(
     }
 
 
-def _start_ws_server(
-    payload: str | None, delay: float = 0.0
-) -> tuple[str, threading.Event, dict[str, Any]]:
+def _start_ws_server(payload: str | None, delay: float = 0.0) -> tuple[str, threading.Event, dict[str, Any]]:
     """Start a WebSocket server in a background thread that sends the given payload.
 
     Returns (url, shutdown_event, server_info). server_info["last_path"] is
@@ -373,15 +368,19 @@ def test_follow_auto_exit_terminal_state() -> None:
     initial_view = _make_task_view(task_id=task_id, status="RUNNING")
     initial_dump = _make_dump(
         task_views={task_id: initial_view},
-        task_updates={task_id: {"chatMessages": [{"id": "msg_1", "role": "user", "content": [{"type": "text", "text": "hi"}]}]}},
+        task_updates={
+            task_id: {"chatMessages": [{"id": "msg_1", "role": "user", "content": [{"type": "text", "text": "hi"}]}]}
+        },
     )
     update_view = _make_task_view(task_id=task_id, status="READY")
     update_dump = {"taskViewsByTaskId": {task_id: update_view}, "taskUpdateByTaskId": {}}
 
-    url, shutdown = _start_ws_server_with_messages([
-        json.dumps(initial_dump),
-        json.dumps(update_dump),
-    ])
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            json.dumps(update_dump),
+        ]
+    )
     try:
         statuses: list[AgentSnapshot] = []
         all_messages: list[list[dict[str, Any]]] = []
@@ -410,10 +409,12 @@ def test_follow_auto_exit_waiting() -> None:
     update_view = _make_task_view(task_id=task_id, status="WAITING", waiting_detail="Need input")
     update_dump = {"taskViewsByTaskId": {task_id: update_view}, "taskUpdateByTaskId": {}}
 
-    url, shutdown = _start_ws_server_with_messages([
-        json.dumps(initial_dump),
-        json.dumps(update_dump),
-    ])
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            json.dumps(update_dump),
+        ]
+    )
     try:
         statuses: list[AgentSnapshot] = []
 
@@ -444,10 +445,12 @@ def test_follow_new_messages() -> None:
         "taskUpdateByTaskId": {task_id: {"chatMessages": [new_msg]}},
     }
 
-    url, shutdown = _start_ws_server_with_messages([
-        json.dumps(initial_dump),
-        json.dumps(update),
-    ])
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            json.dumps(update),
+        ]
+    )
     try:
         all_messages: list[list[dict[str, Any]]] = []
 
@@ -482,10 +485,12 @@ def test_follow_message_deduplication() -> None:
         "taskUpdateByTaskId": {task_id: {"chatMessages": [msg_a, msg_b, msg_c]}},
     }
 
-    url, shutdown = _start_ws_server_with_messages([
-        json.dumps(initial_dump),
-        json.dumps(update),
-    ])
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            json.dumps(update),
+        ]
+    )
     try:
         all_messages: list[list[dict[str, Any]]] = []
 
@@ -522,11 +527,13 @@ def test_follow_ignores_other_agents() -> None:
         "taskUpdateByTaskId": {},
     }
 
-    url, shutdown = _start_ws_server_with_messages([
-        json.dumps(initial_dump),
-        json.dumps(update_other),
-        json.dumps(update_target),
-    ])
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            json.dumps(update_other),
+            json.dumps(update_target),
+        ]
+    )
     try:
         statuses: list[AgentSnapshot] = []
 
@@ -542,7 +549,6 @@ def test_follow_ignores_other_agents() -> None:
         for s in statuses:
             assert s.task_id == target_id
 
-
     finally:
         shutdown.set()
 
@@ -555,12 +561,14 @@ def test_follow_handles_null_keepalive() -> None:
         "taskUpdateByTaskId": {},
     }
 
-    url, shutdown = _start_ws_server_with_messages([
-        json.dumps(initial_dump),
-        "null",
-        "null",
-        json.dumps(terminal_update),
-    ])
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            "null",
+            "null",
+            json.dumps(terminal_update),
+        ]
+    )
     try:
         result = follow_agent(
             url.replace("ws://", "http://"),
@@ -898,9 +906,7 @@ def test_follow_carries_waiting_options_across_view_only_frames() -> None:
     # View-only frame (changed activity, no update): options must persist.
     frame_view_only = {
         "taskViewsByTaskId": {
-            task_id: _make_task_view(
-                task_id=task_id, waiting_detail="Pick one", current_activity="thinking"
-            )
+            task_id: _make_task_view(task_id=task_id, waiting_detail="Pick one", current_activity="thinking")
         },
         "taskUpdateByTaskId": {},
     }

--- a/tools/sculpt/tests/unit/test_ws_client.py
+++ b/tools/sculpt/tests/unit/test_ws_client.py
@@ -15,9 +15,83 @@ from sculpt.ws_client import AgentNotFoundError
 from sculpt.ws_client import AgentSnapshot
 from sculpt.ws_client import ExitReason
 from sculpt.ws_client import _build_ws_url
+from sculpt.ws_client import _options_from_pending_question
+from sculpt.ws_client import _snapshot_from_view
 from sculpt.ws_client import fetch_agent_state
 from sculpt.ws_client import fetch_all_agents
 from sculpt.ws_client import follow_agent
+
+
+def _pending_question_update(
+    *labels: str, chat_messages: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """A task update dict carrying a pendingUserQuestion with the given option labels."""
+    return {
+        "chatMessages": chat_messages or [],
+        "pendingUserQuestion": {
+            "questions": [{"options": [{"label": label} for label in labels]}],
+        },
+    }
+
+
+class TestOptionsFromPendingQuestion:
+    def test_extracts_option_labels(self) -> None:
+        update = _pending_question_update("Red", "Blue")
+        assert _options_from_pending_question(update) == ["Red", "Blue"]
+
+    def test_none_update_yields_none(self) -> None:
+        assert _options_from_pending_question(None) is None
+
+    def test_empty_update_yields_none(self) -> None:
+        assert _options_from_pending_question({}) is None
+
+    def test_missing_pending_question_yields_none(self) -> None:
+        assert _options_from_pending_question({"chatMessages": []}) is None
+
+    def test_null_pending_question_yields_none(self) -> None:
+        assert _options_from_pending_question({"pendingUserQuestion": None}) is None
+
+    def test_non_dict_pending_question_yields_none(self) -> None:
+        assert _options_from_pending_question({"pendingUserQuestion": "bogus"}) is None
+
+    def test_empty_questions_yields_none(self) -> None:
+        assert _options_from_pending_question({"pendingUserQuestion": {"questions": []}}) is None
+
+    def test_empty_options_yields_none(self) -> None:
+        update = {"pendingUserQuestion": {"questions": [{"options": []}]}}
+        assert _options_from_pending_question(update) is None
+
+    def test_options_without_labels_yields_none(self) -> None:
+        update = {"pendingUserQuestion": {"questions": [{"options": [{"label": ""}, {}]}]}}
+        assert _options_from_pending_question(update) is None
+
+    def test_only_first_question_is_read(self) -> None:
+        update = {
+            "pendingUserQuestion": {
+                "questions": [
+                    {"options": [{"label": "First"}]},
+                    {"options": [{"label": "Second"}]},
+                ],
+            },
+        }
+        assert _options_from_pending_question(update) == ["First"]
+
+
+class TestSnapshotFromView:
+    def test_update_populates_waiting_options_and_messages(self) -> None:
+        messages = [{"id": "msg_1", "role": "user", "content": "hi"}]
+        update = _pending_question_update("Red", "Blue", chat_messages=messages)
+
+        snapshot = _snapshot_from_view("tsk_abc", _make_task_view(task_id="tsk_abc"), update)
+
+        assert snapshot.waiting_options == ["Red", "Blue"]
+        assert snapshot.messages == messages
+
+    def test_no_update_yields_no_waiting_options(self) -> None:
+        snapshot = _snapshot_from_view("tsk_abc", _make_task_view(task_id="tsk_abc"))
+
+        assert snapshot.waiting_options is None
+        assert snapshot.messages == []
 
 
 def test_build_ws_url_no_scope() -> None:
@@ -764,5 +838,97 @@ def test_follow_emits_streaming_partial_messages() -> None:
         # message. Partial-aware consumers can dedupe by message id.
         assert len(completed) == 1
         assert completed[0][0]["id"] == "msg_1"
+    finally:
+        shutdown.set()
+
+
+def test_fetch_agent_state_extracts_waiting_options() -> None:
+    task_id = f"tsk_{uuid4().hex}"
+    dump = _make_dump(
+        task_views={task_id: _make_task_view(task_id=task_id, status="WAITING")},
+        task_updates={
+            task_id: {
+                "chatMessages": [],
+                "pendingUserQuestion": {
+                    "questions": [{"options": [{"label": "Red"}, {"label": "Blue"}]}],
+                },
+            }
+        },
+    )
+    url, shutdown, _info = _start_ws_server(json.dumps(dump))
+    try:
+        snapshot = fetch_agent_state(url.replace("ws://", "http://"), "fake-token", task_id)
+        assert snapshot.waiting_options == ["Red", "Blue"]
+    finally:
+        shutdown.set()
+
+
+def test_fetch_agent_state_no_pending_question_yields_no_options() -> None:
+    task_id = f"tsk_{uuid4().hex}"
+    dump = _make_dump(
+        task_views={task_id: _make_task_view(task_id=task_id)},
+        task_updates={task_id: {"chatMessages": []}},
+    )
+    url, shutdown, _info = _start_ws_server(json.dumps(dump))
+    try:
+        snapshot = fetch_agent_state(url.replace("ws://", "http://"), "fake-token", task_id)
+        assert snapshot.waiting_options is None
+    finally:
+        shutdown.set()
+
+
+def test_follow_carries_waiting_options_across_view_only_frames() -> None:
+    """A frame may carry the task view without its update; the follow loop must
+    keep rendering the last-known pending-question options on such frames
+    instead of blanking them."""
+    task_id = f"tsk_{uuid4().hex}"
+    pending_update = {
+        "chatMessages": [],
+        "pendingUserQuestion": {
+            "questions": [{"options": [{"label": "Red"}, {"label": "Blue"}]}],
+        },
+    }
+
+    initial_dump = _make_dump(task_views={task_id: _make_task_view(task_id=task_id)})
+    # Frame with both view and update: options become known.
+    frame_with_question = {
+        "taskViewsByTaskId": {task_id: _make_task_view(task_id=task_id, waiting_detail="Pick one")},
+        "taskUpdateByTaskId": {task_id: pending_update},
+    }
+    # View-only frame (changed activity, no update): options must persist.
+    frame_view_only = {
+        "taskViewsByTaskId": {
+            task_id: _make_task_view(
+                task_id=task_id, waiting_detail="Pick one", current_activity="thinking"
+            )
+        },
+        "taskUpdateByTaskId": {},
+    }
+    terminal_frame = {
+        "taskViewsByTaskId": {task_id: _make_task_view(task_id=task_id, status="READY")},
+        "taskUpdateByTaskId": {},
+    }
+
+    url, shutdown = _start_ws_server_with_messages(
+        [
+            json.dumps(initial_dump),
+            json.dumps(frame_with_question),
+            json.dumps(frame_view_only),
+            json.dumps(terminal_frame),
+        ]
+    )
+    try:
+        statuses: list[AgentSnapshot] = []
+        result = follow_agent(
+            url.replace("ws://", "http://"),
+            "fake-token",
+            task_id,
+            on_status=statuses.append,
+            on_messages=lambda _: None,
+        )
+
+        assert result == ExitReason.TERMINAL_STATE
+        thinking_snapshot = next(s for s in statuses if s.current_activity == "thinking")
+        assert thinking_snapshot.waiting_options == ["Red", "Blue"]
     finally:
         shutdown.set()


### PR DESCRIPTION
Streamlines the `sculpt` CLI for agents and orchestrators driving Sculptor programmatically, based on a hands-on audit of the full workspace/agent lifecycle. Closes SCU-1766.

## What changed

**Cross-workspace agent addressing** — `agent send`/`interrupt`/`rename`/`delete` previously resolved the agent only inside `SCULPT_WORKSPACE_ID` (set in every Sculptor agent shell), so a full, valid agent ID from another workspace failed with a misleading `No resource matches prefix` error. They now resolve across all workspaces: an explicit `--workspace` stays authoritative (a mismatch errors instead of silently redirecting), the env var only narrows ambiguous prefixes, and a stderr note reports the agent's actual workspace on cross-workspace actions.

**`agent send` keeps the agent's model** — the `--model` flag defaulted to opus and silently, persistently switched whatever agent it messaged. A plain `send` now reuses the agent's current model; `--model` still switches explicitly. (Unknown model values from a newer server are handled as raw strings rather than crashing resolution.)

**Identity** — `agent show`/`status`/`messages` and `workspace show` with no argument default to the shell's own `SCULPT_AGENT_ID`/`SCULPT_WORKSPACE_ID`; `agent list`/`workspace list` mark the caller's own row with `*` and report `is_self` in `--json`; the top-level `--help` documents the env vars.

**Workspace location** — workspace directories on disk are named by opaque environment ids, so nothing mapped a `ws_...` API id to its checkout. `workspace show`/`list` (and the underlying web API) now report `working_directory` and `current_branch` — the path computed without resuming the environment, the branch from the branch poller's existing cache.

**Pending-question visibility** — `agent status`/`show` surface the pending AskUserQuestion's answer options (from the stream's server-maintained `pendingUserQuestion`, so it also works against older servers). Answering remains a user-only UI action by design; `interrupt` is the documented escape hatch for scripts.

**Error-output consistency** — resolver failures honor `--json` with the structured error shape; passing the wrong kind of ID (e.g. a `ws_...` where an agent is expected) gets a redirect hint; ambiguity listings show titles and cap at 10; connection failures point at `SCULPT_API_PORT`/`--base-url`; `agent delete` gains the same confirmation prompt (+`-y`) as `workspace delete`.

**Tooling** — `just format`/`just check` now cover `tools/sculpt/` (adds ~tens of milliseconds; the machine-generated OpenAPI client is excluded), with the one-time reformat applied as its own commit.

**Docs** — the bundled sculpt-cli skill is rewritten around agent workflows: identity first, delegate-and-await via `--follow` (exit code 2 = agent stopped to ask a question), model semantics, strategy guidance, and corrected examples.

## Validation

- `just format` / `just check` / `just test-unit` green; sculpt CLI unit suite is now 347 tests (73 new).
- Targeted 11-test subset of `test_sculpt_cli.py` integration tests green (including updated exact-key-set assertions for the new JSON fields).
- Behaviors verified live against a running Sculptor app, including the old-server compatibility paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
