### PR TITLE
[SCU-1778] Persist per-workspace UI state across workspace switches

### DIFF
--- a/sculptor/frontend/src/common/state/hooks/useWorkspaceShellBootstrap.ts
+++ b/sculptor/frontend/src/common/state/hooks/useWorkspaceShellBootstrap.ts
@@ -22,6 +22,7 @@ import {
   workspaceAgentIdsAtomFamily,
 } from "~/common/state/agentPanelPlacement.ts";
 import { viewedAgentIdAtom } from "~/common/state/atoms/viewedAgent.ts";
+import { setAgentForWorkspaceAtom } from "~/common/state/atoms/workspaces.ts";
 import { useMarkRead } from "~/common/state/hooks/useMarkRead";
 import { useRegisterCommandAction } from "~/components/CommandPalette/commandActions.ts";
 import { seedFirstVisitTerminal } from "~/components/sections/addPanelCore.ts";
@@ -62,6 +63,7 @@ export const useWorkspaceShellBootstrap = (inputs: { workspaceId: string; taskId
   const bumpRingNonce = useSetAtom(activeSectionRingNonceAtom);
   const activateAgentPanel = useSetAtom(activateAgentPanelAtom);
   const ensureAgentPanelsPlaced = useSetAtom(ensureAgentPanelsPlacedAtom);
+  const setAgentForWorkspace = useSetAtom(setAgentForWorkspaceAtom);
   const { createRecentAgent } = useAddPanelActions();
 
   // Keep the registry in sync with this workspace's agents.
@@ -102,6 +104,21 @@ export const useWorkspaceShellBootstrap = (inputs: { workspaceId: string; taskId
   // no task, so each is a safe no-op (their task lookups miss).
   useArtifactSync(workspaceId, viewedAgentId ?? "");
   useMarkRead(workspaceId, viewedAgentId ?? "");
+
+  // Persist the viewed agent as this workspace's last-viewed agent so re-entry
+  // restores it. Switching agents via a panel tab flips the active panel without
+  // navigating, so the route (and therefore the persisted per-workspace agent id
+  // that WorkspaceSidebar reads on switch, and rootLoader reads on cold start)
+  // would otherwise only ever track navigations — and the re-entry activation
+  // below would snap focus back to the last-routed agent, discarding a tab-click
+  // selection. Only persist an id that belongs to THIS workspace: on the first
+  // commit of a workspace switch the panel-derived id can still name the previous
+  // workspace's agent (the same window the viewedAgentId fallback above guards).
+  useEffect(() => {
+    if (panelAgentId !== null && workspaceAgentIds.includes(panelAgentId)) {
+      setAgentForWorkspace({ wsId: workspaceId, agentId: panelAgentId });
+    }
+  }, [panelAgentId, workspaceAgentIds, workspaceId, setAgentForWorkspace]);
 
   // Switch the layout scope to this workspace, seeding the default on the
   // workspace's first visit (switchActiveWorkspaceAtom only seeds when the snapshot is

--- a/sculptor/frontend/src/components/sections/persistence/LocalStorageLayoutAdapter.test.ts
+++ b/sculptor/frontend/src/components/sections/persistence/LocalStorageLayoutAdapter.test.ts
@@ -152,6 +152,7 @@ describe("LocalStorageLayoutAdapter", () => {
       sidebarWidthPx: 300,
       sidebarCollapsed: true,
       explorerListWidthPx: 260,
+      explorerSidebarHiddenByPanel: { files: true },
     };
 
     adapter.write(WS_SCOPE, wsOne);
@@ -210,6 +211,7 @@ describe("LocalStorageLayoutAdapter", () => {
       sidebarWidthPx: 300,
       sidebarCollapsed: true,
       explorerListWidthPx: 260,
+      explorerSidebarHiddenByPanel: {},
     });
     // Before the debounce window elapses nothing is committed to storage, but
     // read() already sees the pending snapshot (read-your-writes).
@@ -223,6 +225,7 @@ describe("LocalStorageLayoutAdapter", () => {
       sidebarWidthPx: 300,
       sidebarCollapsed: true,
       explorerListWidthPx: 260,
+      explorerSidebarHiddenByPanel: {},
     });
   });
 

--- a/sculptor/frontend/src/components/sections/persistence/types.ts
+++ b/sculptor/frontend/src/components/sections/persistence/types.ts
@@ -34,6 +34,10 @@ export type GlobalLayoutState = {
   sidebarCollapsed: boolean;
   // Shared across Files/Changes/Commits.
   explorerListWidthPx: number;
+  // Whether each Explorer panel's list sidebar is hidden, keyed by panel id.
+  // Per-panel (unlike the shared width) so hiding one panel's list leaves the
+  // others alone. A panel absent from the map defaults to visible.
+  explorerSidebarHiddenByPanel: Partial<Record<PanelId, boolean>>;
 };
 
 export type LayoutScope = { kind: "workspace"; workspaceId: string } | { kind: "global" };
@@ -59,4 +63,5 @@ export const DEFAULT_GLOBAL_LAYOUT: GlobalLayoutState = {
   sidebarWidthPx: 240,
   sidebarCollapsed: false,
   explorerListWidthPx: 240,
+  explorerSidebarHiddenByPanel: {},
 };

--- a/sculptor/frontend/src/components/sections/persistence/types.ts
+++ b/sculptor/frontend/src/components/sections/persistence/types.ts
@@ -36,8 +36,10 @@ export type GlobalLayoutState = {
   explorerListWidthPx: number;
   // Whether each Explorer panel's list sidebar is hidden, keyed by panel id.
   // Per-panel (unlike the shared width) so hiding one panel's list leaves the
-  // others alone. A panel absent from the map defaults to visible.
-  explorerSidebarHiddenByPanel: Partial<Record<PanelId, boolean>>;
+  // others alone. A panel absent from the map defaults to visible. Optional
+  // because global snapshots persisted before this field existed load without
+  // it; readers must optional-chain (the compiler enforces it via this `?`).
+  explorerSidebarHiddenByPanel?: Partial<Record<PanelId, boolean>>;
 };
 
 export type LayoutScope = { kind: "workspace"; workspaceId: string } | { kind: "global" };

--- a/sculptor/frontend/src/components/sections/sectionAtoms.test.ts
+++ b/sculptor/frontend/src/components/sections/sectionAtoms.test.ts
@@ -11,6 +11,7 @@ import {
   EXPLORER_LIST_MAX_WIDTH_PX,
   EXPLORER_LIST_MIN_WIDTH_PX,
   explorerListWidthAtom,
+  explorerSidebarHiddenAtom,
   globalLayoutAtom,
   isSectionExpandedAtom,
   panelsInSubSectionAtom,
@@ -158,6 +159,35 @@ describe("global clamping write atoms", () => {
     expect(store.get(explorerListWidthAtom)).toBe(EXPLORER_LIST_MIN_WIDTH_PX);
     store.set(explorerListWidthAtom, 10_000);
     expect(store.get(explorerListWidthAtom)).toBe(EXPLORER_LIST_MAX_WIDTH_PX);
+  });
+});
+
+describe("explorer sidebar visibility (per-panel, persisted)", () => {
+  it("defaults to visible and hides each panel independently", () => {
+    const store = createStore();
+    expect(store.get(explorerSidebarHiddenAtom("files"))).toBe(false);
+
+    store.set(explorerSidebarHiddenAtom("files"), true);
+    expect(store.get(explorerSidebarHiddenAtom("files"))).toBe(true);
+    expect(store.get(explorerSidebarHiddenAtom("changes"))).toBe(false);
+  });
+
+  it("reads and writes when a snapshot persisted before the field existed lacks it", () => {
+    const store = createStore();
+    // Stand in for a pre-upgrade global snapshot: everything except the map.
+    store.set(globalLayoutAtom, {
+      sectionSizes: DEFAULT_GLOBAL_LAYOUT.sectionSizes,
+      sidebarWidthPx: DEFAULT_GLOBAL_LAYOUT.sidebarWidthPx,
+      sidebarCollapsed: DEFAULT_GLOBAL_LAYOUT.sidebarCollapsed,
+      explorerListWidthPx: DEFAULT_GLOBAL_LAYOUT.explorerListWidthPx,
+    });
+
+    // The absent map coalesces to "visible" on read...
+    expect(store.get(explorerSidebarHiddenAtom("files"))).toBe(false);
+    // ...and a write seeds the map without crashing on the missing key.
+    store.set(explorerSidebarHiddenAtom("files"), true);
+    expect(store.get(explorerSidebarHiddenAtom("files"))).toBe(true);
+    expect(store.get(globalLayoutAtom).explorerSidebarHiddenByPanel).toEqual({ files: true });
   });
 });
 

--- a/sculptor/frontend/src/components/sections/sectionAtoms.ts
+++ b/sculptor/frontend/src/components/sections/sectionAtoms.ts
@@ -167,6 +167,23 @@ export const explorerListWidthAtom: WritableAtom<number, [number], void> = atom(
   },
 );
 
+// Whether an explorer panel's list sidebar is hidden. Unlike the shared width,
+// this is per-panel-id, so hiding the list in one panel leaves the others
+// visible. Persisted globally, so a panel stays the way the user left it across
+// remounts and workspace switches. The `?? {}`/`?? false` guards let a snapshot
+// persisted before this field existed read back as "visible".
+export const explorerSidebarHiddenAtom = atomFamily((panelId: PanelId) =>
+  atom(
+    (get) => get(globalLayoutAtom).explorerSidebarHiddenByPanel?.[panelId] ?? false,
+    (_get, set, hidden: boolean) => {
+      set(globalLayoutAtom, (prev) => ({
+        ...prev,
+        explorerSidebarHiddenByPanel: { ...(prev.explorerSidebarHiddenByPanel ?? {}), [panelId]: hidden },
+      }));
+    },
+  ),
+);
+
 // Scope switching / removal
 
 // A workspace's snapshot is "empty" (never visited / nothing seeded) when no panel is

--- a/sculptor/frontend/src/pages/workspace/panels/ChangesPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/ChangesPanel.tsx
@@ -187,6 +187,7 @@ const ChangesPanelContent = ({ workspaceId }: { workspaceId: string }): ReactEle
 
   return (
     <ExplorerLayout
+      panelId="changes"
       list={list}
       detail={(sidebarToggle) => (
         <DiffViewer

--- a/sculptor/frontend/src/pages/workspace/panels/CommitsPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/CommitsPanel.tsx
@@ -71,6 +71,7 @@ const CommitsPanelContent = ({ workspaceId }: { workspaceId: string }): ReactEle
 
   return (
     <ExplorerLayout
+      panelId="commits"
       list={list}
       detail={(sidebarToggle) => (
         <DiffViewer

--- a/sculptor/frontend/src/pages/workspace/panels/ExplorerLayout.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/ExplorerLayout.test.tsx
@@ -8,7 +8,9 @@ import {
   EXPLORER_LIST_MAX_WIDTH_PX,
   EXPLORER_LIST_MIN_WIDTH_PX,
   explorerListWidthAtom,
+  explorerSidebarHiddenAtom,
 } from "~/components/sections/sectionAtoms.ts";
+import type { PanelId } from "~/components/sections/sectionTypes.ts";
 
 import { ExplorerLayout } from "./ExplorerLayout";
 
@@ -31,11 +33,12 @@ afterEach(() => {
 
 type JotaiStore = ReturnType<typeof createStore>;
 
-const renderLayout = (store: JotaiStore, listTestId = "list-slot"): void => {
+const renderLayout = (store: JotaiStore, listTestId = "list-slot", panelId: PanelId = "files"): void => {
   render(
     <Provider store={store}>
       <Theme>
         <ExplorerLayout
+          panelId={panelId}
           list={<div data-testid={listTestId}>list</div>}
           detail={(toggle) => (
             <div data-testid="detail-slot">
@@ -126,8 +129,8 @@ describe("ExplorerLayout — drag-resizable shared sidebar", () => {
     // width is one shared atom, so dragging either divider resizes both.
     const store = createStore();
     store.set(explorerListWidthAtom, 240);
-    renderLayout(store, "list-slot-a");
-    renderLayout(store, "list-slot-b");
+    renderLayout(store, "list-slot-a", "files");
+    renderLayout(store, "list-slot-b", "changes");
 
     const [handleA] = screen.getAllByRole("separator", { name: "Resize file list" });
     fireEvent.pointerDown(handleA, { button: 0, clientX: 0, clientY: 0 });
@@ -149,5 +152,40 @@ describe("ExplorerLayout — drag-resizable shared sidebar", () => {
     fireEvent.click(screen.getByTestId(ElementIds.DIFF_HEADER_SHOW_TREE_BTN));
     expect(getResizeHandle()).toBeInTheDocument();
     expect(screen.getByTestId("list-slot")).toBeInTheDocument();
+  });
+
+  it("reads the initial hidden state from the per-panel atom", () => {
+    const store = createStore();
+    store.set(explorerSidebarHiddenAtom("files"), true);
+    renderLayout(store);
+    expect(screen.queryByTestId("list-slot")).not.toBeInTheDocument();
+    expect(screen.getByTestId(ElementIds.DIFF_HEADER_SHOW_TREE_BTN)).toBeInTheDocument();
+  });
+
+  it("persists the hidden state to the per-panel atom when toggled", () => {
+    const store = createStore();
+    renderLayout(store);
+
+    fireEvent.click(screen.getByTestId(ElementIds.FILE_BROWSER_HIDE_TREE_BTN));
+    expect(store.get(explorerSidebarHiddenAtom("files"))).toBe(true);
+
+    fireEvent.click(screen.getByTestId(ElementIds.DIFF_HEADER_SHOW_TREE_BTN));
+    expect(store.get(explorerSidebarHiddenAtom("files"))).toBe(false);
+  });
+
+  it("hides each panel's sidebar independently", () => {
+    // Two panels share one store; hiding one must not hide the other.
+    const store = createStore();
+    renderLayout(store, "list-slot-files", "files");
+    renderLayout(store, "list-slot-changes", "changes");
+
+    // Both panels start visible, so both render a hide button; the first is the
+    // files panel (rendered first).
+    const [hideFilesButton] = screen.getAllByTestId(ElementIds.FILE_BROWSER_HIDE_TREE_BTN);
+    fireEvent.click(hideFilesButton);
+
+    expect(screen.queryByTestId("list-slot-files")).not.toBeInTheDocument();
+    expect(screen.getByTestId("list-slot-changes")).toBeInTheDocument();
+    expect(store.get(explorerSidebarHiddenAtom("changes"))).toBe(false);
   });
 });

--- a/sculptor/frontend/src/pages/workspace/panels/ExplorerLayout.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/ExplorerLayout.tsx
@@ -1,7 +1,7 @@
 import { useAtom } from "jotai";
 import { FolderTree } from "lucide-react";
 import type { ReactElement, ReactNode } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 
 import { ElementIds } from "~/api";
 import { ResizeHandle } from "~/components/sections/ResizeHandle.tsx";
@@ -9,12 +9,19 @@ import {
   EXPLORER_LIST_MAX_WIDTH_PX,
   EXPLORER_LIST_MIN_WIDTH_PX,
   explorerListWidthAtom,
+  explorerSidebarHiddenAtom,
 } from "~/components/sections/sectionAtoms.ts";
+import type { PanelId } from "~/components/sections/sectionTypes.ts";
 import { TooltipIconButton } from "~/components/TooltipIconButton.tsx";
 
 import styles from "./ExplorerLayout.module.scss";
 
 type ExplorerLayoutProps = {
+  /**
+   * The panel this scaffold backs ("files" / "changes" / "commits"). Keys the
+   * persisted, per-panel sidebar-visibility state so each panel is independent.
+   */
+  panelId: PanelId;
   /** The master list (file tree / changes browser / commit history). */
   list: ReactNode;
   /**
@@ -37,9 +44,10 @@ type ExplorerLayoutProps = {
  * It takes the list and viewer as slots — there is no shared "active diff"
  * singleton, so each panel embeds its own instance with its own selection.
  */
-export const ExplorerLayout = ({ list, detail }: ExplorerLayoutProps): ReactElement => {
-  // Sidebar visibility is per-instance UI state (each panel can hide its own).
-  const [isSidebarHidden, setIsSidebarHidden] = useState(false);
+export const ExplorerLayout = ({ panelId, list, detail }: ExplorerLayoutProps): ReactElement => {
+  // Sidebar visibility is persisted per panel, so hiding one panel's list
+  // leaves the others alone and the choice survives remounts / workspace switches.
+  const [isSidebarHidden, setIsSidebarHidden] = useAtom(explorerSidebarHiddenAtom(panelId));
 
   const [listWidthPx, setListWidthPx] = useAtom(explorerListWidthAtom);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -54,7 +62,10 @@ export const ExplorerLayout = ({ list, detail }: ExplorerLayoutProps): ReactElem
     return measured ? measured : listWidthPx;
   }, [listWidthPx]);
 
-  const toggleSidebar = useCallback((): void => setIsSidebarHidden((hidden) => !hidden), []);
+  const toggleSidebar = useCallback(
+    (): void => setIsSidebarHidden(!isSidebarHidden),
+    [isSidebarHidden, setIsSidebarHidden],
+  );
 
   // The sidebar toggle lives in the viewer header in both states: solid while
   // the sidebar is visible, dim while collapsed.

--- a/sculptor/frontend/src/pages/workspace/panels/FilesPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/FilesPanel.tsx
@@ -119,6 +119,7 @@ const FilesPanelContent = ({ workspaceId }: { workspaceId: string }): ReactEleme
 
   return (
     <ExplorerLayout
+      panelId="files"
       list={list}
       detail={(sidebarToggle) => (
         <DiffViewer

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/ChangesTreeView.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/ChangesTreeView.tsx
@@ -129,7 +129,7 @@ export const ChangesTreeView = ({
       return;
     }
     setFileBrowserState((prev) => {
-      // Snapshots persisted before this field existed read back without it.
+      // A persisted snapshot can omit this field, so coalesce before use.
       const prevAutoExpanded = prev.changesAutoExpandedFolders ?? [];
       const alreadyAutoExpanded = new Set(prevAutoExpanded);
       const newlyAppeared = allFolders.filter((path) => !alreadyAutoExpanded.has(path));

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/ChangesTreeView.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/ChangesTreeView.tsx
@@ -19,7 +19,7 @@ import { TreeRow } from "./TreeRow.tsx";
 import type { FileStatus, TreeNode, ViewMode } from "./types.ts";
 import { useActiveFileOperation } from "./useActiveFileOperation.ts";
 import { useKeyboardNavigation } from "./useKeyboardNavigation.ts";
-import { useAgentFileTracking, useCollapseChildren, useTreeNodeMap } from "./useTreeView.ts";
+import { useAgentFileTracking, useCollapseChildren, useSearchAutoExpand, useTreeNodeMap } from "./useTreeView.ts";
 import {
   buildChangesTree,
   collectAllFolderPaths,
@@ -115,18 +115,38 @@ export const ChangesTreeView = ({
 
   const folderChangeCounts = useMemo(() => computeFolderChangeCounts(changesTree), [changesTree]);
 
-  // Auto-expand all folders in the changes tree on first render and when tree changes
-  const prevTreeIdRef = useRef<string>("");
+  // Open each changed folder the first time it appears in the tree, but only once:
+  // folders already recorded in `changesAutoExpandedFolders` are left as the user
+  // left them, so a collapse survives a remount, a change tick, and a workspace
+  // switch. Search-driven expansion is transient and handled by useSearchAutoExpand
+  // below, so this stays out of its way while a search is active.
   useEffect(() => {
-    const allFolders = collectAllFolderPaths(compactedTree);
-    const treeId = [...allFolders].sort().join(",");
-    if (treeId !== prevTreeIdRef.current) {
-      prevTreeIdRef.current = treeId;
-      if (allFolders.length > 0) {
-        expandFolders({ workspaceId, paths: allFolders });
-      }
+    if (isSearchActive) {
+      return;
     }
-  }, [compactedTree, expandFolders, workspaceId]);
+    const allFolders = collectAllFolderPaths(compactedTree);
+    if (allFolders.length === 0) {
+      return;
+    }
+    setFileBrowserState((prev) => {
+      // Snapshots persisted before this field existed read back without it.
+      const prevAutoExpanded = prev.changesAutoExpandedFolders ?? [];
+      const alreadyAutoExpanded = new Set(prevAutoExpanded);
+      const newlyAppeared = allFolders.filter((path) => !alreadyAutoExpanded.has(path));
+      if (newlyAppeared.length === 0) {
+        return prev;
+      }
+      const expanded = new Set(prev.changesExpandedFolders);
+      for (const path of newlyAppeared) {
+        expanded.add(path);
+      }
+      return {
+        ...prev,
+        changesExpandedFolders: Array.from(expanded),
+        changesAutoExpandedFolders: [...prevAutoExpanded, ...newlyAppeared],
+      };
+    });
+  }, [compactedTree, isSearchActive, setFileBrowserState]);
 
   const expandedFoldersSet = useMemo(
     () => new Set(fileBrowserState.changesExpandedFolders),
@@ -190,6 +210,19 @@ export const ChangesTreeView = ({
     },
     [setFileBrowserState],
   );
+
+  // Expand every folder in the filtered tree while a search is active so matches
+  // are visible, then restore the pre-search expand state on clear — the same
+  // transient search behaviour the Files tree uses, so a collapse the user makes
+  // outside search is preserved once the search ends.
+  useSearchAutoExpand({
+    isSearchActive,
+    tree: compactedTree,
+    currentExpandedFolders: fileBrowserState.changesExpandedFolders,
+    expandFolders,
+    setExpandedFolders,
+    workspaceId,
+  });
 
   const handleCollapseChildren = useCollapseChildren({
     flatRows,

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/atoms.test.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/atoms.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { activeWorkspaceIdAtom, workspaceLayoutAtom } from "~/components/sections/sectionAtoms.ts";
 
-import { fileBrowserStateAtomFamily, focusFolderAtom, revealFolderAtom } from "./atoms.ts";
+import { fileBrowserStateAtomFamily, focusFolderAtom, revealFolderAtom, toggleChangesFolderAtom } from "./atoms.ts";
+import type { FileBrowserState } from "./types.ts";
 
 const WORKSPACE_ID = "workspace-1";
 
@@ -128,5 +129,29 @@ describe("revealFolderAtom", () => {
     expect(secondNonce).toBeDefined();
     expect(secondNonce).not.toBe(firstNonce);
     expect(secondNonce!).toBeGreaterThan(firstNonce!);
+  });
+});
+
+describe("backwards compatibility with pre-upgrade snapshots", () => {
+  it("toggles a Changes folder on a snapshot that predates changesAutoExpandedFolders", () => {
+    // A per-workspace snapshot persisted before the field existed loads without it.
+    const legacyState: FileBrowserState = {
+      expandedFolders: [],
+      changesExpandedFolders: [],
+      viewMode: "tree",
+      searchQuery: "",
+      searchOpen: false,
+      scrollPosition: 0,
+    };
+    store.set(fileBrowserStateAtomFamily(WORKSPACE_ID), legacyState);
+    expect(store.get(fileBrowserStateAtomFamily(WORKSPACE_ID)).changesAutoExpandedFolders).toBeUndefined();
+
+    store.set(toggleChangesFolderAtom, { workspaceId: WORKSPACE_ID, folderPath: "src" });
+
+    // The reducer spreads the snapshot, so the toggle lands and the absent field
+    // stays absent rather than crashing on the missing key.
+    const state = store.get(fileBrowserStateAtomFamily(WORKSPACE_ID));
+    expect(state.changesExpandedFolders).toContain("src");
+    expect(state.changesAutoExpandedFolders).toBeUndefined();
   });
 });

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/atoms.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/atoms.ts
@@ -17,6 +17,7 @@ type FolderStateKey = "expandedFolders" | "changesExpandedFolders";
 const DEFAULT_FILE_BROWSER_STATE: FileBrowserState = {
   expandedFolders: [],
   changesExpandedFolders: [],
+  changesAutoExpandedFolders: [],
   viewMode: "tree",
   searchQuery: "",
   searchOpen: false,

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/types.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/types.ts
@@ -24,12 +24,14 @@ export type FlatFileEntry = {
 export type FileBrowserState = {
   expandedFolders: Array<string>;
   changesExpandedFolders: Array<string>;
-  // Folders the Changes tree has already auto-expanded once. The Changes tree
-  // opens each folder the first time it appears; recording that here (rather than
-  // in a per-mount ref) is what lets a folder the user then collapses stay
-  // collapsed across remounts and later change ticks, while genuinely new changed
-  // folders still open on first sight.
-  changesAutoExpandedFolders: Array<string>;
+  // Folders the Changes tree has already auto-expanded once. The tree opens each
+  // folder the first time it appears and records it here (persisted, not a per-mount
+  // ref), so a folder the user then collapses stays collapsed across remounts,
+  // change ticks, and workspace switches, while genuinely new changed folders still
+  // open on first sight. Optional because per-workspace snapshots persisted before
+  // this field existed load without it; readers must coalesce (`?? []`), which this
+  // `?` enforces at the type level.
+  changesAutoExpandedFolders?: Array<string>;
   viewMode: ViewMode;
   searchQuery: string;
   searchOpen: boolean;

--- a/sculptor/frontend/src/pages/workspace/panels/fileBrowser/types.ts
+++ b/sculptor/frontend/src/pages/workspace/panels/fileBrowser/types.ts
@@ -24,6 +24,12 @@ export type FlatFileEntry = {
 export type FileBrowserState = {
   expandedFolders: Array<string>;
   changesExpandedFolders: Array<string>;
+  // Folders the Changes tree has already auto-expanded once. The Changes tree
+  // opens each folder the first time it appears; recording that here (rather than
+  // in a per-mount ref) is what lets a folder the user then collapses stay
+  // collapsed across remounts and later change ticks, while genuinely new changed
+  // folders still open on first sight.
+  changesAutoExpandedFolders: Array<string>;
   viewMode: ViewMode;
   searchQuery: string;
   searchOpen: boolean;

--- a/sculptor/tests/integration/frontend/test_changes_panel.py
+++ b/sculptor/tests/integration/frontend/test_changes_panel.py
@@ -39,6 +39,7 @@ from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
 from sculptor.testing.elements.diff_viewer import ensure_unified_view
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
+from sculptor.testing.playwright_utils import navigate_to_workspace
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
@@ -51,6 +52,28 @@ _WRITE_FILE_PROMPT = """\
 fake_claude:write_file `{
   "file_path": "hello.py",
   "content": "print('hello')\\n"
+}`"""
+
+# Writes an uncommitted nested tree so the Changes tree shows a "src" folder row
+# with a nested "components" folder — enough depth to collapse a folder.
+_NESTED_CHANGES_PROMPT = """\
+fake_claude:multi_step `{
+  "steps": [
+    {
+      "command": "write_file",
+      "args": {
+        "file_path": "src/App.tsx",
+        "content": "export const App = () => null;\\n"
+      }
+    },
+    {
+      "command": "write_file",
+      "args": {
+        "file_path": "src/components/Header.tsx",
+        "content": "export const Header = () => null;\\n"
+      }
+    }
+  ]
 }`"""
 
 # Create a feature branch, write+commit app.py, then edit it without committing,
@@ -461,6 +484,40 @@ def _select_all_scope(changes_panel: PlaywrightChangesPanelElement) -> None:
     expect(scope_all).to_be_visible()
     scope_all.click()
     expect(scope_all).to_have_attribute("data-state", "on")
+
+
+@user_story("to return to a workspace and find the changes tree collapsed the way I left it")
+def test_reentry_preserves_changes_tree_collapse(sculptor_instance_: SculptorInstance) -> None:
+    """Re-entering a workspace keeps a folder the user collapsed in the Changes tree collapsed.
+
+    The Changes tree auto-expands every folder when it first appears, but a folder
+    the user then collapses must stay collapsed across a workspace switch — the
+    panel remounting must not re-expand it.
+    """
+    page = sculptor_instance_.page
+    task_page = start_task_and_wait_for_ready(
+        page, prompt=_NESTED_CHANGES_PROMPT, workspace_name="Changes Tree Collapse A"
+    )
+    wait_for_completed_message_count(chat_panel=task_page.get_chat_panel(), expected_message_count=2)
+    section_root = open_panel(page, "changes", sub_section="left")
+    changes_panel = get_changes_panel_in(section_root, page)
+
+    # src/ auto-expands when the changes tree first appears; collapse it.
+    src_row = changes_panel.get_changes_tree().get_tree_rows().filter(has_text="src").first
+    expect(src_row).to_have_attribute("aria-expanded", "true")
+    src_row.click()
+    expect(src_row).to_have_attribute("aria-expanded", "false")
+
+    # Switch to a second workspace, then return to A.
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Changes Tree Collapse B")
+    navigate_to_workspace(page, "Changes Tree Collapse A")
+    expect(task_page.get_chat_panel()).to_be_visible(timeout=60_000)
+
+    # Reveal the Changes panel and confirm src/ is still collapsed.
+    section_root = open_panel(page, "changes", sub_section="left")
+    changes_panel = get_changes_panel_in(section_root, page)
+    src_row = changes_panel.get_changes_tree().get_tree_rows().filter(has_text="src").first
+    expect(src_row).to_have_attribute("aria-expanded", "false")
 
 
 @user_story("to see only uncommitted changes when clicking a file in the Changes panel")

--- a/sculptor/tests/integration/frontend/test_files_panel.py
+++ b/sculptor/tests/integration/frontend/test_files_panel.py
@@ -659,6 +659,32 @@ def test_sidebar_toggle_from_viewer_header(sculptor_instance_: SculptorInstance)
     expect(layout.get_list()).to_be_visible()
 
 
+@user_story("to return to a workspace and find the file-browser sidebar hidden the way I left it")
+def test_reentry_preserves_hidden_sidebar(sculptor_instance_: SculptorInstance) -> None:
+    """Hiding the Explorer sidebar stays hidden across a workspace switch.
+
+    The sidebar-visibility toggle is persisted per panel, so remounting the
+    panel on a workspace switch must not reopen a sidebar the user hid.
+    """
+    page = sculptor_instance_.page
+    task_page, files_panel = _open_files_panel_with(
+        page, WRITE_FILES_PROMPT, sub_section="left", workspace_name="Sidebar Hide A"
+    )
+    layout = files_panel.get_explorer_layout()
+    expect(layout.get_list()).to_be_visible()
+    layout.hide_sidebar()
+    expect(layout.get_list()).to_have_count(0)
+
+    # Switch to a second workspace, then return to A.
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Sidebar Hide B")
+    navigate_to_workspace(page, "Sidebar Hide A")
+    expect(task_page.get_chat_panel()).to_be_visible(timeout=60_000)
+
+    # Reveal the Files panel and confirm the sidebar is still hidden.
+    files_panel = get_files_panel_in(open_panel(page, "files", sub_section="left"), page)
+    expect(files_panel.get_explorer_layout().get_list()).to_have_count(0)
+
+
 @user_story("to always see the viewer with an empty state when nothing is selected")
 def test_viewer_always_visible_with_empty_state(sculptor_instance_: SculptorInstance) -> None:
     """With files written but nothing selected, the viewer renders its

--- a/sculptor/tests/integration/frontend/test_files_panel.py
+++ b/sculptor/tests/integration/frontend/test_files_panel.py
@@ -502,6 +502,39 @@ def test_file_search_folders_are_collapsible(sculptor_instance_: SculptorInstanc
     expect(app_row.first).to_be_visible()
 
 
+@user_story("to return to a workspace and find the file tree collapsed the way I left it")
+def test_reentry_preserves_file_tree_collapse(sculptor_instance_: SculptorInstance) -> None:
+    """Re-entering a workspace keeps a folder the user collapsed collapsed.
+
+    The Files tree auto-expands ancestors of files an agent is actively writing,
+    but once the agent is idle that must not re-expand a folder the user chose to
+    collapse when the panel remounts on a workspace switch. (Persisting a collapse
+    also proves expansion state survives, since both directions share one atom.)
+    """
+    page = sculptor_instance_.page
+    task_page = start_task_and_wait_for_ready(page, prompt=WRITE_FILES_PROMPT, workspace_name="File Collapse A")
+    wait_for_completed_message_count(chat_panel=task_page.get_chat_panel(), expected_message_count=2)
+
+    # Collapse src/ (it auto-expands while the agent writes into it). Open the panel in
+    # the left section it is seeded into — opening it against the center leaves the
+    # add-panel dropdown's overlay lingering, which then intercepts the next dialog.
+    files_panel = get_files_panel_in(open_panel(page, "files", sub_section="left"), page)
+    _ensure_folder_expanded(files_panel, "src")
+    src_row = files_panel.get_tree_rows().filter(has_text="src").first
+    src_row.click()
+    expect(src_row).to_have_attribute("aria-expanded", "false")
+
+    # Switch to a second workspace, then return to A.
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="File Collapse B")
+    navigate_to_workspace(page, "File Collapse A")
+    expect(task_page.get_chat_panel()).to_be_visible(timeout=60_000)
+
+    # Reveal the Files panel and confirm src/ is still collapsed.
+    files_panel = get_files_panel_in(open_panel(page, "files", sub_section="left"), page)
+    src_row = files_panel.get_tree_rows().filter(has_text="src").first
+    expect(src_row).to_have_attribute("aria-expanded", "false")
+
+
 # --------------------------------------------------------------------------- #
 # Opening a file into the embedded viewer
 #

--- a/sculptor/tests/integration/frontend/test_multi_agent_workspace.py
+++ b/sculptor/tests/integration/frontend/test_multi_agent_workspace.py
@@ -178,6 +178,42 @@ def test_workspaces_have_isolated_agent_tabs(
     expect(tabs).to_have_count(1)
 
 
+@user_story("to return to a workspace and find the agent I was last viewing")
+def test_reentry_preserves_active_agent_selection(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Re-entering a workspace restores the agent the user last viewed, not the last-created one.
+
+    Selecting an agent by clicking its panel tab flips the active panel without
+    navigating, so the choice lives only in the per-workspace layout. Leaving the
+    workspace and returning must restore that agent — the re-entry activation must
+    not snap focus back to whichever agent the route last pointed at (the
+    most-recently-created one).
+    """
+    page = sculptor_instance_.page
+    center = PlaywrightWorkspaceSection(page, "center")
+    panel_tabs = PlaywrightPanelTabElement(page, sub_section="center")
+
+    # Workspace A with two agents; adding the second makes "Claude 2" the active tab.
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Agent Persist A")
+    add_agent_and_wait_for_ready(page)
+    expect(panel_tabs.get_panel_tabs()).to_have_count(2)
+    expect(center.get_active_tab()).to_have_text("Claude 2")
+
+    # Switch to the FIRST agent via its tab. This is a tab click, not a navigation,
+    # so the route still points at "Claude 2".
+    panel_tabs.get_panel_tab_by_name("Claude 1").first.click()
+    expect(center.get_active_tab()).to_have_text("Claude 1")
+
+    # Create a second workspace (navigates away), then return to A.
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Agent Persist B")
+    navigate_to_workspace(page, "Agent Persist A")
+    expect(PlaywrightTaskPage(page=page).get_chat_panel()).to_be_visible(timeout=60_000)
+
+    # The agent last viewed in A ("Claude 1") is the active tab again.
+    expect(center.get_active_tab()).to_have_text("Claude 1")
+
+
 @user_story("to have an agent I watch in a side section stay marked read while it streams")
 def test_mark_read_follows_agent_panel_in_active_side_section(
     sculptor_instance_: SculptorInstance,


### PR DESCRIPTION
## Summary

Several pieces of per-workspace / per-panel UI state lived in component-local React state, so they reset whenever the panel remounted — most visibly when switching workspaces and returning. This persists each of them.

Fixes SCU-1778.

## What changed

**1. Active agent selection** — Selecting an agent via a panel tab doesn't navigate, so the choice updated only the layout's active panel, not the per-workspace `sculptor-tabs` agent id. On re-entry the shell re-activated the last-*navigated* agent, clobbering the tab-click selection. The shell bootstrap now persists the viewed agent into that per-workspace slot whenever it changes.

**2. Changes-tree folder collapse** — The Changes tree re-expanded every folder on each render whose folder set changed, keyed on a per-mount ref; a workspace switch remounted the panel and reopened folders the user had collapsed (also after a search or when new changes arrived). A new per-workspace `changesAutoExpandedFolders` seen-set makes a folder auto-expand only the first time it appears, and search expansion now routes through the shared `useSearchAutoExpand` helper the Files tree already uses. The Files tree already persisted collapses; a regression test locks that in.

**3. Explorer sidebar visibility** — The Files / Changes / Commits panels share an `ExplorerLayout` whose sidebar-hide toggle was component-local `useState`, so hiding the list reset to visible on every remount. It's now persisted per panel on the global layout — each panel keeps its own choice.

## Scoping & compatibility

Agent-selection and Changes-collapse are per-workspace; sidebar-hide is global-per-panel, matching the existing global explorer list-width it sits beside. Both new persisted fields are optional and coalesce a missing value, so snapshots written before the fields existed load cleanly (no migration or version bump).

## Testing

- New failing-then-passing integration tests for each fix (`test_reentry_preserves_active_agent_selection`, `test_reentry_preserves_changes_tree_collapse`, `test_reentry_preserves_hidden_sidebar`) plus a Files-tree lock-in test.
- Unit tests for the new atoms, per-panel independence, and the backward-compat (absent-field) read/write paths.
- `just format`, `just check`, `just test-unit` all green; the full integration set for the touched files verified on Linux (Offload): **54/54**.
- Reviewed via `/code-review-checklist` (whole-branch); findings addressed.

## Follow-up

- SCU-1779 — a narrow Changes-tree search-clear edge case surfaced in review (a folder first appearing during an active search stays collapsed after clearing). Low severity; deferred to avoid a fragile change to the shared search helper in this PR.

(Sent by Claude)
