### PR TITLE
Gate new workspace modal model picker and fast-mode behind agent type

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/agentTabs.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/agentTabs.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import type { TerminalAgentRegistration } from "~/api";
+
+import { encodeRegisteredAgentType, resolveEffectiveAgentType } from "./agentTabs.ts";
+
+const registration = (registrationId: string): TerminalAgentRegistration => ({
+  registrationId,
+  displayName: registrationId,
+  launchCommand: "run",
+});
+
+describe("resolveEffectiveAgentType", () => {
+  it("passes built-in agent types through unchanged", () => {
+    expect(resolveEffectiveAgentType("claude", [])).toEqual({ agentType: "claude", registrationId: undefined });
+    expect(resolveEffectiveAgentType("pi", [])).toEqual({ agentType: "pi", registrationId: undefined });
+    expect(resolveEffectiveAgentType("terminal", [])).toEqual({ agentType: "terminal", registrationId: undefined });
+  });
+
+  it("keeps a registered agent whose registration still exists", () => {
+    const stored = encodeRegisteredAgentType("reg-1");
+    expect(resolveEffectiveAgentType(stored, [registration("reg-1")])).toEqual({
+      agentType: "registered",
+      registrationId: "reg-1",
+    });
+  });
+
+  it("falls back to Claude when the registration was deleted", () => {
+    // The create path can't launch a deleted registration, so it creates Claude;
+    // the form's capability gate reads the same result and shows Claude's controls.
+    const stored = encodeRegisteredAgentType("reg-gone");
+    expect(resolveEffectiveAgentType(stored, [registration("reg-1")])).toEqual({
+      agentType: "claude",
+      registrationId: undefined,
+    });
+  });
+});

--- a/sculptor/frontend/src/common/state/atoms/agentTabs.ts
+++ b/sculptor/frontend/src/common/state/atoms/agentTabs.ts
@@ -1,6 +1,6 @@
 import { atom } from "jotai";
 
-import type { AgentTypeName } from "~/api";
+import type { AgentTypeName, TerminalAgentRegistration } from "~/api";
 
 import { userConfigAtom } from "./userConfig";
 
@@ -33,6 +33,22 @@ export const parseStoredAgentType = (
   value.startsWith(REGISTERED_AGENT_TYPE_PREFIX)
     ? { agentType: "registered", registrationId: value.slice(REGISTERED_AGENT_TYPE_PREFIX.length) }
     : { agentType: value as AgentTypeName, registrationId: undefined };
+
+/** Resolve a stored agent type to the one that will actually be created, given
+ * the live registrations: a `registered:<id>` whose registration no longer
+ * exists falls back to Claude (the create path can't launch a deleted
+ * registration). Shared by the create flow and the new-workspace form's
+ * capability gate so "is this effectively Claude?" is one derivation and the
+ * two surfaces cannot drift. */
+export const resolveEffectiveAgentType = (
+  stored: StoredAgentType,
+  registrations: ReadonlyArray<TerminalAgentRegistration>,
+): { agentType: AgentTypeName; registrationId: string | undefined } => {
+  const { agentType, registrationId } = parseStoredAgentType(stored);
+  const isMissingRegistration =
+    agentType === "registered" && !registrations.some((r) => r.registrationId === registrationId);
+  return isMissingRegistration ? { agentType: "claude", registrationId: undefined } : { agentType, registrationId };
+};
 
 /** The most-recently-used agent type, the default a plain `+` click (or a
  * bare `sculpt agent create`) creates.

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
@@ -6,7 +6,11 @@ import type { EffortLevel, LlmModel, TerminalAgentRegistration } from "~/api";
 import { createWorkspaceAgent, createWorkspaceV2, WorkspaceInitializationStrategy } from "~/api";
 import { HTTPException } from "~/common/Errors.ts";
 import { useImbueNavigate } from "~/common/NavigateUtils.ts";
-import { parseStoredAgentType, type StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
+import {
+  encodeRegisteredAgentType,
+  resolveEffectiveAgentType,
+  type StoredAgentType,
+} from "~/common/state/atoms/agentTabs.ts";
 import { userConfigAtom } from "~/common/state/atoms/userConfig.ts";
 import { lastWorkspaceCreationSettingsAtom } from "~/components/newWorkspace/newWorkspaceAtoms.ts";
 
@@ -101,15 +105,18 @@ export const useCreateWorkspace = (): UseCreateWorkspaceReturn => {
 
         const workspaceId = workspaceResponse.data.objectId;
 
-        // If the remembered registered agent's registration is no longer present
-        // (deleted since it was picked), fall back to Claude rather than leaving
-        // the just-created workspace with a failed, agentless first-agent create.
-        const { agentType, registrationId } = parseStoredAgentType(args.agentTypeValue);
-        const isMissingRegistration =
-          agentType === "registered" && !args.registrations.some((r) => r.registrationId === registrationId);
-        const effectiveAgentType = isMissingRegistration ? "claude" : agentType;
-        const effectiveRegistrationId = isMissingRegistration ? undefined : registrationId;
-        const effectiveAgentTypeValue: StoredAgentType = isMissingRegistration ? "claude" : args.agentTypeValue;
+        // Resolve the agent type that will actually be created: a registered
+        // agent whose registration is gone (deleted since it was picked) falls
+        // back to Claude rather than leaving the just-created workspace with a
+        // failed, agentless first-agent create.
+        const { agentType: effectiveAgentType, registrationId: effectiveRegistrationId } = resolveEffectiveAgentType(
+          args.agentTypeValue,
+          args.registrations,
+        );
+        const effectiveAgentTypeValue: StoredAgentType =
+          effectiveAgentType === "registered" && effectiveRegistrationId !== undefined
+            ? encodeRegisteredAgentType(effectiveRegistrationId)
+            : effectiveAgentType;
 
         // Only Claude consumes a creation-time prompt, model, and the per-prompt
         // agent settings (effort / fast / plan): terminal/registered agents have

--- a/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
@@ -1,6 +1,6 @@
 import { Theme } from "@radix-ui/themes";
 import { cleanup, render, screen } from "@testing-library/react";
-import { Provider, createStore } from "jotai";
+import { createStore, Provider } from "jotai";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -25,7 +25,7 @@ afterEach(() => {
 
 // A stub navigate so the component's navigation wiring doesn't throw.
 vi.mock("~/common/NavigateUtils.ts", () => ({
-  useImbueNavigate: () => ({
+  useImbueNavigate: (): Record<string, () => void> => ({
     navigateToWorkspace: (): void => {},
     navigateToAgent: (): void => {},
     navigateToHome: (): void => {},

--- a/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
@@ -1,0 +1,77 @@
+import { Theme } from "@radix-ui/themes";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { EffortLevel, ElementIds, LlmModel } from "~/api";
+
+import { AgentSettingsControls } from "./AgentSettingsControls.tsx";
+
+const withStore = (children: ReactNode): ReactElement => (
+  <Provider store={createStore()}>
+    <Theme>{children}</Theme>
+  </Provider>
+);
+
+beforeAll(() => {
+  // Radix Select calls scrollIntoView on open; jsdom does not implement it.
+  Element.prototype.scrollIntoView = (): void => {};
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// A stub navigate so the component's navigation wiring doesn't throw.
+vi.mock("~/common/NavigateUtils.ts", () => ({
+  useImbueNavigate: () => ({
+    navigateToWorkspace: (): void => {},
+    navigateToAgent: (): void => {},
+    navigateToHome: (): void => {},
+    navigateToGlobalSettings: (): void => {},
+    navigateToRepoSetupCommand: (): void => {},
+    navigateToRoot: (): void => {},
+  }),
+}));
+
+const defaultProps = {
+  model: LlmModel.CLAUDE_4_OPUS,
+  onModelChange: (): void => {},
+  effort: EffortLevel.XHIGH,
+  onEffortChange: (): void => {},
+  isFastMode: false,
+  onFastModeToggle: (): void => {},
+  isPlanMode: false,
+  onPlanModeToggle: (): void => {},
+};
+
+describe("AgentSettingsControls canSelectModel", () => {
+  it("renders an enabled model picker when canSelectModel defaults to true", () => {
+    render(withStore(<AgentSettingsControls {...defaultProps} />));
+    // The enabled model selector has the standard testid.
+    expect(screen.getByTestId(ElementIds.MODEL_SELECTOR)).toBeTruthy();
+    expect(screen.queryByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeNull();
+  });
+
+  it("renders a disabled model picker when canSelectModel is false", () => {
+    render(withStore(<AgentSettingsControls {...defaultProps} canSelectModel={false} />));
+    // The capability gate replaces the model selector with a disabled trigger.
+    expect(screen.queryByTestId(ElementIds.MODEL_SELECTOR)).toBeNull();
+    expect(screen.getByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeTruthy();
+  });
+});
+
+describe("AgentSettingsControls canUseFastMode", () => {
+  it("hides the fast-mode toggle when canUseFastMode is false", () => {
+    // A model that normally supports fast mode, plus canUseFastMode=false.
+    render(withStore(<AgentSettingsControls {...defaultProps} canUseFastMode={false} />));
+    expect(screen.queryByTestId(ElementIds.FAST_MODE_TOGGLE)).toBeNull();
+  });
+
+  it("shows the fast-mode toggle when the model supports it and canUseFastMode is true", () => {
+    render(withStore(<AgentSettingsControls {...defaultProps} canUseFastMode={true} />));
+    // CLAUDE_4_OPUS supports fast mode in modelCapabilities.
+    expect(screen.getByTestId(ElementIds.FAST_MODE_TOGGLE)).toBeTruthy();
+  });
+});

--- a/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
@@ -49,14 +49,12 @@ const defaultProps = {
 describe("AgentSettingsControls canSelectModel", () => {
   it("renders an enabled model picker when canSelectModel defaults to true", () => {
     render(withStore(<AgentSettingsControls {...defaultProps} />));
-    // The enabled model selector has the standard testid.
     expect(screen.getByTestId(ElementIds.MODEL_SELECTOR)).toBeTruthy();
     expect(screen.queryByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeNull();
   });
 
   it("renders a disabled model picker when canSelectModel is false", () => {
     render(withStore(<AgentSettingsControls {...defaultProps} canSelectModel={false} />));
-    // The capability gate replaces the model selector with a disabled trigger.
     expect(screen.queryByTestId(ElementIds.MODEL_SELECTOR)).toBeNull();
     expect(screen.getByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeTruthy();
   });
@@ -64,14 +62,12 @@ describe("AgentSettingsControls canSelectModel", () => {
 
 describe("AgentSettingsControls canUseFastMode", () => {
   it("hides the fast-mode toggle when canUseFastMode is false", () => {
-    // A model that normally supports fast mode, plus canUseFastMode=false.
     render(withStore(<AgentSettingsControls {...defaultProps} canUseFastMode={false} />));
     expect(screen.queryByTestId(ElementIds.FAST_MODE_TOGGLE)).toBeNull();
   });
 
   it("shows the fast-mode toggle when the model supports it and canUseFastMode is true", () => {
     render(withStore(<AgentSettingsControls {...defaultProps} canUseFastMode={true} />));
-    // CLAUDE_4_OPUS supports fast mode in modelCapabilities.
     expect(screen.getByTestId(ElementIds.FAST_MODE_TOGGLE)).toBeTruthy();
   });
 });

--- a/sculptor/frontend/src/components/AgentSettingsControls.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.tsx
@@ -30,6 +30,13 @@ type AgentSettingsControlsProps = {
    * model's own `supportsFastMode` capability. Defaults to `true`.
    */
   canUseFastMode?: boolean;
+  /**
+   * Gate the model picker on harness support. When false, the picker renders
+   * disabled with a capability-tooltip. Defaults to `true`. Pi and registered
+   * terminal agents set this to false because they manage their own model
+   * catalogs; the Claude models pre-selected here do not apply.
+   */
+  canSelectModel?: boolean;
 };
 
 /**
@@ -39,7 +46,9 @@ type AgentSettingsControlsProps = {
  * prompt textarea without duplicating ChatInput's wiring. The fast-mode
  * toggle is gated on `getModelCapabilities(model).supportsFastMode`
  * here (rather than at every callsite) so consumers only have to pass
- * the selected model.
+ * the selected model. The model picker is gated on `canSelectModel` so
+ * harnesses that manage their own catalogs (pi, registered terminal agents)
+ * can suppress the Claude model list.
  *
  * ChatInput renders a parallel copy of this toolbar block that adds
  * capability-gated disabled states and a backend-model selector it needs in
@@ -57,6 +66,7 @@ export const AgentSettingsControls = ({
   onPlanModeToggle,
   canEnterPlanMode = true,
   canUseFastMode = true,
+  canSelectModel = true,
 }: AgentSettingsControlsProps): ReactElement => {
   const { supportsFastMode: doesSupportFastMode } = getModelCapabilities(model);
   const { navigateToGlobalSettings } = useImbueNavigate();
@@ -85,7 +95,12 @@ export const AgentSettingsControls = ({
       {doesSupportFastMode && canUseFastMode && <FastModeToggle isActive={isFastMode} onToggle={onFastModeToggle} />}
       <EffortSelector effort={effort} onEffortChange={onEffortChange} />
       <Flex pr="1">
-        <ModelSelector model={model} onModelChange={onModelChange} onAuthenticate={handleAuthenticate} />
+        <ModelSelector
+          model={model}
+          onModelChange={onModelChange}
+          capabilityValue={canSelectModel}
+          onAuthenticate={handleAuthenticate}
+        />
       </Flex>
     </Flex>
   );

--- a/sculptor/frontend/src/components/AgentSettingsControls.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.tsx
@@ -32,9 +32,7 @@ type AgentSettingsControlsProps = {
   canUseFastMode?: boolean;
   /**
    * Gate the model picker on harness support. When false, the picker renders
-   * disabled with a capability-tooltip. Defaults to `true`. Pi and registered
-   * terminal agents set this to false because they manage their own model
-   * catalogs; the Claude models pre-selected here do not apply.
+   * disabled with a capability-tooltip. Defaults to `true`.
    */
   canSelectModel?: boolean;
 };
@@ -46,9 +44,8 @@ type AgentSettingsControlsProps = {
  * prompt textarea without duplicating ChatInput's wiring. The fast-mode
  * toggle is gated on `getModelCapabilities(model).supportsFastMode`
  * here (rather than at every callsite) so consumers only have to pass
- * the selected model. The model picker is gated on `canSelectModel` so
- * harnesses that manage their own catalogs (pi, registered terminal agents)
- * can suppress the Claude model list.
+ * the selected model. The model picker is gated on `canSelectModel` (false
+ * disables it with a capability tooltip).
  *
  * ChatInput renders a parallel copy of this toolbar block that adds
  * capability-gated disabled states and a backend-model selector it needs in

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -106,9 +106,7 @@ export const NewWorkspaceForm = ({
     // launch (the picker still lists pi as "Install Pi").
     return seed === "pi" && !isPiAvailable ? "claude" : resolveStoredAgentType(seed);
   });
-  // Fast mode and model selection are only available for the Claude harness;
-  // Pi and registered terminal agents manage their own model catalogs and
-  // don't support fast mode. Derived each render (cheap, not stored).
+  // Fast mode and model selection are only available for the Claude harness.
   const isNonClaudeHarness = parseStoredAgentType(agentTypeValue).agentType !== "claude";
   const [userSelectedBranch, setUserSelectedBranch] = useState<string | undefined>(() => lastSettings?.sourceBranch);
   // `null` means "use the auto-filled preview"; any string means the user has
@@ -467,10 +465,7 @@ export const NewWorkspaceForm = ({
               rendered so the row reserves its space; hidden via `visibility`
               until the user has typed a prompt so the modal doesn't jump. */}
           <div className={styles.agentSettings} data-visible={!isPromptEmpty} aria-hidden={isPromptEmpty}>
-            {/* Pi and registered terminal agents manage their own model
-                catalogs and don't support fast mode; derive both gates from
-                the selected agent type. Pi supports interactive backchannel
-                (plan mode stays enabled). */}
+            {/* Pi supports interactive backchannel, so plan mode stays enabled. */}
             <AgentSettingsControls
               model={agentModel}
               onModelChange={setAgentModel}

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -12,7 +12,11 @@ import {
   WorkspaceInitializationStrategy,
 } from "~/api";
 import { isDismissibleOverlayOpen } from "~/common/overlayUtils.ts";
-import { lastUsedAgentTypeAtom, parseStoredAgentType, type StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
+import {
+  lastUsedAgentTypeAtom,
+  resolveEffectiveAgentType,
+  type StoredAgentType,
+} from "~/common/state/atoms/agentTabs.ts";
 import { isPiAvailableAtom } from "~/common/state/atoms/dependenciesStatus.ts";
 import { projectsArrayAtom, updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { defaultEffortLevelAtom, defaultModelAtom, isDefaultFastModeAtom } from "~/common/state/atoms/userConfig.ts";
@@ -106,8 +110,6 @@ export const NewWorkspaceForm = ({
     // launch (the picker still lists pi as "Install Pi").
     return seed === "pi" && !isPiAvailable ? "claude" : resolveStoredAgentType(seed);
   });
-  // Fast mode and model selection are only available for the Claude harness.
-  const isNonClaudeHarness = parseStoredAgentType(agentTypeValue).agentType !== "claude";
   const [userSelectedBranch, setUserSelectedBranch] = useState<string | undefined>(() => lastSettings?.sourceBranch);
   // `null` means "use the auto-filled preview"; any string means the user has
   // taken over. Both the value and the manual flag collapse into one piece of
@@ -119,6 +121,10 @@ export const NewWorkspaceForm = ({
 
   // State and hooks — external
   const { registrations } = useTerminalAgentRegistrations();
+  // Fast mode and model selection are Claude-only. Resolve through the same
+  // helper the create flow uses so a registered agent whose registration was
+  // deleted (and therefore creates a Claude agent) still shows Claude's controls.
+  const isNonClaudeHarness = resolveEffectiveAgentType(agentTypeValue, registrations).agentType !== "claude";
   const { repoInfo, fetchRepoInfo, fetchCurrentBranch } = useRepoInfo(selectedProjectId);
   const { isCreating, createWorkspace } = useCreateWorkspace();
   const nameInputRef = useRef<HTMLInputElement>(null);

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -12,7 +12,7 @@ import {
   WorkspaceInitializationStrategy,
 } from "~/api";
 import { isDismissibleOverlayOpen } from "~/common/overlayUtils.ts";
-import { lastUsedAgentTypeAtom, type StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
+import { lastUsedAgentTypeAtom, parseStoredAgentType, type StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
 import { isPiAvailableAtom } from "~/common/state/atoms/dependenciesStatus.ts";
 import { projectsArrayAtom, updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { defaultEffortLevelAtom, defaultModelAtom, isDefaultFastModeAtom } from "~/common/state/atoms/userConfig.ts";
@@ -106,6 +106,10 @@ export const NewWorkspaceForm = ({
     // launch (the picker still lists pi as "Install Pi").
     return seed === "pi" && !isPiAvailable ? "claude" : resolveStoredAgentType(seed);
   });
+  // Fast mode and model selection are only available for the Claude harness;
+  // Pi and registered terminal agents manage their own model catalogs and
+  // don't support fast mode. Derived each render (cheap, not stored).
+  const isNonClaudeHarness = parseStoredAgentType(agentTypeValue).agentType !== "claude";
   const [userSelectedBranch, setUserSelectedBranch] = useState<string | undefined>(() => lastSettings?.sourceBranch);
   // `null` means "use the auto-filled preview"; any string means the user has
   // taken over. Both the value and the manual flag collapse into one piece of
@@ -463,6 +467,10 @@ export const NewWorkspaceForm = ({
               rendered so the row reserves its space; hidden via `visibility`
               until the user has typed a prompt so the modal doesn't jump. */}
           <div className={styles.agentSettings} data-visible={!isPromptEmpty} aria-hidden={isPromptEmpty}>
+            {/* Pi and registered terminal agents manage their own model
+                catalogs and don't support fast mode; derive both gates from
+                the selected agent type. Pi supports interactive backchannel
+                (plan mode stays enabled). */}
             <AgentSettingsControls
               model={agentModel}
               onModelChange={setAgentModel}
@@ -472,6 +480,8 @@ export const NewWorkspaceForm = ({
               onFastModeToggle={(): void => setIsAgentFastMode((v) => !v)}
               isPlanMode={isAgentPlanMode}
               onPlanModeToggle={(): void => setIsAgentPlanMode((v) => !v)}
+              canUseFastMode={!isNonClaudeHarness}
+              canSelectModel={!isNonClaudeHarness}
             />
           </div>
         </div>

--- a/sculptor/frontend/src/components/onboarding-wizard/InstallationStep.tsx
+++ b/sculptor/frontend/src/components/onboarding-wizard/InstallationStep.tsx
@@ -594,12 +594,11 @@ export const InstallationStep = ({ onComplete, isLoading, error }: InstallationS
             <Link href="https://github.com/earendil-works/pi" target="_blank" className={styles.inlineLink}>
               Pi
             </Link>{" "}
-            harness — an alternative agent supporting many model providers
+            harness — an alternative harness supporting many model providers
           </Text>
           <DependencyCard
             name="Pi"
             cliName="pi"
-            optional
             status={piStatus}
             installUrl="https://github.com/earendil-works/pi"
             onInstall={() => void triggerPiInstall()}

--- a/sculptor/frontend/src/components/onboarding-wizard/InstallationStep.tsx
+++ b/sculptor/frontend/src/components/onboarding-wizard/InstallationStep.tsx
@@ -599,6 +599,7 @@ export const InstallationStep = ({ onComplete, isLoading, error }: InstallationS
           <DependencyCard
             name="Pi"
             cliName="pi"
+            optional
             status={piStatus}
             installUrl="https://github.com/earendil-works/pi"
             onInstall={() => void triggerPiInstall()}

--- a/sculptor/frontend/src/components/sections/addPanelCore.test.ts
+++ b/sculptor/frontend/src/components/sections/addPanelCore.test.ts
@@ -121,8 +121,8 @@ describe("createAgentInLocation placement", () => {
   });
 });
 
-describe("createAgentInLocation pi agent", () => {
-  it("creates a pi agent when a pi agent is requested (pi is always available)", async () => {
+describe("createAgentInLocation pi harness", () => {
+  it("creates a pi workspace when a pi workspace is requested (pi is always available)", async () => {
     createWorkspaceAgentMock.mockResolvedValue({ data: { id: "task-pi" } });
     const store = createStore();
     store.set(activeWorkspaceIdAtom, "ws-test");

--- a/sculptor/frontend/src/components/sections/addPanelCore.test.ts
+++ b/sculptor/frontend/src/components/sections/addPanelCore.test.ts
@@ -122,7 +122,7 @@ describe("createAgentInLocation placement", () => {
 });
 
 describe("createAgentInLocation pi harness", () => {
-  it("creates a pi workspace when a pi workspace is requested (pi is always available)", async () => {
+  it("creates a pi agent when a pi agent is requested (pi is always available)", async () => {
     createWorkspaceAgentMock.mockResolvedValue({ data: { id: "task-pi" } });
     const store = createStore();
     store.set(activeWorkspaceIdAtom, "ws-test");

--- a/sculptor/frontend/src/pages/settings/sections.ts
+++ b/sculptor/frontend/src/pages/settings/sections.ts
@@ -114,7 +114,7 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSectionDescriptor> = [
     id: SettingsSection.PI,
     displayName: "Pi",
     group: "Harnesses",
-    paletteSubtitle: "Pi agent harness configuration",
+    paletteSubtitle: "Pi harness configuration",
     paletteKeywords: ["pi", "harness", "agent"],
     icon: PlayIcon,
     testId: ElementIds.SETTINGS_NAV_PI,


### PR DESCRIPTION
The new workspace form (`NewWorkspaceForm`) rendered the Claude model list and fast-mode toggle regardless of which agent type the user selected. When Pi or a registered terminal agent was chosen, the form still offered irrelevant Claude models in the pre-creation picker — harnesses that manage their own model catalogs (discovered at runtime) and do not support fast mode.

This branch threads the existing capability-flag prop surface through `AgentSettingsControls` so the pre-creation path matches the behavior `ChatInput` already uses for live Pi tasks.

## Changes

- **`AgentSettingsControls.tsx`** — add `canSelectModel` prop (default `true`), passed through to `ModelSelector` as `capabilityValue`. When `false`, the picker renders as a disabled trigger with the standard "Not supported by this agent harness" tooltip.
- **`NewWorkspaceForm.tsx`** — derive `isNonClaudeHarness` from the selected agent type and pass `canUseFastMode` and `canSelectModel` as `false` for Pi and registered terminal agents. Plan mode stays enabled (Pi supports interactive backchannel).
- **Tighten Pi language** — "Pi agent" → "Pi harness" in the settings palette subtitle and two test descriptions; remove the redundant `optional` prop from the Pi `DependencyCard` in the onboarding wizard (already under the "Optional" section header); "an alternative agent" → "an alternative harness".
- **Tests** — new `AgentSettingsControls.test.tsx` verifying that `canSelectModel={false}` produces the disabled picker and `canUseFastMode={false}` hides the fast-mode toggle.

## Behavior

| Agent type selected | Model picker | Fast-mode toggle | Plan-mode toggle |
|---|---|---|---|
| Claude | Enabled (Claude model list) | Shown (when model supports it) | Shown |
| Pi | Disabled (capability tooltip) | Hidden | Shown |
| Registered terminal agent | Disabled (capability tooltip) | Hidden | Shown |

This matches the existing `ChatInput` behavior for live Pi workspaces, where `sourcesBackendModels` and capability flags are read from the running task.

(Sent by Claude)