### PR TITLE
Refine status-toast styling and the add-panel dropdown rows

### DIFF
--- a/sculptor/frontend/src/components/Toast.module.scss
+++ b/sculptor/frontend/src/components/Toast.module.scss
@@ -45,15 +45,6 @@
     animation: swipeOut 100ms ease-out;
   }
 
-  &.success {
-    background-color: var(--green-a2);
-    border-color: var(--green-a6);
-
-    .title {
-      color: var(--green-12);
-    }
-  }
-
   &.error {
     background-color: var(--red-a2);
     border-color: var(--red-a6);

--- a/sculptor/frontend/src/components/Toast.module.scss
+++ b/sculptor/frontend/src/components/Toast.module.scss
@@ -46,7 +46,7 @@
   }
 
   &.success {
-    background-color: var(--green-2);
+    background-color: var(--green-a2);
     border-color: var(--green-a6);
 
     .title {
@@ -55,7 +55,7 @@
   }
 
   &.error {
-    background-color: var(--red-2);
+    background-color: var(--red-a2);
     border-color: var(--red-a6);
 
     .title {
@@ -64,7 +64,7 @@
   }
 
   &.warning {
-    background-color: var(--yellow-2);
+    background-color: var(--yellow-a2);
     border-color: var(--yellow-a6);
 
     .title {

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.module.scss
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.module.scss
@@ -2,6 +2,14 @@
 // keybinding hint. Rendered inside Radix DropdownMenu items, so the row itself
 // only lays out its contents — hover/active backgrounds come from the Radix item.
 
+// Radix leaves the menu unbounded, so it grows to fit its widest row — a long
+// panel description would otherwise stretch the whole dropdown. Cap the width so a
+// description that runs past it truncates (see .description) while short ones still
+// show in full.
+.content {
+  max-width: 320px;
+}
+
 .item {
   align-items: center;
   display: flex;
@@ -10,27 +18,31 @@
   min-width: 0;
 }
 
-// Vertical stack holding the title and (optionally) the description, so the
-// description sits UNDER the title while the trailing shortcut stays on the row.
-// Takes the row's free space and clamps its width so both lines ellipsize.
+// Single row holding the title and (optionally) the description side by side: the
+// title keeps its intrinsic width while the description takes the remaining space
+// and ellipsizes, so the description sits on the SAME line as the title and the
+// trailing shortcut stays put.
 .itemText {
+  align-items: baseline;
   display: flex;
   flex: 1 1 auto;
-  flex-direction: column;
+  gap: var(--space-2);
   min-width: 0;
 }
 
 .itemTitle {
   color: var(--gray-12);
-  overflow: hidden;
-  text-overflow: ellipsis;
+  flex-shrink: 0;
   white-space: nowrap;
 }
 
-// Secondary line under the title: compact, muted, single-line with ellipsis.
+// Secondary text trailing the title on the same row: compact, muted, and
+// ellipsized when it runs out of room so it never pushes out the shortcut.
 .description {
   color: var(--gray-10);
+  flex: 1 1 auto;
   font-size: var(--font-size-1);
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.module.scss
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.module.scss
@@ -32,8 +32,17 @@
 
 .itemTitle {
   color: var(--gray-12);
-  flex-shrink: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+// When a description shares the row, the title holds its intrinsic width so the
+// description is the element that gives up space and ellipsizes. On a title-only
+// row the base rule lets the title itself ellipsize if it outgrows the menu.
+.itemTitleWithDescription {
+  flex-shrink: 0;
 }
 
 // Secondary text trailing the title on the same row: compact, muted, and

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
@@ -21,6 +21,7 @@ import { type AgentTypeName, ElementIds } from "~/api";
 import { useKeybindingDisplayText } from "~/common/keybindings/hooks.ts";
 import { INSTALL_PI_LABEL, usePiAgentOption } from "~/common/state/hooks/usePiAgentOption.ts";
 import { useTerminalAgentRegistrations } from "~/common/state/hooks/useTerminalAgentRegistrations.ts";
+import { mergeClasses } from "~/common/Utils.ts";
 
 import {
   availableStaticPanelsAtom,
@@ -35,9 +36,10 @@ import { useAddPanelActions } from "./useAddPanelActions.ts";
 // The shared row body rendered inside every dropdown item and sub-trigger: a label
 // with an optional trailing keybinding hint (no leading icons — text-only rows).
 // When a description is supplied it renders inline after the label on the same row,
-// muted and ellipsized when space runs short; rows without one render exactly as a
-// single title line. Hover/active backgrounds come from the wrapping Radix item, so
-// this only lays out the contents.
+// muted and ellipsized when space runs short; the label then holds its width so the
+// description is what gives way. A row without a description is a single title line
+// that ellipsizes if it outgrows the menu. Hover/active backgrounds come from the
+// wrapping Radix item, so this only lays out the contents.
 const MenuRow = ({
   label,
   shortcut,
@@ -46,15 +48,20 @@ const MenuRow = ({
   label: string;
   shortcut?: string;
   description?: string;
-}): ReactElement => (
-  <span className={styles.item}>
-    <span className={styles.itemText}>
-      <span className={styles.itemTitle}>{label}</span>
-      {description !== undefined && description !== "" && <span className={styles.description}>{description}</span>}
+}): ReactElement => {
+  const hasDescription = description !== undefined && description !== "";
+  return (
+    <span className={styles.item}>
+      <span className={styles.itemText}>
+        <span className={mergeClasses(styles.itemTitle, hasDescription ? styles.itemTitleWithDescription : undefined)}>
+          {label}
+        </span>
+        {hasDescription && <span className={styles.description}>{description}</span>}
+      </span>
+      {shortcut !== undefined && shortcut !== "" && <span className={styles.shortcut}>{shortcut}</span>}
     </span>
-    {shortcut !== undefined && shortcut !== "" && <span className={styles.shortcut}>{shortcut}</span>}
-  </span>
-);
+  );
+};
 
 type AddPanelDropdownProps = {
   subSection: SubSectionId;

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
@@ -34,9 +34,10 @@ import { useAddPanelActions } from "./useAddPanelActions.ts";
 
 // The shared row body rendered inside every dropdown item and sub-trigger: a label
 // with an optional trailing keybinding hint (no leading icons — text-only rows).
-// When a description is supplied it renders as a second, smaller line under the
-// label; rows without one render exactly as a single title line. Hover/active
-// backgrounds come from the wrapping Radix item, so this only lays out the contents.
+// When a description is supplied it renders inline after the label on the same row,
+// muted and ellipsized when space runs short; rows without one render exactly as a
+// single title line. Hover/active backgrounds come from the wrapping Radix item, so
+// this only lays out the contents.
 const MenuRow = ({
   label,
   shortcut,
@@ -203,6 +204,7 @@ export const AddPanelDropdown = ({ subSection, trigger, tooltip }: AddPanelDropd
       )}
       <DropdownMenu.Content
         size="1"
+        className={styles.content}
         data-testid={`${ElementIds.ADD_PANEL_DROPDOWN}-${subSection}`}
         onCloseAutoFocus={(event) => {
           if (openedPanelRef.current) {


### PR DESCRIPTION
## Summary

Two follow-up UI refinements from reviewing the compact-layout work:

### Status toasts (SCU-1700)
- Success/error/warning toasts go back to the **translucent alpha backgrounds** (`--green-a2` / `--red-a2` / `--yellow-a2`) so they read as light, layered overlays rather than solid panels. `.errorProminent` keeps its solid, higher-urgency treatment.
- The **success variant is then removed entirely**, so success toasts fall back to the neutral base toast styling (no colored fill or green title). A passing confirmation — "Agent stopped successfully", "Message copied to clipboard", settings saves, etc. — doesn't need the extra visual weight; error and warning keep their tinted surfaces, which do need to catch the eye.

### Add-panel dropdown (SCU-1722)
- The restored plugin-panel description now renders **inline with the title on a single row** (muted, smaller) instead of stacking as a second line. The description takes the remaining space and ellipsizes when it runs short, so the trailing keybinding column is never squeezed.
- The dropdown menu is **width-capped** so a long description truncates rather than stretching the whole menu; short descriptions (e.g. the bundled Linear panel's) still show in full.
- The **title ellipsizes when it owns the whole row** (e.g. "New \<registered agent\> agent" with a long program name); it only pins to its intrinsic width when a description shares the row.

## Changes
- `Toast.module.scss` — translucent variant backgrounds; `.success` variant removed.
- `AddPanelDropdown.tsx` / `AddPanelDropdown.module.scss` — single-row title + description layout, menu `max-width` cap, and conditional title truncation.

## Verification
These are CSS/markup-only changes with no behavioral logic. Verified in the manual QA harness against real Claude: the neutral success toast on agent-stop, the inline description at both wide and narrow dropdown widths, and truncation engaging under the width cap. `just format`, `just check`, and `just test-unit` all pass.

No automated tests are added: per the repo's testing guidance, purely visual changes are verified with screenshots rather than layout-asserting tests.

Tickets: SCU-1700, SCU-1722

(Sent by Claude)
