### PR TITLE
State-ownership burndown: consolidate task cache writes, migrate per-field reads (SCU-1120)

### DIFF
--- a/docs/development/state-ownership-burndown.md
+++ b/docs/development/state-ownership-burndown.md
@@ -79,17 +79,52 @@ segment, …):
 One surface per PR. Order by user-visible risk: failure paths that leave
 permanently stale UI first, hygiene (duplicate paths, dead options) last.
 
+## Classification results (2026-07 judgment pass)
+
+Every `no-fire-and-forget-api-catch` site was judged against the exemption
+test. None is a swallowed rejection; the frozen budget documents them:
+
+- `state/atoms/workspaces.ts` open/close tabs — **sound**. Failure paths
+  clear the pending open/close intent, roll back the guarded insert, and
+  surface a retry toast. The pending-intent overlay + `effectiveOpenTabIdsAtom`
+  derivation is a good example of client-intent state layered over server
+  facts; no change wanted.
+- `useOptimisticWorkspaceDelete.ts` — **handled, but V3**: the rollback
+  restores a snapshot without an interleave check, so a WS workspace frame
+  that lands mid-request can be clobbered. Fix on the workspace surface
+  with the same sync-version approach the task mutations use.
+- `PathAutocomplete.tsx` — **exempt** (fetch fallback, no optimistic
+  write). Separate debt: hand-rolled request-id dedup that
+  `use_tanstack_for_pulled_data` would route through `useQuery`.
+- `RepoSegment.tsx` — **exempt** (error message on failure, no optimistic
+  write).
+- `useOptimisticTaskDelete.ts` — handled with CAS rollback; consolidated
+  behind `useDeleteTaskMutation` so all cache writes live in
+  `state/mutations/`.
+
 ## Known burn-down items
 
-- `useOptimisticTaskDelete.ts` — the two `setQueryData` rollback/tombstone
-  writes should move behind a delete mutation in `state/mutations/`
-  (accounts for the entire `no-scattered-setquerydata` budget).
-- The workspace open/close writes in `state/atoms/workspaces.ts` and
-  `useOptimisticWorkspaceDelete.ts` — same optimistic-write shape as the
-  old task code; classify against V1/V2 and migrate on the same recipe.
-- The Jotai task atoms + `useTaskQueryMirror` — delete both once the last
-  Jotai reader (`tasksArrayAtom` consumers, the per-field selector
-  families) migrates to `useTask`/`useTaskIds`. This is the terminal item.
+- ~~`useOptimisticTaskDelete.ts` `setQueryData` writes~~ — done: delete
+  cache writes live behind `useDeleteTaskMutation`;
+  `no-scattered-setquerydata` budget is `0`.
+- ~~Per-field task selector reads in components~~ — done: the
+  `useTaskHelpers` hooks read the query cache via `select`; only the
+  selector atom families still consumed by Jotai atom graphs remain.
+- `useOptimisticWorkspaceDelete.ts` — add an interleave check to the
+  rollback (V3 above); consider a `workspaceSyncVersion` bumped by
+  `updateWorkspacesAtom`.
+- The Jotai task atoms + `useTaskQueryMirror` — the terminal item, blocked
+  on the remaining Jotai readers, which are no longer components but
+  **atom graphs and the plugin SDK**:
+  - `state/atoms/workspaces.ts`, `state/atoms/mentionDetails.ts`,
+    `state/agentPanelPlacement.ts`, `pages/workspace/panels/workspaceAgentActions.ts`
+    derive from `tasksArrayAtom` / `taskAtomFamily` / four surviving
+    selector families inside Jotai `get(...)` graphs — migrating them means
+    restructuring those derivations, not swapping a hook.
+  - `plugins/sdk/hooks.ts` exposes task state to runtime-loaded plugins —
+    a public API that needs a deprecation path, not a rename.
+  Until those move, the mirror stays, and `taskAtomFamily`/`taskIdsAtom`
+  remain single-writer projections.
 
 ## Exit criteria
 

--- a/ratchet-counts.toml
+++ b/ratchet-counts.toml
@@ -29,9 +29,10 @@
 [no-eval-usage]
 "." = 0
 
-# Frozen at the 2026-07 state-ownership baseline (all pre-existing sites are
-# pure fire-and-forget with no optimistic local write, or tracked in
-# docs/development/state-ownership-burndown.md). Reduce only.
+# Frozen at the 2026-07 state-ownership baseline. Every site is classified in
+# docs/development/state-ownership-burndown.md (handled catches — rollback or
+# toast inside — or pure fire-and-forget with no optimistic local write).
+# Reduce only; bumps need a written justification.
 [no-fire-and-forget-api-catch]
 "." = 6
 
@@ -122,10 +123,10 @@
 [no-relative-imports]
 "." = 0
 
-# Both sites are useOptimisticTaskDelete's tombstone/rollback writes — the
-# first burn-down item in docs/development/state-ownership-burndown.md.
+# Zero is the floor: all cache writes live in queryClient.ts (WS bridge) and
+# src/common/state/mutations/. See docs/development/state-ownership-burndown.md.
 [no-scattered-setquerydata]
-"." = 2
+"." = 0
 
 [no-sculptor-copytree]
 "." = 1

--- a/ratchets/regex/no-direct-harness-capability-read.toml
+++ b/ratchets/regex/no-direct-harness-capability-read.toml
@@ -1,10 +1,14 @@
 [rule]
 id = "no-direct-harness-capability-read"
-description = "Disallow direct `.harnessCapabilities.<field>` reads outside the tasks.ts atom families; route capability reads through the narrow taskSupports<X> atoms/hooks so a mistyped field name cannot silently fail a gate open. The generated twin carries an index signature (its backing pydantic SerializableModel uses extra=\"allow\"), so member access on an unknown key type-checks — hence a lint rule rather than a compile-time check."
+description = "Disallow direct `.harnessCapabilities.<field>` reads outside the narrow-accessor modules (the tasks.ts atom families and the useTaskHelpers.ts field hooks); route capability reads through the narrow taskSupports<X> atoms/hooks so a mistyped field name cannot silently fail a gate open. The generated twin carries an index signature (its backing pydantic SerializableModel uses extra=\"allow\"), so member access on an unknown key type-checks — hence a lint rule rather than a compile-time check."
 severity = "error"
 
 [match]
 pattern = "\\.harnessCapabilities\\."
 languages = ["typescript"]
 include = ["sculptor/frontend/src/**/*.ts", "sculptor/frontend/src/**/*.tsx"]
-exclude = ["sculptor/frontend/src/common/state/atoms/tasks.ts", "sculptor/frontend/src/api/**"]
+exclude = [
+  "sculptor/frontend/src/common/state/atoms/tasks.ts",
+  "sculptor/frontend/src/common/state/hooks/useTaskHelpers.ts",
+  "sculptor/frontend/src/api/**",
+]

--- a/sculptor/frontend/src/common/state/atoms/tasks.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/tasks.test.ts
@@ -1,17 +1,19 @@
 import { createStore } from "jotai";
 import { describe, expect, it } from "vitest";
 
-import type { CodingAgentTaskView, HarnessCapabilities } from "../../../api";
+import type { CodingAgentTaskView } from "../../../api";
 import {
+  taskAcceptsAutomatedPromptsAtomFamily,
   taskAtomFamily,
-  taskAvailableModelsAtomFamily,
-  taskSupportsBackgroundTasksAtomFamily,
-  taskSupportsCompactionAtomFamily,
-  taskSupportsContextResetAtomFamily,
-  taskSupportsInteractiveBackchannelAtomFamily,
-  taskSupportsSessionResumeAtomFamily,
-  taskSupportsToolUseRenderingAtomFamily,
+  taskModelAtomFamily,
+  taskStatusAtomFamily,
+  taskSupportsChatInterfaceAtomFamily,
 } from "./tasks";
+
+// The surviving selector families back Jotai atom graphs only
+// (workspaceAgentActions.ts, mentionDetails.ts); React components read these
+// fields through the useTaskHelpers hooks instead (see useTaskHelpers.test.ts
+// for the fine-grained-subscription coverage).
 
 const createMockTask = (overrides: Partial<CodingAgentTaskView> = {}): CodingAgentTaskView =>
   ({
@@ -27,6 +29,7 @@ const createMockTask = (overrides: Partial<CodingAgentTaskView> = {}): CodingAge
     interface: "API",
     systemPrompt: null,
     model: "CLAUDE_4_SONNET",
+    acceptsAutomatedPrompts: false,
     harnessCapabilities: {
       supportsChatInterface: true,
       supportsInteractiveBackchannel: true,
@@ -53,199 +56,93 @@ const createMockTask = (overrides: Partial<CodingAgentTaskView> = {}): CodingAge
     ...overrides,
   }) as CodingAgentTaskView;
 
-describe("taskSupportsInteractiveBackchannelAtomFamily", () => {
+describe("taskStatusAtomFamily", () => {
   it("returns undefined when no task has been written for the id", () => {
     const store = createStore();
 
-    expect(store.get(taskSupportsInteractiveBackchannelAtomFamily("unknown-task"))).toBeUndefined();
+    expect(store.get(taskStatusAtomFamily("unknown-task"))).toBeUndefined();
   });
 
-  it("returns the task's supports_interactive_backchannel value when true", () => {
+  it("returns the task's status", () => {
     const store = createStore();
-    const task = createMockTask({
-      id: "task-1",
-      harnessCapabilities: {
-        supportsChatInterface: true,
-        supportsInteractiveBackchannel: true,
-        supportsSkills: true,
-        supportsSubAgents: true,
-        supportsImageInput: true,
-        supportsFastMode: true,
-        supportsContextReset: true,
-        supportsCompaction: true,
-        supportsBackgroundTasks: true,
-        supportsSessionResume: true,
-        supportsToolUseRendering: true,
-        supportsFileAttachments: true,
-        supportsInterruption: true,
-        supportsFileReferences: true,
-        supportsModelSelection: true,
-      },
-    });
-    store.set(taskAtomFamily("task-1"), task);
+    store.set(taskAtomFamily("task-1"), createMockTask({ id: "task-1", status: "WAITING" }));
 
-    expect(store.get(taskSupportsInteractiveBackchannelAtomFamily("task-1"))).toBe(true);
-  });
-
-  it("returns the task's supports_interactive_backchannel value when false", () => {
-    const store = createStore();
-    const task = createMockTask({
-      id: "task-1",
-      harnessCapabilities: {
-        supportsChatInterface: true,
-        supportsInteractiveBackchannel: false,
-        supportsSkills: false,
-        supportsSubAgents: false,
-        supportsImageInput: false,
-        supportsFastMode: false,
-        supportsContextReset: false,
-        supportsCompaction: false,
-        supportsBackgroundTasks: false,
-        supportsSessionResume: false,
-        supportsToolUseRendering: false,
-        supportsFileAttachments: false,
-        supportsInterruption: false,
-        supportsFileReferences: false,
-        supportsModelSelection: false,
-      },
-    });
-    store.set(taskAtomFamily("task-1"), task);
-
-    expect(store.get(taskSupportsInteractiveBackchannelAtomFamily("task-1"))).toBe(false);
+    expect(store.get(taskStatusAtomFamily("task-1"))).toBe("WAITING");
   });
 
   it("does not notify subscribers when an unrelated task field changes", () => {
     const store = createStore();
-    const task = createMockTask({
-      id: "task-1",
-      status: "RUNNING",
-      harnessCapabilities: {
-        supportsChatInterface: true,
-        supportsInteractiveBackchannel: true,
-        supportsSkills: true,
-        supportsSubAgents: true,
-        supportsImageInput: true,
-        supportsFastMode: true,
-        supportsContextReset: true,
-        supportsCompaction: true,
-        supportsBackgroundTasks: true,
-        supportsSessionResume: true,
-        supportsToolUseRendering: true,
-        supportsFileAttachments: true,
-        supportsInterruption: true,
-        supportsFileReferences: true,
-        supportsModelSelection: true,
-      },
-    });
+    const task = createMockTask({ id: "task-1", status: "RUNNING" });
     store.set(taskAtomFamily("task-1"), task);
 
     let notificationCount = 0;
-    const unsubscribe = store.sub(taskSupportsInteractiveBackchannelAtomFamily("task-1"), () => {
+    const unsubscribe = store.sub(taskStatusAtomFamily("task-1"), () => {
       notificationCount += 1;
     });
 
-    store.set(taskAtomFamily("task-1"), { ...task, status: "WAITING" } as CodingAgentTaskView);
+    store.set(taskAtomFamily("task-1"), { ...task, goal: "changed" } as CodingAgentTaskView);
     expect(notificationCount).toBe(0);
-
-    unsubscribe();
-  });
-
-  it("does not notify availableModels subscribers on unrelated task updates (stable empty list)", () => {
-    const store = createStore();
-    // No backend catalog (Claude): availableModels is undefined, so the derived
-    // atom must yield a stable empty array rather than a fresh one each recompute.
-    const task = createMockTask({ id: "task-1" });
-    store.set(taskAtomFamily("task-1"), task);
-
-    let notificationCount = 0;
-    const unsubscribe = store.sub(taskAvailableModelsAtomFamily("task-1"), () => {
-      notificationCount += 1;
-    });
-
-    store.set(taskAtomFamily("task-1"), { ...task, status: "WAITING" } as CodingAgentTaskView);
-    expect(notificationCount).toBe(0);
-
-    unsubscribe();
-  });
-
-  it("notifies subscribers when supports_interactive_backchannel changes", () => {
-    const store = createStore();
-    const task = createMockTask({
-      id: "task-1",
-      harnessCapabilities: {
-        supportsChatInterface: true,
-        supportsInteractiveBackchannel: true,
-        supportsSkills: true,
-        supportsSubAgents: true,
-        supportsImageInput: true,
-        supportsFastMode: true,
-        supportsContextReset: true,
-        supportsCompaction: true,
-        supportsBackgroundTasks: true,
-        supportsSessionResume: true,
-        supportsToolUseRendering: true,
-        supportsFileAttachments: true,
-        supportsInterruption: true,
-        supportsFileReferences: true,
-        supportsModelSelection: true,
-      },
-    });
-    store.set(taskAtomFamily("task-1"), task);
-
-    let notificationCount = 0;
-    const unsubscribe = store.sub(taskSupportsInteractiveBackchannelAtomFamily("task-1"), () => {
-      notificationCount += 1;
-    });
-
-    store.set(taskAtomFamily("task-1"), {
-      ...task,
-      harnessCapabilities: { ...task.harnessCapabilities, supportsInteractiveBackchannel: false },
-    } as CodingAgentTaskView);
-    expect(notificationCount).toBe(1);
-    expect(store.get(taskSupportsInteractiveBackchannelAtomFamily("task-1"))).toBe(false);
 
     unsubscribe();
   });
 });
 
-// Build a task whose harness advertises a single capability flag at the
-// given value, leaving every other flag at the all-true default.
-const buildTaskWithCapability = (field: keyof HarnessCapabilities, value: boolean): CodingAgentTaskView => {
-  const base = createMockTask({ id: "task-1" });
-  return { ...base, harnessCapabilities: { ...base.harnessCapabilities, [field]: value } } as CodingAgentTaskView;
-};
-
-// Every narrow capability atom family shares one read shape: an
-// optional-chained read of one twin field, yielding `boolean | undefined`.
-const CAPABILITY_ATOM_CASES: ReadonlyArray<{
-  atomFamily: typeof taskSupportsContextResetAtomFamily;
-  field: keyof HarnessCapabilities;
-}> = [
-  { atomFamily: taskSupportsContextResetAtomFamily, field: "supportsContextReset" },
-  { atomFamily: taskSupportsCompactionAtomFamily, field: "supportsCompaction" },
-  { atomFamily: taskSupportsBackgroundTasksAtomFamily, field: "supportsBackgroundTasks" },
-  { atomFamily: taskSupportsSessionResumeAtomFamily, field: "supportsSessionResume" },
-  { atomFamily: taskSupportsToolUseRenderingAtomFamily, field: "supportsToolUseRendering" },
-];
-
-describe.each(CAPABILITY_ATOM_CASES)("$field capability atom family", ({ atomFamily, field }) => {
+describe("taskModelAtomFamily", () => {
   it("returns undefined when no task has been written for the id", () => {
     const store = createStore();
 
-    expect(store.get(atomFamily("unknown-task"))).toBeUndefined();
+    expect(store.get(taskModelAtomFamily("unknown-task"))).toBeUndefined();
+  });
+
+  it("maps a null model to undefined (terminal agents carry no model)", () => {
+    const store = createStore();
+    store.set(taskAtomFamily("task-1"), createMockTask({ id: "task-1", model: null }));
+
+    expect(store.get(taskModelAtomFamily("task-1"))).toBeUndefined();
+  });
+});
+
+describe("taskSupportsChatInterfaceAtomFamily", () => {
+  it("returns undefined when no task has been written for the id", () => {
+    const store = createStore();
+
+    expect(store.get(taskSupportsChatInterfaceAtomFamily("unknown-task"))).toBeUndefined();
   });
 
   it("returns the capability value when true", () => {
     const store = createStore();
-    store.set(taskAtomFamily("task-1"), buildTaskWithCapability(field, true));
+    const base = createMockTask({ id: "task-1" });
+    store.set(taskAtomFamily("task-1"), {
+      ...base,
+      harnessCapabilities: { ...base.harnessCapabilities, supportsChatInterface: true },
+    } as CodingAgentTaskView);
 
-    expect(store.get(atomFamily("task-1"))).toBe(true);
+    expect(store.get(taskSupportsChatInterfaceAtomFamily("task-1"))).toBe(true);
   });
 
   it("returns the capability value when false", () => {
     const store = createStore();
-    store.set(taskAtomFamily("task-1"), buildTaskWithCapability(field, false));
+    const base = createMockTask({ id: "task-1" });
+    store.set(taskAtomFamily("task-1"), {
+      ...base,
+      harnessCapabilities: { ...base.harnessCapabilities, supportsChatInterface: false },
+    } as CodingAgentTaskView);
 
-    expect(store.get(atomFamily("task-1"))).toBe(false);
+    expect(store.get(taskSupportsChatInterfaceAtomFamily("task-1"))).toBe(false);
+  });
+});
+
+describe("taskAcceptsAutomatedPromptsAtomFamily", () => {
+  it("returns undefined when no task has been written for the id", () => {
+    const store = createStore();
+
+    expect(store.get(taskAcceptsAutomatedPromptsAtomFamily("unknown-task"))).toBeUndefined();
+  });
+
+  it("returns the task's accepts_automated_prompts value", () => {
+    const store = createStore();
+    store.set(taskAtomFamily("task-1"), createMockTask({ id: "task-1", acceptsAutomatedPrompts: true }));
+
+    expect(store.get(taskAcceptsAutomatedPromptsAtomFamily("task-1"))).toBe(true);
   });
 });

--- a/sculptor/frontend/src/common/state/atoms/tasks.ts
+++ b/sculptor/frontend/src/common/state/atoms/tasks.ts
@@ -2,11 +2,17 @@ import type { Atom, PrimitiveAtom } from "jotai";
 import { atom } from "jotai";
 import { atomFamily } from "jotai/utils";
 
-import type { CodingAgentTaskView, ModelOption, TaskStatus } from "../../../api";
+import type { CodingAgentTaskView, TaskStatus } from "../../../api";
 
 // The task atoms are legacy read models: the TanStack Query cache is the
 // written store for task state, and useTaskQueryMirror projects it into these
 // atoms for the remaining Jotai readers. Nothing else should write them.
+//
+// React components read per-task fields through the `useTask*` hooks in
+// `hooks/useTaskHelpers.ts` (select-based reads of the query cache). The
+// selector families that survive here exist ONLY for atom-graph readers that
+// derive from them inside Jotai `get(...)` — `workspaceAgentActions.ts` and
+// `mentionDetails.ts`. When those derivations move off Jotai, these go too.
 
 export const taskAtomFamily = atomFamily<string, PrimitiveAtom<CodingAgentTaskView | null>>(() =>
   atom<CodingAgentTaskView | null>(null),
@@ -24,10 +30,11 @@ export const tasksArrayAtom = atom<ReadonlyArray<CodingAgentTaskView> | undefine
     .filter((task): task is CodingAgentTaskView => task !== null && !task.isDeleted);
 });
 
-// Fine-grained derived atoms for commonly-read task fields.
-// Components subscribing to these only re-render when the specific field changes.
-// Jotai uses Object.is for primitive comparisons, so string/boolean fields that
-// stay the same across a task object update will not notify subscribers.
+// Fine-grained derived atoms for task fields still read inside Jotai atom
+// graphs. Components subscribing to these only re-render when the specific
+// field changes. Jotai uses Object.is for primitive comparisons, so string/
+// boolean fields that stay the same across a task object update will not
+// notify subscribers.
 
 export const taskStatusAtomFamily = atomFamily<string, Atom<TaskStatus | undefined>>((taskId) =>
   atom((get) => get(taskAtomFamily(taskId))?.status),
@@ -38,101 +45,8 @@ export const taskModelAtomFamily = atomFamily<string, Atom<string | undefined>>(
   atom((get) => get(taskAtomFamily(taskId))?.model ?? undefined),
 );
 
-// The workspace that owns the task — immutable once the task view has loaded,
-// so subscribers re-render only on load/removal, never on task churn (status,
-// timestamps, artifacts, ...).
-export const taskWorkspaceIdAtomFamily = atomFamily<string, Atom<string | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.workspaceId ?? undefined),
-);
-
-// A stable reference for the "no backend list" case, so the derived atom below
-// keeps one identity across unrelated task updates instead of a fresh array each
-// recompute.
-const EMPTY_MODEL_OPTIONS: ReadonlyArray<ModelOption> = [];
-
-// The harness's backend-sourced model catalog (pi). A non-capability view field,
-// so the no-direct-harness-capability-read ratchet does not apply. Empty for
-// harnesses that source no list (Claude) — the switcher then falls back to its
-// built-in PRODUCTION_MODELS.
-export const taskAvailableModelsAtomFamily = atomFamily<string, Atom<ReadonlyArray<ModelOption>>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.availableModels ?? EMPTY_MODEL_OPTIONS),
-);
-
-// The model_id the switcher should show as selected for a backend-sourced list
-// (pi), or undefined when the harness tracks no per-task selection.
-export const taskSelectedModelIdAtomFamily = atomFamily<string, Atom<string | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.selectedModelId ?? undefined),
-);
-
-// Whether the harness sources its switcher catalog from a backend (pi). A
-// non-capability view field, so the no-direct-harness-capability-read ratchet
-// does not apply.
-export const taskSourcesBackendModelsAtomFamily = atomFamily<string, Atom<boolean>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.sourcesBackendModels ?? false),
-);
-
-export const taskIsAutoCompactingAtomFamily = atomFamily<string, Atom<boolean>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.isAutoCompacting ?? false),
-);
-
-export const taskSupportsInteractiveBackchannelAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsInteractiveBackchannel),
-);
-
-export const taskSupportsFastModeAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsFastMode),
-);
-
-export const taskSupportsFileAttachmentsAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsFileAttachments),
-);
-
-export const taskSupportsImageInputAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsImageInput),
-);
-
-export const taskSupportsSkillsAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsSkills),
-);
-
-export const taskSupportsSubAgentsAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsSubAgents),
-);
-
-export const taskSupportsInterruptionAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsInterruption),
-);
-
-export const taskSupportsFileReferencesAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsFileReferences),
-);
-
-export const taskSupportsContextResetAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsContextReset),
-);
-
-export const taskSupportsCompactionAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsCompaction),
-);
-
-export const taskSupportsBackgroundTasksAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsBackgroundTasks),
-);
-
-export const taskSupportsSessionResumeAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsSessionResume),
-);
-
-export const taskSupportsToolUseRenderingAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsToolUseRendering),
-);
-
 export const taskSupportsChatInterfaceAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
   atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsChatInterface),
-);
-
-export const taskSupportsModelSelectionAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>
-  atom((get) => get(taskAtomFamily(taskId))?.harnessCapabilities.supportsModelSelection),
 );
 
 export const taskAcceptsAutomatedPromptsAtomFamily = atomFamily<string, Atom<boolean | undefined>>((taskId) =>

--- a/sculptor/frontend/src/common/state/hooks/useOptimisticTaskDelete.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useOptimisticTaskDelete.test.ts
@@ -1,3 +1,4 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import type { ReactElement, ReactNode } from "react";
@@ -48,6 +49,16 @@ const seedTask = (task: CodingAgentTaskView): void => {
   queryClient.setQueryData(taskQueryKey(task.id as string), task);
 };
 
+const getCachedTask = (id: string): CodingAgentTaskView | null | undefined =>
+  queryClient.getQueryData<CodingAgentTaskView | null>(taskQueryKey(id));
+
+// The hook uses both a Jotai store (workspace mapping, toasts) and a TanStack
+// mutation (the delete request), so both providers are required.
+const makeWrapper =
+  (store: ReturnType<typeof createStore>) =>
+  ({ children }: { children: ReactNode }): ReactElement =>
+    createElement(Provider, { store }, createElement(QueryClientProvider, { client: queryClient }, children));
+
 beforeEach(() => {
   vi.clearAllMocks();
   queryClient.removeQueries({ queryKey: ["sculptor"] });
@@ -67,10 +78,9 @@ describe("useOptimisticTaskDelete", () => {
     seedTask(createMockTask("task-A"));
     seedTask(createMockTask("task-B"));
 
-    const wrapper = ({ children }: { children: ReactNode }): ReactElement =>
-      createElement(Provider, { store }, children);
-
-    const { result } = renderHook(() => useOptimisticTaskDelete({ workspaceId: "ws-1" }), { wrapper });
+    const { result } = renderHook(() => useOptimisticTaskDelete({ workspaceId: "ws-1" }), {
+      wrapper: makeWrapper(store),
+    });
 
     // Both initial deletes reject -> two error toasts (each set on the same atom).
     mockDeleteWorkspaceAgent.mockRejectedValue(new Error("network"));
@@ -102,5 +112,29 @@ describe("useOptimisticTaskDelete", () => {
     expect(mockDeleteWorkspaceAgent).toHaveBeenCalledWith(
       expect.objectContaining({ path: expect.objectContaining({ agent_id: "task-A" }) }),
     );
+  });
+
+  it("tombstones the task before the navigation callback observes it", () => {
+    // The removal must be visible in every store by the time callbacks run, so
+    // a callback reading the cache sees the tombstone, not the live task.
+    const store = createStore();
+    queryClient.setQueryData(taskIdsQueryKey(), ["task-A"]);
+    seedTask(createMockTask("task-A"));
+    mockDeleteWorkspaceAgent.mockResolvedValue(undefined);
+
+    let observedDuringCallback: CodingAgentTaskView | null | undefined = createMockTask("task-A");
+    const onNavigateAfterDelete = vi.fn((taskId: string): void => {
+      observedDuringCallback = getCachedTask(taskId);
+    });
+
+    const { result } = renderHook(() => useOptimisticTaskDelete({ workspaceId: "ws-1", onNavigateAfterDelete }), {
+      wrapper: makeWrapper(store),
+    });
+
+    result.current.execute("task-A", "Task A");
+
+    expect(onNavigateAfterDelete).toHaveBeenCalledOnce();
+    expect(observedDuringCallback).toBeNull();
+    expect(queryClient.getQueryData<ReadonlyArray<string>>(taskIdsQueryKey())).toEqual([]);
   });
 });

--- a/sculptor/frontend/src/common/state/hooks/useOptimisticTaskDelete.ts
+++ b/sculptor/frontend/src/common/state/hooks/useOptimisticTaskDelete.ts
@@ -3,12 +3,12 @@ import { posthog } from "posthog-js";
 import { useCallback, useEffect, useRef } from "react";
 
 import type { CodingAgentTaskView } from "../../../api";
-import { deleteWorkspaceAgent } from "../../../api";
 import { ToastType } from "../../../components/Toast.tsx";
 import { useImbueLocation, useImbueNavigate, useImbueParams } from "../../NavigateUtils.ts";
-import { getTaskSyncVersion, queryClient, taskIdsQueryKey, taskQueryKey } from "../../queryClient.ts";
+import { queryClient, taskQueryKey } from "../../queryClient.ts";
 import { deleteErrorToastAtom } from "../atoms/toasts";
 import { agentIdForWorkspaceAtomFamily, setAgentForWorkspaceAtom } from "../atoms/workspaces.ts";
+import { applyOptimisticTaskDelete, useDeleteTaskMutation } from "../mutations";
 
 type UseOptimisticTaskDeleteInputs = {
   workspaceId: string;
@@ -34,6 +34,7 @@ export const useOptimisticTaskDelete = (inputs: UseOptimisticTaskDeleteInputs): 
   const { navigateToRoot } = useImbueNavigate();
   const { isAgentRoute } = useImbueLocation();
   const { taskID } = useImbueParams();
+  const { mutateAsync: deleteTask } = useDeleteTaskMutation();
   // The Retry action re-invokes execute. Reach it through a ref (kept current
   // by the effect below) so the callback doesn't reference itself before it is
   // declared.
@@ -45,17 +46,13 @@ export const useOptimisticTaskDelete = (inputs: UseOptimisticTaskDeleteInputs): 
       if (!snapshot) {
         return;
       }
-      const syncVersion = getTaskSyncVersion(taskId);
 
-      // Tombstone the task and drop it from the ids list. The mirror projects
-      // the removal into the Jotai atoms synchronously, so the navigation
-      // callbacks below already see the task gone from every store.
-      queryClient.setQueryData<CodingAgentTaskView | null>(taskQueryKey(taskId), null);
-      const currentIds = queryClient.getQueryData<ReadonlyArray<string>>(taskIdsQueryKey()) ?? [];
-      queryClient.setQueryData<ReadonlyArray<string>>(
-        taskIdsQueryKey(),
-        currentIds.filter((id) => id !== taskId),
-      );
+      // Tombstone the task and drop it from the ids list *now*, before the
+      // navigation callbacks run: the mirror projects the removal into the
+      // Jotai atoms synchronously, so the callbacks below already see the task
+      // gone from every store. The mutation's onError rolls this back on
+      // failure using the returned context.
+      const deleteContext = applyOptimisticTaskDelete(taskId);
 
       // A deleted agent must not linger as the workspace's saved agent, or the next
       // cold-start redirect targets a dead route. Left cleared on a failed delete —
@@ -75,19 +72,9 @@ export const useOptimisticTaskDelete = (inputs: UseOptimisticTaskDeleteInputs): 
         agent_id: taskId,
       });
 
-      void deleteWorkspaceAgent({
-        path: { workspace_id: workspaceId, agent_id: taskId },
-        meta: { skipWsAck: true },
-      }).catch(() => {
-        // Restore the snapshot unless a WS frame wrote the task while the
-        // request was in flight — the frame holds server truth and must win.
-        if (getTaskSyncVersion(taskId) === syncVersion) {
-          queryClient.setQueryData(taskQueryKey(taskId), snapshot);
-          const restoredIds = queryClient.getQueryData<ReadonlyArray<string>>(taskIdsQueryKey()) ?? [];
-          if (!restoredIds.includes(taskId)) {
-            queryClient.setQueryData(taskIdsQueryKey(), [...restoredIds, taskId]);
-          }
-        }
+      // The mutation owns the rollback (onError, so it survives an unmount); the
+      // rejection here only drives the client-state toast.
+      deleteTask({ workspaceId, agentId: taskId, deleteContext }).catch(() => {
         setDeleteErrorToast({
           title: `Failed to delete "${taskTitle}"`,
           description: "The agent has been restored. Try again or check your connection.",
@@ -111,7 +98,9 @@ export const useOptimisticTaskDelete = (inputs: UseOptimisticTaskDeleteInputs): 
       taskID,
       navigateToRoot,
       workspaceId,
+      deleteTask,
     ],
+    // deleteTask (mutateAsync) is referentially stable across renders.
   );
 
   useEffect(() => {

--- a/sculptor/frontend/src/common/state/hooks/useTaskHelpers.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useTaskHelpers.test.ts
@@ -1,0 +1,119 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, type RenderHookResult } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { createElement, useRef } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { CodingAgentTaskView, ModelOption } from "../../../api";
+import { queryClient, syncTasksToQueryCache } from "../../queryClient.ts";
+import { useTaskAvailableModels, useTaskStatus } from "./useTaskHelpers.ts";
+
+const createMockTask = (overrides: Partial<CodingAgentTaskView> = {}): CodingAgentTaskView =>
+  ({
+    id: "task-1",
+    status: "RUNNING",
+    goal: "Test goal",
+    model: "CLAUDE_4_SONNET",
+    availableModels: [],
+    isDeleted: false,
+    harnessCapabilities: {},
+    ...overrides,
+  }) as unknown as CodingAgentTaskView;
+
+const wrapper = ({ children }: { children: ReactNode }): ReactElement =>
+  createElement(QueryClientProvider, { client: queryClient }, children);
+
+// TanStack delivers observer notifications on a macrotask (its notifyManager
+// batches via setTimeout(0)), so a cache write reaches the hook only on the next
+// tick — flush one inside `act` before asserting.
+const flushNotifications = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const writeTasksAndFlush = async (tasks: Record<string, CodingAgentTaskView>): Promise<void> => {
+  await act(async () => {
+    syncTasksToQueryCache(tasks);
+    await flushNotifications();
+  });
+};
+
+// Render the hook while counting how many times its host re-renders — the
+// fine-grained-subscription assertion is "this count stays put when an unrelated
+// field changes and ticks up when the selected field changes".
+const renderCountingStatus = (taskId: string): RenderHookResult<{ status: unknown; renders: number }, unknown> =>
+  renderHook(
+    () => {
+      const renders = useRef(0);
+      renders.current += 1;
+      return { status: useTaskStatus(taskId), renders: renders.current };
+    },
+    { wrapper },
+  );
+
+beforeEach(() => {
+  queryClient.removeQueries({ queryKey: ["sculptor"] });
+});
+
+describe("useTaskStatus", () => {
+  it("returns undefined for an unknown task id", () => {
+    const { result } = renderHook(() => useTaskStatus("unknown-task"), { wrapper });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("does not re-render when an unrelated task field changes", async () => {
+    const task = createMockTask({ id: "task-1", status: "RUNNING", goal: "before" });
+    await writeTasksAndFlush({ "task-1": task });
+
+    const { result } = renderCountingStatus("task-1");
+    const rendersAfterSeed = result.current.renders;
+    expect(result.current.status).toBe("RUNNING");
+
+    // Same status, different goal: the select result is unchanged, so structural
+    // sharing must suppress the re-render.
+    await writeTasksAndFlush({ "task-1": { ...task, goal: "after" } as CodingAgentTaskView });
+
+    expect(result.current.renders).toBe(rendersAfterSeed);
+    expect(result.current.status).toBe("RUNNING");
+  });
+
+  it("re-renders when the status changes", async () => {
+    const task = createMockTask({ id: "task-1", status: "RUNNING" });
+    await writeTasksAndFlush({ "task-1": task });
+
+    const { result } = renderCountingStatus("task-1");
+    const rendersAfterSeed = result.current.renders;
+
+    await writeTasksAndFlush({ "task-1": { ...task, status: "WAITING" } as CodingAgentTaskView });
+
+    expect(result.current.renders).toBeGreaterThan(rendersAfterSeed);
+    expect(result.current.status).toBe("WAITING");
+  });
+});
+
+describe("useTaskAvailableModels", () => {
+  it("returns a referentially stable empty list across unrelated updates", async () => {
+    // No backend catalog (Claude): availableModels is absent, so the select must
+    // fall back to the shared EMPTY constant — one stable array identity rather
+    // than a fresh `[]` each frame.
+    const task = createMockTask({ id: "task-1", availableModels: undefined, status: "RUNNING" });
+    await writeTasksAndFlush({ "task-1": task });
+
+    const seen: Array<ReadonlyArray<ModelOption>> = [];
+    renderHook(
+      () => {
+        seen.push(useTaskAvailableModels("task-1"));
+        return null;
+      },
+      { wrapper },
+    );
+
+    await writeTasksAndFlush({ "task-1": { ...task, status: "WAITING" } as CodingAgentTaskView });
+
+    // Every observed value is the same reference (both the absent-data coalesce
+    // and the select fallback return the shared EMPTY constant).
+    const first = seen[0];
+    expect(first).toEqual([]);
+    seen.forEach((value) => expect(value).toBe(first));
+  });
+});

--- a/sculptor/frontend/src/common/state/hooks/useTaskHelpers.ts
+++ b/sculptor/frontend/src/common/state/hooks/useTaskHelpers.ts
@@ -1,115 +1,129 @@
-import { useAtomValue } from "jotai";
+import { skipToken, useQuery } from "@tanstack/react-query";
 
-import type { ModelOption, TaskStatus } from "../../../api";
-import {
-  taskAcceptsAutomatedPromptsAtomFamily,
-  taskAvailableModelsAtomFamily,
-  taskIsAutoCompactingAtomFamily,
-  taskModelAtomFamily,
-  taskSelectedModelIdAtomFamily,
-  taskSourcesBackendModelsAtomFamily,
-  taskStatusAtomFamily,
-  taskSupportsBackgroundTasksAtomFamily,
-  taskSupportsChatInterfaceAtomFamily,
-  taskSupportsCompactionAtomFamily,
-  taskSupportsContextResetAtomFamily,
-  taskSupportsFastModeAtomFamily,
-  taskSupportsFileAttachmentsAtomFamily,
-  taskSupportsFileReferencesAtomFamily,
-  taskSupportsImageInputAtomFamily,
-  taskSupportsInteractiveBackchannelAtomFamily,
-  taskSupportsInterruptionAtomFamily,
-  taskSupportsModelSelectionAtomFamily,
-  taskSupportsSessionResumeAtomFamily,
-  taskSupportsSkillsAtomFamily,
-  taskSupportsSubAgentsAtomFamily,
-  taskSupportsToolUseRenderingAtomFamily,
-} from "../atoms/tasks";
+import type { CodingAgentTaskView, ModelOption, TaskStatus } from "../../../api";
+import { taskQueryKey } from "../../queryClient.ts";
 export { useTask } from "./useTask";
 
-/** Subscribe to only the task's status field. Re-renders only when status changes. */
-export const useTaskStatus = (taskId: string): TaskStatus | undefined => useAtomValue(taskStatusAtomFamily(taskId));
+// Each hook subscribes to a single task in the TanStack Query cache (fed by the
+// WS bridge, `skipToken` so it never fetches — see useTask) and returns one
+// derived field via `select`. TanStack's structural sharing keeps the selected
+// value referentially stable across frames that don't touch it, so a subscriber
+// re-renders only when ITS field changes — the fine-grained property the Jotai
+// selector families used to provide. These hooks are the narrow accessors for
+// `harnessCapabilities.<field>`: a mistyped capability key would read
+// `undefined` and gate open, so every capability read goes through one here.
 
-/** Subscribe to only the task's model field. Re-renders only when model changes. */
-export const useTaskModel = (taskId: string): string | undefined => useAtomValue(taskModelAtomFamily(taskId));
+// A stable reference for the "no backend catalog" case (Claude), so the
+// availableModels select keeps one identity across unrelated task updates
+// instead of yielding a fresh array each recompute.
+const EMPTY_MODEL_OPTIONS: ReadonlyArray<ModelOption> = [];
+
+// Subscribe to a single task, projecting one field through `pick`. The cache is
+// subscription-only (`skipToken`), matching useTask; `pick` runs on every cached
+// frame and its structurally-shared result gates re-renders. TanStack skips
+// `select` entirely while the query has no data (the stream hasn't delivered the
+// task), so we coalesce that gap by evaluating `pick(null)` — the same value the
+// old selector atoms yielded for an absent task, since `taskAtomFamily` defaulted
+// to `null`.
+const useTaskField = <T>(taskId: string, pick: (task: CodingAgentTaskView | null) => T): T => {
+  const { data } = useQuery<CodingAgentTaskView | null, unknown, T>({
+    queryKey: taskQueryKey(taskId),
+    queryFn: skipToken,
+    select: pick,
+  });
+  return data === undefined ? pick(null) : data;
+};
+
+/** Subscribe to only the task's status field. Re-renders only when status changes. */
+export const useTaskStatus = (taskId: string): TaskStatus | undefined => useTaskField(taskId, (task) => task?.status);
+
+/** Subscribe to only the task's model field. Terminal agents carry no model
+ * (`model` is null); treat that the same as "unknown". */
+export const useTaskModel = (taskId: string): string | undefined =>
+  useTaskField(taskId, (task) => task?.model ?? undefined);
+
+/** Subscribe to the workspace that owns the task — immutable once the view has
+ * loaded, so subscribers re-render only on load/removal, never on task churn. */
+export const useTaskWorkspaceId = (taskId: string): string | undefined =>
+  useTaskField(taskId, (task) => task?.workspaceId ?? undefined);
 
 /** Subscribe to the harness's backend-sourced model list (pi); empty for Claude. */
 export const useTaskAvailableModels = (taskId: string): ReadonlyArray<ModelOption> =>
-  useAtomValue(taskAvailableModelsAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.availableModels ?? EMPTY_MODEL_OPTIONS);
 
 /** Subscribe to the model_id the switcher should show selected for a backend list (pi). */
 export const useTaskSelectedModelId = (taskId: string): string | undefined =>
-  useAtomValue(taskSelectedModelIdAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.selectedModelId ?? undefined);
 
 /** Subscribe to whether the harness sources its model catalog from a backend (pi). */
 export const useTaskSourcesBackendModels = (taskId: string): boolean =>
-  useAtomValue(taskSourcesBackendModelsAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.sourcesBackendModels ?? false);
 
 export const useTaskIsAutoCompacting = (taskId: string): boolean =>
-  useAtomValue(taskIsAutoCompactingAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.isAutoCompacting ?? false);
 
 /** Subscribe to only the task's `supports_interactive_backchannel` capability. */
 export const useTaskSupportsInteractiveBackchannel = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsInteractiveBackchannelAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsInteractiveBackchannel);
 
 /** Subscribe to only the task's `supports_fast_mode` capability. */
 export const useTaskSupportsFastMode = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsFastModeAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsFastMode);
 
 /** Subscribe to only the task's `supports_file_attachments` capability. */
 export const useTaskSupportsFileAttachments = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsFileAttachmentsAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsFileAttachments);
 
 /** Subscribe to only the task's `supports_image_input` capability. */
 export const useTaskSupportsImageInput = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsImageInputAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsImageInput);
 
 /** Subscribe to only the task's `supports_skills` capability. */
 export const useTaskSupportsSkills = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsSkillsAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsSkills);
 
 /** Subscribe to only the task's `supports_sub_agents` capability. */
 export const useTaskSupportsSubAgents = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsSubAgentsAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsSubAgents);
 
 /** Subscribe to only the task's `supports_interruption` capability. */
 export const useTaskSupportsInterruption = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsInterruptionAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsInterruption);
 
 /** Subscribe to only the task's `supports_file_references` capability. */
 export const useTaskSupportsFileReferences = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsFileReferencesAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsFileReferences);
 
 /** Subscribe to only the task's `supports_context_reset` capability. */
 export const useTaskSupportsContextReset = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsContextResetAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsContextReset);
 
 /** Subscribe to only the task's `supports_compaction` capability. */
 export const useTaskSupportsCompaction = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsCompactionAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsCompaction);
 
 /** Subscribe to only the task's `supports_background_tasks` capability. */
 export const useTaskSupportsBackgroundTasks = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsBackgroundTasksAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsBackgroundTasks);
 
 /** Subscribe to only the task's `supports_session_resume` capability. */
 export const useTaskSupportsSessionResume = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsSessionResumeAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsSessionResume);
 
 /** Subscribe to only the task's `supports_tool_use_rendering` capability. */
 export const useTaskSupportsToolUseRendering = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsToolUseRenderingAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsToolUseRendering);
 
 /** Subscribe to only the task's `supports_chat_interface` capability —
  * the coarse main-panel switch (chat interface vs terminal panel). */
 export const useTaskSupportsChatInterface = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsChatInterfaceAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsChatInterface);
 
 /** Subscribe to only the task's `supports_model_selection` capability. */
 export const useTaskSupportsModelSelection = (taskId: string): boolean | undefined =>
-  useAtomValue(taskSupportsModelSelectionAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.harnessCapabilities.supportsModelSelection);
 
 /** Subscribe to only the task's `accepts_automated_prompts` field — true
  * only for registered terminal agents whose registration opted in. */
 export const useTaskAcceptsAutomatedPrompts = (taskId: string): boolean | undefined =>
-  useAtomValue(taskAcceptsAutomatedPromptsAtomFamily(taskId));
+  useTaskField(taskId, (task) => task?.acceptsAutomatedPrompts);

--- a/sculptor/frontend/src/common/state/mutations/index.test.ts
+++ b/sculptor/frontend/src/common/state/mutations/index.test.ts
@@ -7,16 +7,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as api from "../../../api";
 import type { CodingAgentTaskView } from "../../../api";
 import { TaskStatus } from "../../../api";
-import { queryClient as sharedQueryClient, syncTasksToQueryCache, taskQueryKey } from "../../queryClient.ts";
+import {
+  queryClient as sharedQueryClient,
+  syncTasksToQueryCache,
+  taskIdsQueryKey,
+  taskQueryKey,
+} from "../../queryClient.ts";
 import { isUnreadOverrideActive, resetUnreadOverridesForTesting } from "../atoms/unreadOverrides";
-import { useMarkReadMutation, useMarkUnreadMutation, useRestoreTaskMutation, useTaskRenameMutation } from "./index";
+import {
+  applyOptimisticTaskDelete,
+  useDeleteTaskMutation,
+  useMarkReadMutation,
+  useMarkUnreadMutation,
+  useRestoreTaskMutation,
+  useTaskRenameMutation,
+} from "./index";
 
 // ── Mock API ────────────────────────────────────────────────
-const { mockMarkRead, mockMarkUnread, mockRename, mockRestore } = vi.hoisted(() => ({
+const { mockMarkRead, mockMarkUnread, mockRename, mockRestore, mockDelete } = vi.hoisted(() => ({
   mockMarkRead: vi.fn(),
   mockMarkUnread: vi.fn(),
   mockRename: vi.fn(),
   mockRestore: vi.fn(),
+  mockDelete: vi.fn(),
 }));
 
 vi.mock("../../../api", async () => {
@@ -27,6 +40,7 @@ vi.mock("../../../api", async () => {
     markWorkspaceAgentUnread: mockMarkUnread,
     renameWorkspaceAgent: mockRename,
     restoreWorkspaceAgent: mockRestore,
+    deleteWorkspaceAgent: mockDelete,
   };
 });
 
@@ -72,6 +86,7 @@ beforeEach(() => {
   mockMarkUnread.mockResolvedValue(undefined);
   mockRename.mockResolvedValue(undefined);
   mockRestore.mockResolvedValue(undefined);
+  mockDelete.mockResolvedValue(undefined);
   sharedQueryClient.removeQueries({ queryKey: ["sculptor"] });
   // Unread overrides live in a module-level map, so they leak across tests
   // without an explicit reset.
@@ -391,5 +406,90 @@ describe("useRestoreTaskMutation", () => {
     await flushMicrotasks();
 
     expect(getCachedTask(AGENT_ID)).toEqual(restoredTask);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// useDeleteTaskMutation
+// ═══════════════════════════════════════════════════════════
+
+describe("useDeleteTaskMutation", () => {
+  // The caller tombstones synchronously via applyOptimisticTaskDelete and
+  // threads the context into the mutation; these tests exercise that contract.
+  const seedForDelete = (): void => {
+    sharedQueryClient.setQueryData(taskIdsQueryKey(), [AGENT_ID]);
+    seedTask(makeTask());
+  };
+
+  const getIds = (): ReadonlyArray<string> | undefined =>
+    sharedQueryClient.getQueryData<ReadonlyArray<string>>(taskIdsQueryKey());
+
+  it("calls deleteWorkspaceAgent with the skipWsAck path", async () => {
+    seedForDelete();
+    const deleteContext = applyOptimisticTaskDelete(AGENT_ID);
+    const { result } = renderHook(() => useDeleteTaskMutation(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ workspaceId: WS_ID, agentId: AGENT_ID, deleteContext });
+    });
+    await flushMicrotasks();
+
+    expect(mockDelete).toHaveBeenCalledOnce();
+    expect(mockDelete).toHaveBeenCalledWith({
+      path: { workspace_id: WS_ID, agent_id: AGENT_ID },
+      meta: { skipWsAck: true },
+    });
+  });
+
+  it("tombstones the entry and removes the id (via the caller's apply)", () => {
+    seedForDelete();
+
+    applyOptimisticTaskDelete(AGENT_ID);
+
+    expect(getCachedTask(AGENT_ID)).toBeNull();
+    expect(getIds()).toEqual([]);
+  });
+
+  it("restores the entry and re-adds the id when the request rejects", async () => {
+    seedForDelete();
+    const original = makeTask();
+    mockDelete.mockRejectedValueOnce(new Error("network"));
+
+    const deleteContext = applyOptimisticTaskDelete(AGENT_ID);
+    const { result } = renderHook(() => useDeleteTaskMutation(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ workspaceId: WS_ID, agentId: AGENT_ID, deleteContext }),
+      ).rejects.toThrow("network");
+    });
+
+    expect(getCachedTask(AGENT_ID)).toEqual(original);
+    expect(getIds()).toContain(AGENT_ID);
+  });
+
+  it("skips the restore when a WS frame wrote the task while the request was in flight", async () => {
+    seedForDelete();
+    // A frame carrying the committed delete (e.g. the request timed out after
+    // the server applied it): the tombstone must survive the failed request's
+    // rollback.
+    const serverTask = makeTask({ isDeleted: true });
+    mockDelete.mockImplementationOnce(() => {
+      syncTasksToQueryCache({ [AGENT_ID]: serverTask });
+      return Promise.reject(new Error("timeout"));
+    });
+
+    const deleteContext = applyOptimisticTaskDelete(AGENT_ID);
+    const { result } = renderHook(() => useDeleteTaskMutation(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ workspaceId: WS_ID, agentId: AGENT_ID, deleteContext }),
+      ).rejects.toThrow("timeout");
+    });
+
+    // The frame tombstoned it too, so the entry stays null and the id stays out.
+    expect(getCachedTask(AGENT_ID)).toBeNull();
+    expect(getIds() ?? []).not.toContain(AGENT_ID);
   });
 });

--- a/sculptor/frontend/src/common/state/mutations/index.ts
+++ b/sculptor/frontend/src/common/state/mutations/index.ts
@@ -19,12 +19,13 @@ import { useMutation, type UseMutationResult } from "@tanstack/react-query";
 
 import type { CodingAgentTaskView } from "../../../api";
 import {
+  deleteWorkspaceAgent,
   markWorkspaceAgentRead,
   markWorkspaceAgentUnread,
   renameWorkspaceAgent,
   restoreWorkspaceAgent,
 } from "../../../api";
-import { getTaskSyncVersion, queryClient, taskQueryKey } from "../../queryClient.ts";
+import { getTaskSyncVersion, queryClient, taskIdsQueryKey, taskQueryKey } from "../../queryClient.ts";
 import { clearUnreadOverride, setUnreadOverride } from "../atoms/unreadOverrides";
 
 export type TaskMutationContext = {
@@ -55,6 +56,41 @@ export const rollbackOptimisticTaskUpdate = (agentId: string, ctx: TaskMutationC
   }
   queryClient.setQueryData(taskQueryKey(agentId), ctx.prev);
   return true;
+};
+
+/**
+ * Snapshot a task, tombstone it (`null` entry), and drop its id from the ids
+ * list. Unlike the entry-only helpers, delete also touches the ids list, so it
+ * has its own apply/rollback pair. Exported so the delete hook can apply the
+ * tombstone synchronously before its navigation callbacks run — `onMutate` is
+ * a microtask behind `.mutate()`, and callbacks read the post-delete store.
+ */
+export const applyOptimisticTaskDelete = (agentId: string): TaskMutationContext => {
+  const prev = queryClient.getQueryData<CodingAgentTaskView | null>(taskQueryKey(agentId));
+  queryClient.setQueryData<CodingAgentTaskView | null>(taskQueryKey(agentId), null);
+  const ids = queryClient.getQueryData<ReadonlyArray<string>>(taskIdsQueryKey()) ?? [];
+  queryClient.setQueryData<ReadonlyArray<string>>(
+    taskIdsQueryKey(),
+    ids.filter((id) => id !== agentId),
+  );
+  return { prev, syncVersion: getTaskSyncVersion(agentId) };
+};
+
+/**
+ * Undo an optimistic delete after a failed request: restore the snapshot and
+ * re-append the id, unless a WS frame wrote the task while the request was in
+ * flight (the frame holds server truth and must win). Symmetric with
+ * `applyOptimisticTaskDelete` — restores both the entry and the ids list.
+ */
+export const rollbackOptimisticTaskDelete = (agentId: string, ctx: TaskMutationContext | undefined): void => {
+  if (!ctx?.prev || getTaskSyncVersion(agentId) !== ctx.syncVersion) {
+    return;
+  }
+  queryClient.setQueryData(taskQueryKey(agentId), ctx.prev);
+  const ids = queryClient.getQueryData<ReadonlyArray<string>>(taskIdsQueryKey()) ?? [];
+  if (!ids.includes(agentId)) {
+    queryClient.setQueryData<ReadonlyArray<string>>(taskIdsQueryKey(), [...ids, agentId]);
+  }
 };
 
 type MarkReadVars = { workspaceId: string; agentId: string };
@@ -132,4 +168,34 @@ export const useRestoreTaskMutation = (): UseMutationResult<unknown, Error, Rest
   useMutation({
     mutationFn: (vars: RestoreVars) =>
       restoreWorkspaceAgent({ path: { workspace_id: vars.workspaceId, agent_id: vars.agentId } }),
+  });
+
+type DeleteVars = {
+  workspaceId: string;
+  agentId: string;
+  // The tombstone is applied by the caller (synchronously, before its
+  // navigation callbacks) via `applyOptimisticTaskDelete`, and its snapshot is
+  // threaded here so `onError` can roll back. Applying in `onMutate` would land
+  // a microtask after `.mutate()`, too late for the callbacks — so this
+  // mutation deliberately has no `onMutate`.
+  deleteContext: TaskMutationContext;
+};
+
+/**
+ * Delete an agent. The optimistic tombstone lives in the caller (see
+ * `deleteContext`); this hook owns the request and the version-checked
+ * rollback. `skipWsAck` lets the request complete without waiting for the WS
+ * to acknowledge the removal. Rollback in `onError` (not the caller's `.catch`)
+ * so it can't be skipped if the component unmounts mid-request.
+ */
+export const useDeleteTaskMutation = (): UseMutationResult<unknown, Error, DeleteVars, unknown> =>
+  useMutation({
+    mutationFn: (vars: DeleteVars) =>
+      deleteWorkspaceAgent({
+        path: { workspace_id: vars.workspaceId, agent_id: vars.agentId },
+        meta: { skipWsAck: true },
+      }),
+    onError: (_e, vars): void => {
+      rollbackOptimisticTaskDelete(vars.agentId, vars.deleteContext);
+    },
   });

--- a/sculptor/frontend/src/pages/workspace/components/ChatPanelContent.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatPanelContent.tsx
@@ -4,8 +4,7 @@ import { type ReactElement, useEffect, useRef } from "react";
 
 import { closeBtwPopupIfNotForAgentAtom, isBtwPopupOpenAtom } from "~/common/state/atoms/btwPopup.ts";
 import type { InsertSkillArg } from "~/common/state/atoms/chatActions.ts";
-import { taskWorkspaceIdAtomFamily } from "~/common/state/atoms/tasks.ts";
-import { useTaskSupportsChatInterface } from "~/common/state/hooks/useTaskHelpers.ts";
+import { useTaskSupportsChatInterface, useTaskWorkspaceId } from "~/common/state/hooks/useTaskHelpers.ts";
 import { chatPanelMountedAtom } from "~/pages/workspace/atoms.ts";
 import { lastFocusedChatAgentAtomFamily } from "~/pages/workspace/panels/workspaceAgentActions.ts";
 
@@ -57,11 +56,11 @@ export const ChatPanelContent = ({ taskId }: ChatPanelContentProps): ReactElemen
 
 const ChatPanelInner = ({ taskId }: ChatPanelContentProps): ReactElement => {
   // The chat data hook needs the task's workspace id; derive it from the task
-  // atom rather than the route — the panel's agent can differ from the routed
-  // one (any placed agent panel renders this component). The narrow derived
-  // atom keeps unrelated task churn (status, timestamps) from re-rendering
-  // the whole chat surface.
-  const workspaceID = useAtomValue(taskWorkspaceIdAtomFamily(taskId)) ?? "";
+  // rather than the route — the panel's agent can differ from the routed one
+  // (any placed agent panel renders this component). The narrow field hook
+  // keeps unrelated task churn (status, timestamps) from re-rendering the whole
+  // chat surface.
+  const workspaceID = useTaskWorkspaceId(taskId) ?? "";
 
   // Registration seams tying this panel's composer to the workspace-scoped
   // consumers: useChatData registers the chatActions append/insert closures

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/StatusPill.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/StatusPill.test.tsx
@@ -1,4 +1,5 @@
 import { Theme } from "@radix-ui/themes";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStore, Provider } from "jotai";
@@ -7,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ChatMessage, Task } from "~/api";
 import { AgentTaskStatus, ArtifactType, ElementIds } from "~/api";
+import { queryClient } from "~/common/queryClient.ts";
 import {
   activeTurnIdAtomFamily,
   liveTaskTurnIdAtomFamily,
@@ -45,12 +47,19 @@ vi.mock("~/electron/utils.ts", () => ({
 // is cleared in beforeEach for the same reason — atomWithStorage reads it.
 let testStore = createStore();
 
+// StatusPill reads the interruption capability via useTaskSupportsInterruption,
+// which is a subscription-only useQuery over the task cache, so a
+// QueryClientProvider is required. No task is seeded for "agent-1": an absent
+// task yields `undefined`, and the component's `?? true` keeps Stop enabled —
+// the same default the Jotai atom gave before this hook read the cache.
 const Wrapper = ({ children }: { children: ReactNode }): ReactElement => (
-  <Provider store={testStore}>
-    <ChatTaskProvider workspaceId="ws-1" taskId="agent-1">
-      <Theme>{children}</Theme>
-    </ChatTaskProvider>
-  </Provider>
+  <QueryClientProvider client={queryClient}>
+    <Provider store={testStore}>
+      <ChatTaskProvider workspaceId="ws-1" taskId="agent-1">
+        <Theme>{children}</Theme>
+      </ChatTaskProvider>
+    </Provider>
+  </QueryClientProvider>
 );
 
 const defaultProps = {
@@ -90,6 +99,8 @@ beforeEach(() => {
   liveTaskTurnIdAtomFamily.remove("agent-1");
   tasksPhaseAtomFamily.remove("agent-1");
   testStore = createStore();
+  // Clear the shared query cache so task state can't leak between tests.
+  queryClient.removeQueries({ queryKey: ["sculptor"] });
 });
 
 afterEach(() => {


### PR DESCRIPTION
Stacked on `danver/scu-1120` (this PR targets that branch, not `main`). It executes the first two items of the state-ownership burndown plan that branch introduced (`docs/development/state-ownership-burndown.md`) and records the judgment pass over the remaining candidate sites.

## What's in here

**1. Task delete moves behind `useDeleteTaskMutation`** (`no-scattered-setquerydata` ratchet budget: 2 → **0**)

`useOptimisticTaskDelete` held the last two query-cache writes outside the sanctioned writer modules. The delete-specific `applyOptimisticTaskDelete` / `rollbackOptimisticTaskDelete` pair now lives in `state/mutations/` (delete also touches the ids list, which the entry-only helpers don't). Design note: the hook applies the tombstone synchronously before its navigation callbacks run — `onMutate` is a microtask behind `mutate()`, and callbacks must already see the task gone — while the mutation owns the request and the version-checked rollback in options-level `onError`, so the restore fires even if the component unmounted. The hook's promise `.catch` only drives the failure toast. New tests pin the tombstone-before-navigation contract, the CAS restore of entry + id, and frame-beats-snapshot when a WS frame interleaves with a failed request.

**2. Per-field task reads leave Jotai**

The `useTaskHelpers` hooks are rewritten over the query cache via a shared `useTaskField` helper (`skipToken` + `select`); structural sharing preserves the fine-grained re-render property the selector atom families provided. Hook APIs are unchanged, so no consumer components needed edits. Of the selector atom families, 18 had zero remaining consumers and are deleted; 4 survive because Jotai atom graphs (`workspaceAgentActions.ts`, `mentionDetails.ts`) still derive from them — these, plus `tasksArrayAtom`'s graph readers and the plugin SDK, are documented as the terminal blockers for deleting the mirror. The `no-direct-harness-capability-read` ratchet's exclude list gains `useTaskHelpers.ts`, the new narrow-accessor home, preserving the rule's guarantee that a mistyped capability key can't silently gate open.

**3. Classification pass**

Every `no-fire-and-forget-api-catch` site is now classified in the burndown doc: the workspace open/close pending-intent overlay is sound as designed, workspace delete needs an interleave check on its rollback (queued for the workspace-surface PR), and the two fetch-fallback sites are exempt (no optimistic write to heal).

## Verification

- `just format` / `just check` (typecheck, lint, ratchets) green
- Full frontend unit suite green: 229 files, 2854 passed / 1 pre-existing skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
