### PR TITLE
[SCU-1474] Follow-up fixes batch: layout polish, a11y, error logging, and test guards

### DIFF
--- a/sculptor/frontend/eslint.config.ts
+++ b/sculptor/frontend/eslint.config.ts
@@ -150,6 +150,22 @@ export default tseslint.config(
           selector: "TSEnumDeclaration",
           message: "Replace enum with a literal type or a const assertion.",
         },
+        // A `.catch()` whose callback body is empty silently swallows the
+        // rejection. Log the error (with context on what failed and that the
+        // app continues) so failures are visible in the console and Sentry. A
+        // bare explanatory comment is not enough — it counts as an empty body.
+        {
+          selector:
+            "CallExpression[callee.property.name='catch'] > ArrowFunctionExpression.arguments > BlockStatement.body[body.length=0]",
+          message:
+            "Do not silently swallow a rejected promise. Log the error (with context) inside the .catch() callback.",
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='catch'] > FunctionExpression.arguments > BlockStatement.body[body.length=0]",
+          message:
+            "Do not silently swallow a rejected promise. Log the error (with context) inside the .catch() callback.",
+        },
       ],
 
       // From the section "Naming":
@@ -202,6 +218,11 @@ export default tseslint.config(
       // so we don't include the rules from the "Test" section.
 
       "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+
+      // Empty blocks hide bugs; an empty `catch` additionally swallows the error
+      // silently. The empty-`.catch()`-callback case is handled by the
+      // no-restricted-syntax selectors above (this rule only covers `try/catch`).
+      "no-empty": ["error", { allowEmptyCatch: false }],
 
       /* Eslint stylistic: https://eslint.style/packages/default */
       "@stylistic/padding-line-between-statements": [

--- a/sculptor/frontend/plugins/linear-issue/src/index.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/index.tsx
@@ -19,6 +19,7 @@ export default function activate(api: PluginHostApi): () => void {
     id: PLUGIN_ID,
     displayName: "Linear",
     icon: Hash,
+    description: "Linear issues linked to this workspace",
     component: LinearPanel,
   });
   const disposeSettings = api.registerSettings(LinearSettings);

--- a/sculptor/frontend/src/common/state/atoms/unreadOverrides.ts
+++ b/sculptor/frontend/src/common/state/atoms/unreadOverrides.ts
@@ -134,7 +134,8 @@ export const markAgentUnreadAtom = atom(null, (get, set, target: { workspaceId: 
   }
   setUnreadOverride(target.taskId, task);
   set(taskAtomFamily(target.taskId), { ...task, lastReadAt: null });
-  markWorkspaceAgentUnread({ path: { workspace_id: target.workspaceId, agent_id: target.taskId } }).catch(() => {
+  markWorkspaceAgentUnread({ path: { workspace_id: target.workspaceId, agent_id: target.taskId } }).catch((error) => {
     // Fire-and-forget: the server-authoritative value will arrive via WebSocket.
+    console.warn("Failed to persist mark-unread; the server value will arrive via WebSocket.", error);
   });
 });

--- a/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
+++ b/sculptor/frontend/src/common/state/hooks/useMarkRead.ts
@@ -20,8 +20,9 @@ export const useMarkRead = (workspaceID: string, agentID: string): void => {
     // Functional update: read the latest atom value at apply time so a stale
     // closure can't clobber unrelated task fields that changed since render.
     setTask((prev) => (prev ? { ...prev, lastReadAt: new Date().toISOString() } : prev));
-    markWorkspaceAgentRead({ path: { workspace_id: workspaceID, agent_id: agentID } }).catch(() => {
-      // Fire-and-forget: the server-authoritative value will arrive via WebSocket
+    markWorkspaceAgentRead({ path: { workspace_id: workspaceID, agent_id: agentID } }).catch((error) => {
+      // Fire-and-forget: the server-authoritative value will arrive via WebSocket.
+      console.warn("Failed to persist mark-read; the server value will arrive via WebSocket.", error);
     });
   };
 

--- a/sculptor/frontend/src/common/state/hooks/useWorkspaceDynamicPanels.ts
+++ b/sculptor/frontend/src/common/state/hooks/useWorkspaceDynamicPanels.ts
@@ -115,8 +115,9 @@ export const useWorkspaceDynamicPanels = (workspaceId: string): void => {
         renameWorkspaceAgent({
           path: { workspace_id: workspaceId, agent_id: task.id },
           body: { title: newName },
-        }).catch(() => {
+        }).catch((error) => {
           // Fire-and-forget: server value will arrive via WebSocket.
+          console.warn("Failed to persist agent rename; the server value will arrive via WebSocket.", error);
         });
       },
       // "Mark as unread" on the tab context menu: record the unread override, flip

--- a/sculptor/frontend/src/common/usePollingInterval.ts
+++ b/sculptor/frontend/src/common/usePollingInterval.ts
@@ -46,9 +46,11 @@ export const usePollingInterval = (options?: { intervalMs?: number; timeoutMs?: 
         if (isFetchingRef.current) return;
         isFetchingRef.current = true;
         pollFn()
-          .catch(() => {
-            // Callers handle their own errors inside pollFn.
-            // Swallow here to prevent unhandled promise rejections.
+          .catch((error) => {
+            // Callers handle their own errors inside pollFn; this catch only
+            // prevents an unhandled promise rejection. Log in case a callback
+            // rejects without handling it.
+            console.warn("Polling callback rejected; callers own error handling.", error);
           })
           .finally(() => {
             isFetchingRef.current = false;

--- a/sculptor/frontend/src/components/BackendStatusBoundary.tsx
+++ b/sculptor/frontend/src/components/BackendStatusBoundary.tsx
@@ -68,7 +68,9 @@ export const BackendStatusBoundary = (props: PropsWithChildren<BackendStatusBoun
     window.sculptor
       ?.isCustomCommandMode?.()
       .then(setIsCustomCommandMode)
-      .catch(() => {});
+      .catch((error) => {
+        console.warn("Failed to read custom-command-mode flag; assuming default.", error);
+      });
   }, []);
 
   const [isCustomBackendCleared, setIsCustomBackendCleared] = useState<boolean>(false);

--- a/sculptor/frontend/src/components/CommandPalette/__tests__/contextActions.test.ts
+++ b/sculptor/frontend/src/components/CommandPalette/__tests__/contextActions.test.ts
@@ -43,6 +43,7 @@ const makeWorkspaceRuntime = (overrides: WorkspaceRuntimeOverrides = {}): Worksp
 
 const makeAgentRuntime = (): AgentActionRuntime => ({
   markUnread: vi.fn(),
+  beginRename: vi.fn(),
   beginDelete: vi.fn(),
 });
 
@@ -129,14 +130,26 @@ describe("buildWorkspaceActions", () => {
 });
 
 describe("buildAgentActions", () => {
-  it("emits the canonical right-click menu set", () => {
+  it("emits the canonical right-click menu set in order", () => {
     const actions = buildAgentActions(makeAgentRuntime());
-    expect(actions.map((a) => a.id)).toEqual(["mark_unread", "delete"]);
+    expect(actions.map((a) => a.id)).toEqual(["mark_unread", "rename", "delete"]);
   });
 
-  it("omits rename — agent rename is the panel tab's inline edit, not a palette action", () => {
+  it("rename appends the agent name in the palette and sorts before delete", () => {
     const actions = buildAgentActions(makeAgentRuntime());
-    expect(actions.map((a) => a.id)).not.toContain("rename");
+    const rename = actions.find((a) => a.id === "rename");
+    const del = actions.find((a) => a.id === "delete");
+    expect(rename?.paletteTitleSuffix).toBe("name");
+    expect(rename?.separatorBefore).toBe(true);
+    expect(rename?.paletteOrder).toBeLessThan(del?.paletteOrder ?? Number.POSITIVE_INFINITY);
+  });
+
+  it("rename perform routes to runtime.beginRename with the agent target", () => {
+    const runtime = makeAgentRuntime();
+    const actions = buildAgentActions(runtime);
+    const agent = fakeAgent("a3");
+    actions.find((a) => a.id === "rename")?.perform(agent);
+    expect(runtime.beginRename).toHaveBeenCalledWith(agent);
   });
 
   it("delete is destructive and routes through the runtime", () => {

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/agentActions.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/agentActions.ts
@@ -1,4 +1,4 @@
-import { CircleDot, Trash2 } from "lucide-react";
+import { CircleDot, Pencil, Trash2 } from "lucide-react";
 
 import { ElementIds } from "../../../api";
 import type { AgentAction, AgentActionRuntime } from "./types.ts";
@@ -10,11 +10,11 @@ import type { AgentAction, AgentActionRuntime } from "./types.ts";
  * its extra entries — the copy/diagnostics items — depend on per-agent
  * diagnostics fetched outside the palette; those are not surfaced here.
  *
- * Rename is intentionally absent: agent rename is the panel tab's inline edit
- * (local state in `SectionHeader`), which the palette runtime has no way to
- * trigger. Don't add a rename descriptor here without wiring a real rename
- * flow behind it — a descriptor whose perform goes nowhere still renders as a
- * selectable palette row.
+ * Rename routes through the panel tab's inline edit: its `perform` calls
+ * `runtime.beginRename`, which activates the agent's panel and sets
+ * `agentRenameTargetAtom` so the mounted tab in `SectionHeader` enters its
+ * existing inline-rename mode. Reusing that path keeps the single optimistic
+ * rename mutation and avoids a forked dialog.
  */
 export const buildAgentActions = (runtime: AgentActionRuntime): ReadonlyArray<AgentAction> => [
   {
@@ -26,6 +26,16 @@ export const buildAgentActions = (runtime: AgentActionRuntime): ReadonlyArray<Ag
     perform: (agent): void => runtime.markUnread(agent),
   },
   {
+    id: "rename",
+    title: "Rename",
+    icon: Pencil,
+    separatorBefore: true,
+    testId: ElementIds.TAB_CONTEXT_MENU_RENAME,
+    paletteOrder: 50,
+    paletteTitleSuffix: "name",
+    perform: (agent): void => runtime.beginRename(agent),
+  },
+  {
     id: "delete",
     title: "Delete",
     icon: Trash2,
@@ -33,6 +43,7 @@ export const buildAgentActions = (runtime: AgentActionRuntime): ReadonlyArray<Ag
     separatorBefore: true,
     testId: ElementIds.TAB_CONTEXT_MENU_DELETE,
     paletteSubtitle: "Permanently delete this agent",
+    paletteOrder: 110,
     paletteTitleSuffix: "name",
     perform: (agent): void => runtime.beginDelete(agent),
   },

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/atoms.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/atoms.ts
@@ -19,11 +19,11 @@ import type { SubSectionId } from "~/components/sections/sectionTypes.ts";
 export const renamingWorkspaceIdAtom = atom<string | null>(null);
 
 /**
- * The agent PANEL id whose tab should enter inline-rename mode, set by the
- * command palette's agent `beginRename`. The mounted tab in `SectionHeader`
- * observes this, flips into `isRenaming` when it matches its own panel id, and
- * clears the atom so a re-render doesn't re-trigger the edit. Null when no
- * rename is pending.
+ * The agent PANEL id whose tab should be in inline-rename mode, set by the
+ * command palette's agent `beginRename`. The matching tab in `SectionHeader`
+ * derives its rename mode from this atom during render (no effect, no local
+ * mirror) and clears it on commit/cancel alongside the tab's own rename flag.
+ * Null when no rename is pending.
  */
 export const agentRenameTargetAtom = atom<string | null>(null);
 

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/atoms.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/atoms.ts
@@ -9,12 +9,23 @@ import type { SubSectionId } from "~/components/sections/sectionTypes.ts";
  * invoked from anywhere — including the command palette runtime — drive the
  * same UI flows the right-click menu drives.
  *
- * Agent rename has no atom here on purpose: it's the panel tab's inline edit,
- * driven by local state in `SectionHeader`, and isn't palette-triggerable.
+ * Agent rename reaches the panel tab's inline edit through
+ * `agentRenameTargetAtom`: the palette runtime activates the agent's panel and
+ * sets this atom to the panel id, and the mounted tab in `SectionHeader` reacts
+ * by entering its existing inline-rename mode.
  */
 
 /** Read by the sidebar workspace rows to switch into inline-rename mode. */
 export const renamingWorkspaceIdAtom = atom<string | null>(null);
+
+/**
+ * The agent PANEL id whose tab should enter inline-rename mode, set by the
+ * command palette's agent `beginRename`. The mounted tab in `SectionHeader`
+ * observes this, flips into `isRenaming` when it matches its own panel id, and
+ * clears the atom so a re-render doesn't re-trigger the edit. Null when no
+ * rename is pending.
+ */
+export const agentRenameTargetAtom = atom<string | null>(null);
 
 export const workspaceDeleteTargetAtom = atom<{ id: string; name: string } | null>(null);
 

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/types.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/types.ts
@@ -155,5 +155,6 @@ export type WorkspaceActionRuntime = {
 
 export type AgentActionRuntime = {
   markUnread: (agent: Agent) => void;
+  beginRename: (agent: Agent) => void;
   beginDelete: (agent: Agent) => void;
 };

--- a/sculptor/frontend/src/components/CommandPalette/useContextActionRuntimes.ts
+++ b/sculptor/frontend/src/components/CommandPalette/useContextActionRuntimes.ts
@@ -1,8 +1,15 @@
 import { useSetAtom } from "jotai";
 import { useMemo } from "react";
 
+import { activateAgentPanelAtom } from "../../common/state/agentPanelPlacement.ts";
 import { markAgentUnreadAtom } from "../../common/state/atoms/unreadOverrides.ts";
-import { agentDeleteTargetAtom, renamingWorkspaceIdAtom, workspaceDeleteTargetAtom } from "./contextActions/atoms.ts";
+import { makeAgentPanelId } from "../sections/registry/dynamicPanels.tsx";
+import {
+  agentDeleteTargetAtom,
+  agentRenameTargetAtom,
+  renamingWorkspaceIdAtom,
+  workspaceDeleteTargetAtom,
+} from "./contextActions/atoms.ts";
 import type { AgentActionRuntime, WorkspaceActionRuntime } from "./contextActions/types.ts";
 import { useGitAndOpenInRuntime } from "./contextActions/useGitAndOpenInRuntime.ts";
 
@@ -17,6 +24,8 @@ export const useContextActionRuntimes = (): {
   const setRenamingWorkspaceId = useSetAtom(renamingWorkspaceIdAtom);
   const setWorkspaceDeleteTarget = useSetAtom(workspaceDeleteTargetAtom);
   const setAgentDeleteTarget = useSetAtom(agentDeleteTargetAtom);
+  const setAgentRenameTarget = useSetAtom(agentRenameTargetAtom);
+  const activateAgentPanel = useSetAtom(activateAgentPanelAtom);
   const markAgentUnread = useSetAtom(markAgentUnreadAtom);
   const gitAndOpenIn = useGitAndOpenInRuntime();
 
@@ -40,9 +49,17 @@ export const useContextActionRuntimes = (): {
         if (agent.workspaceId == null) return;
         markAgentUnread({ workspaceId: agent.workspaceId, taskId: agent.id });
       },
+      // Activate the agent's panel first so its tab is guaranteed mounted, then
+      // hand the panel id to the tab (via agentRenameTargetAtom) to enter inline
+      // rename. Activation is scoped to the active workspace's layout, so it
+      // keys off the task id alone.
+      beginRename: (agent): void => {
+        activateAgentPanel(agent.id);
+        setAgentRenameTarget(makeAgentPanelId(agent.id));
+      },
       beginDelete: (agent): void => setAgentDeleteTarget({ id: agent.id, name: agent.title ?? "" }),
     }),
-    [markAgentUnread, setAgentDeleteTarget],
+    [markAgentUnread, activateAgentPanel, setAgentRenameTarget, setAgentDeleteTarget],
   );
 
   return { workspaceActionRuntime, agentActionRuntime };

--- a/sculptor/frontend/src/components/ConfigLoader.tsx
+++ b/sculptor/frontend/src/components/ConfigLoader.tsx
@@ -15,8 +15,12 @@ export const ConfigLoader = ({ children }: ConfigLoaderProps): ReactElement => {
   const { loadConfig } = useUserConfig();
 
   useEffect(() => {
-    // Fire-and-forget on mount; loadConfig logs its own failures internally.
-    void loadConfig().catch(() => {});
+    // Fire-and-forget on mount. loadConfig also logs failures at its call to the
+    // server, but log again here so the fire-and-forget site is not a silent sink
+    // and the message records that the app renders on with default settings.
+    void loadConfig().catch((error) => {
+      console.error("Failed to load user config on mount; continuing with default settings until it loads.", error);
+    });
   }, [loadConfig]);
 
   return <>{children}</>;

--- a/sculptor/frontend/src/components/DevModeIndicator.module.scss
+++ b/sculptor/frontend/src/components/DevModeIndicator.module.scss
@@ -1,46 +1,26 @@
 .root {
   align-items: center;
   display: inline-flex;
-  font-family: var(--mono-font-family);
-  font-size: var(--font-size-1);
-  gap: var(--space-2);
+  flex-shrink: 0;
   line-height: 1;
-  max-width: 100%;
-  // Allow children to shrink below their intrinsic size so ellipsis kicks in
-  // when the bottom-bar's center column is narrower than the full text.
-  min-width: 0;
 }
 
 .icon {
-  // Sized to fill the bottom-bar content height (matches the side-toggle
-  // IconButton size="1"). The image itself is already recolored on a canvas
-  // using the same algorithm as devIcon.ts, so no CSS filter is needed.
+  // Sized to sit inline with the version text in the sidebar footer. The image
+  // itself is already recolored on a canvas using the same algorithm as
+  // devIcon.ts, so no CSS filter is needed.
   display: block;
   flex-shrink: 0;
-  height: var(--space-5);
-  width: var(--space-5);
+  height: var(--space-4);
+  width: var(--space-4);
 }
 
-.label {
-  color: var(--accent-9);
+.dot {
+  background-color: var(--accent-9);
+  border-radius: 50%;
   flex-shrink: 0;
-  font-weight: var(--font-weight-bold);
-}
-
-.detail {
-  color: var(--gray-10);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-// Below ~800px viewport the center column is too narrow to show secondary
-// text legibly — collapse to icon + label only. The full detail remains
-// available in the tooltip.
-@media (width <= 800px) {
-  .detail {
-    display: none;
-  }
+  height: 6px;
+  width: 6px;
 }
 
 .tooltipContent {

--- a/sculptor/frontend/src/components/DevModeIndicator.tsx
+++ b/sculptor/frontend/src/components/DevModeIndicator.tsx
@@ -8,8 +8,8 @@ import styles from "./DevModeIndicator.module.scss";
 // In Electron the recolored dock icon, label, and workspace id arrive from
 // the GET_DEV_INFO IPC channel — the same NativeImage already used for the
 // dock icon, serialized at full resolution. The browser scales it via CSS.
-// When running in pure-browser dev (Vite dev server, no Electron), we fall
-// back to a minimal label-only banner gated on import.meta.env.DEV.
+// When running in pure-browser dev (Vite dev server, no Electron), there is no
+// icon, so we fall back to a small colored dot gated on import.meta.env.DEV.
 export const DevModeIndicator = (): ReactElement | null => {
   const [devInfo, setDevInfo] = useState<SculptorDevInfo | null>(null);
   const isViteDev = import.meta.env.DEV;
@@ -32,7 +32,6 @@ export const DevModeIndicator = (): ReactElement | null => {
 
   if (!devInfo && !isViteDev) return null;
 
-  const label = devInfo?.label ?? "src";
   const iconDataUrl = devInfo?.iconDataUrl ?? null;
   const workspaceId = devInfo?.workspaceId ?? null;
 
@@ -46,15 +45,17 @@ export const DevModeIndicator = (): ReactElement | null => {
     </span>
   );
 
+  // Compact dev-source indicator that sits inline beside the version string:
+  // the recolored Electron icon when it's available, otherwise a small colored
+  // dot (matching VersionPopover's update dot). Full detail — source running
+  // plus the workspace id — lives in the tooltip.
   return (
     <Tooltip content={tooltipContent}>
       <span className={styles.root} data-testid="dev-mode-indicator">
-        {iconDataUrl && <img className={styles.icon} src={iconDataUrl} alt="" aria-hidden="true" />}
-        <span className={styles.label}>{label}</span>
-        {workspaceId && (
-          <span className={styles.detail} data-testid="dev-mode-workspace-id">
-            {workspaceId}
-          </span>
+        {iconDataUrl ? (
+          <img className={styles.icon} src={iconDataUrl} alt="" aria-hidden="true" />
+        ) : (
+          <span className={styles.dot} aria-hidden="true" />
         )}
       </span>
     </Tooltip>

--- a/sculptor/frontend/src/components/Toast.module.scss
+++ b/sculptor/frontend/src/components/Toast.module.scss
@@ -46,7 +46,7 @@
   }
 
   &.success {
-    background-color: var(--green-a2);
+    background-color: var(--green-2);
     border-color: var(--green-a6);
 
     .title {
@@ -55,7 +55,7 @@
   }
 
   &.error {
-    background-color: var(--red-a2);
+    background-color: var(--red-2);
     border-color: var(--red-a6);
 
     .title {
@@ -64,7 +64,7 @@
   }
 
   &.warning {
-    background-color: var(--yellow-a2);
+    background-color: var(--yellow-2);
     border-color: var(--yellow-a6);
 
     .title {

--- a/sculptor/frontend/src/components/VerticalOverlayScrollbar.tsx
+++ b/sculptor/frontend/src/components/VerticalOverlayScrollbar.tsx
@@ -46,6 +46,13 @@ type VerticalOverlayScrollbarProps = {
   scrollRef: RefObject<HTMLElement | null>;
   /** Applied to the draggable thumb so tests (and callers) can target it. */
   thumbTestId?: string;
+  /**
+   * `id` of the scroll container the thumb controls, exposed as the thumb's
+   * `aria-controls`. Wiring it gives the `role="scrollbar"` thumb its expected
+   * relationship to the scrolled region, so it surfaces in accessibility trees
+   * (and Playwright snapshots) instead of reading as empty.
+   */
+  scrollContainerId?: string;
 };
 
 /**
@@ -68,6 +75,7 @@ type VerticalOverlayScrollbarProps = {
 export const VerticalOverlayScrollbar = ({
   scrollRef,
   thumbTestId,
+  scrollContainerId,
 }: VerticalOverlayScrollbarProps): ReactElement | null => {
   const [geometry, setGeometry] = useState<Geometry>(EMPTY_GEOMETRY);
   const [isHovered, setIsHovered] = useState(false);
@@ -189,7 +197,12 @@ export const VerticalOverlayScrollbar = ({
 
   const thumbHeight = computeThumbHeight(geometry);
   const travel = geometry.height - thumbHeight;
-  const thumbTop = travel > 0 ? (geometry.scrollTop / maxScroll) * travel : 0;
+  const scrollFraction = geometry.scrollTop / maxScroll;
+  const thumbTop = travel > 0 ? scrollFraction * travel : 0;
+  // Scroll progress as a 0–100 percentage for the ARIA scrollbar role, which
+  // pairs `aria-valuenow` with `aria-controls`. It rides the same per-scroll
+  // render as `thumbTop`, so no extra work outside the existing update path.
+  const scrollPercent = Math.round(scrollFraction * 100);
   const isActive = isHovered || isDragging;
 
   return createPortal(
@@ -205,6 +218,13 @@ export const VerticalOverlayScrollbar = ({
       <div
         className={styles.thumb}
         data-testid={thumbTestId}
+        role="scrollbar"
+        aria-orientation="vertical"
+        aria-label="Scrollbar"
+        aria-controls={scrollContainerId}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={scrollPercent}
         style={{ height: thumbHeight, transform: `translateY(${thumbTop}px)` }}
         onPointerEnter={(): void => setIsHovered(true)}
         onPointerLeave={(): void => setIsHovered(false)}

--- a/sculptor/frontend/src/components/add-repo/useRemoteRepos.ts
+++ b/sculptor/frontend/src/components/add-repo/useRemoteRepos.ts
@@ -82,8 +82,9 @@ export const prefetchInitialRemoteRepos = (provider: RemoteProvider): Promise<vo
       staleTime: REMOTE_REPOS_STALE_TIME_MS,
       gcTime: REMOTE_REPOS_GC_TIME_MS,
     })
-    .catch(() => {
-      // Swallow — the hook will retry/handle on mount.
+    .catch((error) => {
+      // Best-effort warm-up: the hook will retry and surface errors on mount.
+      console.warn("Failed to prefetch remote repos; the combobox will retry on mount.", error);
     });
 
 export const useRemoteRepos = (

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.module.scss
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.module.scss
@@ -58,11 +58,12 @@
   flex-shrink: 0;
 }
 
-// Version string on its own row beneath the nav items, inset to align with
-// their labels.
+// Version string beneath the nav items, inset to align with their labels,
+// with an optional dev-source indicator trailing it on the same line.
 .versionRow {
   align-items: center;
   display: flex;
+  gap: var(--space-2);
   min-width: 0;
   padding: var(--space-1) var(--space-2);
 }

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
@@ -232,12 +232,14 @@ export const WorkspaceSidebar = (): ReactElement | null => {
             testId={ElementIds.SIDEBAR_CMDK_LINK}
           />
           {/* Opens the new-workspace dialog; the per-repo "+" in the repo groups
-            below is the direct-create affordance. */}
+            below is the direct-create affordance. Disabled on first run, but with
+            no tooltip: the inline first-run form is the obvious create affordance,
+            so a tooltip pointing back at the sidebar row would just float detached
+            beside the centered form. */}
           <NavItem
             icon={Plus}
             label="New Workspace"
             disabled={isWorkspaceListEmpty}
-            disabledTooltip="Use the form to create your first workspace"
             onClick={() => setNewWorkspaceModal({ open: true })}
             testId={ElementIds.SIDEBAR_NEW_WORKSPACE_BUTTON}
           />

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
@@ -286,9 +286,9 @@ export const WorkspaceSidebar = (): ReactElement | null => {
               <span className={navItemStyles.navLabel}>Report a bug</span>
             </button>
           </ReportProblemPopover>
-          <DevModeIndicator />
           <div className={styles.versionRow} data-testid={ElementIds.SIDEBAR_VERSION}>
             <VersionPopover />
+            <DevModeIndicator />
           </div>
         </nav>
 

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.module.scss
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.module.scss
@@ -10,9 +10,27 @@
   min-width: 0;
 }
 
+// Vertical stack holding the title and (optionally) the description, so the
+// description sits UNDER the title while the trailing shortcut stays on the row.
+// Takes the row's free space and clamps its width so both lines ellipsize.
+.itemText {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+}
+
 .itemTitle {
   color: var(--gray-12);
-  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Secondary line under the title: compact, muted, single-line with ellipsis.
+.description {
+  color: var(--gray-10);
+  font-size: var(--font-size-1);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
@@ -49,9 +49,7 @@ const MenuRow = ({
   <span className={styles.item}>
     <span className={styles.itemText}>
       <span className={styles.itemTitle}>{label}</span>
-      {description !== undefined && description !== "" && (
-        <span className={styles.description}>{description}</span>
-      )}
+      {description !== undefined && description !== "" && <span className={styles.description}>{description}</span>}
     </span>
     {shortcut !== undefined && shortcut !== "" && <span className={styles.shortcut}>{shortcut}</span>}
   </span>

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
@@ -34,11 +34,25 @@ import { useAddPanelActions } from "./useAddPanelActions.ts";
 
 // The shared row body rendered inside every dropdown item and sub-trigger: a label
 // with an optional trailing keybinding hint (no leading icons — text-only rows).
-// Hover/active backgrounds come from the wrapping Radix item, so this only lays out
-// the contents.
-const MenuRow = ({ label, shortcut }: { label: string; shortcut?: string }): ReactElement => (
+// When a description is supplied it renders as a second, smaller line under the
+// label; rows without one render exactly as a single title line. Hover/active
+// backgrounds come from the wrapping Radix item, so this only lays out the contents.
+const MenuRow = ({
+  label,
+  shortcut,
+  description,
+}: {
+  label: string;
+  shortcut?: string;
+  description?: string;
+}): ReactElement => (
   <span className={styles.item}>
-    <span className={styles.itemTitle}>{label}</span>
+    <span className={styles.itemText}>
+      <span className={styles.itemTitle}>{label}</span>
+      {description !== undefined && description !== "" && (
+        <span className={styles.description}>{description}</span>
+      )}
+    </span>
     {shortcut !== undefined && shortcut !== "" && <span className={styles.shortcut}>{shortcut}</span>}
   </span>
 );
@@ -163,7 +177,7 @@ const AddPanelMenuItems = ({
                 actions.openStaticPanel(panel.id, subSection);
               }}
             >
-              <MenuRow label={panel.displayName} />
+              <MenuRow label={panel.displayName} description={panel.description} />
             </DropdownMenu.Item>
           ))}
         </>

--- a/sculptor/frontend/src/components/sections/EmptySectionState.module.scss
+++ b/sculptor/frontend/src/components/sections/EmptySectionState.module.scss
@@ -38,7 +38,18 @@
   padding: var(--space-1) var(--space-3);
 }
 
-// The split-half escape hatch, spaced below the Quick add block.
+// The split-half escape hatch, spaced below the Quick add block. Outlined
+// secondary action mirroring the primary Add panel button's launcher look
+// (border, softer radius, roomier padding) but one notch dimmer, so it reads
+// as subordinate to the filled primary above.
 .closeSplit {
+  border: 1px solid var(--gray-a5);
+  border-radius: var(--radius-3);
+  // The outline Button variant draws its own inset ring; the launcher border
+  // above replaces it so both launcher buttons share the same border token.
+  box-shadow: none;
+  color: var(--gray-11);
+  height: auto;
   margin-top: var(--space-4);
+  padding: var(--space-1) var(--space-3);
 }

--- a/sculptor/frontend/src/components/sections/EmptySectionState.tsx
+++ b/sculptor/frontend/src/components/sections/EmptySectionState.tsx
@@ -124,7 +124,7 @@ const EmptySectionStateComponent = ({ subSection }: EmptySectionStateProps): Rea
 
         {isSplitPane && (
           <Button
-            variant="ghost"
+            variant="outline"
             color="gray"
             size="1"
             className={styles.closeSplit}

--- a/sculptor/frontend/src/components/sections/PanelSection.module.scss
+++ b/sculptor/frontend/src/components/sections/PanelSection.module.scss
@@ -47,11 +47,10 @@
 // Maximized section: absolutely positioned to fill the workspace page container
 // (every ancestor up to it is static), covering the header and the rest of the grid
 // while the nav rail stays visible. Opaque background so the layout beneath (still
-// mounted) is fully hidden. Uses the app page background — the same backdrop a
-// non-maximized section shows through its transparent body — so maximizing an empty
-// section doesn't shift its background color.
+// mounted) is fully hidden. Fills with AppShell's content-area background
+// (var(--gray-2)) so maximizing an empty section doesn't shift the backdrop color.
 .maximized {
-  background: var(--color-background);
+  background: var(--gray-2);
   inset: 0;
   position: absolute;
   z-index: var(--z-sticky);

--- a/sculptor/frontend/src/components/sections/SectionHeader.tsx
+++ b/sculptor/frontend/src/components/sections/SectionHeader.tsx
@@ -15,7 +15,7 @@ import { ContextMenu, Flex, IconButton, Tooltip } from "@radix-ui/themes";
 import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { Maximize2, Minimize2, Plus, X } from "lucide-react";
 import type { ReactElement } from "react";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useRef, useState } from "react";
 
 import { ElementIds } from "~/api";
 import { agentRenameTargetAtom } from "~/components/CommandPalette/contextActions/atoms.ts";
@@ -75,7 +75,7 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
   const store = useStore();
   const [isRenaming, setIsRenaming] = useState<boolean>(false);
   // The command palette's agent rename sets this to the panel id it wants
-  // renamed; the matching tab reacts by entering inline rename below.
+  // renamed; the matching tab derives its rename mode from it below.
   const [agentRenameTarget, setAgentRenameTarget] = useAtom(agentRenameTargetAtom);
   const labelRef = useRef<HTMLSpanElement>(null);
   const [isLabelTruncated, setIsLabelTruncated] = useState<boolean>(false);
@@ -90,23 +90,16 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
     data: { kind: "panel", panelId, from: subSection, index },
   });
 
-  // When the command palette targets THIS tab for rename, flip into inline edit
-  // and clear the atom so a later re-render doesn't re-open the editor. Only
-  // multi-instance panels (agent/terminal) can rename; a target that names a
-  // single-instance panel is dropped so it can't get stuck pending.
-  useEffect(() => {
-    if (agentRenameTarget !== panelId) return;
-    if (definition !== undefined && isMultiInstanceKind(definition.kind)) {
-      setIsRenaming(true);
-    }
-    setAgentRenameTarget(null);
-  }, [agentRenameTarget, panelId, definition, setAgentRenameTarget]);
-
   if (definition === undefined) {
     return null;
   }
 
   const canRename = isMultiInstanceKind(definition.kind);
+  // Renaming is active from the tab's own entry points (double-click, context
+  // menu) or when the command palette targets this tab through the atom. The
+  // atom is consumed as derived render state — no effect, no local mirror —
+  // and commit/cancel clear it alongside the local flag.
+  const isRenameActive = (isRenaming || agentRenameTarget === panelId) && canRename;
 
   // `definition` comes through the equality-guarded per-id slice, which deliberately
   // suppresses callback-only changes (see panelDefinitionEqual) — so its callbacks and
@@ -175,8 +168,17 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
     }
   };
 
-  const handleRenameCommit = (newName: string): void => {
+  // Leaves rename mode however it was entered: resets the tab's own flag and
+  // releases a palette rename target pointing at this tab.
+  const stopRenaming = (): void => {
     setIsRenaming(false);
+    if (agentRenameTarget === panelId) {
+      setAgentRenameTarget(null);
+    }
+  };
+
+  const handleRenameCommit = (newName: string): void => {
+    stopRenaming();
     // Persist the new name on the underlying entity (agent title / terminal label).
     // Only multi-instance panels supply onRename; static panels cannot be renamed
     // so this is a no-op for them. InlineRenameInput already trims and drops
@@ -219,10 +221,10 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
       ref={setTabRef}
       className={tabClassName}
       {...attributes}
-      {...(isRenaming ? {} : listeners)}
+      {...(isRenameActive ? {} : listeners)}
       // After the listeners spread so this composed handler REPLACES the sensor's
       // raw onKeyDown (it delegates every non-Enter key back to it).
-      onKeyDown={isRenaming ? undefined : handleKeyDown}
+      onKeyDown={isRenameActive ? undefined : handleKeyDown}
       role="tab"
       aria-selected={isActive}
       data-testid={`${ElementIds.PANEL_TAB}-${panelId}`}
@@ -251,11 +253,11 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
           {getTabStatusIcon(definition.connectionStatus)}
         </div>
       )}
-      {isRenaming && canRename ? (
+      {isRenameActive ? (
         <InlineRenameInput
           value={definition.displayName}
           onCommit={handleRenameCommit}
-          onCancel={() => setIsRenaming(false)}
+          onCancel={stopRenaming}
           isEditing
         />
       ) : isLabelTruncated ? (

--- a/sculptor/frontend/src/components/sections/SectionHeader.tsx
+++ b/sculptor/frontend/src/components/sections/SectionHeader.tsx
@@ -12,12 +12,13 @@
 
 import { useDraggable } from "@dnd-kit/core";
 import { ContextMenu, Flex, IconButton, Tooltip } from "@radix-ui/themes";
-import { useAtomValue, useSetAtom, useStore } from "jotai";
+import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { Maximize2, Minimize2, Plus, X } from "lucide-react";
 import type { ReactElement } from "react";
-import { memo, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 import { ElementIds } from "~/api";
+import { agentRenameTargetAtom } from "~/components/CommandPalette/contextActions/atoms.ts";
 import { InlineRenameInput } from "~/components/InlineRenameInput.tsx";
 import { sidebarCollapsedAtom } from "~/components/layout/sidebarAtoms.ts";
 import { AgentStatusDot } from "~/components/statusDot";
@@ -73,6 +74,9 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
   const recordRecentlyClosed = useSetAtom(recentlyClosedPanelIdsAtom);
   const store = useStore();
   const [isRenaming, setIsRenaming] = useState<boolean>(false);
+  // The command palette's agent rename sets this to the panel id it wants
+  // renamed; the matching tab reacts by entering inline rename below.
+  const [agentRenameTarget, setAgentRenameTarget] = useAtom(agentRenameTargetAtom);
   const labelRef = useRef<HTMLSpanElement>(null);
   const [isLabelTruncated, setIsLabelTruncated] = useState<boolean>(false);
   // The context-menu items shown while the menu is open, resolved fresh on each open
@@ -85,6 +89,18 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
     id: panelId,
     data: { kind: "panel", panelId, from: subSection, index },
   });
+
+  // When the command palette targets THIS tab for rename, flip into inline edit
+  // and clear the atom so a later re-render doesn't re-open the editor. Only
+  // multi-instance panels (agent/terminal) can rename; a target that names a
+  // single-instance panel is dropped so it can't get stuck pending.
+  useEffect(() => {
+    if (agentRenameTarget !== panelId) return;
+    if (definition !== undefined && isMultiInstanceKind(definition.kind)) {
+      setIsRenaming(true);
+    }
+    setAgentRenameTarget(null);
+  }, [agentRenameTarget, panelId, definition, setAgentRenameTarget]);
 
   if (definition === undefined) {
     return null;

--- a/sculptor/frontend/src/components/sections/SectionHeader.tsx
+++ b/sculptor/frontend/src/components/sections/SectionHeader.tsx
@@ -15,7 +15,7 @@ import { ContextMenu, Flex, IconButton, Tooltip } from "@radix-ui/themes";
 import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { Maximize2, Minimize2, Plus, X } from "lucide-react";
 import type { ReactElement } from "react";
-import { memo, useState } from "react";
+import { memo, useRef, useState } from "react";
 
 import { ElementIds } from "~/api";
 import { InlineRenameInput } from "~/components/InlineRenameInput.tsx";
@@ -73,6 +73,8 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
   const recordRecentlyClosed = useSetAtom(recentlyClosedPanelIdsAtom);
   const store = useStore();
   const [isRenaming, setIsRenaming] = useState<boolean>(false);
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [isLabelTruncated, setIsLabelTruncated] = useState<boolean>(false);
   // The context-menu items shown while the menu is open, resolved fresh on each open
   // (see resolveLiveDefinition below).
   const [openMenuActions, setOpenMenuActions] = useState<ReadonlyArray<PanelContextMenuItem>>([]);
@@ -176,6 +178,26 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
     setActivatorNodeRef(node);
   };
 
+  // The label ellipsis-clips at a fixed max-width, so a tooltip is only useful when the
+  // text is actually cut off. Truncation is measured on hover (scrollWidth vs
+  // clientWidth) rather than via a ResizeObserver: the tab strip re-renders heavily
+  // during drags, and measuring at hover time reads layout exactly when the tooltip
+  // could appear — no observer to keep alive across those churny re-renders.
+  const labelSpan = (
+    <span
+      ref={labelRef}
+      className={styles.label}
+      onMouseEnter={() => {
+        const el = labelRef.current;
+        if (el !== null) {
+          setIsLabelTruncated(el.scrollWidth > el.clientWidth);
+        }
+      }}
+    >
+      {definition.displayName}
+    </span>
+  );
+
   const tabBody = (
     <div
       ref={setTabRef}
@@ -220,8 +242,10 @@ const PanelTabComponent = ({ panelId, subSection, index, isActive, isGhost }: Pa
           onCancel={() => setIsRenaming(false)}
           isEditing
         />
+      ) : isLabelTruncated ? (
+        <Tooltip content={definition.displayName}>{labelSpan}</Tooltip>
       ) : (
-        <span className={styles.label}>{definition.displayName}</span>
+        labelSpan
       )}
       <IconButton
         variant="ghost"

--- a/sculptor/frontend/src/components/sections/addPanelCore.ts
+++ b/sculptor/frontend/src/components/sections/addPanelCore.ts
@@ -175,7 +175,10 @@ function availableStaticPanelListsEqual(
     a.length === b.length &&
     a.every(
       (panel, index) =>
-        panel.id === b[index].id && panel.displayName === b[index].displayName && panel.icon === b[index].icon,
+        panel.id === b[index].id &&
+        panel.displayName === b[index].displayName &&
+        panel.icon === b[index].icon &&
+        panel.description === b[index].description,
     )
   );
 }

--- a/sculptor/frontend/src/components/sections/layoutQueries.ts
+++ b/sculptor/frontend/src/components/sections/layoutQueries.ts
@@ -84,6 +84,7 @@ export type AvailableStaticPanel = {
   id: PanelId;
   displayName: string;
   icon: PanelDefinition["icon"];
+  description?: string;
 };
 
 // Single-instance static panels not currently open anywhere — the re-add list.
@@ -97,5 +98,10 @@ export function listAvailableStaticPanels(
   const openPanelIds = new Set<PanelId>(Object.keys(placement));
   return registry
     .filter((definition) => definition.kind === "static" && !openPanelIds.has(definition.id))
-    .map((definition) => ({ id: definition.id, displayName: definition.displayName, icon: definition.icon }));
+    .map((definition) => ({
+      id: definition.id,
+      displayName: definition.displayName,
+      icon: definition.icon,
+      description: definition.description,
+    }));
 }

--- a/sculptor/frontend/src/components/sections/registry/panelRegistry.ts
+++ b/sculptor/frontend/src/components/sections/registry/panelRegistry.ts
@@ -29,6 +29,9 @@ export type PanelDefinition = {
   kind: PanelKind;
   // Optional: review-all and browser have no default section (not opened by default).
   defaultSection?: SubSectionId;
+  // Secondary text shown under the panel's label in the add-panel dropdown. Only
+  // plugin panels supply it; static built-ins leave it unset and render title-only.
+  description?: string;
   component: ComponentType;
   // The agent/terminal-agent status reflected by the tab's status dot. Exposed on the
   // tab element as `data-dot-status` so tests can read read/unread/running/waiting/error
@@ -103,6 +106,7 @@ export type PluginRegistryPanel = {
   icon: LucideIcon;
   component: ComponentType;
   defaultSection?: SubSectionId;
+  description?: string;
 };
 
 // Adapt plugin-contributed panels into registry PanelDefinitions so the new shell can
@@ -118,6 +122,7 @@ export function buildPluginPanelDefinitions(
     icon: panel.icon,
     kind: "static",
     defaultSection: panel.defaultSection,
+    description: panel.description,
     component: panel.component,
   }));
 }
@@ -153,6 +158,7 @@ function panelDefinitionEqual(a: PanelDefinition | undefined, b: PanelDefinition
       a.icon === b.icon &&
       a.kind === b.kind &&
       a.defaultSection === b.defaultSection &&
+      a.description === b.description &&
       a.dotStatus === b.dotStatus &&
       a.connectionStatus === b.connectionStatus &&
       a.component === b.component)

--- a/sculptor/frontend/src/electron/main.ts
+++ b/sculptor/frontend/src/electron/main.ts
@@ -899,8 +899,9 @@ const createWindow = async (): Promise<void> => {
           })();
           `,
         )
-        .catch(() => {
-          // Swallow: the page may have navigated away before we could inject.
+        .catch((error) => {
+          // The page may have navigated away before we could inject.
+          console.warn("Failed to inject target=_blank interceptor; the page likely navigated away.", error);
         });
     };
     attachedContents.on("dom-ready", injectTargetBlankInterceptor);

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
@@ -126,7 +126,9 @@ const WorkspaceHeaderComponent = (): ReactElement | null => {
         if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
         copyTimerRef.current = setTimeout(() => setIsCopied(false), 1500);
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.warn("Failed to copy branch name to clipboard.", error);
+      });
   }, [branchName]);
 
   const handleTargetBranchChange = useCallback(

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
@@ -3,7 +3,7 @@ import type { Editor as TipTapEditor } from "@tiptap/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { posthog } from "posthog-js";
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
 import {
@@ -88,6 +88,8 @@ export const AlphaChatInterface = ({
     if (!open) setToast(null);
   }, []);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Links the scroll container to the overlay scrollbar's `aria-controls`.
+  const scrollContainerId = useId();
 
   // Queued message promotion logic. The agent holds queued messages whenever
   // it is mid-turn — either actively running, or paused on an AskUserQuestion /
@@ -540,6 +542,7 @@ export const AlphaChatInterface = ({
             <div className={styles.scrollArea}>
               <div
                 ref={scrollContainerRef}
+                id={scrollContainerId}
                 className={styles.scrollContainer}
                 data-testid={ElementIds.ALPHA_CHAT_VIEW}
                 role="log"
@@ -627,6 +630,7 @@ export const AlphaChatInterface = ({
               </div>
               <VerticalOverlayScrollbar
                 scrollRef={scrollContainerRef}
+                scrollContainerId={scrollContainerId}
                 thumbTestId={ElementIds.ALPHA_CHAT_SCROLLBAR_THUMB}
               />
             </div>

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChipDiffPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChipDiffPopover.tsx
@@ -160,12 +160,16 @@ export const AlphaChipDiffPopover = ({
 
   const handleCopyPath = useCallback((): void => {
     if (!chipData.filePath) return;
-    navigator.clipboard.writeText(chipData.filePath).catch(() => {});
+    navigator.clipboard.writeText(chipData.filePath).catch((error) => {
+      console.warn("Failed to copy file path to clipboard.", error);
+    });
     flashCopied("path");
   }, [chipData.filePath, flashCopied]);
 
   const handleCopyError = useCallback((): void => {
-    navigator.clipboard.writeText(chipData.errorDetail ?? "").catch(() => {});
+    navigator.clipboard.writeText(chipData.errorDetail ?? "").catch((error) => {
+      console.warn("Failed to copy error detail to clipboard.", error);
+    });
     flashCopied("error");
   }, [chipData.errorDetail, flashCopied]);
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaCommandPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaCommandPopover.tsx
@@ -66,7 +66,9 @@ export const AlphaCommandPopover = ({
   const handleCopyCommand = useCallback(
     (e: React.MouseEvent): void => {
       e.stopPropagation();
-      navigator.clipboard.writeText(command).catch(() => {});
+      navigator.clipboard.writeText(command).catch((error) => {
+        console.warn("Failed to copy command to clipboard.", error);
+      });
       setIsCommandCopied(true);
       clearTimeout(commandCopyTimerRef.current);
       commandCopyTimerRef.current = setTimeout(() => setIsCommandCopied(false), COPY_FEEDBACK_DURATION_MS);
@@ -77,7 +79,9 @@ export const AlphaCommandPopover = ({
   const handleCopyOutput = useCallback(
     (e: React.MouseEvent): void => {
       e.stopPropagation();
-      navigator.clipboard.writeText(outputText).catch(() => {});
+      navigator.clipboard.writeText(outputText).catch((error) => {
+        console.warn("Failed to copy output to clipboard.", error);
+      });
       setIsOutputCopied(true);
       clearTimeout(outputCopyTimerRef.current);
       outputCopyTimerRef.current = setTimeout(() => setIsOutputCopied(false), COPY_FEEDBACK_DURATION_MS);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaToolPopover.tsx
@@ -80,7 +80,9 @@ const ReadEntry = ({
     (e: React.MouseEvent): void => {
       e.stopPropagation();
       if (!filePath) return;
-      navigator.clipboard.writeText(filePath).catch(() => {});
+      navigator.clipboard.writeText(filePath).catch((error) => {
+        console.warn("Failed to copy file path to clipboard.", error);
+      });
       setIsCopied(true);
       clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setIsCopied(false), 1500);

--- a/sculptor/frontend/src/pages/workspace/panels/ExplorerLayout.module.scss
+++ b/sculptor/frontend/src/pages/workspace/panels/ExplorerLayout.module.scss
@@ -25,8 +25,8 @@
   display: flex;
   flex: 0 0 auto;
   flex-direction: column;
-  // stylelint-disable-next-line sculptor/no-hardcoded-values -- divider + viewer-sliver reserve
-  max-width: calc(100% - 48px);
+  // stylelint-disable-next-line sculptor/no-hardcoded-values -- viewer floor (160px) + divider slack
+  max-width: calc(100% - 168px);
   min-width: 0;
   overflow: hidden;
 }
@@ -35,7 +35,11 @@
   display: flex;
   flex: 1 1 0;
   flex-direction: column;
-  min-width: 0;
+  // Floor the viewer so it always keeps enough room to preview content; paired
+  // with the list's max-width reserve, the list (tree) loses width first at
+  // narrow widths and the viewer never collapses below this.
+  // stylelint-disable-next-line sculptor/no-hardcoded-values -- viewer floor paired with .list max-width reserve
+  min-width: 160px;
   overflow: hidden;
 }
 

--- a/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/browser/useBrowserWebview.ts
@@ -121,7 +121,9 @@ export const useBrowserWebview = (
       const pendingUrl = pendingNavigationUrlRef.current;
       if (pendingUrl !== null) {
         pendingNavigationUrlRef.current = null;
-        webview.loadURL(pendingUrl).catch(() => {});
+        webview.loadURL(pendingUrl).catch((error) => {
+          console.warn("Failed to load pending URL in browser webview.", error);
+        });
       }
     };
 
@@ -153,7 +155,9 @@ export const useBrowserWebview = (
     if (!api?.onBrowserPanelOpenInPanel || !api.removeBrowserPanelOpenInPanelListener) return;
     const listener = api.onBrowserPanelOpenInPanel((payload) => {
       if (payload.webContentsId !== webContentsId) return;
-      webviewRef.current?.loadURL(payload.url).catch(() => {});
+      webviewRef.current?.loadURL(payload.url).catch((error) => {
+        console.warn("Failed to load forwarded URL in browser webview.", error);
+      });
     });
     return (): void => {
       api.removeBrowserPanelOpenInPanelListener?.(listener);
@@ -185,7 +189,9 @@ export const useBrowserWebview = (
       pendingNavigationUrlRef.current = url;
       return;
     }
-    webview.loadURL(url).catch(() => {});
+    webview.loadURL(url).catch((error) => {
+      console.warn("Failed to navigate browser webview.", error);
+    });
   }, []);
 
   return {

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/FileTree.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/FileTree.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text } from "@radix-ui/themes";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { type ReactElement, useCallback, useEffect, useId, useMemo, useRef } from "react";
 
 import { ElementIds } from "~/api";
 import { VerticalOverlayScrollbar } from "~/components/VerticalOverlayScrollbar.tsx";
@@ -103,6 +103,8 @@ export const FileTree = ({
   );
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Links the scroll container to the overlay scrollbar's `aria-controls`.
+  const scrollContainerId = useId();
 
   const itemCount = viewMode === "tree" ? flatRows.length : flatFiles.length;
 
@@ -232,6 +234,7 @@ export const FileTree = ({
   return (
     <div
       ref={scrollContainerRef}
+      id={scrollContainerId}
       className={styles.scrollContainer}
       onScroll={handleScroll}
       onKeyDown={onKeyDown}
@@ -327,7 +330,11 @@ export const FileTree = ({
           );
         })}
       </div>
-      <VerticalOverlayScrollbar scrollRef={scrollContainerRef} thumbTestId={ElementIds.FILE_BROWSER_SCROLLBAR_THUMB} />
+      <VerticalOverlayScrollbar
+        scrollRef={scrollContainerRef}
+        scrollContainerId={scrollContainerId}
+        thumbTestId={ElementIds.FILE_BROWSER_SCROLLBAR_THUMB}
+      />
     </div>
   );
 };

--- a/sculptor/frontend/src/plugins/types.ts
+++ b/sculptor/frontend/src/plugins/types.ts
@@ -10,8 +10,8 @@ import type { SectionId } from "~/components/sections/sectionTypes.ts";
  * the user opens it from the section "+" / Cmd+K, which drops it into the
  * sub-section they pick. `defaultSection` is recorded on the registry entry but
  * no placement path reads it yet — it is reserved for a future default-placement
- * pass. The legacy `defaultZone` / `defaultShortcut` / `description` fields are
- * accepted but ignored — the docking shell they targeted is gone.
+ * pass. The legacy `defaultZone` / `defaultShortcut` fields are accepted but
+ * ignored — the docking shell they targeted is gone.
  */
 export type PluginPanelDefinition = {
   /** Stable id; registering twice with the same id replaces the previous one. */
@@ -25,7 +25,7 @@ export type PluginPanelDefinition = {
   defaultZone?: string;
   /** @deprecated Ignored — per-panel keybindings were removed. */
   defaultShortcut?: string;
-  /** @deprecated Ignored. */
+  /** Secondary text shown under the panel's label in the add-panel dropdown. */
   description?: string;
   /** Set by the loader to the owning plugin's id; not supplied by plugins. */
   pluginId?: string;

--- a/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
@@ -12,8 +12,8 @@ export type SectionId = "left" | "center" | "right" | "bottom";
  * the user opens it from the section "+" / Cmd+K, which drops it into the
  * sub-section they pick. `defaultSection` is recorded on the registry entry but
  * no placement path reads it yet — it is reserved for a future default-placement
- * pass. The legacy `defaultZone` / `defaultShortcut` / `description` fields are
- * accepted but ignored — the docking shell they targeted is gone.
+ * pass. The legacy `defaultZone` / `defaultShortcut` fields are accepted but
+ * ignored — the docking shell they targeted is gone.
  */
 export type PluginPanelDefinition = {
 	/** Stable id; registering twice with the same id replaces the previous one. */
@@ -27,7 +27,7 @@ export type PluginPanelDefinition = {
 	defaultZone?: string;
 	/** @deprecated Ignored — per-panel keybindings were removed. */
 	defaultShortcut?: string;
-	/** @deprecated Ignored. */
+	/** Secondary text shown under the panel's label in the add-panel dropdown. */
 	description?: string;
 	/** Set by the loader to the owning plugin's id; not supplied by plugins. */
 	pluginId?: string;

--- a/sculptor/sculptor/testing/elements/diff_panel.py
+++ b/sculptor/sculptor/testing/elements/diff_panel.py
@@ -36,9 +36,6 @@ class PlaywrightDiffPanelElement(PlaywrightIntegrationTestElement):
     def get_unified_diff_views(self) -> Locator:
         return self.get_by_test_id(ElementIDs.DIFF_VIEW_UNIFIED)
 
-    def get_split_view_toggle(self) -> Locator:
-        return self.get_by_test_id(ElementIDs.DIFF_SPLIT_VIEW_TOGGLE)
-
     def get_split_view(self) -> Locator:
         return self.get_by_test_id(ElementIDs.DIFF_VIEW_SPLIT)
 
@@ -82,20 +79,6 @@ class PlaywrightDiffPanelElement(PlaywrightIntegrationTestElement):
 
     def get_copy_file_path_menu_item(self) -> Locator:
         return self._page.get_by_test_id("copy-path")
-
-    def ensure_unified_mode(self) -> None:
-        split_toggle = self.get_split_view_toggle()
-        expect(split_toggle).to_be_visible()
-        if split_toggle.get_attribute("data-state") == "split":
-            split_toggle.click()
-        expect(split_toggle).to_have_attribute("data-state", "unified")
-
-    def ensure_split_mode(self) -> None:
-        split_toggle = self.get_split_view_toggle()
-        expect(split_toggle).to_be_visible()
-        if split_toggle.get_attribute("data-state") != "split":
-            split_toggle.click()
-        expect(split_toggle).to_have_attribute("data-state", "split")
 
     def expect_shows_file(self, file_name: str) -> None:
         """Assert the single viewer is open and rendering ``file_name``'s content.

--- a/sculptor/sculptor/testing/elements/diff_viewer.py
+++ b/sculptor/sculptor/testing/elements/diff_viewer.py
@@ -241,17 +241,27 @@ def wait_for_full_content_diff_render(page: Page, last_hunk_text: str) -> None:
     ``DIFF_VIEW_SPLIT`` and does not require forcing a particular view first.
     The shadow root is pierced manually because these are Pierre attributes
     with no Playwright locator equivalent.
+
+    The combined "Review all" view mounts ONE such diff view per changed file,
+    so every ``DIFF_VIEW_*`` on the page is scanned and a SINGLE view must carry
+    both the expandable separator and ``last_hunk_text`` — the signature of the
+    one file whose full-content pass this call is gating. Matching the separator
+    on one file and the text on another would return too early, so both must be
+    found in the same shadow root. The single-file diff panel mounts exactly one
+    view, so this collapses to that view there.
     """
     page.wait_for_function(
         """({ unifiedTestid, splitTestid, text }) => {
-            const view =
-                document.querySelector(`[data-testid="${unifiedTestid}"]`) ??
-                document.querySelector(`[data-testid="${splitTestid}"]`);
-            const shadow = view?.querySelector("diffs-container")?.shadowRoot;
-            if (!shadow?.querySelector("[data-separator][data-expand-index]")) return false;
-            return [...shadow.querySelectorAll("div[data-line]")].some(
-                (line) => line.textContent.includes(text)
+            const views = document.querySelectorAll(
+                `[data-testid="${unifiedTestid}"], [data-testid="${splitTestid}"]`
             );
+            return [...views].some((view) => {
+                const shadow = view.querySelector("diffs-container")?.shadowRoot;
+                if (!shadow?.querySelector("[data-separator][data-expand-index]")) return false;
+                return [...shadow.querySelectorAll("div[data-line]")].some(
+                    (line) => line.textContent.includes(text)
+                );
+            });
         }""",
         arg={
             "unifiedTestid": ElementIDs.DIFF_VIEW_UNIFIED,

--- a/sculptor/sculptor/testing/elements/diff_viewer.py
+++ b/sculptor/sculptor/testing/elements/diff_viewer.py
@@ -219,3 +219,43 @@ def ensure_unified_view(viewer: PlaywrightDiffViewerElement) -> None:
     if split.count() > 0:
         viewer.toggle_view_option_via_menu("split_view")
     expect(viewer.get_unified_diff_views()).to_be_visible()
+
+
+def wait_for_full_content_diff_render(page: Page, last_hunk_text: str) -> None:
+    """Block until Pierre's full-content render pass paints through ``last_hunk_text``.
+
+    Pierre paints the diff twice: first straight from the diff string (a
+    *partial* diff), then again once ``useFileLines`` resolves and the full
+    old/new file lines reach Pierre — the pass whose hunk rows are looked up
+    by index in those arrays, and the pass where an out-of-range index (a
+    too-short old/new lines array) makes ``DiffHunksRenderer`` throw. Only a
+    non-partial diff marks its hunk separators expandable, so a separator
+    carrying ``data-expand-index`` is the signature of that second pass. Its
+    rows then stream in as Shiki tokenises, so additionally wait for the
+    ``div[data-line]`` carrying ``last_hunk_text`` — pass text from the diff's
+    LAST hunk so every hunk's line-array lookups have run by the time this
+    returns.
+
+    The ``<diffs-container>`` custom element and its shadow root are the same
+    in unified and split view, so this matches either ``DIFF_VIEW_UNIFIED`` or
+    ``DIFF_VIEW_SPLIT`` and does not require forcing a particular view first.
+    The shadow root is pierced manually because these are Pierre attributes
+    with no Playwright locator equivalent.
+    """
+    page.wait_for_function(
+        """({ unifiedTestid, splitTestid, text }) => {
+            const view =
+                document.querySelector(`[data-testid="${unifiedTestid}"]`) ??
+                document.querySelector(`[data-testid="${splitTestid}"]`);
+            const shadow = view?.querySelector("diffs-container")?.shadowRoot;
+            if (!shadow?.querySelector("[data-separator][data-expand-index]")) return false;
+            return [...shadow.querySelectorAll("div[data-line]")].some(
+                (line) => line.textContent.includes(text)
+            );
+        }""",
+        arg={
+            "unifiedTestid": ElementIDs.DIFF_VIEW_UNIFIED,
+            "splitTestid": ElementIDs.DIFF_VIEW_SPLIT,
+            "text": last_hunk_text,
+        },
+    )

--- a/sculptor/tests/integration/frontend/test_diff_viewer.py
+++ b/sculptor/tests/integration/frontend/test_diff_viewer.py
@@ -49,6 +49,7 @@ from sculptor.testing.elements.clipboard import read_intercepted_clipboard
 from sculptor.testing.elements.clipboard import reset_intercepted_clipboard
 from sculptor.testing.elements.diff_viewer import PlaywrightDiffViewerElement
 from sculptor.testing.elements.diff_viewer import ensure_unified_view
+from sculptor.testing.elements.diff_viewer import wait_for_full_content_diff_render
 from sculptor.testing.elements.files_panel import get_files_panel_in
 from sculptor.testing.elements.workspace_section import PlaywrightWorkspaceSection
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -667,34 +668,6 @@ def _wait_for_decorated_diff_line(page: Page, text: str) -> None:
             );
         }""",
         arg={"testid": ElementIDs.DIFF_VIEW_UNIFIED, "text": text},
-    )
-
-
-def _wait_for_full_content_diff_render(page: Page, last_hunk_text: str) -> None:
-    """Block until Pierre's full-content render pass paints through ``last_hunk_text``.
-
-    Pierre paints the diff twice: first straight from the diff string (a
-    *partial* diff), then again once ``useFileLines`` resolves and the full
-    old/new file lines reach Pierre — the pass whose hunk rows are looked up
-    by index in those arrays. Only a non-partial diff marks its hunk
-    separators expandable, so a separator carrying ``data-expand-index`` is
-    the signature of that second pass. Its rows then stream in as Shiki
-    tokenises, so additionally wait for the ``div[data-line]`` carrying
-    ``last_hunk_text`` — pass text from the diff's LAST hunk so every hunk's
-    line-array lookups have run by the time this returns. The shadow root is
-    pierced manually because these are Pierre attributes with no Playwright
-    locator equivalent.
-    """
-    page.wait_for_function(
-        """({ testid, text }) => {
-            const view = document.querySelector(`[data-testid="${testid}"]`);
-            const shadow = view?.querySelector("diffs-container")?.shadowRoot;
-            if (!shadow?.querySelector("[data-separator][data-expand-index]")) return false;
-            return [...shadow.querySelectorAll("div[data-line]")].some(
-                (line) => line.textContent.includes(text)
-            );
-        }""",
-        arg={"testid": ElementIDs.DIFF_VIEW_UNIFIED, "text": last_hunk_text},
     )
 
 
@@ -1452,7 +1425,7 @@ def test_all_scope_diff_renders_without_error_for_committed_file(sculptor_instan
         # paints at all. Anchor instead on the full-content pass's signature —
         # an expandable separator — plus the last hunk's final deleted line, so
         # the whole risky pass has run before the captured errors are read.
-        _wait_for_full_content_diff_render(page, "return text[:max_length - 3]")
+        wait_for_full_content_diff_render(page, "return text[:max_length - 3]")
 
         # The crash message names Pierre's renderer: "renderHunks" in older
         # @pierre/diffs releases, "DiffHunksRenderer" in 1.2.x.

--- a/sculptor/tests/integration/regression/test_regression_review_all_shiki_error_target_branch.py
+++ b/sculptor/tests/integration/regression/test_regression_review_all_shiki_error_target_branch.py
@@ -115,7 +115,10 @@ def test_review_all_diff_stays_visible_when_target_branch_longer_than_head(
     # in the collapsed gap between the hunks and paints in the first partial pass,
     # so it cannot gate this second pass. helpers.py is Modified, so the combined
     # view honors the shared unified/split preference; the anchor pierces either
-    # view's <diffs-container> shadow root, so no view needs forcing here.
+    # view's <diffs-container> shadow root, so no view needs forcing here. The
+    # combined view mounts one diff view per changed file, so the anchor scans
+    # them all and locks onto helpers.py — the only file whose shadow root
+    # carries both the expandable separator and truncate's deleted body.
     wait_for_full_content_diff_render(page, "return text[:max_length - 3]")
 
     # Diff must still be visible afterwards.

--- a/sculptor/tests/integration/regression/test_regression_review_all_shiki_error_target_branch.py
+++ b/sculptor/tests/integration/regression/test_regression_review_all_shiki_error_target_branch.py
@@ -23,6 +23,7 @@ let `useFileLines` fall back to the target branch ref.
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.diff_viewer import wait_for_full_content_diff_render
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -76,6 +77,14 @@ def test_review_all_diff_stays_visible_when_target_branch_longer_than_head(
     """
     page = sculptor_instance_.page
 
+    # Capture Pierre's hunk-renderer crash. Pierre throws during hunk expansion
+    # from its async Shiki highlight callback (outside React's render cycle, so
+    # the FileDiff error boundary does not catch it), surfacing as an uncaught
+    # pageerror or a console error rather than replacing the body with a banner.
+    js_errors: list[str] = []
+    page.on("pageerror", lambda err: js_errors.append(err.message))
+    page.on("console", lambda msg: js_errors.append(msg.text) if msg.type == "error" else None)
+
     task_page = start_task_and_wait_for_ready(page, prompt=_PROMPT)
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
@@ -97,13 +106,26 @@ def test_review_all_diff_stays_visible_when_target_branch_longer_than_head(
     expect(review_all_panel).to_contain_text("helpers.py")
     expect(review_all_panel).to_contain_text("is_even")
 
-    # Wait for syntax highlighting decorations and Pierre's
-    # context-expansion to run — the bug caused the diff to disappear at
-    # this point because oldLines came from the wrong ref.
-    page.wait_for_timeout(3000)
+    # Block until Pierre's full-content render pass — the pass that reads the
+    # fetched old/new line arrays at the diff's merge-base-aligned hunk indices,
+    # and where the wrong-ref bug either crashes the renderer or applies an
+    # out-of-range Shiki decoration — has run all the way through the LAST hunk.
+    # The two-hunk deletion diff drops the trailing truncate() group, so its last
+    # hunk's final deleted line is truncate's body; is_even is unchanged context
+    # in the collapsed gap between the hunks and paints in the first partial pass,
+    # so it cannot gate this second pass. helpers.py is Modified, so the combined
+    # view honors the shared unified/split preference; the anchor pierces either
+    # view's <diffs-container> shadow root, so no view needs forcing here.
+    wait_for_full_content_diff_render(page, "return text[:max_length - 3]")
 
     # Diff must still be visible afterwards.
     expect(review_all_panel).to_contain_text("helpers.py")
     expect(review_all_panel).to_contain_text("is_even")
     # No Shiki crash banner.
     expect(review_all_panel).not_to_contain_text("Invalid decoration position")
+
+    # Defense in depth: Pierre must not have crashed during hunk expansion. The
+    # crash message names Pierre's renderer: "renderHunks" in older @pierre/diffs
+    # releases, "DiffHunksRenderer" in 1.2.x.
+    render_hunks_errors = [e for e in js_errors if "renderHunks" in e or "DiffHunksRenderer" in e]
+    assert not render_hunks_errors, f"Pierre renderHunks crash: {render_hunks_errors[:1]}"

--- a/sculptor/tests/integration/regression/test_regression_target_branch_merge_base_oldlines.py
+++ b/sculptor/tests/integration/regression/test_regression_target_branch_merge_base_oldlines.py
@@ -193,11 +193,6 @@ def test_target_branch_diff_fetches_oldlines_from_merge_base(
         + "merge-base line numbers the diff references (the SCU-1371 crash)."
     )
 
-    # Force unified so the deterministic render anchor has a single shadow-root
-    # body to pierce (the split/unified preference persists across the shared
-    # instance, so a prior test can leave it on either view).
-    diff_panel.ensure_unified_mode()
-
     # Block until Pierre's full-content render pass — the pass whose merge-base
     # aligned hunk indices read the fetched old/new line arrays, and where the
     # crash fires — has run all the way through the LAST hunk. The two-hunk

--- a/sculptor/tests/integration/regression/test_regression_target_branch_merge_base_oldlines.py
+++ b/sculptor/tests/integration/regression/test_regression_target_branch_merge_base_oldlines.py
@@ -47,6 +47,7 @@ from playwright.sync_api import Response
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.diff_viewer import wait_for_full_content_diff_render
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -192,12 +193,28 @@ def test_target_branch_diff_fetches_oldlines_from_merge_base(
         + "merge-base line numbers the diff references (the SCU-1371 crash)."
     )
 
+    # Force unified so the deterministic render anchor has a single shadow-root
+    # body to pierce (the split/unified preference persists across the shared
+    # instance, so a prior test can leave it on either view).
+    diff_panel.ensure_unified_mode()
+
+    # Block until Pierre's full-content render pass — the pass whose merge-base
+    # aligned hunk indices read the fetched old/new line arrays, and where the
+    # crash fires — has run all the way through the LAST hunk. The two-hunk
+    # deletion diff drops the trailing truncate() group, so its last hunk's
+    # final deleted line is truncate's body; the 16-line unchanged gap between
+    # the hunks stays a COLLAPSED (expandable) separator, so gap-only context
+    # like is_even paints in the first partial pass and would let the read fire
+    # too early. Anchoring on the expandable separator plus the last hunk's
+    # deleted line guarantees the whole risky pass has run before errors are read.
+    wait_for_full_content_diff_render(page, "return text[:max_length - 3]")
+
     # With the fix the expandable diff renders correctly, so the changed content
-    # is visible.  Waiting on this auto-retrying condition also gives Shiki's
-    # async highlight pass — where the bug throws renderHunks — time to run,
-    # without a fixed sleep.
+    # is visible.
     expect(diff_panel).to_contain_text("is_even")
 
-    # Defense in depth: Pierre must not have crashed during hunk expansion.
-    render_hunks_errors = [e for e in js_errors if "renderHunks" in e]
+    # Defense in depth: Pierre must not have crashed during hunk expansion. The
+    # crash message names Pierre's renderer: "renderHunks" in older @pierre/diffs
+    # releases, "DiffHunksRenderer" in 1.2.x.
+    render_hunks_errors = [e for e in js_errors if "renderHunks" in e or "DiffHunksRenderer" in e]
     assert not render_hunks_errors, f"Pierre renderHunks crash: {render_hunks_errors[:1]}"


### PR DESCRIPTION
A batch of twelve small follow-up fixes from the compact-workspace-layout merge (#248), one commit per ticket.

## Visual & layout polish
- **Maximized sections no longer darken**: the maximized overlay now paints the same token as the AppShell backdrop it covers (`--gray-2`).
- **Toasts are opaque**: success/error/warning variants moved off the translucent alpha scale onto the solid step-2 scale, matching `.errorProminent`.
- **Explorer preview keeps a readable floor** (~160px) at narrow section widths; the file tree shrinks first.
- **"Close split" has real affordance weight**: outlined secondary button sharing the launcher border language, instead of a bare ghost text link.
- **Clipped panel tab labels show a tooltip** with the full name, measured at hover time so no observer fights drag-time re-renders.
- **First-run tooltip removed**: the disabled New Workspace row no longer floats a detached hint pointing at the centered create form.
- **Dev-source indicator sits inline** with the sidebar version as a small dot (detail lives in its tooltip); production builds are unchanged.

## Features & accessibility
- **Agent rename is back in the command palette**, mirroring workspace rename: the palette activates the agent's panel and the tab derives inline-rename mode from a shared atom, reusing the existing optimistic rename mutation.
- **Plugin panels can describe themselves again**: `description` is un-deprecated and threaded end-to-end into the add-panel dropdown (bundled Linear plugin supplies one; the generated plugin SDK dts is regenerated).
- **The overlay scrollbar thumb has ARIA scrollbar semantics** (role, orientation, label, `aria-controls` wired at both call sites, `aria-valuenow` riding the existing render), so it appears in accessibility trees and Playwright snapshots.

## Error handling & test infrastructure
- **Seventeen silently-swallowed promise rejections now log with context**, and new lint rules (`no-restricted-syntax` selectors + `no-empty` without `allowEmptyCatch`) ban empty catches going forward.
- **Two dead regression guards are revived**: their console-error filters match both the legacy and current @pierre/diffs renderer names, and fixed sleeps are replaced by a shared deterministic render anchor that scans every mounted diff view (the combined Review-All view mounts one per file). Broken split-toggle POM helpers that asserted a nonexistent `data-state` are deleted.

## Verification
- `just format` / `just check` / `just test-unit` green.
- 15-file integration sweep (panel/section/sidebar/first-run/regression) plus a recheck of the touched diff-viewer tests: 87 tests passing on cloud CI sandboxes.
- Visual QA via the headless harness: 7/7 checks pass with screenshots (backgrounds, preview floor, tooltips, split affordance, footer indicator).

Fixes SCU-1731
Fixes SCU-1700
Fixes SCU-1708
Fixes SCU-1709
Fixes SCU-1729
Fixes SCU-1722
Fixes SCU-1711
Fixes SCU-1757
Fixes SCU-1744
Fixes SCU-1745
Fixes SCU-1697
Part of SCU-1474 and SCU-1728 (the deeper create/close split symmetry rework stays open on its ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)