### PR TITLE
Bump Claude CLI floor to 2.1.202 to fix resume stuck-streaming

### DIFF
--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -212,8 +212,8 @@ packaging Sculptor):
 
 ### 3.3 Required external binaries
 
-- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.195,
-  minimum 2.1.195, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
+- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.202,
+  minimum 2.1.202, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
   **linux-x64** (`sculptor/sculptor/services/managed_tools.py`). Sculptor can install/manage it and can use a
   user-supplied binary (`SPEC.md` §7.1, §7.10).
 - **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -240,9 +240,16 @@ _CLAUDE_MANIFEST_FETCH_TIMEOUT_SECONDS = 30.0
 # the existing service -> managed_tools edge, which would be an import cycle. The
 # service re-imports this constant for its status / version-range logic.
 CLAUDE_VERSION_RANGE = VersionRange(
-    min_version="2.1.195",
+    # Floor is 2.1.202: earlier releases mishandle a session resume that carries
+    # `stopped` background-task notifications (left over from tasks killed by a
+    # prior interrupt). The CLI can deliver such a notification so that the user
+    # turn being awaited never emits its own terminating `result`, which wedges
+    # the chat in a perpetual "streaming" state. The resume-of-background-tasks
+    # path was reworked in 2.1.198; 2.1.202 is the earliest release validated
+    # against this failure. Do not lower this without re-validating that case.
+    min_version="2.1.202",
     max_version="2.99.99",
-    recommended_version="2.1.195",
+    recommended_version="2.1.202",
     # Blocked versions create background tool invocations that are missing events
     # describing them.
     blocked_versions=(BlockedVersionRange(min_version="2.1.101", max_version="2.1.101"),),


### PR DESCRIPTION
## Original bug

[SCU-1767](https://linear.app/imbue/issue/SCU-1767): a chat turn can complete cleanly (full response + `TurnMetrics` persisted) yet leave the UI stuck **"streaming" forever** — and it survives reloads, because the state is derived from the persisted message stream, not a live-connection flag. Distinct from the SCU-1446 restart fix (this is a clean-finish, no-restart case).

## Root cause (a Claude CLI resume behavior, ≤ 2.1.197)

The trigger is a prior turn being interrupted while it had `run_in_background` tasks: those tasks are killed, and their `stopped` notifications are delivered on the **next** session resume. Older Claude CLI releases can deliver such a `stopped` notification so that the user's turn is folded into a **single** turn (init → assistant → result) rather than getting its own separate turn after the notification's.

Sculptor's notification-turn accounting (`ClaudeOutputProcessor._pending_notification_turn_results`, added in SCU-1660) assumes a task-notification delivered before a turn's result is a *notification-delivery turn* that will be followed by a *separate* user-turn result. When the CLI folds them into one turn, that single `result` is consumed as a notification-turn "skip" and `found_final_message` is reset to `False` — so the output loop waits **indefinitely** for a follow-up result that never comes. The turn's terminal `RequestSuccessAgentMessage` is never emitted, leaving an orphaned `RequestStartedAgentMessage` that the frontend renders as perpetual "streaming."

## Investigation / proof of work

Reproduced end-to-end against **real Claude** (harness drives the same stream-json protocol Sculptor uses: launch background tasks → interrupt → resume → send a message):

| Claude version | Model | Observed resume stream | Outcome |
| --- | --- | --- | --- |
| **2.1.195** | Opus 4.8 (`--effort xhigh`) | `N N I R` (notifications → one turn → nothing more) | **HANG (~1/3 of runs)** |
| **2.1.202** | Opus 4.8 (`--effort xhigh`) | `N N I R I R I R` (notifications up front, then balanced turns, always a trailing un-promoted init) | **clean (0/10)** |

- The hang is **intermittent** and **model-dependent**: a more capable model handles the resume in a single turn (the hanging shape), whereas a chattier model runs extra balancing turns. Replaying the captured `2.1.195` frames through a faithful simulation of the accounting confirms `found_final_message` ends `False` → hang.
- The Claude changelog reworked the resume-of-background-tasks path in **2.1.198** ("background tasks stuck 'Running' … after resuming a session"), which matches the observed 2.1.195 → 2.1.202 behavior change.

## Fix

Bump the managed/bundled Claude pin in `CLAUDE_VERSION_RANGE` (`min` + `recommended`) from **2.1.195 → 2.1.202**, which eliminates the trigger, and update `REQ-COMPAT-020` to match. The 2.1.202 release manifest is published for both supported platforms (`darwin-arm64`, `linux-x64`). Test stubs derive their expected version from the pin, so they follow automatically.

## Testing

- **No automated regression test.** The defect is a Claude CLI behavior that is **not reproducible on the pinned version** — there is nothing for a Sculptor-side test to exercise. The proof is the 2.1.195-vs-2.1.202 reproduction above.
- `just format`, `just check` (lint + types + ratchets), and the backend unit suite all pass, including the `managed_tools` / `dependency_management` tests.

## Deferred follow-up

Sculptor's notification-turn accounting remains **latently fragile** — any future CLI/model/scenario that promotes the last result would wedge the UI again. A defense-in-depth idle backstop in `ClaudeOutputProcessor` (conclude the turn complete after a grace of total silence, so a mispredicted/dropped result can never wedge the UI forever) was intentionally deferred and tracked as [SCU-1770](https://linear.app/imbue/issue/SCU-1770/harden-claudeoutputprocessor-against-notification-turn-accounting-hang).

(Sent by Claude)
