### PR TITLE
Cherry-pick #306 into 0.41.0: bump Claude CLI floor to 2.1.202 (resume stuck-streaming fix)

### DIFF
--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -212,8 +212,8 @@ packaging Sculptor):
 
 ### 3.3 Required external binaries
 
-- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.195,
-  minimum 2.1.195, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
+- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.202,
+  minimum 2.1.202, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
   **linux-x64** (`sculptor/sculptor/services/managed_tools.py`). Sculptor can install/manage it and can use a
   user-supplied binary (`SPEC.md` §7.1, §7.10).
 - **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -240,9 +240,16 @@ _CLAUDE_MANIFEST_FETCH_TIMEOUT_SECONDS = 30.0
 # the existing service -> managed_tools edge, which would be an import cycle. The
 # service re-imports this constant for its status / version-range logic.
 CLAUDE_VERSION_RANGE = VersionRange(
-    min_version="2.1.195",
+    # Floor is 2.1.202: earlier releases mishandle a session resume that carries
+    # `stopped` background-task notifications (left over from tasks killed by a
+    # prior interrupt). The CLI can deliver such a notification so that the user
+    # turn being awaited never emits its own terminating `result`, which wedges
+    # the chat in a perpetual "streaming" state. The resume-of-background-tasks
+    # path was reworked in 2.1.198; 2.1.202 is the earliest release validated
+    # against this failure. Do not lower this without re-validating that case.
+    min_version="2.1.202",
     max_version="2.99.99",
-    recommended_version="2.1.195",
+    recommended_version="2.1.202",
     # Blocked versions create background tool invocations that are missing events
     # describing them.
     blocked_versions=(BlockedVersionRange(min_version="2.1.101", max_version="2.1.101"),),


### PR DESCRIPTION
Cherry-picks #306 into the 0.41.0 release branch — raises the managed Claude CLI floor to 2.1.202, which fixes a resume stuck-streaming issue.

## Included
- `bb47628108e` Bump Claude CLI floor to 2.1.202 to fix resume stuck-streaming

Original commit on `main`. Clean cherry-pick, no conflicts — touches only `sculptor/services/managed_tools.py` (the version pin) and `docs/specs/requirements.md`. Neither file had any intervening change on the 0.41 branch since the cut, so this is self-contained.

After this merges, `just fixup` on the release branch will tag rc2.

(Sent by Claude)