### PR TITLE
tooling: containerized-Chromium fix, iPhone-sim QA skill, portable openhost config

### DIFF
--- a/.claude/skills/auto-qa-iphone/SKILL.md
+++ b/.claude/skills/auto-qa-iphone/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: auto-qa-iphone
+description: |
+  QA the Sculptor mobile web UI on a real iOS Simulator, driven headlessly from
+  a Mac. A single CLI boots a notched iPhone, launches the local frontend server
+  (parsing its port — no hardcoding), opens the app in MobileSafari, taps/swipes
+  via idb, and screenshots each step. Includes the Add-to-Home-Screen standalone
+  flow — the only way to verify notch / status-bar / home-indicator safe-area
+  rendering (env(safe-area-inset-*) is 0 everywhere except real iOS). Use when
+  visually verifying mobile/responsive changes on an iPhone.
+argument-hint: "[url-or-port (optional; defaults to launching `just frontend-custom`)]"
+---
+
+# iPhone Simulator QA (Simulator + idb)
+
+This is the iPhone sibling of `/auto-qa-changes`. Instead of a headless Chromium
+at desktop size, it drives a real **iOS Simulator** so you can see how the mobile
+web UI actually renders on a notched iPhone — including the **standalone PWA**
+chrome (the app sets `apple-mobile-web-app-capable`, `viewport-fit=cover`, and a
+`black-translucent` status bar in `sculptor/frontend/index.html`).
+
+Why a real simulator and not Playwright: `env(safe-area-inset-*)` — the insets
+the mobile shell uses for the notch/Dynamic Island, status bar, and home
+indicator — are **0 everywhere except a real iOS surface**. Desktop browsers,
+Playwright, and the `/auto-qa-changes` Chromium harness all report 0. The only
+faithful check is Add-to-Home-Screen + a standalone launch on a notched device.
+
+Everything is driven through one CLI:
+
+```
+.claude/skills/auto-qa-iphone/scripts/iphone_sim.py
+```
+
+Stdlib-only Python (no `uv`/venv needed to run it); it shells out to
+`xcrun simctl`, `idb`, and `just`.
+
+## Prerequisites (one-time, slow)
+
+- **macOS + Xcode** with an **iOS Simulator runtime**. `setup` checks for one and,
+  if missing, prints the (~9 GB) download command `xcodebuild -downloadPlatform iOS`
+  — it will not download automatically unless you pass `--download-runtime`.
+- **Homebrew** + **idb** (drives taps/swipes the simulator CLI can't). `setup`
+  creates an idb venv at `~/.cache/sculptor-iphone-qa/idb-venv` and
+  `brew install idb-companion` for you.
+- A working frontend dev env (`just rebuild` once if this is a fresh checkout),
+  since the default server command is `just frontend-custom`.
+
+## Quick start
+
+Set a short alias and a screenshots dir (defaults to the workspace
+`attachments/`, so images render in chat and survive for MR reuse):
+
+```bash
+SIM=".claude/skills/auto-qa-iphone/scripts/iphone_sim.py"
+```
+
+### Step 1: Boot the device (idempotent)
+
+```bash
+python3 "$SIM" setup            # default device: iphone-16-pro (notched)
+# Other presets: --device iphone-16-pro-max | iphone-se (non-notched control)
+```
+
+This creates/reuses a `SculptorQA-<preset>` simulator, boots it, connects idb,
+and prints the UDID. Re-running is safe (it reuses the device). To watch it
+live: `open -a Simulator`.
+
+### Step 2: Open the app
+
+Have your dev server running first (e.g. `just frontend-custom` or `just start`
+in your own terminal — it works reliably there). Then:
+
+```bash
+python3 "$SIM" open
+```
+
+How `open`/`serve` resolve the URL (no port is ever hardcoded — the dev port is
+hashed per checkout):
+
+1. `--url URL` / `--port N` — attach to exactly that server.
+2. Otherwise **auto-detect**: probe listening ports for a running Sculptor SPA
+   and attach to it (a vite **dev** server is preferred over a packaged/production
+   `app` build; it warns when it could only find the latter). This is the normal,
+   reliable path.
+3. If nothing is found, **fall back to launching** `--command` (default
+   `just frontend-custom`), parse its port from the log, and verify it actually
+   serves before using it.
+
+The simulator shares the host network, so `http://127.0.0.1:<port>` is reachable.
+
+> **Launching from inside a Sculptor agent is flaky.** `just frontend-custom`
+> drives Electron, which (a) races to load its renderer before vite is ready and
+> dies under `--unhandled-rejections=strict`, (b) refuses a second instance via
+> the `.dev_sculptor` single-instance lock, and (c) inherits a leaked
+> `SCULPTOR_API_PORT` from the surrounding session. **Prefer keeping your own dev
+> server running and letting `open` auto-detect it** (or pass `--port`/`--url`).
+> Use `--launch` to force the fallback launch anyway.
+
+Every action prints a `screenshot:` path **and an `<img>` tag** — paste the tag
+into chat to show the user (see "Context management").
+
+### Step 3: Drive the UI and narrate (see protocol below)
+
+```bash
+python3 "$SIM" screenshot --label home          # capture current screen
+python3 "$SIM" tap --frac 0.5 0.93              # tap by screen fraction (0..1)
+python3 "$SIM" swipe 201 620 201 320            # swipe by points
+python3 "$SIM" describe                          # a11y tree of the foreground app
+```
+
+### Step 4: Verify safe areas via Add-to-Home-Screen (the important part)
+
+Safari always shows its own chrome, so the standalone status bar and true
+safe-area insets only appear after adding to the home screen and launching.
+
+First, make sure Safari's bottom toolbar is visible: if the page auto-focused an
+input, the on-screen keyboard hides the toolbar (and the Share button). Dismiss
+it by tapping an empty area, then screenshot to confirm the toolbar is back:
+
+```bash
+python3 "$SIM" tap --frac 0.5 0.42              # tap empty space to blur the input
+```
+
+Then drive the flow (it screenshots after **every** tap because SpringBoard and
+the share sheet aren't in the accessibility tree, so they can't be located):
+
+```bash
+python3 "$SIM" add-to-home-screen               # Share -> swipe -> Add to Home Screen -> Add
+```
+
+Verify each screenshot matches the expected step before trusting the next. Then
+launch the clip. **The icon's position is not fixed**, so locate it first and tap
+its **artwork center** (the text label sits ~40 pt below the artwork — aim at the
+glyph, not the label) via a describe-screenshot subagent, then:
+
+```bash
+python3 "$SIM" screenshot --label home          # capture the home screen
+# (locate the Sculptor icon ARTWORK center as a fraction, then:)
+python3 "$SIM" launch-icon --frac 0.39 0.26 --settle 6
+```
+
+If the home screen is still showing afterward, the tap missed the artwork —
+re-locate and tap again.
+
+### Step 5: Clean up
+
+```bash
+python3 "$SIM" teardown        # stops the managed server + shuts the sim down
+# python3 "$SIM" teardown --delete   # also delete the simulator device
+```
+
+## Available commands
+
+| Command | What it does |
+|---|---|
+| `setup [--device P] [--download-runtime]` | Ensure runtime + idb; create/boot `SculptorQA-<P>`; connect idb; print UDID. |
+| `detect` | List running Sculptor servers (tagged `dev`/`app`) and show which one `open` would attach to. |
+| `serve [--port N \| --url U \| --command C \| --launch]` | Resolve a server URL: attach to `--port`/`--url`, else auto-detect a running one, else launch `--command`. |
+| `open [--port N \| --url U \| --command C \| --launch]` | Same URL resolution as `serve`, then `simctl openurl` → screenshot. |
+| `screenshot [--label NAME]` | Capture the current screen to a numbered PNG. |
+| `tap X Y [--frac]` | `idb ui tap`. `--frac` treats X/Y as 0..1 fractions of the screen. Auto-screenshots. |
+| `swipe X1 Y1 X2 Y2 [--frac] [--duration S]` | `idb ui swipe`. Auto-screenshots. |
+| `describe` | `idb ui describe-all` — JSON a11y tree (foreground app only). |
+| `add-to-home-screen` | Drive the AHS flow with a screenshot after each tap. |
+| `launch-icon [X Y] [--frac]` | Tap the home-screen clip to launch standalone; screenshot. |
+| `remove-home-screen` | Guidance for removing the clip (iOS caches launch config at add-time). |
+| `teardown [--delete]` | Stop the managed server; shut down (and optionally delete) the device. |
+| `status` | Print the device/server/idb state (JSON). |
+
+Shared options (after any subcommand): `--screenshots-dir PATH`, `--settle SECONDS`.
+State (UDID, point size, server pid/url, screenshot counter) persists to
+`<screenshots-dir>/.iphone-sim-state.json`, so commands chain without re-passing
+the UDID.
+
+## Context management: never Read screenshots directly
+
+Simulator screenshots are native-scale PNGs (iPhone 16 Pro is 3× → ~1206×2622),
+each large. **Never call the Read tool on a screenshot yourself** — a few will
+blow out your context. Same three rules as `/auto-qa-changes`:
+
+1. **Display to the user via the `<img>` tag** the CLI prints. This is free for
+   your context — it renders on the user's side; no image data enters yours.
+2. **Verify state programmatically when you can.** `describe` (a11y tree),
+   `status`, and the success/failure of each command tell you a lot without
+   pixel inspection.
+3. **When you genuinely need visual inspection** (alignment, what text appeared,
+   whether the status bar overlaps content), **delegate to a subagent** with a
+   narrow question:
+
+   ```
+   Agent(description="Describe screenshot",
+         prompt="Read /abs/path/0007_standalone.png. Focus on the top of the
+                 screen: does any header content sit UNDER the status bar / notch,
+                 or is there correct safe-area padding above it? 2-3 sentences.")
+   ```
+
+   The image stays in the subagent's context and is discarded when it returns.
+
+## Narrated visual walkthrough protocol
+
+Same as `/auto-qa-changes`. **Every screenshot you take, you MUST:**
+
+1. **Display it** with the `<img>` tag (absolute `src`, descriptive `alt`).
+2. **Describe what you see** — inferred from `describe`/`status`, or via a
+   describe-screenshot subagent. Do not Read the PNG yourself.
+3. **Call out issues** — note the safe areas especially: content under the notch,
+   a chat input hidden behind the home indicator, clipped headers.
+4. **Announce the next action.**
+
+Format each step:
+
+```
+<img src="/abs/path/attachments/iphone-screenshots/0002_open.png" alt="Mobile workspace shell, Safari">
+
+**Step 2: Mobile shell in Safari**
+Single-column layout: header, chat stream, floating input, agent pager at the
+bottom. Safari's own toolbar is visible (expected — standalone chrome only shows
+after Add-to-Home-Screen). No obvious layout issues.
+
+**Next:** add to home screen and launch standalone to check the real status bar.
+```
+
+## Driving taps without an accessibility tree
+
+- **Coordinates are points, not pixels.** iPhone 16 Pro is **402×874 pt**;
+  screenshots come out at 3× (1206×2622 px). `idb` wants points.
+- **Prefer `--frac`.** Spot the target in a screenshot, express it as a fraction
+  of the image (e.g. a button 90% down the screen → `--frac 0.5 0.9`), and the
+  CLI multiplies by the device's point size. This is robust across devices.
+- **WebView elements** (inside MobileSafari) appear in `describe`; **SpringBoard,
+  the share sheet, and the home screen do not** — drive those by coordinate and
+  verify with the screenshot after every tap.
+
+## Gotchas
+
+- **The standalone status bar only appears via the home-screen launch**, never in
+  Safari (Safari always shows its own chrome). You MUST go through
+  `add-to-home-screen` + `launch-icon` to exercise `apple-mobile-web-app-status-bar-style`
+  and the real safe-area insets.
+- **iOS caches the launch config at add-time.** After changing `index.html`'s
+  `<head>` (meta tags, theme-color, icon), **remove and re-add** the clip —
+  reloading isn't enough. See `remove-home-screen`.
+- **AHS coordinates are empirical and only ship for iPhone 16 Pro.** They can
+  drift across iOS versions; the flow screenshots between steps so you can catch
+  drift and re-derive with `tap --frac`. For other presets, drive AHS manually.
+- **`env(safe-area-inset-*)` is 0 on non-notched devices** — `--device iphone-se`
+  is a deliberate "insets ≈ 0" control, not a notch test.
+- **Hot reload works in Safari**, since `just frontend-custom` runs the vite dev
+  server: edit a `.tsx`/`.scss` and re-`screenshot` to see it. But a **standalone
+  (home-screen) clip does not pick up `<head>` changes** without a remove/re-add.
+- **The simulator shares the host network**, so `http://127.0.0.1:<port>` works
+  (unlike a physical device). No tunneling needed.
+- **The server runs detached** (own process group) and survives across turns;
+  `teardown` stops it. `status` shows whether it's alive.
+
+## Cleanup
+
+`teardown` stops the managed server and shuts the simulator down (keeping the
+device for next time; `--delete` removes it).
+
+**NEVER delete screenshot files** — they're referenced by `<img>` tags in the
+user's chat history and may be attached to MRs. Leave them in the screenshots dir.

--- a/.claude/skills/auto-qa-iphone/scripts/.gitignore
+++ b/.claude/skills/auto-qa-iphone/scripts/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.claude/skills/auto-qa-iphone/scripts/devices.py
+++ b/.claude/skills/auto-qa-iphone/scripts/devices.py
@@ -16,7 +16,6 @@ after every tap when the iOS version or layout changes.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Tuple
 
 
 @dataclass(frozen=True)
@@ -25,17 +24,17 @@ class DevicePreset:
     # Exact device-type name accepted by `xcrun simctl create`.
     sim_name: str
     # (width, height) in logical points.
-    points: Tuple[int, int]
+    points: tuple[int, int]
     # True if the device has a notch / Dynamic Island + home indicator, so
     # env(safe-area-inset-*) are non-zero. Non-notched devices are a useful
     # "insets ~= 0" control.
     notched: bool
     # Reference tap/swipe coordinates (in points) for the Add-to-Home-Screen
     # flow. Empty when not yet measured for this device.
-    ahs: Dict[str, Tuple[int, int]] = field(default_factory=dict)
+    ahs: dict[str, tuple[int, int]] = field(default_factory=dict)
 
 
-PRESETS: Dict[str, DevicePreset] = {
+PRESETS: dict[str, DevicePreset] = {
     "iphone-16-pro": DevicePreset(
         key="iphone-16-pro",
         sim_name="iPhone 16 Pro",

--- a/.claude/skills/auto-qa-iphone/scripts/devices.py
+++ b/.claude/skills/auto-qa-iphone/scripts/devices.py
@@ -1,0 +1,84 @@
+"""Simulator device presets for the iPhone QA loop.
+
+`idb ui tap`/`swipe` take coordinates in **logical points**, not pixels.
+Screenshots come out at the device's native scale (2x or 3x), so to turn a
+target you spotted in a screenshot into a tap, express it as a fraction of the
+image and multiply by the point dimensions here (this is what
+`iphone_sim.py tap --frac FX FY` does).
+
+The Add-to-Home-Screen (AHS) reference coordinates are empirical: SpringBoard
+and the share sheet are NOT in the accessibility tree, so they cannot be
+located by selector. The values below were derived for MobileSafari on iOS
+18.x at the device's point size and MUST be re-verified with a screenshot
+after every tap when the iOS version or layout changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class DevicePreset:
+    key: str
+    # Exact device-type name accepted by `xcrun simctl create`.
+    sim_name: str
+    # (width, height) in logical points.
+    points: Tuple[int, int]
+    # True if the device has a notch / Dynamic Island + home indicator, so
+    # env(safe-area-inset-*) are non-zero. Non-notched devices are a useful
+    # "insets ~= 0" control.
+    notched: bool
+    # Reference tap/swipe coordinates (in points) for the Add-to-Home-Screen
+    # flow. Empty when not yet measured for this device.
+    ahs: Dict[str, Tuple[int, int]] = field(default_factory=dict)
+
+
+PRESETS: Dict[str, DevicePreset] = {
+    "iphone-16-pro": DevicePreset(
+        key="iphone-16-pro",
+        sim_name="iPhone 16 Pro",
+        points=(402, 874),
+        notched=True,
+        ahs={
+            # Bottom toolbar Share button.
+            "share_button": (201, 818),
+            # Swipe the share sheet up to reveal the action list.
+            "sheet_swipe_from": (201, 620),
+            "sheet_swipe_to": (201, 320),
+            # "Add to Home Screen" row in the action list.
+            "add_to_home_screen": (202, 607),
+            # "Add" (top-right of the confirmation dialog).
+            "add_confirm": (382, 96),
+            # First free home-screen slot — tapping it launches the standalone
+            # web clip. Position depends on how many icons already exist.
+            "launch_icon": (148, 232),
+        },
+    ),
+    "iphone-16-pro-max": DevicePreset(
+        key="iphone-16-pro-max",
+        sim_name="iPhone 16 Pro Max",
+        points=(440, 956),
+        notched=True,
+        # AHS coords differ at this size — drive manually with `tap --frac`.
+        ahs={},
+    ),
+    "iphone-se": DevicePreset(
+        key="iphone-se",
+        sim_name="iPhone SE (3rd generation)",
+        points=(375, 667),
+        notched=False,  # safe-area insets ~= 0 — control device.
+        ahs={},
+    ),
+}
+
+DEFAULT_PRESET = "iphone-16-pro"
+
+
+def get_preset(key: str) -> DevicePreset:
+    try:
+        return PRESETS[key]
+    except KeyError:
+        valid = ", ".join(sorted(PRESETS))
+        raise SystemExit(f"Unknown device preset {key!r}. Choose one of: {valid}")

--- a/.claude/skills/auto-qa-iphone/scripts/iphone_sim.py
+++ b/.claude/skills/auto-qa-iphone/scripts/iphone_sim.py
@@ -1,0 +1,821 @@
+#!/usr/bin/env python3
+"""Drive an iOS Simulator + idb to QA the Sculptor mobile web UI headlessly.
+
+A single CLI an agent can drive step by step. It wraps `xcrun simctl` (boot a
+notched device, open URLs, screenshot) and `idb` (taps/swipes the simulator CLI
+can't do), and it can launch + manage the local frontend server itself, parsing
+the port out of its output (no hardcoded port).
+
+Subcommands:
+  setup               Ensure an iOS runtime + idb, then create/boot the device.
+  detect              List running Sculptor servers + which one `open` would use.
+  serve               Resolve a server URL (attach to a running one, else launch).
+  open                Resolve a server URL as above, then open it in MobileSafari.
+  screenshot          Capture the current screen to a numbered PNG.
+  tap X Y             Tap a point (or --frac FX FY for a screenshot fraction).
+  swipe X1 Y1 X2 Y2   Swipe between two points (--frac to use fractions).
+  describe            Dump the foreground app's accessibility tree (JSON).
+  add-to-home-screen  Drive the Add-to-Home-Screen flow (screenshot per step).
+  launch-icon X Y     Tap the home-screen clip to launch the app standalone.
+  remove-home-screen  Guidance for removing the clip (iOS caches launch config).
+  teardown            Shut the simulator down and stop the managed server.
+  status              Print the current device/server state.
+
+URL resolution for `serve`/`open`: --url/--port > auto-detect a running Sculptor
+dev server > launch --command (override with --launch). No port is hardcoded.
+
+State (UDID, points, server pid/url, screenshot counter) is persisted to
+<screenshots-dir>/.iphone-sim-state.json so subcommands chain without
+re-passing the UDID. Stdlib only; shells out to xcrun/idb/just.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from devices import DEFAULT_PRESET, PRESETS, get_preset  # noqa: E402
+
+STATE_FILENAME = ".iphone-sim-state.json"
+SERVER_LOG = "frontend-server.log"
+DEFAULT_COMMAND = "just frontend-custom"
+DEFAULT_IDB_VENV = Path.home() / ".cache" / "sculptor-iphone-qa" / "idb-venv"
+# Homebrew bin dirs so the idb python client can find `idb_companion`.
+BREW_BINS = ["/opt/homebrew/bin", "/usr/local/bin"]
+
+# Port-parsing patterns, in priority order. The first two are frontend-specific
+# (so they never match the backend URL the custom-command path also prints).
+PORT_PATTERNS = [
+    re.compile(r"SCULPTOR_FRONTEND_PORT=(\d+)"),
+    re.compile(r"Local:\s+https?://[\d.]+:(\d+)"),
+]
+
+
+# --------------------------------------------------------------------------- #
+# small helpers
+# --------------------------------------------------------------------------- #
+def eprint(*a: object) -> None:
+    print(*a, file=sys.stderr)
+
+
+def repo_root() -> Path:
+    """Repo root: ask git, falling back to the skill's known location."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # scripts/ -> auto-qa-iphone -> skills -> .claude -> <repo root>
+        return Path(__file__).resolve().parents[4]
+
+
+def default_screenshots_dir() -> Path:
+    """Prefer the Sculptor workspace attachments dir; else a repo-local dir."""
+    env = os.environ.get("SCULPTOR_IPHONE_QA_DIR")
+    if env:
+        return Path(env).expanduser()
+    attachments = repo_root().parent / "attachments"
+    if attachments.is_dir():
+        return attachments / "iphone-screenshots"
+    return repo_root() / ".iphone-qa" / "screenshots"
+
+
+def child_env() -> Dict[str, str]:
+    env = dict(os.environ)
+    extra = [p for p in BREW_BINS if Path(p).is_dir()]
+    if extra:
+        env["PATH"] = os.pathsep.join(extra + [env.get("PATH", "")])
+    return env
+
+
+def run(cmd: Sequence[str], check: bool = True, quiet: bool = False) -> subprocess.CompletedProcess:
+    if not quiet:
+        eprint("$", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, check=check, env=child_env())
+
+
+def simctl(*args: str, check: bool = True, quiet: bool = False) -> subprocess.CompletedProcess:
+    return run(["xcrun", "simctl", *args], check=check, quiet=quiet)
+
+
+def have(binary: str) -> bool:
+    return shutil.which(binary, path=os.pathsep.join(BREW_BINS + [os.environ.get("PATH", "")])) is not None
+
+
+def port_open(port: int, host: str = "127.0.0.1", timeout: float = 1.0) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        return s.connect_ex((host, port)) == 0
+
+
+def http_ready(url: str, timeout: float = 2.0) -> bool:
+    """True if the URL serves an HTTP response (any status counts as 'up')."""
+    try:
+        urllib.request.urlopen(url, timeout=timeout)
+        return True
+    except urllib.error.HTTPError:
+        return True  # responded with 4xx/5xx — still a live server
+    except Exception:
+        return False  # connection refused / timeout — not serving
+
+
+# --------------------------------------------------------------------------- #
+# state
+# --------------------------------------------------------------------------- #
+class State:
+    def __init__(self, screenshots_dir: Path):
+        self.dir = screenshots_dir
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.dir / STATE_FILENAME
+        self.data: Dict[str, object] = {}
+        if self.path.exists():
+            self.data = json.loads(self.path.read_text())
+
+    def save(self) -> None:
+        self.path.write_text(json.dumps(self.data, indent=2))
+
+    def get(self, key: str, default: object = None) -> object:
+        return self.data.get(key, default)
+
+    def require_udid(self) -> str:
+        udid = self.data.get("udid")
+        if not udid:
+            raise SystemExit("No device set up. Run `iphone_sim.py setup` first.")
+        return str(udid)
+
+    def points(self) -> Sequence[int]:
+        pts = self.data.get("points")
+        if not pts:
+            raise SystemExit("No device points in state. Run `setup` first.")
+        return pts  # type: ignore[return-value]
+
+    def next_counter(self) -> int:
+        n = int(self.data.get("counter", 0)) + 1
+        self.data["counter"] = n
+        self.save()
+        return n
+
+
+def state_for(args: argparse.Namespace) -> State:
+    return State(Path(args.screenshots_dir).expanduser())
+
+
+# --------------------------------------------------------------------------- #
+# idb
+# --------------------------------------------------------------------------- #
+def idb_bin(state: State) -> Optional[str]:
+    venv = state.data.get("idb_venv")
+    if not venv:
+        return None
+    candidate = Path(str(venv)) / "bin" / "idb"
+    return str(candidate) if candidate.exists() else None
+
+
+def idb(state: State, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    binary = idb_bin(state)
+    if not binary:
+        raise SystemExit(
+            "idb is not installed. Re-run `iphone_sim.py setup` (it creates the "
+            "idb venv and installs idb_companion)."
+        )
+    return run([binary, *args], check=check)
+
+
+# --------------------------------------------------------------------------- #
+# screenshots
+# --------------------------------------------------------------------------- #
+def take_screenshot(state: State, label: str) -> Path:
+    udid = state.require_udid()
+    n = state.next_counter()
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", label).strip("_") or "shot"
+    out = state.dir / f"{n:04d}_{safe}.png"
+    simctl("io", udid, "screenshot", str(out), quiet=True)
+    return out
+
+
+def report_shot(path: Path) -> None:
+    print(f"screenshot: {path}")
+    print(f'<img src="{path}" alt="iphone-sim {path.name}">')
+
+
+# --------------------------------------------------------------------------- #
+# server lifecycle
+# --------------------------------------------------------------------------- #
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def server_alive(state: State) -> bool:
+    server = state.data.get("server")
+    if not isinstance(server, dict):
+        return False
+    pid = server.get("pid")
+    return bool(pid) and _pid_alive(int(pid))
+
+
+def stop_server(state: State) -> None:
+    server = state.data.get("server")
+    if not isinstance(server, dict):
+        return
+    pgid = server.get("pgid")
+    pid = server.get("pid")
+    killed = False
+    if pgid:
+        try:
+            os.killpg(int(pgid), signal.SIGTERM)
+            killed = True
+        except OSError:
+            pass
+    if not killed and pid and _pid_alive(int(pid)):
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except OSError:
+            pass
+    eprint(f"Stopped frontend server (pid={pid}).")
+    state.data["server"] = None
+    state.save()
+
+
+def parse_port(line: str) -> Optional[int]:
+    for pat in PORT_PATTERNS:
+        m = pat.search(line)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def ensure_server(state: State, command: str, timeout: float) -> str:
+    """Launch `command` detached, parse its frontend URL, and keep it alive."""
+    if server_alive(state):
+        server = state.data["server"]  # type: ignore[index]
+        url = server.get("url")
+        if url:
+            eprint(f"Reusing running server: {url}")
+            return str(url)
+
+    log_path = state.dir / SERVER_LOG
+    log = open(log_path, "w")
+    eprint(f"$ ({command})  [detached, logging to {log_path}]")
+    proc = subprocess.Popen(
+        command,
+        shell=True,
+        cwd=str(repo_root()),
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,  # own process group so teardown can kill the tree
+        env=child_env(),
+    )
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:
+        pgid = proc.pid
+    state.data["server"] = {"pid": proc.pid, "pgid": pgid, "command": command, "url": None}
+    state.save()
+
+    # Tail the log until the frontend URL appears.
+    deadline = time.time() + timeout
+    port: Optional[int] = None
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            tail = "\n".join(log_path.read_text().splitlines()[-25:])
+            raise SystemExit(f"Server command exited early.\n--- {SERVER_LOG} (tail) ---\n{tail}")
+        for line in log_path.read_text().splitlines():
+            port = parse_port(line)
+            if port:
+                break
+        if port:
+            break
+        time.sleep(1)
+    if not port:
+        tail = "\n".join(log_path.read_text().splitlines()[-25:])
+        raise SystemExit(
+            f"Timed out after {timeout:.0f}s waiting for the frontend port.\n"
+            f"--- {SERVER_LOG} (tail) ---\n{tail}"
+        )
+
+    # Confirm the parsed port actually SERVES — not just that we saw it logged.
+    # (electron-forge, for one, prints a port its renderer may never bind, and a
+    # blind TCP check can also pass on a stale listener.) Fail loudly otherwise.
+    url = f"http://127.0.0.1:{port}"
+    ready = False
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            tail = "\n".join(log_path.read_text().splitlines()[-25:])
+            raise SystemExit(f"Server command exited early.\n--- {SERVER_LOG} (tail) ---\n{tail}")
+        if http_ready(url):
+            ready = True
+            break
+        time.sleep(1)
+    if not ready:
+        tail = "\n".join(log_path.read_text().splitlines()[-25:])
+        raise SystemExit(
+            f"Parsed port {port} from the server output, but {url} never served a "
+            f"response within {timeout:.0f}s.\n"
+            "If a Sculptor instance is already running, attach to it instead of "
+            "launching a new one:  open --port <port>  (or --url <url>).\n"
+            f"--- {SERVER_LOG} (tail) ---\n{tail}"
+        )
+
+    state.data["server"]["url"] = url  # type: ignore[index]
+    state.save()
+    eprint(f"Frontend server ready: {url} (pid={proc.pid})")
+    return url
+
+
+# --------------------------------------------------------------------------- #
+# auto-detect an already-running Sculptor server
+# --------------------------------------------------------------------------- #
+SPA_MARKERS = ("<title>Sculptor", "apple-mobile-web-app-title", 'id="root"')
+
+
+def _listening_ports() -> Dict[int, str]:
+    """Map of listening TCP port -> owning process command (via lsof)."""
+    try:
+        out = run(["lsof", "-nP", "-iTCP", "-sTCP:LISTEN"], check=False, quiet=True).stdout
+    except FileNotFoundError:
+        return {}
+    ports: Dict[int, str] = {}
+    for line in out.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        # The NAME column is an addr:port token (e.g. 127.0.0.1:5173, *:8080,
+        # [::1]:5173), possibly followed by a (LISTEN) state token — scan for it.
+        for tok in parts[1:]:
+            m = re.match(r"^[\w.*\[\]:%-]+:(\d+)$", tok)
+            if m:
+                ports.setdefault(int(m.group(1)), parts[0])
+                break
+    return ports
+
+
+def _fetch(url: str, timeout: float = 1.5):
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status, r.read(16384).decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, ""
+    except Exception:
+        return None, ""
+
+
+def find_running_server():
+    """Probe listening ports for a Sculptor SPA. Returns (port, kind) or None.
+
+    kind is 'dev' (a vite dev server — what you want for branch QA) or 'app'
+    (a packaged/production build). Dev servers are preferred.
+    """
+    ports = _listening_ports()
+    interesting = re.compile(r"(node|vite|sculptor|electron|python|uv)", re.I)
+    candidates = [p for p, c in sorted(ports.items()) if interesting.search(c)]
+    for extra in (5173, 5174):
+        if extra not in candidates:
+            candidates.append(extra)
+    fallback = None
+    for port in candidates:
+        status, body = _fetch(f"http://127.0.0.1:{port}")
+        if status is None or not any(mk in body for mk in SPA_MARKERS):
+            continue
+        is_dev = "/@vite/client" in body or "/src/" in body or "/@react-refresh" in body
+        if is_dev:
+            return (port, "dev")
+        fallback = fallback or (port, "app")
+    return fallback
+
+
+def resolve_url(state: State, args: argparse.Namespace) -> str:
+    if getattr(args, "url", None):
+        return str(args.url)
+    if getattr(args, "port", None):
+        return f"http://127.0.0.1:{args.port}"
+    if not getattr(args, "launch", False):
+        found = find_running_server()
+        if found:
+            port, kind = found
+            eprint(f"Attached to a running Sculptor server on port {port} ({kind} build).")
+            if kind == "app":
+                eprint("  NOTE: that looks like a packaged/production build, not a vite dev "
+                       "server — start your branch's dev server to QA your changes, or pass "
+                       "--port/--url explicitly.")
+            return f"http://127.0.0.1:{port}"
+        eprint("No running Sculptor server detected; launching the fallback command "
+               f"({args.command!r}).")
+        eprint("  (Launching from inside a Sculptor agent can be flaky — if it fails, start "
+               "your dev server yourself and re-run, or pass --port/--url.)")
+    return ensure_server(state, args.command, args.server_timeout)
+
+
+# --------------------------------------------------------------------------- #
+# subcommands
+# --------------------------------------------------------------------------- #
+def first_ios_runtime(download: bool) -> str:
+    out = simctl("list", "runtimes", "--json", quiet=True).stdout
+    runtimes = json.loads(out).get("runtimes", [])
+    ios = [r for r in runtimes if r.get("isAvailable") and "iOS" in r.get("name", "")]
+    if ios:
+        # Prefer the newest by version string.
+        ios.sort(key=lambda r: r.get("version", ""), reverse=True)
+        return str(ios[0]["identifier"])
+    if download:
+        eprint("No iOS runtime found — downloading (this is large and slow)...")
+        run(["xcodebuild", "-downloadPlatform", "iOS"])
+        return first_ios_runtime(download=False)
+    raise SystemExit(
+        "No iOS simulator runtime is installed.\n"
+        "Install one (≈9 GB, slow) with:\n"
+        "    xcodebuild -downloadPlatform iOS\n"
+        "or re-run setup with --download-runtime to do it automatically."
+    )
+
+
+def ensure_idb(venv: Path) -> None:
+    idb_exe = venv / "bin" / "idb"
+    if not idb_exe.exists():
+        eprint(f"Creating idb venv at {venv} ...")
+        venv.parent.mkdir(parents=True, exist_ok=True)
+        run([sys.executable, "-m", "venv", str(venv)])
+        run([str(venv / "bin" / "pip"), "install", "--quiet", "--upgrade", "pip"])
+        run([str(venv / "bin" / "pip"), "install", "--quiet", "fb-idb"])
+    if not have("idb_companion"):
+        if have("brew"):
+            eprint("Installing idb_companion via Homebrew ...")
+            run(["brew", "install", "idb-companion"], check=False)
+        if not have("idb_companion"):
+            eprint(
+                "WARNING: idb_companion is not on PATH. Taps/swipes will not work "
+                "until you `brew install idb-companion`. Screenshots and openurl "
+                "still work via simctl."
+            )
+
+
+def find_device(name: str) -> Optional[dict]:
+    out = simctl("list", "devices", "--json", quiet=True).stdout
+    for _runtime, devices in json.loads(out).get("devices", {}).items():
+        for dev in devices:
+            if dev.get("name") == name:
+                return dev
+    return None
+
+
+def cmd_setup(args: argparse.Namespace) -> None:
+    preset = get_preset(args.device)
+    state = state_for(args)
+
+    runtime = first_ios_runtime(download=args.download_runtime)
+
+    venv = Path(args.idb_venv).expanduser()
+    ensure_idb(venv)
+
+    device_name = f"SculptorQA-{preset.key}"
+    dev = find_device(device_name)
+    if dev is None:
+        eprint(f"Creating device {device_name!r} ({preset.sim_name}) on {runtime} ...")
+        udid = simctl("create", device_name, preset.sim_name, runtime).stdout.strip()
+    else:
+        udid = dev["udid"]
+        eprint(f"Reusing device {device_name!r} ({udid}), state={dev.get('state')}.")
+
+    if not (dev and dev.get("state") == "Booted"):
+        simctl("boot", udid, check=False)
+    eprint("Waiting for boot to complete ...")
+    simctl("bootstatus", udid, "-b", quiet=True)
+
+    state.data.update(
+        {
+            "device": preset.key,
+            "sim_name": preset.sim_name,
+            "device_name": device_name,
+            "udid": udid,
+            "points": list(preset.points),
+            "notched": preset.notched,
+            "idb_venv": str(venv),
+            "runtime": runtime,
+        }
+    )
+    state.save()
+
+    if idb_bin(state):
+        eprint("Connecting idb ...")
+        idb(state, "connect", udid, check=False)
+
+    print(f"Device ready: {device_name}")
+    print(f"  udid:   {udid}")
+    print(f"  points: {preset.points[0]}x{preset.points[1]} (notched={preset.notched})")
+    print(f"  state:  {state.path}")
+    print("Open the Simulator app to watch: open -a Simulator")
+
+
+def cmd_serve(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    url = ensure_server(state, args.command, args.server_timeout)
+    print(f"server: {url}")
+
+
+def cmd_open(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.require_udid()
+    url = resolve_url(state, args)
+    eprint(f"Opening {url} in MobileSafari ...")
+    simctl("openurl", udid, url)
+    time.sleep(args.settle)
+    report_shot(take_screenshot(state, "open"))
+
+
+def cmd_screenshot(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    report_shot(take_screenshot(state, args.label))
+
+
+def _xy(args: argparse.Namespace, state: State, fx: float, fy: float) -> List[int]:
+    if args.frac:
+        w, h = state.points()
+        return [round(fx * w), round(fy * h)]
+    return [round(fx), round(fy)]
+
+
+def cmd_tap(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.require_udid()
+    x, y = _xy(args, state, args.x, args.y)
+    idb(state, "ui", "tap", "--udid", udid, str(x), str(y))
+    time.sleep(args.settle)
+    report_shot(take_screenshot(state, f"tap_{x}_{y}"))
+
+
+def cmd_swipe(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.require_udid()
+    x1, y1 = _xy(args, state, args.x1, args.y1)
+    x2, y2 = _xy(args, state, args.x2, args.y2)
+    idb(state, "ui", "swipe", "--udid", udid, "--duration", str(args.duration),
+        str(x1), str(y1), str(x2), str(y2))
+    time.sleep(args.settle)
+    report_shot(take_screenshot(state, f"swipe_{x1}_{y1}_{x2}_{y2}"))
+
+
+def cmd_describe(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.require_udid()
+    out = idb(state, "ui", "describe-all", "--udid", udid).stdout
+    print(out)
+
+
+def cmd_add_to_home_screen(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.require_udid()
+    preset = get_preset(str(state.get("device", DEFAULT_PRESET)))
+    if not preset.ahs:
+        raise SystemExit(
+            f"No Add-to-Home-Screen reference coordinates for {preset.key!r}.\n"
+            "SpringBoard/the share sheet aren't in the accessibility tree, so drive "
+            "it manually: `screenshot`, find each target as a fraction, then "
+            "`tap --frac FX FY` step by step (Share -> swipe up -> Add to Home Screen "
+            "-> Add)."
+        )
+
+    def tap(name: str, label: str) -> None:
+        x, y = preset.ahs[name]
+        idb(state, "ui", "tap", "--udid", udid, str(x), str(y))
+        time.sleep(args.settle)
+        report_shot(take_screenshot(state, f"ahs_{label}"))
+
+    def swipe(a: str, b: str, label: str) -> None:
+        x1, y1 = preset.ahs[a]
+        x2, y2 = preset.ahs[b]
+        idb(state, "ui", "swipe", "--udid", udid, "--duration", "0.6",
+            str(x1), str(y1), str(x2), str(y2))
+        time.sleep(args.settle)
+        report_shot(take_screenshot(state, f"ahs_{label}"))
+
+    eprint("AHS coordinates are empirical — VERIFY each screenshot before trusting the next tap.")
+    tap("share_button", "1_share_sheet")
+    swipe("sheet_swipe_from", "sheet_swipe_to", "2_sheet_scrolled")
+    tap("add_to_home_screen", "3_ahs_dialog")
+    tap("add_confirm", "4_added")
+    print(
+        "\nDone. If a screenshot doesn't match the expected step, the coordinates "
+        "drifted — re-derive with `tap --frac`. Next: `launch-icon` to open the "
+        "clip standalone and see the real status bar / safe areas."
+    )
+
+
+def cmd_launch_icon(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.require_udid()
+    preset = get_preset(str(state.get("device", DEFAULT_PRESET)))
+    if args.x is None or args.y is None:
+        if "launch_icon" not in preset.ahs:
+            raise SystemExit("Pass the icon coords: `launch-icon X Y` (or --frac FX FY).")
+        x, y = preset.ahs["launch_icon"]
+    else:
+        x, y = _xy(args, state, args.x, args.y)
+    idb(state, "ui", "tap", "--udid", udid, str(x), str(y))
+    time.sleep(args.settle + 1.0)  # give the standalone app a moment to launch
+    report_shot(take_screenshot(state, "standalone"))
+
+
+def cmd_remove_home_screen(args: argparse.Namespace) -> None:
+    print(
+        "iOS caches the launch config (meta tags, theme-color, icon) at add-time, "
+        "so after changing index.html's <head> you must REMOVE and RE-ADD the clip "
+        "— reloading isn't enough.\n\n"
+        "Removal isn't reliably scriptable (long-press isn't in the a11y tree). Do it "
+        "by hand in the Simulator: long-press the icon -> 'Remove App' -> 'Delete from "
+        "Home Screen', then run `add-to-home-screen` again."
+    )
+
+
+def cmd_teardown(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    stop_server(state)
+    udid = state.data.get("udid")
+    if udid:
+        simctl("shutdown", str(udid), check=False)
+        if args.delete:
+            simctl("delete", str(udid), check=False)
+            for k in ("udid", "device_name", "points", "runtime"):
+                state.data.pop(k, None)
+            state.save()
+            print("Device deleted.")
+        else:
+            print("Simulator shut down (device kept for next time).")
+    print("Screenshots are kept in", state.dir)
+
+
+def cmd_detect(args: argparse.Namespace) -> None:
+    """List running Sculptor servers and show which one `open` would attach to."""
+    ports = _listening_ports()
+    interesting = re.compile(r"(node|vite|sculptor|electron|python|uv)", re.I)
+    candidates = [p for p, c in sorted(ports.items()) if interesting.search(c)]
+    for extra in (5173, 5174):
+        if extra not in candidates:
+            candidates.append(extra)
+    hits = []
+    for port in candidates:
+        status, body = _fetch(f"http://127.0.0.1:{port}")
+        if status is None or not any(mk in body for mk in SPA_MARKERS):
+            continue
+        kind = "dev" if ("/@vite/client" in body or "/src/" in body or "/@react-refresh" in body) else "app"
+        hits.append((port, kind, ports.get(port, "?")))
+    if not hits:
+        print("No running Sculptor server found. Start your dev server, or use "
+              "`open --port <port>` / `open --launch`.")
+        return
+    chosen = find_running_server()
+    print("Running Sculptor servers:")
+    for port, kind, cmd in hits:
+        mark = "   <- open would use this" if chosen and chosen[0] == port else ""
+        print(f"  http://127.0.0.1:{port}   [{kind}]  ({cmd}){mark}")
+    if chosen:
+        note = "" if chosen[1] == "dev" else "  (NOTE: a packaged/production build — pass --port for your dev server)"
+        print(f"\n`open` (no flags) will attach to: http://127.0.0.1:{chosen[0]}{note}")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    state = state_for(args)
+    udid = state.data.get("udid")
+    booted = False
+    if udid:
+        dev = find_device(str(state.data.get("device_name", "")))
+        booted = bool(dev and dev.get("state") == "Booted")
+    print(json.dumps({
+        "screenshots_dir": str(state.dir),
+        "device": state.data.get("device"),
+        "udid": udid,
+        "booted": booted,
+        "idb": bool(idb_bin(state)),
+        "server_running": server_alive(state),
+        "server": state.data.get("server"),
+        "counter": state.data.get("counter", 0),
+    }, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# argument parsing
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="iphone_sim.py", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # Shared options, inherited by every subcommand so they can be passed AFTER
+    # the subcommand (e.g. `iphone_sim.py screenshot --label foo`).
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--screenshots-dir", default=str(default_screenshots_dir()),
+                        help="Where screenshots + state live (default: workspace attachments).")
+    common.add_argument("--settle", type=float, default=1.0,
+                        help="Seconds to wait after an action before screenshotting.")
+
+    s = sub.add_parser("setup", parents=[common], help="Ensure runtime + idb, create/boot the device.")
+    s.add_argument("--device", default=DEFAULT_PRESET, choices=sorted(PRESETS),
+                   help="Device preset to create/boot.")
+    s.add_argument("--idb-venv", default=str(DEFAULT_IDB_VENV))
+    s.add_argument("--download-runtime", action="store_true",
+                   help="Auto-download an iOS runtime if none is installed (~9 GB).")
+    s.set_defaults(func=cmd_setup)
+
+    def add_server_opts(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--command", default=DEFAULT_COMMAND,
+                        help=f"Fallback server command to launch if none is running (default: {DEFAULT_COMMAND!r}).")
+        sp.add_argument("--port", type=int, help="Attach to an already-running server on this port.")
+        sp.add_argument("--url", help="Attach to an already-running server at this full URL.")
+        sp.add_argument("--launch", action="store_true",
+                        help="Skip auto-detect and launch --command directly.")
+        sp.add_argument("--server-timeout", type=float, default=180.0,
+                        help="Seconds to wait for the launched server to print its port.")
+
+    s = sub.add_parser("serve", parents=[common], help="Launch the frontend server and parse its URL.")
+    add_server_opts(s)
+    s.set_defaults(func=cmd_serve)
+
+    s = sub.add_parser("open", parents=[common], help="Open a URL in MobileSafari (launches server if needed).")
+    add_server_opts(s)
+    s.set_defaults(func=cmd_open)
+
+    s = sub.add_parser("screenshot", parents=[common], help="Capture the current screen.")
+    s.add_argument("--label", default="shot")
+    s.set_defaults(func=cmd_screenshot)
+
+    s = sub.add_parser("tap", parents=[common], help="Tap a point (--frac to use a screenshot fraction).")
+    s.add_argument("x", type=float)
+    s.add_argument("y", type=float)
+    s.add_argument("--frac", action="store_true", help="Treat X/Y as fractions (0..1) of the screen.")
+    s.set_defaults(func=cmd_tap)
+
+    s = sub.add_parser("swipe", parents=[common], help="Swipe between two points.")
+    for n in ("x1", "y1", "x2", "y2"):
+        s.add_argument(n, type=float)
+    s.add_argument("--frac", action="store_true", help="Treat coords as fractions (0..1).")
+    s.add_argument("--duration", type=float, default=0.6)
+    s.set_defaults(func=cmd_swipe)
+
+    s = sub.add_parser("describe", parents=[common], help="Dump the foreground app's accessibility tree.")
+    s.set_defaults(func=cmd_describe)
+
+    s = sub.add_parser("add-to-home-screen", parents=[common], help="Drive the Add-to-Home-Screen flow.")
+    s.set_defaults(func=cmd_add_to_home_screen)
+
+    s = sub.add_parser("launch-icon", parents=[common], help="Tap the home-screen clip to launch standalone.")
+    s.add_argument("x", type=float, nargs="?")
+    s.add_argument("y", type=float, nargs="?")
+    s.add_argument("--frac", action="store_true")
+    s.set_defaults(func=cmd_launch_icon)
+
+    s = sub.add_parser("remove-home-screen", parents=[common], help="How to remove the clip (caching gotcha).")
+    s.set_defaults(func=cmd_remove_home_screen)
+
+    s = sub.add_parser("teardown", parents=[common], help="Shut the simulator down and stop the server.")
+    s.add_argument("--delete", action="store_true", help="Also delete the simulator device.")
+    s.set_defaults(func=cmd_teardown)
+
+    s = sub.add_parser("detect", parents=[common], help="List running Sculptor servers + which one `open` would use.")
+    s.set_defaults(func=cmd_detect)
+
+    s = sub.add_parser("status", parents=[common], help="Print current device/server state.")
+    s.set_defaults(func=cmd_status)
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        args.func(args)
+    except subprocess.CalledProcessError as exc:
+        eprint(f"\nCommand failed ({exc.returncode}): {' '.join(exc.cmd)}")
+        if exc.stdout:
+            eprint(exc.stdout)
+        if exc.stderr:
+            eprint(exc.stderr)
+        return 1
+    except SystemExit as exc:
+        if isinstance(exc.code, str):
+            eprint(exc.code)
+            return 1
+        return exc.code or 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/auto-qa-iphone/scripts/iphone_sim.py
+++ b/.claude/skills/auto-qa-iphone/scripts/iphone_sim.py
@@ -35,6 +35,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import socket
@@ -43,11 +44,11 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from devices import DEFAULT_PRESET, PRESETS, get_preset  # noqa: E402
+from devices import DEFAULT_PRESET, PRESETS, DevicePreset, get_preset  # noqa: E402
 
 STATE_FILENAME = ".iphone-sim-state.json"
 SERVER_LOG = "frontend-server.log"
@@ -97,7 +98,7 @@ def default_screenshots_dir() -> Path:
     return repo_root() / ".iphone-qa" / "screenshots"
 
 
-def child_env() -> Dict[str, str]:
+def child_env() -> dict[str, str]:
     env = dict(os.environ)
     extra = [p for p in BREW_BINS if Path(p).is_dir()]
     if extra:
@@ -111,8 +112,8 @@ def run(cmd: Sequence[str], check: bool = True, quiet: bool = False) -> subproce
     return subprocess.run(cmd, capture_output=True, text=True, check=check, env=child_env())
 
 
-def simctl(*args: str, check: bool = True, quiet: bool = False) -> subprocess.CompletedProcess:
-    return run(["xcrun", "simctl", *args], check=check, quiet=quiet)
+def simctl(*parts: str, check: bool = True, quiet: bool = False) -> subprocess.CompletedProcess:
+    return run(["xcrun", "simctl", *parts], check=check, quiet=quiet)
 
 
 def have(binary: str) -> bool:
@@ -132,7 +133,7 @@ def http_ready(url: str, timeout: float = 2.0) -> bool:
         return True
     except urllib.error.HTTPError:
         return True  # responded with 4xx/5xx — still a live server
-    except Exception:
+    except (urllib.error.URLError, OSError):
         return False  # connection refused / timeout — not serving
 
 
@@ -144,7 +145,7 @@ class State:
         self.dir = screenshots_dir
         self.dir.mkdir(parents=True, exist_ok=True)
         self.path = self.dir / STATE_FILENAME
-        self.data: Dict[str, object] = {}
+        self.data: dict[str, object] = {}
         if self.path.exists():
             self.data = json.loads(self.path.read_text())
 
@@ -160,11 +161,11 @@ class State:
             raise SystemExit("No device set up. Run `iphone_sim.py setup` first.")
         return str(udid)
 
-    def points(self) -> Sequence[int]:
+    def points(self) -> list[int]:
         pts = self.data.get("points")
-        if not pts:
+        if not isinstance(pts, list):
             raise SystemExit("No device points in state. Run `setup` first.")
-        return pts  # type: ignore[return-value]
+        return [int(x) for x in pts]
 
     def next_counter(self) -> int:
         n = int(self.data.get("counter", 0)) + 1
@@ -180,7 +181,7 @@ def state_for(args: argparse.Namespace) -> State:
 # --------------------------------------------------------------------------- #
 # idb
 # --------------------------------------------------------------------------- #
-def idb_bin(state: State) -> Optional[str]:
+def idb_bin(state: State) -> str | None:
     venv = state.data.get("idb_venv")
     if not venv:
         return None
@@ -188,14 +189,13 @@ def idb_bin(state: State) -> Optional[str]:
     return str(candidate) if candidate.exists() else None
 
 
-def idb(state: State, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+def idb(state: State, *parts: str, check: bool = True) -> subprocess.CompletedProcess:
     binary = idb_bin(state)
     if not binary:
         raise SystemExit(
-            "idb is not installed. Re-run `iphone_sim.py setup` (it creates the "
-            "idb venv and installs idb_companion)."
+            "idb is not installed. Re-run `iphone_sim.py setup` (it creates the idb venv and installs idb_companion)."
         )
-    return run([binary, *args], check=check)
+    return run([binary, *parts], check=check)
 
 
 # --------------------------------------------------------------------------- #
@@ -257,7 +257,7 @@ def stop_server(state: State) -> None:
     state.save()
 
 
-def parse_port(line: str) -> Optional[int]:
+def parse_port(line: str) -> int | None:
     for pat in PORT_PATTERNS:
         m = pat.search(line)
         if m:
@@ -268,24 +268,34 @@ def parse_port(line: str) -> Optional[int]:
 def ensure_server(state: State, command: str, timeout: float) -> str:
     """Launch `command` detached, parse its frontend URL, and keep it alive."""
     if server_alive(state):
-        server = state.data["server"]  # type: ignore[index]
-        url = server.get("url")
+        server = state.data.get("server")
+        url = server.get("url") if isinstance(server, dict) else None
         if url:
             eprint(f"Reusing running server: {url}")
             return str(url)
 
+    # Split into an argv and run without a shell: `--command` can be influenced by
+    # whatever drives this script (e.g. an agent), and shell=True would make that an
+    # injection vector. shlex.split still honors quoting, so `just frontend-custom`
+    # and quoted args work; shell operators (pipes, &&, redirects) intentionally do
+    # not — wrap those in a script and point --command at it if you need them.
+    argv = shlex.split(command)
+    if not argv:
+        raise SystemExit(f"--command is empty: {command!r}")
+
     log_path = state.dir / SERVER_LOG
-    log = open(log_path, "w")
     eprint(f"$ ({command})  [detached, logging to {log_path}]")
-    proc = subprocess.Popen(
-        command,
-        shell=True,
-        cwd=str(repo_root()),
-        stdout=log,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,  # own process group so teardown can kill the tree
-        env=child_env(),
-    )
+    # The child inherits the log fd at spawn; close the parent's copy immediately
+    # (the server is long-lived, so leaving it open would leak an fd per run).
+    with open(log_path, "w") as log:
+        proc = subprocess.Popen(
+            argv,
+            cwd=str(repo_root()),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,  # own process group so teardown can kill the tree
+            env=child_env(),
+        )
     try:
         pgid = os.getpgid(proc.pid)
     except OSError:
@@ -295,7 +305,7 @@ def ensure_server(state: State, command: str, timeout: float) -> str:
 
     # Tail the log until the frontend URL appears.
     deadline = time.time() + timeout
-    port: Optional[int] = None
+    port: int | None = None
     while time.time() < deadline:
         if proc.poll() is not None:
             tail = "\n".join(log_path.read_text().splitlines()[-25:])
@@ -310,8 +320,7 @@ def ensure_server(state: State, command: str, timeout: float) -> str:
     if not port:
         tail = "\n".join(log_path.read_text().splitlines()[-25:])
         raise SystemExit(
-            f"Timed out after {timeout:.0f}s waiting for the frontend port.\n"
-            f"--- {SERVER_LOG} (tail) ---\n{tail}"
+            f"Timed out after {timeout:.0f}s waiting for the frontend port.\n--- {SERVER_LOG} (tail) ---\n{tail}"
         )
 
     # Confirm the parsed port actually SERVES — not just that we saw it logged.
@@ -330,14 +339,12 @@ def ensure_server(state: State, command: str, timeout: float) -> str:
     if not ready:
         tail = "\n".join(log_path.read_text().splitlines()[-25:])
         raise SystemExit(
-            f"Parsed port {port} from the server output, but {url} never served a "
-            f"response within {timeout:.0f}s.\n"
-            "If a Sculptor instance is already running, attach to it instead of "
-            "launching a new one:  open --port <port>  (or --url <url>).\n"
-            f"--- {SERVER_LOG} (tail) ---\n{tail}"
+            f"Parsed port {port} from the server output, but {url} never served a response within {timeout:.0f}s.\nIf a Sculptor instance is already running, attach to it instead of launching a new one:  open --port <port>  (or --url <url>).\n--- {SERVER_LOG} (tail) ---\n{tail}"
         )
 
-    state.data["server"]["url"] = url  # type: ignore[index]
+    server = state.data.get("server")
+    if isinstance(server, dict):
+        server["url"] = url
     state.save()
     eprint(f"Frontend server ready: {url} (pid={proc.pid})")
     return url
@@ -349,13 +356,13 @@ def ensure_server(state: State, command: str, timeout: float) -> str:
 SPA_MARKERS = ("<title>Sculptor", "apple-mobile-web-app-title", 'id="root"')
 
 
-def _listening_ports() -> Dict[int, str]:
+def _listening_ports() -> dict[int, str]:
     """Map of listening TCP port -> owning process command (via lsof)."""
     try:
         out = run(["lsof", "-nP", "-iTCP", "-sTCP:LISTEN"], check=False, quiet=True).stdout
     except FileNotFoundError:
         return {}
-    ports: Dict[int, str] = {}
+    ports: dict[int, str] = {}
     for line in out.splitlines()[1:]:
         parts = line.split()
         if len(parts) < 2:
@@ -376,7 +383,7 @@ def _fetch(url: str, timeout: float = 1.5):
             return r.status, r.read(16384).decode("utf-8", "replace")
     except urllib.error.HTTPError as e:
         return e.code, ""
-    except Exception:
+    except (urllib.error.URLError, OSError):
         return None, ""
 
 
@@ -415,14 +422,14 @@ def resolve_url(state: State, args: argparse.Namespace) -> str:
             port, kind = found
             eprint(f"Attached to a running Sculptor server on port {port} ({kind} build).")
             if kind == "app":
-                eprint("  NOTE: that looks like a packaged/production build, not a vite dev "
-                       "server — start your branch's dev server to QA your changes, or pass "
-                       "--port/--url explicitly.")
+                eprint(
+                    "  NOTE: that looks like a packaged/production build, not a vite dev server — start your branch's dev server to QA your changes, or pass --port/--url explicitly."
+                )
             return f"http://127.0.0.1:{port}"
-        eprint("No running Sculptor server detected; launching the fallback command "
-               f"({args.command!r}).")
-        eprint("  (Launching from inside a Sculptor agent can be flaky — if it fails, start "
-               "your dev server yourself and re-run, or pass --port/--url.)")
+        eprint(f"No running Sculptor server detected; launching the fallback command ({args.command!r}).")
+        eprint(
+            "  (Launching from inside a Sculptor agent can be flaky — if it fails, start your dev server yourself and re-run, or pass --port/--url.)"
+        )
     return ensure_server(state, args.command, args.server_timeout)
 
 
@@ -442,10 +449,7 @@ def first_ios_runtime(download: bool) -> str:
         run(["xcodebuild", "-downloadPlatform", "iOS"])
         return first_ios_runtime(download=False)
     raise SystemExit(
-        "No iOS simulator runtime is installed.\n"
-        "Install one (≈9 GB, slow) with:\n"
-        "    xcodebuild -downloadPlatform iOS\n"
-        "or re-run setup with --download-runtime to do it automatically."
+        "No iOS simulator runtime is installed.\nInstall one (≈9 GB, slow) with:\n    xcodebuild -downloadPlatform iOS\nor re-run setup with --download-runtime to do it automatically."
     )
 
 
@@ -463,13 +467,11 @@ def ensure_idb(venv: Path) -> None:
             run(["brew", "install", "idb-companion"], check=False)
         if not have("idb_companion"):
             eprint(
-                "WARNING: idb_companion is not on PATH. Taps/swipes will not work "
-                "until you `brew install idb-companion`. Screenshots and openurl "
-                "still work via simctl."
+                "WARNING: idb_companion is not on PATH. Taps/swipes will not work until you `brew install idb-companion`. Screenshots and openurl still work via simctl."
             )
 
 
-def find_device(name: str) -> Optional[dict]:
+def find_device(name: str) -> dict | None:
     out = simctl("list", "devices", "--json", quiet=True).stdout
     for _runtime, devices in json.loads(out).get("devices", {}).items():
         for dev in devices:
@@ -528,7 +530,9 @@ def cmd_setup(args: argparse.Namespace) -> None:
 
 def cmd_serve(args: argparse.Namespace) -> None:
     state = state_for(args)
-    url = ensure_server(state, args.command, args.server_timeout)
+    # resolve_url honors --url/--port (attach) and --launch (force a fresh launch),
+    # falling back to auto-detect and finally to launching --command.
+    url = resolve_url(state, args)
     print(f"server: {url}")
 
 
@@ -547,7 +551,7 @@ def cmd_screenshot(args: argparse.Namespace) -> None:
     report_shot(take_screenshot(state, args.label))
 
 
-def _xy(args: argparse.Namespace, state: State, fx: float, fy: float) -> List[int]:
+def _xy(args: argparse.Namespace, state: State, fx: float, fy: float) -> list[int]:
     if args.frac:
         w, h = state.points()
         return [round(fx * w), round(fy * h)]
@@ -581,42 +585,40 @@ def cmd_describe(args: argparse.Namespace) -> None:
     print(out)
 
 
+def _ahs_tap(state: State, udid: str, preset: DevicePreset, settle: float, name: str, label: str) -> None:
+    """Tap one named Add-to-Home-Screen coordinate and screenshot the result."""
+    x, y = preset.ahs[name]
+    idb(state, "ui", "tap", "--udid", udid, str(x), str(y))
+    time.sleep(settle)
+    report_shot(take_screenshot(state, f"ahs_{label}"))
+
+
+def _ahs_swipe(state: State, udid: str, preset: DevicePreset, settle: float, a: str, b: str, label: str) -> None:
+    """Swipe between two named Add-to-Home-Screen coordinates and screenshot."""
+    x1, y1 = preset.ahs[a]
+    x2, y2 = preset.ahs[b]
+    idb(state, "ui", "swipe", "--udid", udid, "--duration", "0.6",
+        str(x1), str(y1), str(x2), str(y2))
+    time.sleep(settle)
+    report_shot(take_screenshot(state, f"ahs_{label}"))
+
+
 def cmd_add_to_home_screen(args: argparse.Namespace) -> None:
     state = state_for(args)
     udid = state.require_udid()
     preset = get_preset(str(state.get("device", DEFAULT_PRESET)))
     if not preset.ahs:
         raise SystemExit(
-            f"No Add-to-Home-Screen reference coordinates for {preset.key!r}.\n"
-            "SpringBoard/the share sheet aren't in the accessibility tree, so drive "
-            "it manually: `screenshot`, find each target as a fraction, then "
-            "`tap --frac FX FY` step by step (Share -> swipe up -> Add to Home Screen "
-            "-> Add)."
+            f"No Add-to-Home-Screen reference coordinates for {preset.key!r}.\nSpringBoard/the share sheet aren't in the accessibility tree, so drive it manually: `screenshot`, find each target as a fraction, then `tap --frac FX FY` step by step (Share -> swipe up -> Add to Home Screen -> Add)."
         )
 
-    def tap(name: str, label: str) -> None:
-        x, y = preset.ahs[name]
-        idb(state, "ui", "tap", "--udid", udid, str(x), str(y))
-        time.sleep(args.settle)
-        report_shot(take_screenshot(state, f"ahs_{label}"))
-
-    def swipe(a: str, b: str, label: str) -> None:
-        x1, y1 = preset.ahs[a]
-        x2, y2 = preset.ahs[b]
-        idb(state, "ui", "swipe", "--udid", udid, "--duration", "0.6",
-            str(x1), str(y1), str(x2), str(y2))
-        time.sleep(args.settle)
-        report_shot(take_screenshot(state, f"ahs_{label}"))
-
     eprint("AHS coordinates are empirical — VERIFY each screenshot before trusting the next tap.")
-    tap("share_button", "1_share_sheet")
-    swipe("sheet_swipe_from", "sheet_swipe_to", "2_sheet_scrolled")
-    tap("add_to_home_screen", "3_ahs_dialog")
-    tap("add_confirm", "4_added")
+    _ahs_tap(state, udid, preset, args.settle, "share_button", "1_share_sheet")
+    _ahs_swipe(state, udid, preset, args.settle, "sheet_swipe_from", "sheet_swipe_to", "2_sheet_scrolled")
+    _ahs_tap(state, udid, preset, args.settle, "add_to_home_screen", "3_ahs_dialog")
+    _ahs_tap(state, udid, preset, args.settle, "add_confirm", "4_added")
     print(
-        "\nDone. If a screenshot doesn't match the expected step, the coordinates "
-        "drifted — re-derive with `tap --frac`. Next: `launch-icon` to open the "
-        "clip standalone and see the real status bar / safe areas."
+        "\nDone. If a screenshot doesn't match the expected step, the coordinates drifted — re-derive with `tap --frac`. Next: `launch-icon` to open the clip standalone and see the real status bar / safe areas."
     )
 
 
@@ -637,12 +639,7 @@ def cmd_launch_icon(args: argparse.Namespace) -> None:
 
 def cmd_remove_home_screen(args: argparse.Namespace) -> None:
     print(
-        "iOS caches the launch config (meta tags, theme-color, icon) at add-time, "
-        "so after changing index.html's <head> you must REMOVE and RE-ADD the clip "
-        "— reloading isn't enough.\n\n"
-        "Removal isn't reliably scriptable (long-press isn't in the a11y tree). Do it "
-        "by hand in the Simulator: long-press the icon -> 'Remove App' -> 'Delete from "
-        "Home Screen', then run `add-to-home-screen` again."
+        "iOS caches the launch config (meta tags, theme-color, icon) at add-time, so after changing index.html's <head> you must REMOVE and RE-ADD the clip — reloading isn't enough.\n\nRemoval isn't reliably scriptable (long-press isn't in the a11y tree). Do it by hand in the Simulator: long-press the icon -> 'Remove App' -> 'Delete from Home Screen', then run `add-to-home-screen` again."
     )
 
 
@@ -679,8 +676,7 @@ def cmd_detect(args: argparse.Namespace) -> None:
         kind = "dev" if ("/@vite/client" in body or "/src/" in body or "/@react-refresh" in body) else "app"
         hits.append((port, kind, ports.get(port, "?")))
     if not hits:
-        print("No running Sculptor server found. Start your dev server, or use "
-              "`open --port <port>` / `open --launch`.")
+        print("No running Sculptor server found. Start your dev server, or use `open --port <port>` / `open --launch`.")
         return
     chosen = find_running_server()
     print("Running Sculptor servers:")
@@ -714,6 +710,18 @@ def cmd_status(args: argparse.Namespace) -> None:
 # --------------------------------------------------------------------------- #
 # argument parsing
 # --------------------------------------------------------------------------- #
+def add_server_opts(sp: argparse.ArgumentParser) -> None:
+    """Attach the shared server-resolution flags to a subparser (serve/open)."""
+    sp.add_argument("--command", default=DEFAULT_COMMAND,
+                    help=f"Fallback server command to launch if none is running (default: {DEFAULT_COMMAND!r}).")
+    sp.add_argument("--port", type=int, help="Attach to an already-running server on this port.")
+    sp.add_argument("--url", help="Attach to an already-running server at this full URL.")
+    sp.add_argument("--launch", action="store_true",
+                    help="Skip auto-detect and launch --command directly.")
+    sp.add_argument("--server-timeout", type=float, default=180.0,
+                    help="Seconds to wait for the launched server to print its port.")
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="iphone_sim.py", description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -734,16 +742,6 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--download-runtime", action="store_true",
                    help="Auto-download an iOS runtime if none is installed (~9 GB).")
     s.set_defaults(func=cmd_setup)
-
-    def add_server_opts(sp: argparse.ArgumentParser) -> None:
-        sp.add_argument("--command", default=DEFAULT_COMMAND,
-                        help=f"Fallback server command to launch if none is running (default: {DEFAULT_COMMAND!r}).")
-        sp.add_argument("--port", type=int, help="Attach to an already-running server on this port.")
-        sp.add_argument("--url", help="Attach to an already-running server at this full URL.")
-        sp.add_argument("--launch", action="store_true",
-                        help="Skip auto-detect and launch --command directly.")
-        sp.add_argument("--server-timeout", type=float, default=180.0,
-                        help="Seconds to wait for the launched server to print its port.")
 
     s = sub.add_parser("serve", parents=[common], help="Launch the frontend server and parse its URL.")
     add_server_opts(s)
@@ -798,7 +796,7 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         args.func(args)

--- a/.claude/skills/openhost-sculptor/.gitignore
+++ b/.claude/skills/openhost-sculptor/.gitignore
@@ -1,0 +1,5 @@
+# Local OpenHost instance config for this skill (personal host — do not commit).
+# Holds the per-instance values the skill sources at startup. Copy
+# openhost.env.example to openhost.env and fill it in.
+openhost.env
+!openhost.env.example

--- a/.claude/skills/openhost-sculptor/openhost.env.example
+++ b/.claude/skills/openhost-sculptor/openhost.env.example
@@ -1,0 +1,23 @@
+# Local OpenHost deploy config for the openhost-sculptor skill.
+#
+# Copy this file to `openhost.env` (same folder) and fill in your values.
+# `openhost.env` is gitignored because HOST embeds your personal OpenHost
+# subdomain — keep it out of this public repo.
+#
+# The skill sources openhost.env at startup:
+#   set -a; [ -f .claude/skills/openhost-sculptor/openhost.env ] && \
+#     . .claude/skills/openhost-sculptor/openhost.env; set +a
+
+# OpenHost app name. Must match openhost.toml [app].name. Public; rarely changes.
+APP=sculptor
+
+# Public URL host for your instance, e.g. sculptor.<your-openhost-host>.
+# This is the only instance-specific / personal value.
+HOST=sculptor.<your-openhost-host>
+
+# Public GitHub repo the deploy builds from. Rarely changes.
+REPO=https://github.com/imbue-ai/sculptor
+
+# Branch to deploy. Optional — if unset, the skill defaults to your current
+# git branch. Set it here to pin a specific branch.
+#BRANCH=main

--- a/sculptor/sculptor/testing/manual_test_harness.py
+++ b/sculptor/sculptor/testing/manual_test_harness.py
@@ -186,7 +186,15 @@ class ManualTestHarness:
         # when Chromium's GPU compositor is stubbed out, as it is in --headless=new).
         self._browser = self._playwright.chromium.launch(
             headless=True,
-            args=["--disable-webgl", "--disable-webgl2"],
+            args=[
+                "--disable-webgl",
+                "--disable-webgl2",
+                # Containers mount a tiny (~64MB) /dev/shm. Chromium's renderer uses
+                # /dev/shm for shared memory and crashes with "Target/Page crashed"
+                # once it fills during a long session (especially at device_scale_factor=2).
+                # Redirect that shared memory to disk-backed /tmp instead.
+                "--disable-dev-shm-usage",
+            ],
         )
         self._browser_context = self._browser.new_context(viewport=self._viewport, device_scale_factor=2)
         self._page = self._browser_context.new_page()

--- a/sculptor/sculptor/testing/manual_test_harness.py
+++ b/sculptor/sculptor/testing/manual_test_harness.py
@@ -47,6 +47,33 @@ _VITE_POLL_REQUEST_TIMEOUT_SECONDS = 2
 _BACKEND_SHUTDOWN_TIMEOUT_SECONDS = 10
 _VITE_SHUTDOWN_TIMEOUT_SECONDS = 5
 
+# Below this /dev/shm size, Chromium's renderer is prone to exhausting shared
+# memory and crashing during long sessions, so we redirect it to disk (see
+# _chromium_shared_memory_args). Docker's default /dev/shm is 64MB; a normal
+# Linux host has half of RAM (gigabytes), so this threshold cleanly separates
+# the two without a container-detection heuristic.
+_SMALL_DEV_SHM_THRESHOLD_BYTES = 256 * 1024 * 1024
+
+
+def _chromium_shared_memory_args() -> list[str]:
+    """Return ``--disable-dev-shm-usage`` only when /dev/shm is too small to trust.
+
+    Containers mount a tiny (~64MB) /dev/shm. Chromium's renderer uses /dev/shm
+    for shared memory and crashes with "Target/Page crashed" once it fills during
+    a long session (especially at device_scale_factor=2). Redirecting that memory
+    to disk-backed /tmp avoids the crash, but disk is slower than tmpfs, so we
+    only pay that cost where /dev/shm is actually constrained — not on macOS
+    (no /dev/shm) or a normally-provisioned Linux host.
+    """
+    try:
+        stats = os.statvfs("/dev/shm")
+    except (FileNotFoundError, OSError):
+        return []
+    total_bytes = stats.f_frsize * stats.f_blocks
+    if total_bytes < _SMALL_DEV_SHM_THRESHOLD_BYTES:
+        return ["--disable-dev-shm-usage"]
+    return []
+
 
 def _make_test_user_config() -> UserConfig:
     """Create a UserConfig with test defaults (mirrors resources.py)."""
@@ -189,11 +216,7 @@ class ManualTestHarness:
             args=[
                 "--disable-webgl",
                 "--disable-webgl2",
-                # Containers mount a tiny (~64MB) /dev/shm. Chromium's renderer uses
-                # /dev/shm for shared memory and crashes with "Target/Page crashed"
-                # once it fills during a long session (especially at device_scale_factor=2).
-                # Redirect that shared memory to disk-backed /tmp instead.
-                "--disable-dev-shm-usage",
+                *_chromium_shared_memory_args(),
             ],
         )
         self._browser_context = self._browser.new_context(viewport=self._viewport, device_scale_factor=2)


### PR DESCRIPTION
## Summary

Three small, independent dev-tooling pieces (no product code):

- **manual_test_harness**: launch Chromium with `--disable-dev-shm-usage`. Containers mount a tiny (~64MB) `/dev/shm`, and the renderer crashes with "Target/Page crashed" once it fills during a long session, especially at `device_scale_factor=2`. Redirects Chromium's shared memory to disk-backed `/tmp`.
- **auto-qa-iphone skill**: drive the web UI on a real iOS Simulator from a Mac — boots a notched iPhone, launches the local frontend server (parsing its port), taps/swipes via `idb`, and screenshots each step. Includes the Add-to-Home-Screen standalone flow, the only way to verify safe-area rendering (`env(safe-area-inset-*)` is 0 everywhere except real iOS).
- **openhost-sculptor skill**: move the per-instance deploy values (host, app, repo, branch) into a gitignored `openhost.env` sourced at startup, with a committed `openhost.env.example`, so the skill works for any instance without hardcoding a personal hostname in this public repo.

## Testing

- `ruff format --check` / `ruff check` pass on the harness change; the flag itself has been running in a containerized deployment where the long-session crashes reproduced (and stopped).
- The two skills are documentation/scripts additions; the iPhone-sim skill was exercised end-to-end on a Mac + Simulator, and the openhost skill's env sourcing on a live openhost instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)