### PR TITLE
[SCU-1714][SCU-1715] Fast-QA `just start` + sidebar test-cleanup helper

### DIFF
--- a/.claude/skills/manually-qa-branch/SKILL.md
+++ b/.claude/skills/manually-qa-branch/SKILL.md
@@ -105,6 +105,13 @@ port conflicts and authentication issues:
 env -u SESSION_TOKEN -u SCULPTOR_API_PORT -u SCULPTOR_FRONTEND_PORT just start
 ```
 
+> **Testing the onboarding flow?** Plain `just start` seeds a dev config and
+> skips the welcome flow, landing straight in the app — ideal for QAing the PR's
+> feature. To walk the full first-run/onboarding flow instead, swap `just start`
+> for `just start-onboard` (alias `just source`) in the command above. Both exist
+> only on branches that include the fast-QA `just start` change; on older
+> branches `just start` still shows onboarding.
+
 Run that command via the Bash tool with `run_in_background: true`. Note the
 shell ID returned — you'll use it later to check on the app if needed.
 

--- a/docs/development/getting_started.md
+++ b/docs/development/getting_started.md
@@ -24,6 +24,17 @@ Start the frontend and backend in a tmux session:
 just start
 ```
 
+`just start` is the fast-QA path: it seeds an onboarded dev config so the app
+skips the welcome flow, then creates a ready workspace on the current repo so you
+land straight in a usable workspace. It's idempotent — safe to re-run.
+
+To exercise the full first-run experience instead (onboarding + repo selection),
+wipe the dev config folder and launch with no initial project:
+
+```bash
+just start-onboarding
+```
+
 Or run them separately:
 
 ```bash

--- a/docs/development/getting_started.md
+++ b/docs/development/getting_started.md
@@ -25,8 +25,8 @@ just start
 ```
 
 `just start` is the fast-QA path: it seeds an onboarded dev config so the app
-skips the welcome flow, then creates a ready workspace on the current repo so you
-land straight in a usable workspace. It's idempotent — safe to re-run.
+skips the welcome flow and lands straight on the new-workspace form for the
+current repo, ready to create a workspace. It's idempotent — safe to re-run.
 
 To exercise the full first-run experience instead (onboarding + repo selection),
 wipe the dev config folder and launch with no initial project:

--- a/docs/development/getting_started.md
+++ b/docs/development/getting_started.md
@@ -28,12 +28,16 @@ just start
 skips the welcome flow and lands straight on the new-workspace form for the
 current repo, ready to create a workspace. It's idempotent — safe to re-run.
 
-To exercise the full first-run experience instead (onboarding + repo selection),
-wipe the dev config folder and launch with no initial project:
+To instead run the app the way a fresh clone behaves for a real user — the full
+first-run flow, welcome through onboarding and repo selection, from source — wipe
+the dev state and launch with no initial project:
 
 ```bash
-just start-onboarding
+just source   # alias: just start-onboard
 ```
+
+Either way, `just stop` tears down the whole session (both frontend and
+backend); only one can run per checkout at a time.
 
 Or run them separately:
 

--- a/docs/development/getting_started.md
+++ b/docs/development/getting_started.md
@@ -18,26 +18,25 @@ just clean rebuild
 
 ## Running Locally
 
-Start the frontend and backend in a tmux session:
+`just source` (alias `just start-onboard`) runs the app from source the way a
+fresh clone behaves for a real user — the full first-run flow: welcome,
+onboarding, and repo selection. It resets local dev state each run, so every
+launch is a true first-run.
+
+```bash
+just source
+```
+
+Skip onboarding with `just start` — it seeds an onboarded config and lands
+straight on the new-workspace form for the current repo, preserving your dev
+state:
 
 ```bash
 just start
 ```
 
-`just start` is the fast-QA path: it seeds an onboarded dev config so the app
-skips the welcome flow and lands straight on the new-workspace form for the
-current repo, ready to create a workspace. It's idempotent — safe to re-run.
-
-To instead run the app the way a fresh clone behaves for a real user — the full
-first-run flow, welcome through onboarding and repo selection, from source — wipe
-the dev state and launch with no initial project:
-
-```bash
-just source   # alias: just start-onboard
-```
-
-Either way, `just stop` tears down the whole session (both frontend and
-backend); only one can run per checkout at a time.
+`just stop` tears down the session (both frontend and backend); only one runs
+per checkout at a time.
 
 Or run them separately:
 

--- a/justfile
+++ b/justfile
@@ -128,8 +128,6 @@ quiet_by_default() {
 '''
 
 # -------- Sculptor Aliases --------
-alias start := tmux-dev
-alias start-no-project := tmux-dev-no-project
 alias stop := tmux-stop
 alias app := build-desktop-app
 alias pkg := package-desktop-installer
@@ -690,8 +688,32 @@ backend repo_path=".":
       uv run --project sculptor python -m sculptor.cli.main --no-open-browser --no-serve-static "{{justfile_directory()}}/{{repo_path}}"
     fi
 
+# Seed a valid (onboarded) dev config up front so the app boots past the welcome
+# flow, then — once the backend is up — a bootstrap window creates a workspace with
+# a waiting agent via the source-built sculpt CLI.
+# Fast QA: skip onboarding and land in a ready workspace on the current repo.
 [group("dev")]
-tmux-dev repo_path=".":
+start:
+    just _seed-dev-config
+    just tmux-dev "." true
+
+# Wipe the dev config folder and launch with no initial project.
+# Full first-run: exercise the entire onboarding flow, including repo selection.
+[group("dev")]
+start-onboarding:
+    just _reset-dev-config
+    just tmux-dev none
+
+# Seed a valid, onboarded UserConfig into the dev config folder (idempotent).
+_seed-dev-config:
+    uv run --project sculptor python sculptor/sculptor/scripts/dev_config.py seed
+
+# Wipe the dev Sculptor folder (config + db + logs) for a clean first-run.
+_reset-dev-config:
+    uv run --project sculptor python sculptor/sculptor/scripts/dev_config.py reset
+
+[group("dev")]
+tmux-dev repo_path="." seed_workspace="false":
     #!/bin/bash
     just stop || true
     echo "Starting tmux development session..."
@@ -722,16 +744,69 @@ tmux-dev repo_path=".":
     WORKSPACES_FOLDER_ARG="${SCULPTOR_WORKSPACES_FOLDER:+SCULPTOR_WORKSPACES_FOLDER=\"$SCULPTOR_WORKSPACES_FOLDER\"}"
     tmux send-keys -t {{session_name}}:frontend "cd '{{justfile_directory()}}' && env $SCULPT_UNSETS PATH=\"$DEV_PATH_PREFIX:\$PATH\" SCULPTOR_API_PORT={{SCULPTOR_API_PORT}} SCULPTOR_FRONTEND_PORT={{SCULPTOR_FRONTEND_PORT}} $WORKSPACES_FOLDER_ARG just frontend" Enter
     tmux send-keys -t {{session_name}}:backend "cd '{{justfile_directory()}}' && env $SCULPT_UNSETS PATH=\"$DEV_PATH_PREFIX:\$PATH\" SCULPTOR_API_PORT={{SCULPTOR_API_PORT}} SCULPTOR_FRONTEND_PORT={{SCULPTOR_FRONTEND_PORT}} SCULPTOR_CLAUDE_BINARY_DEFAULT_OVERRIDE=claude$CLAUDE_ENV_VARS $WORKSPACES_FOLDER_ARG just backend {{repo_path}}" Enter
+    # Fast-QA path: once the backend is up, create a ready workspace in its own
+    # window so its progress is visible without blocking the dev servers.
+    if [ "{{seed_workspace}}" = "true" ]; then
+        tmux new-window -t {{session_name}} -n bootstrap `shell echo $$SHELL`
+        tmux send-keys -t {{session_name}}:bootstrap "cd '{{justfile_directory()}}' && just _seed-fast-qa-workspace {{SCULPTOR_API_PORT}}" Enter
+    fi
     echo "Development servers started in tmux session '{{session_name}}'"
     echo "Backend serving repository: {{repo_path}}"
     echo "Use 'tmux attach -t {{session_name}}' to attach to the session"
     echo "Use 'just tmux-stop' to stop the session"
+    # Land on the backend window rather than the transient bootstrap one.
+    tmux select-window -t {{session_name}}:backend
     tmux attach -t {{session_name}} || echo "Failed to attach to tmux session. You can attach manually using 'tmux attach -t {{session_name}}'"
 
-# Start development servers without auto-creating a project (simulates first-run experience)
+# Wait for the dev backend to accept requests, then create one ready workspace (a
+# worktree with a waiting agent) via the source-built sculpt CLI, so `just start`
+# lands directly in a usable workspace. Idempotent: skips seeding when the repo
+# already has a live workspace, so reruns don't pile up throwaways.
 [group("dev")]
-tmux-dev-no-project:
-    just tmux-dev none
+_seed-fast-qa-workspace api_port:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Resolve the source-built sculpt CLI and point it at the dev backend.
+    export PATH="{{justfile_directory()}}/.venv/bin:$PATH"
+    export SCULPT_API_PORT="{{api_port}}"
+    # Drop any SCULPT_* ids leaked from an outer Sculptor session; every sculpt
+    # call below passes --repo/--workspace explicitly, but this keeps the shell clean.
+    unset SCULPT_WORKSPACE_ID SCULPT_PROJECT_ID SCULPT_AGENT_ID
+    repo="{{justfile_directory()}}"
+
+    echo "Waiting for the dev backend on port {{api_port}} to accept sculpt requests..."
+    # `sculpt workspace list --repo` connects, fetches a session token, and
+    # initializes/resolves the project in one call, so a clean exit means the
+    # backend is up AND the repo is registered — a stronger readiness probe than a
+    # bare health check.
+    ready=""
+    for _ in $(seq 1 180); do
+        if sculpt workspace list --repo "$repo" --json >/dev/null 2>&1; then
+            ready=1
+            break
+        fi
+        sleep 1
+    done
+    if [ -z "$ready" ]; then
+        echo "Backend did not become ready in time; skipping workspace seed." >&2
+        exit 1
+    fi
+
+    live_count=$(sculpt workspace list --repo "$repo" --json 2>/dev/null \
+        | python -c 'import sys, json; print(sum(1 for w in json.load(sys.stdin) if not w.get("is_deleted")))')
+    if [ "$live_count" -gt 0 ]; then
+        echo "Repo already has $live_count workspace(s); skipping seed."
+        exit 0
+    fi
+
+    # Worktree workspaces require a source branch; base it on the repo's current
+    # branch so the QA workspace forks from whatever you're working on.
+    source_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+    echo "Creating a ready workspace off '$source_branch' with a waiting agent..."
+    workspace_id=$(sculpt workspace create --repo "$repo" --name "QA" --branch "$source_branch" --json \
+        | python -c 'import sys, json; print(json.load(sys.stdin)["id"])')
+    sculpt agent create --workspace "$workspace_id" >/dev/null
+    echo "Ready workspace created: $workspace_id"
 
 tmux-stop:
 	tmux kill-session -t {{session_name}} 2>/dev/null && echo "Session '{{session_name}}' terminated" || echo "Session '{{session_name}}' did not exist"

--- a/justfile
+++ b/justfile
@@ -726,8 +726,8 @@ tmux-dev repo_path=".":
     echo "Killing existing session if present..."
     tmux kill-session -t {{session_name}} 2>/dev/null || true
     echo "Creating new tmux session..."
-    tmux new-session -d -s {{session_name}} -n frontend `shell echo $$SHELL`
-    tmux new-window -t {{session_name}} -n backend `shell echo $$SHELL`
+    tmux new-session -d -s {{session_name}} -n frontend {{_ENV_SHELL}}
+    tmux new-window -t {{session_name}} -n backend {{_ENV_SHELL}}
     # Collect CLAUDE_* env vars (e.g. CLAUDE_AUTOCOMPACT_PCT_OVERRIDE) so they
     # reach the backend server and its claude child processes.  tmux send-keys
     # types text into a fresh shell that doesn't inherit the caller's env, so

--- a/justfile
+++ b/justfile
@@ -129,6 +129,7 @@ quiet_by_default() {
 
 # -------- Sculptor Aliases --------
 alias stop := tmux-stop
+alias start-onboard := source
 alias app := build-desktop-app
 alias pkg := package-desktop-installer
 alias refresh := refresh-assets
@@ -700,10 +701,11 @@ start:
     just _seed-dev-config
     just tmux-dev "."
 
-# Wipe the dev config folder and launch with no initial project.
-# Full first-run: exercise the entire onboarding flow, including repo selection.
+# Wipe the dev state and launch with no initial project so the app behaves like a
+# fresh clone would for a real user — welcome, onboarding, and repo selection.
+# Full flow from source: run Sculptor the way a real user would, not the shortcut.
 [group("dev")]
-start-onboarding:
+source:
     just _reset-dev-config
     just tmux-dev none
 

--- a/justfile
+++ b/justfile
@@ -598,7 +598,11 @@ frontend:
     {{ nvm_use }}
     just _patch-electron-app-name "Sculptor (from source)"
     cd "{{justfile_directory()}}/sculptor/frontend"
+    # Start the first-run prompt box empty in the from-source dev app so QA can
+    # type immediately (see homePromptPrefill.ts). The test harness launches
+    # electron:start directly, not via this recipe, so tests keep the prefill.
     env SCULPTOR_ICON_LABEL="src" \
+      SCULPTOR_EMPTY_FIRST_RUN_PROMPT="1" \
       pnpm run electron:start -- --unhandled-rejections=strict --trace-warnings
 
 # Start Electron with the backend running in a Docker container (dev mode).
@@ -689,13 +693,12 @@ backend repo_path=".":
     fi
 
 # Seed a valid (onboarded) dev config up front so the app boots past the welcome
-# flow, then — once the backend is up — a bootstrap window creates a workspace with
-# a waiting agent via the source-built sculpt CLI.
-# Fast QA: skip onboarding and land in a ready workspace on the current repo.
+# flow and lands straight on the new-workspace form for the current repo.
+# Fast QA: skip onboarding and land on the new-workspace form.
 [group("dev")]
 start:
     just _seed-dev-config
-    just tmux-dev "." true
+    just tmux-dev "."
 
 # Wipe the dev config folder and launch with no initial project.
 # Full first-run: exercise the entire onboarding flow, including repo selection.
@@ -713,7 +716,7 @@ _reset-dev-config:
     uv run --project sculptor python sculptor/sculptor/scripts/dev_config.py reset
 
 [group("dev")]
-tmux-dev repo_path="." seed_workspace="false":
+tmux-dev repo_path=".":
     #!/bin/bash
     just stop || true
     echo "Starting tmux development session..."
@@ -744,69 +747,11 @@ tmux-dev repo_path="." seed_workspace="false":
     WORKSPACES_FOLDER_ARG="${SCULPTOR_WORKSPACES_FOLDER:+SCULPTOR_WORKSPACES_FOLDER=\"$SCULPTOR_WORKSPACES_FOLDER\"}"
     tmux send-keys -t {{session_name}}:frontend "cd '{{justfile_directory()}}' && env $SCULPT_UNSETS PATH=\"$DEV_PATH_PREFIX:\$PATH\" SCULPTOR_API_PORT={{SCULPTOR_API_PORT}} SCULPTOR_FRONTEND_PORT={{SCULPTOR_FRONTEND_PORT}} $WORKSPACES_FOLDER_ARG just frontend" Enter
     tmux send-keys -t {{session_name}}:backend "cd '{{justfile_directory()}}' && env $SCULPT_UNSETS PATH=\"$DEV_PATH_PREFIX:\$PATH\" SCULPTOR_API_PORT={{SCULPTOR_API_PORT}} SCULPTOR_FRONTEND_PORT={{SCULPTOR_FRONTEND_PORT}} SCULPTOR_CLAUDE_BINARY_DEFAULT_OVERRIDE=claude$CLAUDE_ENV_VARS $WORKSPACES_FOLDER_ARG just backend {{repo_path}}" Enter
-    # Fast-QA path: once the backend is up, create a ready workspace in its own
-    # window so its progress is visible without blocking the dev servers.
-    if [ "{{seed_workspace}}" = "true" ]; then
-        tmux new-window -t {{session_name}} -n bootstrap `shell echo $$SHELL`
-        tmux send-keys -t {{session_name}}:bootstrap "cd '{{justfile_directory()}}' && just _seed-fast-qa-workspace {{SCULPTOR_API_PORT}}" Enter
-    fi
     echo "Development servers started in tmux session '{{session_name}}'"
     echo "Backend serving repository: {{repo_path}}"
     echo "Use 'tmux attach -t {{session_name}}' to attach to the session"
     echo "Use 'just tmux-stop' to stop the session"
-    # Land on the backend window rather than the transient bootstrap one.
-    tmux select-window -t {{session_name}}:backend
     tmux attach -t {{session_name}} || echo "Failed to attach to tmux session. You can attach manually using 'tmux attach -t {{session_name}}'"
-
-# Wait for the dev backend to accept requests, then create one ready workspace (a
-# worktree with a waiting agent) via the source-built sculpt CLI, so `just start`
-# lands directly in a usable workspace. Idempotent: skips seeding when the repo
-# already has a live workspace, so reruns don't pile up throwaways.
-[group("dev")]
-_seed-fast-qa-workspace api_port:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # Resolve the source-built sculpt CLI and point it at the dev backend.
-    export PATH="{{justfile_directory()}}/.venv/bin:$PATH"
-    export SCULPT_API_PORT="{{api_port}}"
-    # Drop any SCULPT_* ids leaked from an outer Sculptor session; every sculpt
-    # call below passes --repo/--workspace explicitly, but this keeps the shell clean.
-    unset SCULPT_WORKSPACE_ID SCULPT_PROJECT_ID SCULPT_AGENT_ID
-    repo="{{justfile_directory()}}"
-
-    echo "Waiting for the dev backend on port {{api_port}} to accept sculpt requests..."
-    # `sculpt workspace list --repo` connects, fetches a session token, and
-    # initializes/resolves the project in one call, so a clean exit means the
-    # backend is up AND the repo is registered — a stronger readiness probe than a
-    # bare health check.
-    ready=""
-    for _ in $(seq 1 180); do
-        if sculpt workspace list --repo "$repo" --json >/dev/null 2>&1; then
-            ready=1
-            break
-        fi
-        sleep 1
-    done
-    if [ -z "$ready" ]; then
-        echo "Backend did not become ready in time; skipping workspace seed." >&2
-        exit 1
-    fi
-
-    live_count=$(sculpt workspace list --repo "$repo" --json 2>/dev/null \
-        | python -c 'import sys, json; print(sum(1 for w in json.load(sys.stdin) if not w.get("is_deleted")))')
-    if [ "$live_count" -gt 0 ]; then
-        echo "Repo already has $live_count workspace(s); skipping seed."
-        exit 0
-    fi
-
-    # Worktree workspaces require a source branch; base it on the repo's current
-    # branch so the QA workspace forks from whatever you're working on.
-    source_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
-    echo "Creating a ready workspace off '$source_branch' with a waiting agent..."
-    workspace_id=$(sculpt workspace create --repo "$repo" --name "QA" --branch "$source_branch" --json \
-        | python -c 'import sys, json; print(json.load(sys.stdin)["id"])')
-    sculpt agent create --workspace "$workspace_id" >/dev/null
-    echo "Ready workspace created: $workspace_id"
 
 tmux-stop:
 	tmux kill-session -t {{session_name}} 2>/dev/null && echo "Session '{{session_name}}' terminated" || echo "Session '{{session_name}}' did not exist"

--- a/sculptor/frontend/src/components/newWorkspace/homePromptPrefill.test.ts
+++ b/sculptor/frontend/src/components/newWorkspace/homePromptPrefill.test.ts
@@ -1,19 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { BUILTIN_SCULPTOR_ACTIONS } from "~/common/builtinActions.ts";
 
 import { HOME_PROMPT_PREFILL } from "./homePromptPrefill.ts";
 
 describe("HOME_PROMPT_PREFILL", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
   it("leads with the built-in /help action prompt, so the command never drifts", () => {
     const help = BUILTIN_SCULPTOR_ACTIONS.find((action) => action.name === "/help");
     expect(help).toBeDefined();
     expect(HOME_PROMPT_PREFILL.startsWith(`${help?.prompt} `)).toBe(true);
   });
 
-  it("is the sculptor help command plus the onboarding question", () => {
+  it("is the sculptor help command plus the onboarding question for users and tests", () => {
     expect(HOME_PROMPT_PREFILL).toBe(
       "/sculptor:help I just set up Sculptor for the first time. What should I know to get started?",
     );
+  });
+
+  it("is empty in the from-source dev app (SCULPTOR_EMPTY_FIRST_RUN_PROMPT set)", async () => {
+    vi.stubEnv("SCULPTOR_EMPTY_FIRST_RUN_PROMPT", "1");
+    vi.resetModules();
+    const { HOME_PROMPT_PREFILL: devPrefill } = await import("./homePromptPrefill.ts");
+    expect(devPrefill).toBe("");
   });
 });

--- a/sculptor/frontend/src/components/newWorkspace/homePromptPrefill.ts
+++ b/sculptor/frontend/src/components/newWorkspace/homePromptPrefill.ts
@@ -7,14 +7,21 @@ const HELP_ACTION_NAME = "/help";
 // first-run prompt reads like a real question a brand-new user would ask.
 const ONBOARDING_QUESTION = "I just set up Sculptor for the first time. What should I know to get started?";
 
-/**
- * The prompt the empty first-run form starts with: the `/sculptor:help` slash
- * command (sourced from the built-in `/help` action so the command can never
- * drift) followed by the onboarding question, e.g.
- * `/sculptor:help I just set up Sculptor for the first time. What should I know to get started?`.
- * This lands a brand-new user's very first workspace in the help flow with
- * context about who is asking.
- */
-export const HOME_PROMPT_PREFILL: string = `${
+// The `/sculptor:help` slash command (sourced from the built-in `/help` action
+// so the command can never drift) followed by the onboarding question, e.g.
+// `/sculptor:help I just set up Sculptor for the first time. What should I know to get started?`.
+const HELP_PROMPT_PREFILL: string = `${
   BUILTIN_SCULPTOR_ACTIONS.find((action) => action.name === HELP_ACTION_NAME)?.prompt ?? "/sculptor:help"
 } ${ONBOARDING_QUESTION}`;
+
+/**
+ * The prompt the empty first-run form starts with. For real (packaged) users and
+ * in tests this is the `/sculptor:help` onboarding prompt, which lands a brand-new
+ * user's very first workspace in the help flow with context about who is asking.
+ *
+ * The from-source dev app starts it empty instead so QA can type immediately:
+ * `just frontend` sets `SCULPTOR_EMPTY_FIRST_RUN_PROMPT`, which Vite exposes here
+ * via the `SCULPTOR_` env prefix. The test harness launches the frontend without
+ * that flag, so tests keep the onboarding prompt.
+ */
+export const HOME_PROMPT_PREFILL: string = import.meta.env.SCULPTOR_EMPTY_FIRST_RUN_PROMPT ? "" : HELP_PROMPT_PREFILL;

--- a/sculptor/frontend/src/vite-env.d.ts
+++ b/sculptor/frontend/src/vite-env.d.ts
@@ -4,6 +4,9 @@
 type ImportMetaEnv = {
   readonly SCULPTOR_API_PORT?: string;
   readonly SCULPTOR_FRONTEND_PORT?: string;
+  // Set only by the `just frontend` dev recipe: starts the empty first-run prompt
+  // box blank so QA can type immediately. Unset for packaged builds and tests.
+  readonly SCULPTOR_EMPTY_FIRST_RUN_PROMPT?: string;
 };
 
 type ImportMeta = {

--- a/sculptor/sculptor/scripts/dev_config.py
+++ b/sculptor/sculptor/scripts/dev_config.py
@@ -1,0 +1,56 @@
+"""Seed or reset the local dev Sculptor config folder for the `just start` recipes.
+
+Both operations resolve their target from the same functions the running
+backend uses (``get_config_path`` / ``get_sculptor_folder``) rather than
+hard-coding a path, so they always act on the folder the from-source app
+actually reads — which is ``<repo_root>/.dev_sculptor`` when running from source,
+not ``~/.dev_sculptor``.
+"""
+
+import shutil
+
+import typer
+from loguru import logger
+
+from sculptor.services.user_config.user_config import get_config_path
+from sculptor.services.user_config.user_config import seed_onboarded_config_if_needed
+from sculptor.utils.build import get_sculptor_folder
+
+app = typer.Typer(help="Seed or reset the local dev Sculptor config folder.")
+
+
+@app.command()
+def seed() -> None:
+    """Seed a valid, onboarded UserConfig so `just start` boots past onboarding.
+
+    Idempotent: an already-onboarded config is preserved so local settings
+    survive repeated launches. Telemetry is left disabled so local QA sessions
+    are not reported to Sentry/PostHog.
+    """
+    config_path = get_config_path()
+    if seed_onboarded_config_if_needed(config_path, is_telemetry_enabled=False):
+        logger.info("Seeded onboarded dev config at {}", config_path)
+    else:
+        logger.info("Dev config at {} is already onboarded; leaving it untouched", config_path)
+
+
+@app.command()
+def reset() -> None:
+    """Delete the entire dev Sculptor folder so the next launch is a clean first-run.
+
+    Refuses to touch a non-dev folder (e.g. a production ``~/.sculptor``) as a
+    safety rail, since this is destructive.
+    """
+    folder = get_sculptor_folder()
+    if "dev" not in folder.name:
+        logger.error("Refusing to delete {}: not a dev Sculptor folder", folder)
+        raise typer.Exit(code=1)
+    if folder.exists():
+        logger.info("Removing dev Sculptor folder for a clean first-run: {}", folder)
+        shutil.rmtree(folder)
+    else:
+        logger.info("Dev Sculptor folder {} does not exist; nothing to reset", folder)
+
+
+if __name__ == "__main__":
+    app()

--- a/sculptor/sculptor/services/user_config/user_config.py
+++ b/sculptor/sculptor/services/user_config/user_config.py
@@ -273,3 +273,43 @@ def initialize_from_file() -> bool:
     else:
         logger.info("No config file found at {}, will require onboarding", config_path)
         return False
+
+
+def make_onboarded_user_config(base: UserConfig, is_telemetry_enabled: bool) -> UserConfig:
+    """Return a copy of ``base`` with onboarding marked complete.
+
+    Records privacy-policy consent and sets the telemetry level to the given
+    consent — the same two flags ``complete_onboarding`` persists once a user
+    finishes the welcome flow. Used to fabricate a ready-to-run config (e.g. for
+    local dev/QA) without walking the onboarding UI.
+    """
+    return model_update(
+        base,
+        {
+            "is_privacy_policy_consented": True,
+            "is_telemetry_level_set": True,
+            **get_privacy_settings_for_telemetry(is_telemetry_enabled).model_dump(),
+        },
+    )
+
+
+def seed_onboarded_config_if_needed(config_path: Path, is_telemetry_enabled: bool) -> bool:
+    """Idempotently ensure ``config_path`` holds a valid, onboarded config.
+
+    Returns True when a config was written, False when an existing valid,
+    already-onboarded config was left untouched. Safe to re-run: a config that
+    already loads and has completed onboarding is preserved so local
+    customizations survive repeated launches, while a missing or corrupt one is
+    (re)written from the anonymized default.
+    """
+    existing: UserConfig | None = None
+    if config_path.exists():
+        try:
+            existing = load_config(config_path)
+        except (ValidationError, InvalidConfigError, tomllib.TOMLDecodeError):
+            existing = None
+    if existing is not None and existing.is_privacy_policy_consented and existing.is_telemetry_level_set:
+        return False
+    base = existing if existing is not None else get_default_user_config_instance()
+    save_config(make_onboarded_user_config(base, is_telemetry_enabled), config_path)
+    return True

--- a/sculptor/sculptor/services/user_config/user_config_test.py
+++ b/sculptor/sculptor/services/user_config/user_config_test.py
@@ -7,8 +7,11 @@ import pytest
 import sculptor.services.user_config.user_config as user_config_module
 from sculptor.config.user_config import UserConfig
 from sculptor.services.user_config.user_config import canonicalize_telemetry_flags
+from sculptor.services.user_config.user_config import load_config
+from sculptor.services.user_config.user_config import make_onboarded_user_config
 from sculptor.services.user_config.user_config import merge_config
 from sculptor.services.user_config.user_config import save_config
+from sculptor.services.user_config.user_config import seed_onboarded_config_if_needed
 
 
 def _make_config(
@@ -78,6 +81,84 @@ def test_initialize_from_file_normalizes_mixed_flags_and_persists(tmp_path: Path
         assert reloaded.is_product_analytics_enabled is False
     finally:
         user_config_module.set_user_config_instance(None)
+
+
+def test_make_onboarded_user_config_sets_consent_and_enables_telemetry() -> None:
+    base = _make_config(is_error_reporting_enabled=False, is_product_analytics_enabled=False)
+    assert base.is_privacy_policy_consented is False
+    assert base.is_telemetry_level_set is False
+
+    onboarded = make_onboarded_user_config(base, is_telemetry_enabled=True)
+
+    assert onboarded.is_privacy_policy_consented is True
+    assert onboarded.is_telemetry_level_set is True
+    assert onboarded.is_error_reporting_enabled is True
+    assert onboarded.is_product_analytics_enabled is True
+    # Session recording has no consent toggle and stays off even when telemetry is on.
+    assert onboarded.is_session_recording_enabled is False
+    # Identity fields are carried through untouched.
+    assert onboarded.user_email == base.user_email
+
+
+def test_make_onboarded_user_config_can_disable_telemetry() -> None:
+    onboarded = make_onboarded_user_config(_make_config(), is_telemetry_enabled=False)
+
+    assert onboarded.is_privacy_policy_consented is True
+    assert onboarded.is_telemetry_level_set is True
+    assert onboarded.is_error_reporting_enabled is False
+    assert onboarded.is_product_analytics_enabled is False
+    assert onboarded.is_session_recording_enabled is False
+
+
+def test_seed_onboarded_config_writes_when_missing(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+
+    wrote = seed_onboarded_config_if_needed(config_path, is_telemetry_enabled=False)
+
+    assert wrote is True
+    seeded = load_config(config_path)
+    assert seeded.is_privacy_policy_consented is True
+    assert seeded.is_telemetry_level_set is True
+    assert seeded.is_error_reporting_enabled is False
+    assert seeded.is_product_analytics_enabled is False
+
+
+def test_seed_onboarded_config_is_idempotent_for_onboarded_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    assert seed_onboarded_config_if_needed(config_path, is_telemetry_enabled=False) is True
+    original_bytes = config_path.read_bytes()
+
+    # A second call must leave an already-onboarded config exactly as-is.
+    assert seed_onboarded_config_if_needed(config_path, is_telemetry_enabled=True) is False
+    assert config_path.read_bytes() == original_bytes
+
+
+def test_seed_onboarded_config_completes_partially_onboarded_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    not_onboarded = _make_config()
+    assert not_onboarded.is_privacy_policy_consented is False
+    save_config(not_onboarded, config_path)
+
+    wrote = seed_onboarded_config_if_needed(config_path, is_telemetry_enabled=False)
+
+    assert wrote is True
+    completed = load_config(config_path)
+    assert completed.is_privacy_policy_consented is True
+    assert completed.is_telemetry_level_set is True
+    # The developer's existing identity is preserved rather than reset to the default.
+    assert completed.user_email == not_onboarded.user_email
+
+
+def test_seed_onboarded_config_overwrites_corrupt_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("this is not valid toml = = =")
+
+    wrote = seed_onboarded_config_if_needed(config_path, is_telemetry_enabled=False)
+
+    assert wrote is True
+    recovered = load_config(config_path)
+    assert recovered.is_privacy_policy_consented is True
+    assert recovered.is_telemetry_level_set is True
 
 
 # Concurrency regression test: concurrent partial updates to different fields

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -31,6 +31,7 @@ from sculptor.testing.elements.panel_tab import PlaywrightPanelTabElement
 from sculptor.testing.elements.task_starter import FAKE_CLAUDE_MODEL_NAME
 from sculptor.testing.elements.user_config import enable_clone_workspaces
 from sculptor.testing.elements.workspace_section import PlaywrightWorkspaceSection
+from sculptor.testing.elements.workspace_sidebar import get_workspace_sidebar
 from sculptor.testing.pages.settings_page import PlaywrightSettingsPage
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.utils import get_playwright_modifier_key
@@ -349,32 +350,28 @@ _MAX_WORKSPACE_DELETE_ITERATIONS = 50
 
 
 def delete_all_workspaces_via_ui(page: Page) -> None:
-    """Delete every workspace through the Home page workspace list.
+    """Delete every workspace through the sidebar workspace rows.
 
-    Workspaces live in the sidebar + Home list now (no tab strip); deleting each
-    Home row via its inline delete button + confirmation removes them all and
-    lands on the empty first-run state.
+    The sidebar is the primary navigation surface in the new shell and lists every
+    workspace on all in-app routes, so deleting each row via its hover-revealed
+    trash icon + confirmation clears them all without routing to the Home list.
     """
     # Dismiss any open popover/context menu that might intercept clicks.
     page.keyboard.press("Escape")
 
-    confirm_button = page.get_by_test_id(ElementIDs.DELETE_CONFIRMATION_CONFIRM)
-    confirm_dialog = page.get_by_test_id(ElementIDs.DELETE_CONFIRMATION_DIALOG)
+    sidebar = get_workspace_sidebar(page)
+    # A collapsed sidebar hides its rows behind the expand icon; expand first so
+    # the rows (and their delete affordances) are reachable.
+    if sidebar.get_expand_icon().count() > 0:
+        sidebar.expand()
 
-    navigate_to_home_page(page)
-
-    # Delete each workspace from the Home page workspace list.
-    # navigate_to_home_page already waits for workspace rows or empty state.
-    workspace_rows = page.get_by_test_id(ElementIDs.WORKSPACE_ROW)
+    confirm_dialog = sidebar.get_delete_confirmation_dialog()
+    workspace_rows = sidebar.get_workspace_rows()
 
     for _ in range(_MAX_WORKSPACE_DELETE_ITERATIONS):
         if workspace_rows.count() == 0:
             break
-        delete_button = workspace_rows.first.get_by_test_id(ElementIDs.WORKSPACE_ROW_CONTEXT_MENU_DELETE)
-        expect(delete_button).to_be_visible()
-        delete_button.click()
-        expect(confirm_button).to_be_visible()
-        confirm_button.click()
+        sidebar.delete_workspace_via_row_icon(workspace_rows.first)
         expect(confirm_dialog).to_be_hidden()
     else:
         remaining = workspace_rows.count()

--- a/sculptor/tests/integration/frontend/test_pr_button_errors.py
+++ b/sculptor/tests/integration/frontend/test_pr_button_errors.py
@@ -89,14 +89,14 @@ def _set_path_without_cli(factory: SculptorInstanceFactory, tmp_path: Path) -> N
 
 
 def _cleanup_workspaces(instance: SculptorInstance) -> None:
-    """Delete all workspaces and navigate to the add-workspace page for the next scenario.
+    """Delete all workspaces, then land on the add-workspace page for the next scenario.
 
-    `delete_all_workspaces_via_ui` ends on /home (where Phase 2 finds the
-    closed-workspace rows). With sculptor-tabs MRU restoration, leaving the
-    user on /home means the next `_set_remote` full reload's rootLoader
-    sees __home__ as the active tab and redirects there — and the test
-    expects to land on /ws/new instead. Explicitly navigate to the
-    add-workspace page to set the active tab before any subsequent reload.
+    `delete_all_workspaces_via_ui` clears the sidebar rows in place without forcing
+    a route, so the resulting active tab is indeterminate. With sculptor-tabs MRU
+    restoration, the next `_set_remote` full reload's rootLoader restores whatever
+    tab was last active — and the test expects to land on /ws/new instead.
+    Explicitly open the add-workspace form to pin the active tab before any
+    subsequent reload.
     """
     delete_all_workspaces_via_ui(instance.page)
     open_new_workspace_form(instance.page)


### PR DESCRIPTION
## Summary

Two devex follow-ups from the SCU-1474 batch.

### SCU-1714 — Split `just start` into fast-QA and full-onboarding recipes

Manual QA of the workspace UI meant relaunching the dev app constantly and
walking onboarding + creating a workspace by hand every time. The two flows are
now split:

- **`just start` (fast QA):** seeds a valid, onboarded `UserConfig` into the dev
  config folder so the app boots past the welcome flow, then — once the backend
  is up — a bootstrap `tmux` window creates a ready workspace (a worktree with a
  waiting agent) on the current repo via the source-built `sculpt` CLI. Both the
  config seed and the workspace seed are idempotent, so QA reruns don't clobber
  local settings or pile up throwaway workspaces.
- **`just start-onboarding` (new):** wipes the dev config folder and launches
  with no initial project so the full first-run flow (including repo selection)
  is exercised from scratch. Replaces `start-no-project` / `tmux-dev-no-project`.

Implementation notes:

- The seed/reset scripts resolve the dev folder from the same functions the
  backend uses (`get_config_path` / `get_sculptor_folder`) rather than
  hard-coding a path, so they always act on the folder the from-source app
  actually reads (`<repo>/.dev_sculptor`, not `~/.dev_sculptor`).
- Config seeding reuses the existing `UserConfig` helpers (the anonymized default
  plus telemetry settings) instead of hand-rolling TOML, and leaves telemetry
  disabled so dev QA isn't reported to analytics.
- Worktree workspaces require a source branch, so the seed bases the QA
  workspace on the repo's current branch.

Adds unit tests for the new config-seed helpers.

### SCU-1715 — Delete workspaces via the sidebar in the test-harness cleanup helper

`delete_all_workspaces_via_ui` deleted workspaces through the Home page list, but
the sidebar is the primary navigation surface in the new shell (and the
shared-instance cleanup already probes the sidebar for stale rows before
invoking this helper). It now deletes each workspace through its sidebar row
(hover-revealed trash icon + the shared delete-confirmation dialog), reusing the
existing sidebar POM, and expands a collapsed sidebar first.

## Testing

- `just format`, `just check`, `just test-unit` — all green.
- SCU-1714 fast-QA seed validated end-to-end against a live dev backend (a
  workspace with a waiting agent was created via the `sculpt` CLI).
- SCU-1715 validated via an offload integration sweep of the tests that exercise
  the helper (pr-button-errors, workspace deletion / optimistic-deletion,
  sidebar smoke, row context menu, shared-instance validation): **22 passed, 0
  failed**. The sole-workspace sidebar ghost-row behavior flagged in the ticket
  did not reproduce.

Fixes SCU-1714
Fixes SCU-1715

(Sent by Claude)
