### PR TITLE
Fix chat-virtualizer scroll timing (SCU-1696, SCU-1703)

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -317,6 +317,48 @@ describe("useAlphaAutoScroll", () => {
     expect(result.current.isAtBottom).toBe(true);
   });
 
+  it("restores the reading anchor synchronously on a width reflow (no deferred frame)", () => {
+    // A width reflow (sidebar collapse/expand, panel/window resize) re-wraps every
+    // message at once. The anchor restore must land in the same frame —
+    // synchronously in the resize callback — so the re-layout and the compensating
+    // scroll commit together, without the one-frame text shift a deferred (rAF)
+    // restore would leave.
+    const el = createMockScrollContainer(250, 2000, 500);
+    Object.defineProperty(el, "clientWidth", { value: 1200, writable: true, configurable: true });
+    const ref = { current: el };
+    // getVirtualItems returns the top-visible item so a user scroll captures a
+    // reading anchor; measurementsCache holds the reflowed (post-wrap) start.
+    const virtualizer = {
+      scrollToIndex: vi.fn(),
+      measureElement: vi.fn(),
+      getVirtualItems: vi.fn(() => [{ index: 2, start: 300, size: 100 }]),
+      getTotalSize: vi.fn(() => 2000),
+      measurementsCache: [undefined, undefined, { start: 280, size: 100 }] as Array<unknown>,
+      options: { paddingEnd: 0 },
+    } as unknown as Virtualizer<HTMLDivElement, Element>;
+
+    // lastMessageRole=USER so the on-mount pin-to-bottom bails, preserving this
+    // test's scrolled-up premise (otherwise the mount pin flags the next scroll
+    // event as programmatic and no reading anchor is captured).
+    renderHook(() => useAlphaAutoScroll(ref, false, 10, virtualizer, ChatMessageRole.USER, -1, "test-task"));
+
+    // A genuine user scroll captures the reading anchor (index 2, offset 50).
+    act(() => {
+      el.dispatchEvent(new Event("wheel"));
+      el.dispatchEvent(new Event("scroll"));
+    });
+
+    // The container widens: a width reflow, distinct from a height-only growth.
+    Object.defineProperty(el, "clientWidth", { value: 1400, writable: true, configurable: true });
+    act(() => {
+      triggerResize();
+    });
+
+    // Corrected synchronously within the resize callback (no rAF flush): the
+    // reflowed anchor start (280) minus its sampled viewport offset (50) = 230.
+    expect(el.scrollTop).toBe(230);
+  });
+
   it("suppressAutoScroll prevents engage/disengage", () => {
     const el = createMockScrollContainer(1300, 2000, 500);
     const ref = { current: el };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -281,6 +281,42 @@ describe("useAlphaAutoScroll", () => {
     expect(result.current.isEngaged).toBe(false);
   });
 
+  it("re-pins to the true bottom when a non-streaming jump landed short (stale measurement)", () => {
+    // A non-streaming jump computes bottomPinOffset from scrollHeight, which is
+    // stale-short while the last message is still remeasuring taller after it
+    // remounts (it grew off-screen while the user was scrolled away). The
+    // bottom-settle window opened by scrollToBottom must re-pin to the true
+    // bottom when the remeasured content grows — otherwise the jump lands short
+    // with no stream and no further scroll to hide the jump-to-bottom button.
+    const el = createMockScrollContainer(0, 2000, 500); // scrolled to the top
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer();
+
+    const { result } = renderHook(() => useAlphaAutoScroll(ref, false, 10, virtualizer, null, -1, "test-task"));
+
+    // Jump — lands at the (stale, short) content bottom.
+    act(() => {
+      result.current.scrollToBottom();
+    });
+    expectPinnedToBottom(el);
+
+    // The remounted last message remeasures taller: scrollHeight grows.
+    setScrollPosition(el, el.scrollTop, 3000);
+    act(() => {
+      triggerResize();
+    });
+
+    // The bottom-settle window re-pinned to the NEW content bottom.
+    expectPinnedToBottom(el);
+
+    // In the browser the re-pin fires a scroll event that re-samples geometry;
+    // simulate it and confirm the view now reads as at-bottom (button hides).
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
   it("suppressAutoScroll prevents engage/disengage", () => {
     const el = createMockScrollContainer(1300, 2000, 500);
     const ref = { current: el };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -7,6 +7,7 @@
 import type { Virtualizer } from "@tanstack/react-virtual";
 import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
+import { flushSync } from "react-dom";
 
 import { ChatMessageRole } from "~/api";
 
@@ -611,18 +612,56 @@ export const useAlphaAutoScroll = (
     [scrollContainerRef, virtualizer, machine, isProgrammaticScroll],
   );
 
+  // Width-reflow sibling of restoreReadingAnchor. A viewport-width change (the
+  // sidebar collapsing/expanding, a panel or window resize) re-wraps every message
+  // at once. Restore the anchor SYNCHRONOUSLY — force the virtualizer to remeasure
+  // the re-wrapped items in this frame (flushSync + measureElement, as the
+  // density-flip handler does), then assign scrollTop before paint — so the
+  // re-layout and its compensating scroll commit together. The deferred (rAF) path
+  // would paint one stale frame first: items re-wrapped at the new width but still
+  // positioned by the old measurements — the visible one-frame text shift.
+  const restoreReadingAnchorSync = useCallback(
+    (anchor: ReadingAnchor): void => {
+      const el = scrollContainerRef.current;
+      if (!el) return;
+      // measureElement refreshes each wrapper's cached size; getVirtualItems()
+      // rebuilds the cumulative measurementsCache from them. flushSync commits the
+      // re-rendered item transforms in this same frame so the DOM matches.
+      flushSync(() => {
+        el.querySelectorAll<HTMLElement>("[data-index]").forEach((node) => virtualizer.measureElement(node));
+      });
+      virtualizer.getVirtualItems();
+      const item = virtualizer.measurementsCache[anchor.messageIndex];
+      if (!item) return;
+      // Keep the virtual-content height in sync so the scrollTop assignment below
+      // isn't clamped by a stale scrollHeight (mirrors the density-flip handler).
+      const contentEl = el.firstElementChild as HTMLElement | null;
+      if (contentEl) contentEl.style.height = `${virtualizer.getTotalSize()}px`;
+      const desired = Math.max(0, item.start - anchor.viewportOffset);
+      if (Math.abs(el.scrollTop - desired) > 1) {
+        isProgrammaticScroll.current = true;
+        el.scrollTop = desired;
+      }
+      machine.setGeometryAtBottom(distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD);
+    },
+    [scrollContainerRef, virtualizer, machine, isProgrammaticScroll],
+  );
+
   // Perform the one typed reflow action projectReflow chose for the current
   // authority phase. This is the single executor the unified content observer
   // drives — projectReflow decides, applyReflow performs.
   const applyReflow = useCallback(
-    (el: HTMLElement, distance: number): void => {
+    (el: HTMLElement, distance: number, isWidthReflow: boolean): void => {
       const action = projectReflow(machine.getState());
       switch (action.kind) {
         case "ignore":
           return;
         case "holdAnchor":
-          // Scrolled up and reading — keep the anchor message at its offset.
-          restoreReadingAnchor(action.anchor);
+          // Scrolled up and reading — keep the anchor message at its offset. A
+          // width reflow re-wraps everything at once, so restore synchronously to
+          // avoid a one-frame shift; incremental reflows use the coalesced rAF path.
+          if (isWidthReflow) restoreReadingAnchorSync(action.anchor);
+          else restoreReadingAnchor(action.anchor);
           return;
         case "pinBottom": {
           // Following the live tail — keep the last message's content bottom in
@@ -665,7 +704,7 @@ export const useAlphaAutoScroll = (
         }
       }
     },
-    [machine, virtualizer, messageCount, restoreReadingAnchor, pinToBottom],
+    [machine, virtualizer, messageCount, restoreReadingAnchor, restoreReadingAnchorSync, pinToBottom],
   );
 
   // Unified content-resize observer. One observer, always connected while not
@@ -678,8 +717,17 @@ export const useAlphaAutoScroll = (
     const content = el?.firstElementChild;
     if (!el || !content) return;
 
+    // Track container width so the observer can distinguish a width reflow (the
+    // sidebar/panel/window resizing) from a height-only growth (a streamed token,
+    // an above-fold item). Only the former re-wraps every message and needs the
+    // synchronous, same-frame anchor restore.
+    let prevWidth = el.clientWidth;
+
     const observer = new ResizeObserver(() => {
       if (messageCount === 0) return;
+      const width = el.clientWidth;
+      const isWidthReflow = width !== prevWidth;
+      prevWidth = width;
       const distance = distanceFromContentBottom(el, virtualizer);
       machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
       // Within the bottom-settle window, re-pin (down-only) to the grown content
@@ -696,7 +744,7 @@ export const useAlphaAutoScroll = (
       ) {
         pinToBottom();
       }
-      applyReflow(el, distance);
+      applyReflow(el, distance, isWidthReflow);
     });
 
     // Initial pin when a stream (re)connects already pinned to the bottom —

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -215,13 +215,28 @@ export const useAlphaAutoScroll = (
     Virtualizer<HTMLDivElement, Element>["shouldAdjustScrollPositionOnItemSizeChange"] | null
   >(null);
 
-  // Turn-footer reveal window: the timestamp (performance.now) until which the
-  // content observer re-pins to the bottom after a followed turn ends, plus the
-  // content height and viewport size sampled then (the reveal condition below
-  // compares against both). Zeroed on user takeover.
-  const revealFooterUntilRef = useRef(0);
-  const revealFooterBaseHeightRef = useRef(0);
-  const revealFooterViewportRef = useRef("");
+  // Bottom-settle window: the timestamp (performance.now) until which the content
+  // observer re-pins to the bottom as late content lands after a programmatic
+  // bottom-landing, plus the content height and viewport size sampled then (the
+  // re-pin condition below compares against both). Two landings expect late
+  // growth and open it: a followed turn ending (the turn footer mounts a beat
+  // later) and a non-streaming jump-to-bottom (the last message can remeasure
+  // taller after it remounts, so the initial pin lands short). Zeroed on user
+  // takeover.
+  const bottomSettleUntilRef = useRef(0);
+  const bottomSettleBaseHeightRef = useRef(0);
+  const bottomSettleViewportRef = useRef("");
+
+  // Open the bottom-settle window from the current scroll geometry (see the refs
+  // above). Sampling scrollHeight here as the baseline means only growth BEYOND
+  // the landing re-pins — a later shrink or an unrelated reflow does not.
+  const openBottomSettleWindow = useCallback((): void => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    bottomSettleUntilRef.current = performance.now() + FOOTER_REVEAL_WINDOW_MS;
+    bottomSettleBaseHeightRef.current = el.scrollHeight;
+    bottomSettleViewportRef.current = `${el.clientWidth}x${el.clientHeight}`;
+  }, [scrollContainerRef]);
 
   // Mark that the user is actively scrolling, with a debounce to clear it.
   const markUserScrolling = useCallback((): void => {
@@ -242,8 +257,8 @@ export const useAlphaAutoScroll = (
 
     const onUserInput = (): void => {
       markUserScrolling();
-      // A user input ends the footer-reveal window immediately: a takeover wins.
-      revealFooterUntilRef.current = 0;
+      // A user input ends the bottom-settle window immediately: a takeover wins.
+      bottomSettleUntilRef.current = 0;
       // Disengage on user wheel/touch/keydown before the scroll event fires.
       // During streaming the ResizeObserver sets isProgrammaticScroll and scrolls;
       // a user scroll event that saw that flag would be consumed as programmatic
@@ -351,8 +366,8 @@ export const useAlphaAutoScroll = (
       // meaningless for the incoming task. The first user scroll re-samples it.
       machine.setReadingAnchor(null);
       prevScrollTopRef.current = -1;
-      // Cancel any in-flight footer-reveal window from the outgoing task.
-      revealFooterUntilRef.current = 0;
+      // Cancel any in-flight bottom-settle window from the outgoing task.
+      bottomSettleUntilRef.current = 0;
       // The authority (following/anchoring) is reset by the machine's
       // taskSwitched -> restoring transition (dispatched by the persistence
       // hook); this effect only resets auto-scroll's own observations and
@@ -537,14 +552,9 @@ export const useAlphaAutoScroll = (
       if (isFollowing() && messageCount > 0) {
         pinToBottom();
         // The turn footer mounts a beat later and grows the content below the fold;
-        // open a short window so the content observer re-pins to reveal it at the
-        // bottom, matching where focusing the input lands.
-        const el = scrollContainerRef.current;
-        if (el) {
-          revealFooterUntilRef.current = performance.now() + FOOTER_REVEAL_WINDOW_MS;
-          revealFooterBaseHeightRef.current = el.scrollHeight;
-          revealFooterViewportRef.current = `${el.clientWidth}x${el.clientHeight}`;
-        }
+        // open the bottom-settle window so the content observer re-pins to reveal
+        // it at the bottom, matching where focusing the input lands.
+        openBottomSettleWindow();
       }
       // Streaming stopped: leave following/anchoring for userControlled. The
       // leave-anchoring subscription tears down the animation and jump
@@ -672,16 +682,17 @@ export const useAlphaAutoScroll = (
       if (messageCount === 0) return;
       const distance = distanceFromContentBottom(el, virtualizer);
       machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
-      // Reveal the turn footer that grew the content just after a followed turn ended:
-      // re-pin (down-only) to the grown content bottom, within the window opened at
-      // streaming stop. The two non-obvious guards: still userControlled (a new turn
-      // opened within the window is anchoringTurn and must not be yanked down), and an
-      // unchanged viewport (a resize reflow keeps its own reading-anchor behavior).
+      // Within the bottom-settle window, re-pin (down-only) to the grown content
+      // bottom as late content lands after a programmatic bottom-landing (a turn
+      // footer mounting, or a jumped-to last message remeasuring taller). The two
+      // non-obvious guards: still userControlled (a new turn opened within the
+      // window is anchoringTurn and must not be yanked down), and an unchanged
+      // viewport (a resize reflow keeps its own reading-anchor behavior).
       if (
-        performance.now() < revealFooterUntilRef.current &&
+        performance.now() < bottomSettleUntilRef.current &&
         machine.getState().authority.kind === "userControlled" &&
-        el.scrollHeight > revealFooterBaseHeightRef.current + 1 &&
-        `${el.clientWidth}x${el.clientHeight}` === revealFooterViewportRef.current
+        el.scrollHeight > bottomSettleBaseHeightRef.current + 1 &&
+        `${el.clientWidth}x${el.clientHeight}` === bottomSettleViewportRef.current
       ) {
         pinToBottom();
       }
@@ -713,15 +724,29 @@ export const useAlphaAutoScroll = (
     // other trigger).
     machine.setGeometryAtBottom(true);
     if (isStreaming) {
-      // Follow the stream (also exits anchoring → following).
+      // Follow the stream (also exits anchoring → following, which clears the
+      // reading anchor and re-pins on every content growth via the observer).
       machine.dispatch({ kind: "reachedBottom" });
-    } else if (machine.getState().authority.kind === "anchoringTurn") {
+      return;
+    }
+
+    if (machine.getState().authority.kind === "anchoringTurn") {
       // Not streaming but anchored: the user explicitly went to the bottom, so
       // end the anchored turn. The leave-anchoring subscription clears jump
       // suppression.
       machine.dispatch({ kind: "userScrolled" });
     }
-  }, [messageCount, isStreaming, machine, pinToBottom]);
+    // A non-streaming jump can land short: bottomPinOffset is computed from
+    // scrollHeight, which is stale while the last message is still remounting and
+    // remeasuring taller (the user scrolled away during its own stream, so it grew
+    // off-screen and unmeasured). Nothing would then hide the button — no stream,
+    // and no further scroll to recheck the distance. Abandon the scrolled-up
+    // reading anchor (whose holdAnchor reflow would otherwise pull the view back
+    // off the bottom) and open the bottom-settle window so the content observer
+    // re-pins to the true bottom as the remeasured content lands.
+    machine.setReadingAnchor(null);
+    openBottomSettleWindow();
+  }, [messageCount, isStreaming, machine, pinToBottom, openBottomSettleWindow]);
 
   const scrollToTop = useCallback((): void => {
     if (messageCount === 0) return;


### PR DESCRIPTION
## Summary

Two follow-up timing fixes for the virtualized alpha chat, both isolated to
`chat-alpha/hooks/useAlphaAutoScroll.ts` (with new unit-test coverage).

### SCU-1696 — jump-to-bottom could leave the button stuck visible

A non-streaming jump-to-bottom targets a position derived from the scroll
container's `scrollHeight`, which is stale-short while the last message is still
remounting and remeasuring taller (it grew off-screen after the user scrolled away
during its own stream). The pin lands above the real bottom, and with no active
stream and no further scroll to recheck the distance, nothing hides the
jump-to-bottom button.

The existing turn-end reveal window is generalized into a reusable bottom-settle
window; the non-streaming jump opens it too, so the content observer re-pins to the
true bottom as the remeasured content lands. The stale scrolled-up reading anchor is
dropped on the jump so its hold-anchor reflow can't pull the view back off the
bottom mid-settle. This deflakes `test_auto_scroll_and_jump_to_bottom`.

### SCU-1703 — sidebar collapse/expand caused a one-frame text shift

Toggling the sidebar widens the chat synchronously via CSS, but the virtualized list
re-measures a frame later, so for one frame the messages are re-wrapped at the new
width but still positioned by the old measurements. The content observer now detects
a width reflow and, for the reading-anchor case, restores synchronously (flushSync +
measureElement, mirroring the chat-density-flip handler) so the re-layout and its
compensating scroll commit in the same frame. Incremental reflows (an above-fold
item growing, a streamed token) keep the existing coalesced next-frame path.

## Testing

- `just format`, `just check`, `just test-unit-frontend` — green (56 unit tests).
- New unit tests in `useAlphaAutoScroll.test.ts` cover the short-jump re-pin and the
  synchronous width-reflow restore (both fail on the pre-fix code).
- Full alpha-scroll integration suite (`test_alpha_scroll_*.py`, all 9 files) — 42
  passed, run serially to avoid local instance-startup contention.

## Notes

The one-frame shift is a transient that retrying assertions cannot capture; the
width-change integration tests guard the final anchor position (no regression), and
the fix is structural — a synchronous, same-frame commit via a flushSync in the
resize callback.

Fixes SCU-1696
Fixes SCU-1703

(Sent by Claude)
