### PR TITLE
perf(frontend): chat derivation caching + keystroke-decoupled ChatInput

### DIFF
--- a/sculptor/frontend/src/components/EffortSelector.tsx
+++ b/sculptor/frontend/src/components/EffortSelector.tsx
@@ -1,6 +1,6 @@
 import { Flex, Select, Text } from "@radix-ui/themes";
 import { Brain } from "lucide-react";
-import type { ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 
 import { EffortLevel, ElementIds } from "~/api";
 
@@ -20,30 +20,34 @@ type EffortSelectorProps = {
   onEffortChange: (effort: EffortLevel) => void;
 };
 
-export const EffortSelector = ({ effort, onEffortChange }: EffortSelectorProps): ReactElement => (
-  <Select.Root size="1" value={effort} onValueChange={onEffortChange}>
-    <Select.Trigger
-      className={styles.trigger}
-      variant="ghost"
-      data-testid={ElementIds.EFFORT_SELECTOR}
-      data-value={effort}
-    >
-      <Flex align="center" gap="1">
-        <Brain size={14} />
-        <span className={styles.fillBar}>
-          <span className={styles.fillBarInner} style={{ height: `${EFFORT_FILL_PERCENT[effort]}%` }} />
-        </span>
-      </Flex>
-    </Select.Trigger>
-    <Select.Content position="popper" sideOffset={5}>
-      <Select.Group>
-        <Select.Label>Effort level</Select.Label>
-        {EFFORT_OPTIONS.map((level) => (
-          <Select.Item key={level} value={level} data-testid={ElementIds.EFFORT_SELECTOR_OPTION}>
-            <Text size="1">{EFFORT_DISPLAY_NAMES[level]}</Text>
-          </Select.Item>
-        ))}
-      </Select.Group>
-    </Select.Content>
-  </Select.Root>
+// Memoized so it bails out of ChatInput's re-renders (effort is atom-backed
+// and onEffortChange is a stable useCallback).
+export const EffortSelector = memo(
+  ({ effort, onEffortChange }: EffortSelectorProps): ReactElement => (
+    <Select.Root size="1" value={effort} onValueChange={onEffortChange}>
+      <Select.Trigger
+        className={styles.trigger}
+        variant="ghost"
+        data-testid={ElementIds.EFFORT_SELECTOR}
+        data-value={effort}
+      >
+        <Flex align="center" gap="1">
+          <Brain size={14} />
+          <span className={styles.fillBar}>
+            <span className={styles.fillBarInner} style={{ height: `${EFFORT_FILL_PERCENT[effort]}%` }} />
+          </span>
+        </Flex>
+      </Select.Trigger>
+      <Select.Content position="popper" sideOffset={5}>
+        <Select.Group>
+          <Select.Label>Effort level</Select.Label>
+          {EFFORT_OPTIONS.map((level) => (
+            <Select.Item key={level} value={level} data-testid={ElementIds.EFFORT_SELECTOR_OPTION}>
+              <Text size="1">{EFFORT_DISPLAY_NAMES[level]}</Text>
+            </Select.Item>
+          ))}
+        </Select.Group>
+      </Select.Content>
+    </Select.Root>
+  ),
 );

--- a/sculptor/frontend/src/components/ModelSelector.tsx
+++ b/sculptor/frontend/src/components/ModelSelector.tsx
@@ -1,5 +1,5 @@
 import { Button, DropdownMenu, Flex, Select, Text, Tooltip } from "@radix-ui/themes";
-import type { ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 
 import type { LlmModel, ModelOption } from "~/api";
 import { ElementIds } from "~/api";
@@ -42,7 +42,10 @@ type ModelSelectorProps = {
 
 const PI_NO_MODELS_COPY = "No models available — please log in to authenticate";
 
-export const ModelSelector = ({
+// Memoized: ChatInput re-renders on draft-flag flips, send state, and task/
+// capability churn. The model props here are atom-backed (stable refs) +
+// useCallback handlers, so memo lets this Radix Select subtree bail out.
+export const ModelSelector = memo(function ModelSelector({
   model,
   onModelChange,
   capabilityValue,
@@ -51,7 +54,7 @@ export const ModelSelector = ({
   onBackendModelChange,
   sourcesBackendModels = false,
   onAuthenticate,
-}: ModelSelectorProps): ReactElement => {
+}: ModelSelectorProps): ReactElement {
   const gate = useCapabilityGate(capabilityValue, ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION);
 
   const models = backendModels ?? [];
@@ -167,7 +170,7 @@ export const ModelSelector = ({
       </Select.Content>
     </Select.Root>
   );
-};
+});
 
 type CascadingProviderMenuProps = {
   groups: ReadonlyArray<{ provider: string; models: ReadonlyArray<ModelOption> }>;

--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -1,10 +1,10 @@
 import { Flex, IconButton, Tooltip } from "@radix-ui/themes";
 import type { Editor as TipTapEditor } from "@tiptap/react";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { ListChecks, Plus } from "lucide-react";
 import { posthog } from "posthog-js";
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { HTTPException } from "~/common/Errors.ts";
 import { isTextBlock } from "~/common/Guards.ts";
@@ -47,6 +47,7 @@ import {
   modelAtomFamily,
 } from "../../../common/state/atoms/draftAgentSettings.ts";
 import { isCancellableAtomFamily } from "../../../common/state/atoms/interruptState.ts";
+import { promptDraftAtomFamily } from "../../../common/state/atoms/promptDrafts.ts";
 import {
   defaultEffortLevelAtom,
   isAlwaysInterruptAndSendAtom,
@@ -56,7 +57,6 @@ import {
 } from "../../../common/state/atoms/userConfig.ts";
 import { useDraftAttachedFiles } from "../../../common/state/hooks/useDraftAttachedFiles.ts";
 import { useInterruptAgent } from "../../../common/state/hooks/useInterruptAgent.ts";
-import { usePromptDraft } from "../../../common/state/hooks/usePromptDraft.ts";
 import { useTaskDetailWithDefaults } from "../../../common/state/hooks/useTaskDetail";
 import {
   useTaskAvailableModels,
@@ -109,6 +109,16 @@ function draftIsBypassCommand(draft: string | null | undefined): boolean {
   const rest = trimmed.slice("/btw".length);
   return rest === "" || /^\s/.test(rest);
 }
+
+/** The only draft-derived facts the toolbar render needs: whether the send
+ *  button is enabled (`hasContent`) and whether the draft is a /btw bypass
+ *  command (which can send even while the agent is busy). Tracking these as a
+ *  bailout state lets ChatInput avoid re-rendering on every keystroke. */
+type DraftFlags = { hasContent: boolean; isBypass: boolean };
+const deriveDraftFlags = (draft: string | null): DraftFlags => ({
+  hasContent: Boolean(draft?.trim()),
+  isBypass: draftIsBypassCommand(draft),
+});
 
 type ChatInputProps = {
   isDisabled: boolean;
@@ -212,7 +222,73 @@ export const ChatInput = ({
     toast: interruptToast,
     setToast: setInterruptToast,
   } = useInterruptAgent(workspaceID, taskID);
-  const [promptDraft, setPromptDraft] = usePromptDraft(taskID ?? "");
+  // Decoupled from per-keystroke re-render: ChatInput WRITES the draft atom but
+  // does not SUBSCRIBE to it (useSetAtom + store reads), so typing the prompt
+  // does not re-render this whole toolbar. The send button reads `draftFlags`, a
+  // derived state that only changes on empty<->non-empty / bypass-command flips —
+  // so a render happens on those flips, not on every keystroke. Reads of the live
+  // draft (send, append) go through `getDraft()`.
+  const draftAtom = useMemo(() => promptDraftAtomFamily(taskID ?? ""), [taskID]);
+  const writeDraftAtom = useSetAtom(draftAtom);
+  const draftStore = useStore();
+  // Reads the LIVE editor content — authoritative even if a host coalesces
+  // onChange; falls back to the persisted atom before the editor mounts.
+  const getDraft = useCallback((): string | null => {
+    const editor = editorRef.current;
+    if (editor) {
+      const md = editor.getMarkdown();
+      return md === "​" ? "" : md;
+    }
+    return draftStore.get(draftAtom);
+  }, [editorRef, draftStore, draftAtom]);
+  // Stable per-task initial content for the editor. The editor is uncontrolled after
+  // mount (its value prop doesn't track the atom — that would fight typing);
+  // external draft writes reach it via the store subscription below.
+  const initialDraft = useMemo(() => draftStore.get(draftAtom) ?? "", [draftStore, draftAtom]);
+  const [draftFlags, setDraftFlags] = useState<DraftFlags>(() => deriveDraftFlags(draftStore.get(draftAtom)));
+  // The last draft value THIS editor wrote — lets the external-write subscription
+  // below tell our own keystrokes apart from EXTERNAL writes without serializing
+  // the editor on every keystroke.
+  const lastEditorEmitRef = useRef<string | null>(draftStore.get(draftAtom));
+  const setPromptDraft = useCallback(
+    (value: string | null): void => {
+      lastEditorEmitRef.current = value;
+      writeDraftAtom(value);
+      setDraftFlags((prev) => {
+        const next = deriveDraftFlags(value);
+        return prev.hasContent === next.hasContent && prev.isBypass === next.isBypass ? prev : next;
+      });
+    },
+    [writeDraftAtom],
+  );
+  // ChatInput no longer subscribes to the draft atom for renders, so an EXTERNAL
+  // write (e.g. QueuedMessages restoring an overwritten draft) would never reach
+  // the editor. Subscribe manually and push external writes into the editor
+  // imperatively; our own writes (typing) are skipped via lastEditorEmitRef, so a
+  // keystroke never triggers a re-serialize or setContent here.
+  useEffect(() => {
+    return draftStore.sub(draftAtom, () => {
+      const next = draftStore.get(draftAtom);
+      if (next === lastEditorEmitRef.current) return; // our own write — already in the editor
+      lastEditorEmitRef.current = next;
+      const editor = editorRef.current;
+      if (editor) {
+        if (next) {
+          editor.commands.setContent(next, { contentType: "markdown" });
+        } else {
+          editor.commands.clearContent();
+        }
+      }
+      setDraftFlags(deriveDraftFlags(next));
+    });
+  }, [draftStore, draftAtom, editorRef]);
+  // Re-sync the emit ref + bailout flags when the active task (and its persisted
+  // draft) changes; this component doesn't subscribe to the atom for renders.
+  useEffect(() => {
+    lastEditorEmitRef.current = draftStore.get(draftAtom);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync flags to the new task's persisted draft on task switch; not derivable during render without subscribing
+    setDraftFlags(deriveDraftFlags(draftStore.get(draftAtom)));
+  }, [draftAtom, draftStore]);
 
   // Stable callbacks so the memoized <Toast> instances below bail out instead
   // of re-rendering on every unrelated parent render. (SCU-1455)
@@ -359,7 +435,8 @@ export const ChatInput = ({
   );
 
   const sendMessage = useCallback(async (): Promise<void> => {
-    if (!promptDraft?.trim() || !taskID) {
+    const draft = getDraft();
+    if (!draft?.trim() || !taskID) {
       return;
     }
 
@@ -370,7 +447,7 @@ export const ChatInput = ({
     }
 
     if (editorRef.current) {
-      const parsed = parsePseudoSkillCommand(editorRef.current, promptDraft ?? "");
+      const parsed = parsePseudoSkillCommand(editorRef.current, draft ?? "");
       if (parsed !== null) {
         executePseudoSkill(parsed);
         return;
@@ -384,7 +461,7 @@ export const ChatInput = ({
       await sendWorkspaceAgentMessages({
         path: { workspace_id: workspaceID, agent_id: taskID },
         body: {
-          message: promptDraft?.replace(/\u200B/g, "\u00A0").replace(/(\n\n\u00A0)+$/, ""),
+          message: draft?.replace(/\u200B/g, "\u00A0").replace(/(\n\n\u00A0)+$/, ""),
           model: localModel,
           files: attachedFiles,
           // The plan-mode toggle is gated (disabled-with-tooltip) for harnesses
@@ -404,8 +481,9 @@ export const ChatInput = ({
         has_attached_files: attachedFiles.length > 0,
         is_plan_first: isPlanFirst,
       });
-      setPromptDraft(null);
-      setAttachedFiles([]);
+      // The editor is uncontrolled (stable value prop), so clearing the draft atom
+      // alone no longer empties it — clearEditor() also clears the editor content.
+      clearEditor();
     } catch (error) {
       console.error("Failed to send message:", error);
       // Editor is intentionally left populated so the user does not lose
@@ -427,7 +505,7 @@ export const ChatInput = ({
       setIsSending(false);
     }
   }, [
-    promptDraft,
+    getDraft,
     workspaceID,
     taskID,
     localModel,
@@ -437,8 +515,7 @@ export const ChatInput = ({
     isFastMode,
     modelCapabilities,
     effort,
-    setPromptDraft,
-    setAttachedFiles,
+    clearEditor,
     executePseudoSkill,
     setLastSendError,
     editorRef,
@@ -448,7 +525,7 @@ export const ChatInput = ({
     // A send is already in flight; ignore the trigger entirely so we neither
     // re-send nor fire the trailing interrupt below for a send that no-ops.
     if (isSendingRef.current) return;
-    const isBtwDraft = draftIsBypassCommand(promptDraft);
+    const isBtwDraft = draftIsBypassCommand(getDraft());
     if (isDisabled && !isBtwDraft) return;
     await sendMessage();
 
@@ -461,16 +538,16 @@ export const ChatInput = ({
     if (!isBtwDraft && isAlwaysInterruptAndSend && isAgentBusy && taskID) {
       await interruptWorkspaceAgent({ path: { workspace_id: workspaceID, agent_id: taskID } });
     }
-  }, [isDisabled, promptDraft, sendMessage, isAlwaysInterruptAndSend, isAgentBusy, taskID, workspaceID]);
+  }, [isDisabled, getDraft, sendMessage, isAlwaysInterruptAndSend, isAgentBusy, taskID, workspaceID]);
 
   const handleInterruptAndSend = useCallback(async (): Promise<void> => {
     if (isSendingRef.current) return;
-    if (!promptDraft?.trim() || !taskID) return;
+    if (!getDraft()?.trim() || !taskID) return;
     await sendMessage();
     if (isAgentBusy) {
       await interruptWorkspaceAgent({ path: { workspace_id: workspaceID, agent_id: taskID } });
     }
-  }, [promptDraft, taskID, sendMessage, isAgentBusy, workspaceID]);
+  }, [getDraft, taskID, sendMessage, isAgentBusy, workspaceID]);
 
   // Out-of-band model switch for a harness with a backend model list (pi). The
   // value stays server-driven (selectedModelId), so on success the persisted
@@ -617,11 +694,16 @@ export const ChatInput = ({
     }
 
     appendTextRef.current = (text: string): void => {
-      const currentDraft = promptDraft || "";
-      setPromptDraft(currentDraft ? `${currentDraft}\n${text}\n` : `${text}\n`);
+      const currentDraft = getDraft() || "";
+      const newDraft = currentDraft ? `${currentDraft}\n${text}\n` : `${text}\n`;
+      // ChatInput no longer re-renders on draft changes, so push the new content
+      // into the editor imperatively (the value prop won't carry it), then mirror
+      // it to the draft atom + flags.
+      editorRef.current?.commands.setContent(newDraft, { contentType: "markdown" });
+      setPromptDraft(newDraft);
       editorRef.current?.commands.focus("end");
     };
-  }, [appendTextRef, setPromptDraft, promptDraft, editorRef]);
+  }, [appendTextRef, getDraft, setPromptDraft, editorRef]);
 
   useEffect(() => {
     if (!insertSkillRef) return;
@@ -694,11 +776,12 @@ export const ChatInput = ({
           <Editor
             wrapperClassName={styles.editorInner}
             placeholder="Enter a prompt..."
-            value={promptDraft || ""}
+            // Stable initial content (uncontrolled after mount — see initialDraft).
+            value={initialDraft}
             // Read-only while a send is in flight: prevents edits from being
             // wiped by the on-success clear, and visually signals "sending".
             disabled={isSending}
-            onChange={(newValue: string) => setPromptDraft(newValue)}
+            onChange={setPromptDraft}
             onKeyDown={handleKeyPress}
             tagName="CHAT_INPUT"
             editorRef={editorRef}
@@ -785,7 +868,7 @@ export const ChatInput = ({
               </Flex>
               <SendButton
                 onClick={handleSend}
-                disabled={isSending || (isDisabled && !draftIsBypassCommand(promptDraft)) || !promptDraft?.trim()}
+                disabled={isSending || (isDisabled && !draftFlags.isBypass) || !draftFlags.hasContent}
                 loading={shouldShowSendSpinner}
                 tooltip={`${sendHint} to send message`}
                 ariaLabel="Send message"

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
@@ -35,8 +35,7 @@ import { AlphaChatIntro } from "./AlphaChatIntro.tsx";
 import { AlphaMessageNode } from "./AlphaChatView.tsx";
 import {
   buildToolResultMap,
-  hasOnlySubagentResults,
-  hasOnlyToolResults,
+  filterRenderableNodes,
   mergeChatAndQueuedMessages,
   omitMessagesAlreadyInChat,
 } from "./alphaMessageUtils.ts";
@@ -122,10 +121,7 @@ export const AlphaChatInterface = ({
     [effectiveChatMessages],
   );
 
-  const filteredNodes = useMemo(
-    () => messageTree.filter((node) => !hasOnlyToolResults(node.message) && !hasOnlySubagentResults(node.message)),
-    [messageTree],
-  );
+  const filteredNodes = useMemo(() => filterRenderableNodes(messageTree), [messageTree]);
 
   // Build a map from filtered index to the previous filtered node (for isNewCycle detection)
   const prevNodeMap = useMemo(() => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/alphaMessageUtils.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/alphaMessageUtils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ChatMessage } from "~/api";
 
-import { mergeChatAndQueuedMessages, omitMessagesAlreadyInChat } from "./alphaMessageUtils.ts";
+import { buildToolResultMap, mergeChatAndQueuedMessages, omitMessagesAlreadyInChat } from "./alphaMessageUtils.ts";
 
 const makeMessage = (id: string): ChatMessage =>
   ({
@@ -61,5 +61,23 @@ describe("omitMessagesAlreadyInChat", () => {
     const filtered = omitMessagesAlreadyInChat([queuedFirst, queuedSecond], [sent]);
 
     expect(filtered.map((message) => message.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("reference stability and memoization", () => {
+  // The chat view remounts on every agent switch and rebuilds its derived data
+  // from scratch. These behaviors let that rebuild reuse the prior computation
+  // when the underlying message array is unchanged (idle agent, nothing queued).
+  it("mergeChatAndQueuedMessages returns the input reference when nothing is queued", () => {
+    const messages = [makeMessage("a"), makeMessage("b")];
+    // Same reference out — this is what lets the builder caches below hit on remount.
+    expect(mergeChatAndQueuedMessages(messages, [])).toBe(messages);
+  });
+
+  it("buildToolResultMap caches by input-array reference", () => {
+    const messages = [makeMessage("a")];
+    const first = buildToolResultMap(messages);
+    expect(buildToolResultMap(messages)).toBe(first); // same reference -> cached result
+    expect(buildToolResultMap([...messages])).not.toBe(first); // new reference -> recomputed
   });
 });

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/alphaMessageUtils.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/alphaMessageUtils.ts
@@ -1,9 +1,18 @@
 import type { ChatMessage, ToolResultBlock } from "~/api";
 import { ChatMessageRole } from "~/api";
 import { isToolResultBlock } from "~/common/Guards";
-import { SUBAGENT_TOOL_NAMES } from "~/pages/workspace/utils/subagentTree.ts";
+import { SUBAGENT_TOOL_NAMES, type SubagentTreeNode } from "~/pages/workspace/utils/subagentTree.ts";
+
+// Memoize by input-array reference. On an agent switch the chat view remounts
+// and rebuilds this from scratch; when the message array keeps its reference
+// (idle agent, no queued messages — see mergeChatAndQueuedMessages), the
+// remount reuses the prior map instead of re-scanning O(history). WeakMap
+// entries are GC'd with their input array, so nothing leaks.
+const toolResultMapCache = new WeakMap<ReadonlyArray<ChatMessage>, Map<string, ToolResultBlock>>();
 
 export const buildToolResultMap = (messages: ReadonlyArray<ChatMessage>): Map<string, ToolResultBlock> => {
+  const cached = toolResultMapCache.get(messages);
+  if (cached) return cached;
   const map = new Map<string, ToolResultBlock>();
   for (const message of messages) {
     for (const block of message.content) {
@@ -12,6 +21,7 @@ export const buildToolResultMap = (messages: ReadonlyArray<ChatMessage>): Map<st
       }
     }
   }
+  toolResultMapCache.set(messages, map);
   return map;
 };
 
@@ -39,6 +49,19 @@ export const hasOnlySubagentResults = (message: ChatMessage): boolean =>
     return SUBAGENT_TOOL_NAMES.has(block.toolName);
   });
 
+// Drop tool-result-only / subagent-result-only nodes so they don't occupy a
+// virtualizer slot. Memoized by the tree reference: when buildSubagentTree
+// returns its cached tree on a remount, the filtered list is reused too.
+const filteredNodesCache = new WeakMap<Array<SubagentTreeNode>, Array<SubagentTreeNode>>();
+
+export const filterRenderableNodes = (nodes: Array<SubagentTreeNode>): Array<SubagentTreeNode> => {
+  const cached = filteredNodesCache.get(nodes);
+  if (cached) return cached;
+  const result = nodes.filter((node) => !hasOnlyToolResults(node.message) && !hasOnlySubagentResults(node.message));
+  filteredNodesCache.set(nodes, result);
+  return result;
+};
+
 // Merge the completed chat messages with the queued messages for rendering,
 // keeping each id at most once (first occurrence wins, so a completed/sent
 // message takes precedence over a queued copy of the same id).
@@ -53,6 +76,15 @@ export const mergeChatAndQueuedMessages = (
   chatMessages: ReadonlyArray<ChatMessage>,
   queuedChatMessages: ReadonlyArray<ChatMessage>,
 ): Array<ChatMessage> => {
+  // Fast path: nothing queued (the common case). Return the input as-is so its
+  // reference stays stable across renders/remounts — completedChatMessages is
+  // already deduped upstream, so there is nothing to merge. A stable reference
+  // is what lets the reference-keyed builder caches (tree / tool-result map /
+  // metadata / filtered nodes) hit on remount instead of recomputing O(history).
+  if (queuedChatMessages.length === 0) {
+    return chatMessages as Array<ChatMessage>;
+  }
+
   const seenIds = new Set<string>();
   const merged: Array<ChatMessage> = [];
   for (const message of [...chatMessages, ...queuedChatMessages]) {

--- a/sculptor/frontend/src/pages/workspace/utils/subagentTree.test.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/subagentTree.test.ts
@@ -391,3 +391,21 @@ describe("hasVisibleToolContent", () => {
     expect(hasVisibleToolContent([])).toBe(false);
   });
 });
+
+describe("buildSubagentTree / buildSubagentMetadataMap memoization", () => {
+  // Reused on every agent-switch remount; memoized by input-array reference so an
+  // unchanged message array reuses the prior tree/map instead of rebuilding it.
+  it("buildSubagentTree caches by input-array reference", () => {
+    const messages = [makeMessage("a", [])];
+    const first = buildSubagentTree(messages);
+    expect(buildSubagentTree(messages)).toBe(first); // same reference -> cached tree
+    expect(buildSubagentTree([...messages])).not.toBe(first); // new reference -> rebuilt
+  });
+
+  it("buildSubagentMetadataMap caches by input-array reference", () => {
+    const messages = [makeMessage("a", [])];
+    const first = buildSubagentMetadataMap(messages);
+    expect(buildSubagentMetadataMap(messages)).toBe(first);
+    expect(buildSubagentMetadataMap([...messages])).not.toBe(first);
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/utils/subagentTree.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/subagentTree.ts
@@ -39,7 +39,23 @@ export const getToolUseId = (block: ChatMessage["content"][number]): string | un
  *
  * Supports multi-level nesting (subagents spawning sub-subagents).
  */
+// Memoize the derived tree by its input-array reference. AlphaChatInterface
+// rebuilds this on every mount; when an agent is switched away and back, the
+// message array keeps its reference (for an idle agent with no queued messages
+// it comes straight from the task-detail atom), so a remount reuses the prior
+// tree instead of rebuilding it O(history). WeakMap entries are GC'd with their
+// input array, so nothing leaks and stale data can never be returned.
+const subagentTreeCache = new WeakMap<ReadonlyArray<ChatMessage>, Array<SubagentTreeNode>>();
+
 export const buildSubagentTree = (messages: ReadonlyArray<ChatMessage>): Array<SubagentTreeNode> => {
+  const cached = subagentTreeCache.get(messages);
+  if (cached) return cached;
+  const result = buildSubagentTreeUncached(messages);
+  subagentTreeCache.set(messages, result);
+  return result;
+};
+
+const buildSubagentTreeUncached = (messages: ReadonlyArray<ChatMessage>): Array<SubagentTreeNode> => {
   const topLevel: Array<SubagentTreeNode> = [];
 
   // Group child messages by their parentToolUseId
@@ -162,7 +178,18 @@ type MetadataBuilderMessage = {
  * it and instead derive responseText + durationSeconds from the subagent's own child
  * messages (parentToolUseId === the Agent's tool_use id).
  */
+// Memoized by input-array reference for the same reason as buildSubagentTree.
+const subagentMetadataCache = new WeakMap<Array<MetadataBuilderMessage>, Map<string, SubagentMetadata>>();
+
 export const buildSubagentMetadataMap = (messages: Array<MetadataBuilderMessage>): Map<string, SubagentMetadata> => {
+  const cached = subagentMetadataCache.get(messages);
+  if (cached) return cached;
+  const result = buildSubagentMetadataMapUncached(messages);
+  subagentMetadataCache.set(messages, result);
+  return result;
+};
+
+const buildSubagentMetadataMapUncached = (messages: Array<MetadataBuilderMessage>): Map<string, SubagentMetadata> => {
   const map = new Map<string, SubagentMetadata>();
   // toolUseId → creation time of the message that contained the Agent tool_use.
   // Used to compute background subagent run time from the subagent's reply time.


### PR DESCRIPTION
## Summary

Two chat-surface performance improvements, one commit each. Both were developed and validated on a long-running staging branch and are ported here onto current `main` (preserving the section-shell panel model — the panel-supplied `taskId`/`workspaceId` plumbing and desktop toolbar are untouched).

### 1. Reuse derived chat data across chat remounts

Mounting a chat rebuilds the message tree, tool-result map, subagent metadata map, and the renderable-node filter from scratch — O(history) work that repeats on every agent switch even when the message array is unchanged.

- Memoize the four builders by input-array reference (WeakMap: entries are GC'd with their input array, and a hit can never be stale since message arrays are never mutated in place).
- `mergeChatAndQueuedMessages` returns its input by reference when nothing is queued (the common idle case) — the stable reference is what lets the caches hit across remounts.
- `AlphaChatInterface`'s inline node filter moves into the shared `filterRenderableNodes` so it participates in the same reference-keyed reuse.

### 2. Stop re-rendering ChatInput on every keystroke

ChatInput subscribed to the per-task prompt-draft atom, so each keystroke re-rendered the whole composer (toolbar, capability gates, selectors) — none of which depends on the draft text, only on whether a sendable/bypass draft exists.

- ChatInput now writes the draft atom without subscribing (`useSetAtom` + store reads); the send button tracks a small `DraftFlags` state that only changes on empty↔non-empty / bypass-command flips.
- The editor becomes uncontrolled after mount (stable initial value). External draft writes (e.g. QueuedMessages restoring a draft) reach it via an explicit store subscription that ignores the editor's own emits; send/append paths read the live editor through `getDraft()`.
- `ModelSelector` / `EffortSelector` are memo'd so they bail out of ChatInput's remaining re-renders (their props are atom-backed values + stable callbacks).

## Testing

- `tsc`, `eslint`, and the full frontend unit suite (2809 tests) pass; includes 4 new unit tests covering the reference-stability contract (merge fast path + builder caches).
- Behavior spot-checks exercised on the staging deployment: send/clear-on-send, draft persistence across task switches and blur, QueuedMessages draft restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)