### PR TITLE
[SCU-1771] Open the left section by default in new workspaces

### DIFF
--- a/sculptor/frontend/src/components/sections/persistence/defaultLayout.ts
+++ b/sculptor/frontend/src/components/sections/persistence/defaultLayout.ts
@@ -3,7 +3,7 @@
 // agent/terminal ids are resolved by the caller (the bootstrap) from the active
 // task and the first-visit seeded terminal — never hardcoded.
 //
-//   center — the only EXPANDED section: holds the active agent, and is the
+//   center — EXPANDED: holds the active agent, and is the
 //            active sub-section on load.
 //   left   — EXPANDED, with Files/Changes/Commits open and Files active.
 //   bottom — COLLAPSED, with one terminal open.

--- a/sculptor/frontend/src/components/sections/persistence/defaultLayout.ts
+++ b/sculptor/frontend/src/components/sections/persistence/defaultLayout.ts
@@ -5,7 +5,7 @@
 //
 //   center — the only EXPANDED section: holds the active agent, and is the
 //            active sub-section on load.
-//   left   — COLLAPSED, with Files/Changes/Commits open and Files active.
+//   left   — EXPANDED, with Files/Changes/Commits open and Files active.
 //   bottom — COLLAPSED, with one terminal open.
 //   right  — COLLAPSED and empty; Actions/Skills/Notes default here only WHEN opened,
 //            and nothing is open at first run.
@@ -51,9 +51,9 @@ export function buildDefaultWorkspaceLayout({
       left: DEFAULT_ACTIVE_LEFT_PANEL_ID,
       bottom: terminalPanelId,
     },
-    // center omitted — always expanded; the other three start collapsed.
+    // center omitted — always expanded. left also starts expanded; right/bottom collapsed.
     expanded: {
-      left: false,
+      left: true,
       right: false,
       bottom: false,
     },

--- a/sculptor/sculptor/testing/elements/add_panel_dropdown.py
+++ b/sculptor/sculptor/testing/elements/add_panel_dropdown.py
@@ -131,7 +131,7 @@ class PlaywrightAddPanelDropdownElement:
 
 
 # Panels the default workspace layout seeds OPEN on a workspace's first visit:
-# Files/Changes/Commits live in the (collapsed) left section, Files active.
+# Files/Changes/Commits live in the left section, Files active.
 # A single-instance panel can only live in ONE section at a time, and the add-panel
 # dropdown only offers panels not already open anywhere, so to land a seeded panel in
 # a DIFFERENT section the helper first closes it from its seeded section (which a
@@ -185,8 +185,8 @@ def open_panel(page: Page, panel_id: str, sub_section: str = "center") -> Locato
         expect(home_root).to_be_visible()
         return home_root
 
-    # Open into an explicitly-requested section. Non-center sections start collapsed, so
-    # their PanelSection — and the header `+` / tabs — aren't mounted; expand first.
+    # Open into an explicitly-requested section. A collapsed section's PanelSection —
+    # and its header `+` / tabs — aren't mounted; expand first (idempotent).
     section = PlaywrightWorkspaceSection(page, sub_section)
     section.expand_section()
     existing_tab = section.get_panel_tab(panel_id)
@@ -213,8 +213,8 @@ def open_panel(page: Page, panel_id: str, sub_section: str = "center") -> Locato
 def close_seeded_panel(page: Page, panel_id: str) -> None:
     """Close a default-seeded single-instance panel from its seeded section.
 
-    The default layout seeds Files/Changes/Commits OPEN in the (collapsed) left
-    section, so they are not offered by the add-panel dropdown until closed.
+    The default layout seeds Files/Changes/Commits OPEN in the left section, so
+    they are not offered by the add-panel dropdown until closed.
     Expands the seeded section to render the tab's close button (page-wide by panel id)
     and clicks it; a single-instance close removes the panel silently (no confirmation),
     which both returns it to the dropdown's re-add list and records it as recently-closed

--- a/sculptor/tests/integration/frontend/test_agentless_workspace.py
+++ b/sculptor/tests/integration/frontend/test_agentless_workspace.py
@@ -26,7 +26,7 @@ def test_agentless_workspace_renders_section_shell(sculptor_instance_: SculptorI
     2. Verify the sidebar and workspace header render.
     3. Verify the center section renders its empty state with quick actions.
     4. Verify the default arrangement was seeded around the empty center: the
-       left section expands to reveal its Files/Changes/Commits tabs.
+       expanded left section shows its Files/Changes/Commits tabs.
     """
     page = sculptor_instance_.page
 
@@ -45,10 +45,9 @@ def test_agentless_workspace_renders_section_shell(sculptor_instance_: SculptorI
     expect(empty_state.get_add_panel_button()).to_be_visible()
     expect(empty_state.get_quick_action("new-agent")).to_be_visible()
 
-    # Step 4: The rest of the default arrangement was seeded — expanding the left
-    # section reveals its seeded explorer tabs.
+    # Step 4: The rest of the default arrangement was seeded — the expanded left
+    # section shows its seeded explorer tabs.
     left = PlaywrightWorkspaceSection(page, "left")
-    left.expand_section()
     expect(left.get_panel_tab("files")).to_be_visible()
     expect(left.get_panel_tab("changes")).to_be_visible()
     expect(left.get_panel_tab("commits")).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_changes_panel.py
+++ b/sculptor/tests/integration/frontend/test_changes_panel.py
@@ -14,9 +14,9 @@ panel's OWN embedded viewer rather than a page-wide active diff. The discard
 controls only render in the Uncommitted scope, so tests select the Uncommitted
 scope through the picker before discarding.
 
-The Changes panel is seeded into the (collapsed-by-default) left section, so
-opening it reveals it there while the agent chat stays mounted in the center
-section. Tests that observe a chat message after a panel action (the commit
+The Changes panel is seeded into the left section, so opening it reveals it there
+while the agent chat stays mounted in the center section. Tests that observe a
+chat message after a panel action (the commit
 button) read the still-mounted center chat.
 
 The scope picker also drives the scope-dependent diff modes (HEAD-vs-working in

--- a/sculptor/tests/integration/frontend/test_command_palette.py
+++ b/sculptor/tests/integration/frontend/test_command_palette.py
@@ -378,7 +378,7 @@ def test_command_palette_show_panel_is_jump_only(sculptor_instance_: SculptorIns
     task_page = start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Cmd+K Show Panel WS")
     left = PlaywrightWorkspaceSection(page, "left")
 
-    # First run: reveals the Files panel (seeded into the collapsed left section).
+    # First run: reveals the Files panel (seeded, open in the left section).
     palette = task_page.open_command_palette()
     palette.type_query("Show Files")
     palette.select_by_command_id("view.toggle_panel.files")

--- a/sculptor/tests/integration/frontend/test_commits_panel.py
+++ b/sculptor/tests/integration/frontend/test_commits_panel.py
@@ -19,9 +19,9 @@ the *surface* moved:
   opened section, and clicking a commit's file opens its commit-scoped diff into
   the panel's OWN embedded viewer rather than a page-wide active diff.
 
-The Commits panel is seeded into the (collapsed-by-default) LEFT section, so
-``_open_commits_panel_with`` reveals it there while the agent chat stays mounted
-in the CENTER section. These history assertions are read-only; the one test that
+The Commits panel is seeded into the LEFT section, so ``_open_commits_panel_with``
+reveals it there while the agent chat stays mounted in the CENTER section. These
+history assertions are read-only; the one test that
 sends a follow-up commit types into the still-mounted chat, then re-activates the
 Commits tab to read the refreshed history.
 
@@ -501,9 +501,9 @@ def _reactivate_commits_panel(page: Page) -> PlaywrightCommitsPanelElement:
 
     A single-instance panel that is already open is dropped from the add-panel
     dropdown's re-add list, so re-opening it that way would fail. The Commits panel
-    is seeded into the (collapsed-by-default) LEFT section; ``_open_commits_panel_with``
-    already expanded it, so this re-expands it (idempotent) and clicks its LEFT-section
-    panel tab to make the already-open Commits panel active again.
+    is seeded into the LEFT section; this expands it (idempotent — the left section
+    is expanded in the default layout) and clicks its LEFT-section panel tab to make
+    the already-open Commits panel active again.
     """
     left_section = PlaywrightWorkspaceSection(page, "left")
     left_section.expand_section()

--- a/sculptor/tests/integration/frontend/test_panel_rename_and_close.py
+++ b/sculptor/tests/integration/frontend/test_panel_rename_and_close.py
@@ -29,7 +29,7 @@ def test_static_panel_tab_has_no_rename_in_context_menu(sculptor_instance_: Scul
 
     start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Static No Rename WS")
 
-    # Files is seeded into the (collapsed) left section, so open_panel reveals it there;
+    # Files is seeded into the left section, so open_panel reveals it there;
     # the tab and its affordances live in the left header.
     left = PlaywrightWorkspaceSection(page, "left")
     open_panel(page, "files", "left")
@@ -56,7 +56,7 @@ def test_static_panel_tab_double_click_does_not_rename(sculptor_instance_: Sculp
 
     start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Static No Dblclick WS")
 
-    # Files is seeded into the (collapsed) left section, so open_panel reveals it there.
+    # Files is seeded into the left section, so open_panel reveals it there.
     left = PlaywrightWorkspaceSection(page, "left")
     open_panel(page, "files", "left")
     files_tab = left.get_panel_tab("files")
@@ -75,7 +75,7 @@ def test_static_panel_close_removes_it_from_header(sculptor_instance_: SculptorI
 
     start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Static Close WS")
 
-    # Files is seeded into the (collapsed) left section, so open_panel reveals it there.
+    # Files is seeded into the left section, so open_panel reveals it there.
     left = PlaywrightWorkspaceSection(page, "left")
     open_panel(page, "files", "left")
     expect(left.get_panel_tab("files")).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_recent_files_dropdown.py
+++ b/sculptor/tests/integration/frontend/test_recent_files_dropdown.py
@@ -7,9 +7,9 @@ dropdown (and vice versa) — and picking an entry stays in the originating
 panel: Files re-opens a read-only file view, Changes re-opens the file's diff,
 and Commits re-opens the file's diff within the commit it was viewed in.
 
-The three panels are seeded into the (collapsed) left section, so the tests
-drive them by expanding that section and switching its panel tabs (via
-``open_panel``, which reveals a seeded panel where it lives).
+The three panels are seeded into the left section, so the tests drive them by
+switching its panel tabs (via ``open_panel``, which reveals a seeded panel
+where it lives).
 """
 
 from playwright.sync_api import Page

--- a/sculptor/tests/integration/frontend/test_sculpt_ui_open_file.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_ui_open_file.py
@@ -24,6 +24,7 @@ from playwright.sync_api import expect
 
 from sculptor.testing.elements.add_panel_dropdown import open_panel
 from sculptor.testing.elements.diff_panel import get_diff_panel_from_page
+from sculptor.testing.elements.files_panel import get_files_panel_in
 from sculptor.testing.elements.workspace_section import PlaywrightWorkspaceSection
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import navigate_to_workspace
@@ -227,10 +228,10 @@ def test_open_file_for_inactive_workspace_leaves_viewed_workspace_alone(
     Open-file events arrive over the unified stream for EVERY workspace, but the
     reveal (open/expand the host panel, jump to its section) may only run in the
     workspace the event targets. Here the event targets workspace A while
-    workspace B is being viewed: B's layout must stay untouched — no file viewer
-    mounts in it, including after a round-trip away and back (so no layout change
-    was persisted for B) — while A surfaces the file in its Files viewer on the
-    next visit.
+    workspace B is being viewed: B's layout must stay untouched — its default
+    Files viewer stays at the empty placeholder (no file surfaced), including
+    after a round-trip away and back (so no layout change was persisted for B) —
+    while A surfaces the file in its Files viewer on the next visit.
     """
     page = sculptor_instance_.page
 
@@ -240,11 +241,11 @@ def test_open_file_for_inactive_workspace_leaves_viewed_workspace_alone(
     target_workspace_id = _extract_workspace_id_from_url(page.url)
     open_panel(page, "files", sub_section="left")
 
-    # Workspace B (the viewed one): keeps its seeded default — left expanded with its
-    # explorer, but no file viewer mounted.
+    # Workspace B (the viewed one): keeps its seeded default — left expanded with the
+    # Files explorer, whose embedded viewer sits at the empty placeholder (no file open).
     start_task_and_wait_for_ready(page, prompt=_NO_OP_PROMPT, workspace_name="Open File Viewer WS")
-    expect(PlaywrightWorkspaceSection(page, "left").get_header()).to_be_visible()
-    expect(get_diff_panel_from_page(page)).to_have_count(0)
+    viewer_ws_files = get_files_panel_in(PlaywrightWorkspaceSection(page, "left").get_section(), page)
+    expect(viewer_ws_files.get_diff_viewer().get_empty_body()).to_be_visible()
 
     with _temp_readable_file(content="hello from the target workspace\n") as file_path:
         exit_code, _stdout, stderr = _run_sculpt_ui_open_file(
@@ -259,9 +260,9 @@ def test_open_file_for_inactive_workspace_leaves_viewed_workspace_alone(
         navigate_to_workspace(page, "Open File Target WS")
         get_diff_panel_from_page(page).expect_shows_file(Path(file_path).name)
 
-        # Back to B: nothing was opened or persisted for it — the left section keeps
-        # its default expanded explorer and no file viewer is mounted.
+        # Back to B: nothing was opened or persisted for it — its Files viewer still
+        # sits at the empty placeholder, confirming the event surfaced no file here.
         navigate_to_workspace(page, "Open File Viewer WS")
         expect(PlaywrightTaskPage(page=page).get_chat_panel()).to_be_visible(timeout=60_000)
-        expect(PlaywrightWorkspaceSection(page, "left").get_header()).to_be_visible()
-        expect(get_diff_panel_from_page(page)).to_have_count(0)
+        viewer_ws_files = get_files_panel_in(PlaywrightWorkspaceSection(page, "left").get_section(), page)
+        expect(viewer_ws_files.get_diff_viewer().get_empty_body()).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_sculpt_ui_open_file.py
+++ b/sculptor/tests/integration/frontend/test_sculpt_ui_open_file.py
@@ -227,10 +227,10 @@ def test_open_file_for_inactive_workspace_leaves_viewed_workspace_alone(
     Open-file events arrive over the unified stream for EVERY workspace, but the
     reveal (open/expand the host panel, jump to its section) may only run in the
     workspace the event targets. Here the event targets workspace A while
-    workspace B is being viewed: B's layout must stay untouched — its left
-    section stays collapsed and no viewer mounts, including after a round-trip
-    away and back (so no layout change was persisted for B) — while A surfaces
-    the file in its Files viewer on the next visit.
+    workspace B is being viewed: B's layout must stay untouched — no file viewer
+    mounts in it, including after a round-trip away and back (so no layout change
+    was persisted for B) — while A surfaces the file in its Files viewer on the
+    next visit.
     """
     page = sculptor_instance_.page
 
@@ -240,9 +240,11 @@ def test_open_file_for_inactive_workspace_leaves_viewed_workspace_alone(
     target_workspace_id = _extract_workspace_id_from_url(page.url)
     open_panel(page, "files", sub_section="left")
 
-    # Workspace B (the viewed one): keeps its seeded default — left collapsed.
+    # Workspace B (the viewed one): keeps its seeded default — left expanded with its
+    # explorer, but no file viewer mounted.
     start_task_and_wait_for_ready(page, prompt=_NO_OP_PROMPT, workspace_name="Open File Viewer WS")
-    expect(PlaywrightWorkspaceSection(page, "left").get_header()).to_have_count(0)
+    expect(PlaywrightWorkspaceSection(page, "left").get_header()).to_be_visible()
+    expect(get_diff_panel_from_page(page)).to_have_count(0)
 
     with _temp_readable_file(content="hello from the target workspace\n") as file_path:
         exit_code, _stdout, stderr = _run_sculpt_ui_open_file(
@@ -257,9 +259,9 @@ def test_open_file_for_inactive_workspace_leaves_viewed_workspace_alone(
         navigate_to_workspace(page, "Open File Target WS")
         get_diff_panel_from_page(page).expect_shows_file(Path(file_path).name)
 
-        # Back to B: nothing was opened or persisted for it — the left section
-        # is still collapsed and no viewer is mounted.
+        # Back to B: nothing was opened or persisted for it — the left section keeps
+        # its default expanded explorer and no file viewer is mounted.
         navigate_to_workspace(page, "Open File Viewer WS")
         expect(PlaywrightTaskPage(page=page).get_chat_panel()).to_be_visible(timeout=60_000)
-        expect(PlaywrightWorkspaceSection(page, "left").get_header()).to_have_count(0)
+        expect(PlaywrightWorkspaceSection(page, "left").get_header()).to_be_visible()
         expect(get_diff_panel_from_page(page)).to_have_count(0)

--- a/sculptor/tests/integration/frontend/test_section_collapse_expand.py
+++ b/sculptor/tests/integration/frontend/test_section_collapse_expand.py
@@ -1,6 +1,6 @@
 """Integration tests for section collapse/expand + within-section panel cycling.
 
-The default test layout has only the CENTER section expanded; the left, right, and
+The default test layout has the CENTER and LEFT sections expanded; the right and
 bottom sections are collapsed and render no header until expanded. A non-center
 section can be expanded/collapsed either by its workspace-header toggle or by the
 ``mod+Alt+Arrow*`` keyboard shortcut; the center section has no toggle and cannot be
@@ -31,7 +31,9 @@ def test_expand_side_section_via_header_toggle(sculptor_instance_: SculptorInsta
 
     start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Expand Toggle WS")
 
-    for section_id in ("left", "right", "bottom"):
+    # Left starts expanded in the default layout, so the collapsed-by-default sections
+    # exercised by the header toggle are right and bottom.
+    for section_id in ("right", "bottom"):
         section = PlaywrightWorkspaceSection(page, section_id)
         # Collapsed by default: no header is rendered.
         expect(section.get_header()).to_have_count(0)
@@ -41,21 +43,22 @@ def test_expand_side_section_via_header_toggle(sculptor_instance_: SculptorInsta
 
 @user_story("to expand and collapse a side section with the keyboard")
 def test_toggle_side_section_via_hotkey(sculptor_instance_: SculptorInstance) -> None:
-    """The ``mod+Alt+Arrow*`` shortcut expands a collapsed section and collapses it again."""
+    """The ``mod+Alt+Arrow*`` shortcut collapses an expanded section and expands it again."""
     page = sculptor_instance_.page
 
     start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Toggle Hotkey WS")
 
     left = PlaywrightWorkspaceSection(page, "left")
-    expect(left.get_header()).to_have_count(0)
-
-    # Expand via the hotkey -> header renders.
-    toggle_section_via_hotkey(page, "left")
+    # Left is expanded in the default layout, so its header renders from the start.
     expect(left.get_header()).to_be_visible()
 
-    # Collapse via the hotkey -> header removed again.
+    # Collapse via the hotkey -> header removed.
     toggle_section_via_hotkey(page, "left")
     expect(left.get_header()).to_have_count(0)
+
+    # Expand via the hotkey -> header renders again.
+    toggle_section_via_hotkey(page, "left")
+    expect(left.get_header()).to_be_visible()
 
 
 @user_story("to keep the center section always visible because it cannot be collapsed")

--- a/sculptor/tests/integration/frontend/test_section_default_layout.py
+++ b/sculptor/tests/integration/frontend/test_section_default_layout.py
@@ -2,14 +2,14 @@
 
 On a workspace's FIRST visit the shell seeds the default arrangement:
 
-* center — the only expanded section, holding the active agent;
-* left   — collapsed, with Files/Changes/Commits open and Files active;
+* center — expanded, holding the active agent;
+* left   — expanded, with Files/Changes/Commits open and Files active;
 * bottom — collapsed, with one terminal;
 * right  — collapsed and empty.
 
 These assert the seeded default by driving the section collapse/expand POMs the way a
-user would (the seeded sections start collapsed; expanding one reveals its seeded
-panels).
+user would: the expanded sections show their seeded panels straight away, while the
+collapsed sections reveal theirs once expanded.
 """
 
 import re
@@ -36,17 +36,15 @@ def test_default_center_holds_the_active_agent(sculptor_instance_: SculptorInsta
     expect(center.get_active_tab()).to_have_attribute("data-panel-id", re.compile(r"^agent:"))
 
 
-@user_story("to find Files/Changes/Commits ready in a collapsed left section")
-def test_default_left_collapsed_with_files_changes_commits(sculptor_instance_: SculptorInstance) -> None:
-    """Left starts collapsed; expanded it holds Files/Changes/Commits with Files active."""
+@user_story("to find Files/Changes/Commits ready in an expanded left section")
+def test_default_left_expanded_with_files_changes_commits(sculptor_instance_: SculptorInstance) -> None:
+    """Left starts expanded, holding Files/Changes/Commits with Files active."""
     page = sculptor_instance_.page
     start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Default Left WS")
 
     left = PlaywrightWorkspaceSection(page, "left")
-    # Collapsed by default: a collapsed section renders no header.
-    expect(left.get_header()).to_have_count(0)
-
-    left.expand_section()
+    # Expanded by default: its header renders with no expand interaction.
+    expect(left.get_header()).to_be_visible()
     expect(left.get_panel_tab("files")).to_be_visible()
     expect(left.get_panel_tab("changes")).to_be_visible()
     expect(left.get_panel_tab("commits")).to_be_visible()


### PR DESCRIPTION
## Summary

On a workspace's first visit the shell seeds a default layout. Previously every non-center section was seeded collapsed, so a brand-new workspace opened with only the center (agent) section visible and the Files/Changes/Commits explorer hidden behind a toggle — even though the explorer is the surface most users reach for on entering a workspace.

This makes the default layout seed the **left section expanded** so Files/Changes/Commits (Files active) are visible on first open, alongside the always-expanded center. The right and bottom sections stay collapsed, and the left section remains collapsible.

Ticket: SCU-1771.

## What changed

- **`defaultLayout.ts`** — `buildDefaultWorkspaceLayout()` now sets `expanded.left: true`. The left section already seeds Files/Changes/Commits with Files active, so it now renders open with no expand interaction. Agentless workspaces inherit this automatically (their default is built on top of the same function).
- **Integration tests** — updated the tests that asserted the left section was collapsed on first visit (default-layout, section collapse/expand, agentless shell, open-file isolation) to the new expanded default, and refreshed the POM-helper and docstring comments that described the left section as collapsed.
- **Open-file isolation test** — the "viewed workspace is untouched" check previously leaned on the left section being collapsed (so no viewer was mounted). Because the Files panel now mounts its embedded viewer by default, the test now asserts the real invariant directly: the viewed workspace's Files viewer stays at its empty placeholder (no file surfaced), scoped within the panel rather than matching the viewer test id page-wide.

## Why

The explorer is the most-used surface on entering a workspace; hiding it behind a manual expand added friction to the common case. Opening it by default matches how most users arrange the workspace anyway, while the section stays collapsible for those who want the center-only view.

## Testing

- `just format`, `just check` (lint + types + ratchets), and `just test-unit` (backend, frontend, foundation, sculpt) all pass.
- Ran the affected frontend integration tests locally — **20 passed** across `test_section_default_layout.py`, `test_section_collapse_expand.py`, `test_sculpt_ui_open_file.py`, and `test_agentless_workspace.py`. CI runs the full suite.

(Sent by Claude)
