### PR TITLE
Focus a section on toggle-open and close Cmd+K after toggling (SCU-1783)

### DIFF
--- a/sculptor/frontend/src/components/CommandPalette/__tests__/builtinCommands.test.ts
+++ b/sculptor/frontend/src/components/CommandPalette/__tests__/builtinCommands.test.ts
@@ -378,12 +378,18 @@ describe("buildPanelCommands", () => {
     }
   });
 
-  it("the three section-toggle commands have keepOpen: true", () => {
+  it("the section and sidebar toggles close the palette (no keepOpen)", () => {
+    // These toggles act on chrome hidden behind the palette, so the palette
+    // closes to reveal the result — matching the maximize toggle. (The theme
+    // toggle keeps the palette open because its effect is visible in the
+    // palette itself.)
     const cmds = buildPanelCommands(makeRuntime());
     const byId = (id: string): Command => cmds.find((c) => c.id === id)!;
-    expect(byId("view.toggle_left_panel").keepOpen).toBe(true);
-    expect(byId("view.toggle_right_panel").keepOpen).toBe(true);
-    expect(byId("view.toggle_bottom_panel").keepOpen).toBe(true);
+    expect(byId("view.toggle_left_panel").keepOpen).not.toBe(true);
+    expect(byId("view.toggle_right_panel").keepOpen).not.toBe(true);
+    expect(byId("view.toggle_bottom_panel").keepOpen).not.toBe(true);
+    expect(byId("view.toggle_sidebar").keepOpen).not.toBe(true);
+    expect(byId("view.maximize_section").keepOpen).not.toBe(true);
   });
 
   it("perform delegates to the matching runtime.ui method", () => {
@@ -399,12 +405,6 @@ describe("buildPanelCommands", () => {
     expect(runtime.ui.toggleBottomPanel).toHaveBeenCalledTimes(1);
     expect(runtime.ui.toggleSidebar).toHaveBeenCalledTimes(1);
     expect(runtime.ui.toggleMaximizeSection).toHaveBeenCalledTimes(1);
-  });
-
-  it("the sidebar toggle keeps the palette open; the maximize toggle closes it", () => {
-    const cmds = buildPanelCommands(makeRuntime());
-    expect(cmds.find((c) => c.id === "view.toggle_sidebar")!.keepOpen).toBe(true);
-    expect(cmds.find((c) => c.id === "view.maximize_section")!.keepOpen).not.toBe(true);
   });
 
   it("view.maximize_section lives on the view.layout sub-page", () => {

--- a/sculptor/frontend/src/components/CommandPalette/builtinCommands/panels.ts
+++ b/sculptor/frontend/src/components/CommandPalette/builtinCommands/panels.ts
@@ -71,7 +71,6 @@ export const buildPanelCommands = (runtime: CommandRuntime): Array<Command> => [
     order: 10,
     when: (ctx) => ctx.route.isWorkspace,
     perform: () => runtime.ui.toggleBottomPanel(),
-    keepOpen: true,
   },
   {
     id: "view.toggle_left_panel",
@@ -88,7 +87,6 @@ export const buildPanelCommands = (runtime: CommandRuntime): Array<Command> => [
     order: 20,
     when: (ctx) => ctx.route.isWorkspace,
     perform: () => runtime.ui.toggleLeftPanel(),
-    keepOpen: true,
   },
   {
     id: "view.toggle_right_panel",
@@ -102,7 +100,6 @@ export const buildPanelCommands = (runtime: CommandRuntime): Array<Command> => [
     order: 30,
     when: (ctx) => ctx.route.isWorkspace,
     perform: () => runtime.ui.toggleRightPanel(),
-    keepOpen: true,
   },
   // The sidebar is workspace-navigation chrome rather than a section, so its
   // toggle lives in the Navigation group at the root (not on the sections
@@ -121,7 +118,6 @@ export const buildPanelCommands = (runtime: CommandRuntime): Array<Command> => [
     shortcut: "toggle_sidebar",
     order: 100,
     perform: () => runtime.ui.toggleSidebar(),
-    keepOpen: true,
   },
   {
     id: "view.maximize_section",

--- a/sculptor/frontend/src/components/sections/sectionActions.test.ts
+++ b/sculptor/frontend/src/components/sections/sectionActions.test.ts
@@ -70,6 +70,34 @@ describe("collapse/expand invariants", () => {
     expect(store.get(workspaceLayoutAtom).expanded.left).toBe(true);
     expect(store.get(maximizedSectionAtom)).toBe("left");
   });
+
+  it("toggling a section open focuses it and pulses the active-section ring", () => {
+    const store = storeWith({ activeSubSection: "center", expanded: { left: false } });
+    const nonceBefore = store.get(activeSectionRingNonceAtom);
+    store.set(toggleSectionAtom, { section: "left" });
+    const layout = store.get(workspaceLayoutAtom);
+    expect(layout.expanded.left).toBe(true);
+    expect(layout.activeSubSection).toBe("left");
+    expect(store.get(activeSectionRingNonceAtom)).toBe(nonceBefore + 1);
+  });
+
+  it("toggling a split section open focuses its primary half", () => {
+    const store = storeWith({
+      activeSubSection: "center",
+      expanded: { left: false },
+      splits: { left: { axis: "horizontal", ratio: 0.5 } },
+    });
+    store.set(toggleSectionAtom, { section: "left" });
+    expect(store.get(workspaceLayoutAtom).activeSubSection).toBe("left");
+  });
+
+  it("collapsing a section does not pulse the active-section ring", () => {
+    const store = storeWith({ expanded: { left: true }, activeSubSection: "left" });
+    const nonceBefore = store.get(activeSectionRingNonceAtom);
+    store.set(toggleSectionAtom, { section: "left" });
+    expect(store.get(workspaceLayoutAtom).activeSubSection).toBe("center");
+    expect(store.get(activeSectionRingNonceAtom)).toBe(nonceBefore);
+  });
 });
 
 describe("single-instance invariant", () => {

--- a/sculptor/frontend/src/components/sections/sectionActions.ts
+++ b/sculptor/frontend/src/components/sections/sectionActions.ts
@@ -14,7 +14,7 @@ import type { WorkspaceLayoutState } from "./persistence/types.ts";
 import { isMultiInstancePanelId } from "./registry/dynamicPanels.tsx";
 import { activeWorkspaceIdAtom, workspaceLayoutAtom } from "./sectionAtoms.ts";
 import type { PanelId, SectionId, SplitAxis, SubSectionId } from "./sectionTypes.ts";
-import { canSplitAxis, toSecondary, toSection } from "./sectionTypes.ts";
+import { canSplitAxis, primaryOf, toSecondary, toSection } from "./sectionTypes.ts";
 import { activeSectionRingNonceAtom, maximizedSectionAtom } from "./transientAtoms.ts";
 
 export const SPLIT_RATIO_MIN = 0.15;
@@ -239,13 +239,21 @@ export const setActivePanelAtom = atom(null, (_get, set, params: SetActivePanelP
 );
 
 export const toggleSectionAtom = atom(null, (get, set, params: ToggleSectionParams) => {
+  const isCollapsibleSection = params.section !== "center";
+  const isAlreadyExpanded = isCollapsibleSection && isSectionExpanded(get(workspaceLayoutAtom), params.section);
   // A collapsed section must never stay maximized: the transient full-screen view
   // would otherwise show a section the persisted layout says is closed.
-  const willCollapse = params.section !== "center" && isSectionExpanded(get(workspaceLayoutAtom), params.section);
-  if (willCollapse && get(maximizedSectionAtom) === params.section) {
+  if (isAlreadyExpanded && get(maximizedSectionAtom) === params.section) {
     set(maximizedSectionAtom, null);
   }
   set(workspaceLayoutAtom, (prev) => withToggleSection(prev, params));
+  // Toggling a section open focuses it and pulses the active-section ring — a
+  // deliberate jump, like the keyboard section-cycle and panel add/drop. Collapsing
+  // never focuses: withToggleSection reassigns the active sub-section to center when
+  // the closed section held it.
+  if (isCollapsibleSection && !isAlreadyExpanded) {
+    set(jumpToSectionAtom, { subSection: primaryOf(params.section) });
+  }
 });
 
 export const splitSectionAtom = atom(null, (_get, set, params: SplitSectionParams) =>

--- a/sculptor/tests/integration/frontend/test_command_palette.py
+++ b/sculptor/tests/integration/frontend/test_command_palette.py
@@ -409,6 +409,12 @@ def test_command_palette_section_toggle_closes_palette(sculptor_instance_: Sculp
     task_page = start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Cmd+K Toggle Section WS")
     right = PlaywrightWorkspaceSection(page, "right")
 
+    # Force the precondition rather than trusting the default layout: the right section
+    # must be collapsed so the toggle command below OPENS it. The command is a raw
+    # toggle, so an already-expanded section would collapse and invert the final assertion.
+    right.collapse_section()
+    expect(right.get_header()).to_have_count(0)
+
     palette = task_page.open_command_palette()
     palette.type_query("Toggle right section")
     expect(palette.get_item_by_command_id("view.toggle_right_panel")).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_command_palette.py
+++ b/sculptor/tests/integration/frontend/test_command_palette.py
@@ -397,6 +397,26 @@ def test_command_palette_show_panel_is_jump_only(sculptor_instance_: SculptorIns
     expect(task_page.get_file_browser()).to_be_visible()
 
 
+@user_story("to have the palette close after I toggle a section from Cmd+K")
+def test_command_palette_section_toggle_closes_palette(sculptor_instance_: SculptorInstance) -> None:
+    # Regression lock for the view.toggle_{left,right,bottom}_panel commands: unlike
+    # the jump-only "Show X" panel reveals, the section toggles act on chrome behind
+    # the palette, so the palette must CLOSE to reveal the result. The right section
+    # starts collapsed; toggling it from Cmd+K opens it and dismisses the palette.
+    # Not @release-marked: start_task_and_wait_for_ready selects the Fake Claude model,
+    # which is gated off in packaged-release runs.
+    page = sculptor_instance_.page
+    task_page = start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Cmd+K Toggle Section WS")
+    right = PlaywrightWorkspaceSection(page, "right")
+
+    palette = task_page.open_command_palette()
+    palette.type_query("Toggle right section")
+    expect(palette.get_item_by_command_id("view.toggle_right_panel")).to_be_visible()
+    palette.select_by_command_id("view.toggle_right_panel")
+    expect(palette).not_to_be_visible()
+    expect(right.get_header()).to_be_visible()
+
+
 @user_story("to create and land on a new agent via the palette's Add panel flow")
 def test_command_palette_add_panel_agent_create_navigates(sculptor_instance_: SculptorInstance) -> None:
     # Regression lock for the addpanel.panels.new_agent row: it must share the

--- a/sculptor/tests/integration/frontend/test_section_active_and_maximize.py
+++ b/sculptor/tests/integration/frontend/test_section_active_and_maximize.py
@@ -90,6 +90,31 @@ def test_cycle_sections_pulses_ring(sculptor_instance_: SculptorInstance) -> Non
     expect(right_ring).to_have_attribute("data-active", "true")
 
 
+@user_story("to focus a section when I toggle it open")
+def test_toggling_section_open_focuses_it_and_pulses_ring(sculptor_instance_: SculptorInstance) -> None:
+    """Toggling a collapsed section open makes it the active section and pulses its ring."""
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(page, prompt="Say hello", workspace_name="Toggle Open Focus WS")
+    center = PlaywrightWorkspaceSection(page, "center")
+    right = PlaywrightWorkspaceSection(page, "right")
+
+    # The right section starts collapsed. Make the center active first so the toggle
+    # has to move the active section for the assertion to mean anything.
+    center.get_active_tab().click()
+    expect(center.get_active_ring()).to_have_attribute("data-active", "true")
+
+    # Toggle the right section open via its keyboard shortcut -> it becomes the active
+    # section and its ring pulses visible (a deliberate jump, like the section-cycle).
+    toggle_section_via_hotkey(page, "right")
+    right_ring = right.get_active_ring()
+    # Assert the ring pulse FIRST — data-ring-visible clears after RING_VISIBLE_MS, so
+    # it must be caught before the fade; data-active persists and is checked after.
+    expect(right_ring).to_have_attribute("data-ring-visible", "true")
+    expect(right_ring).to_have_attribute("data-active", "true")
+    expect(center.get_active_ring()).not_to_have_attribute("data-active", "true")
+
+
 @user_story("to maximize a section so it covers the workspace content")
 def test_maximize_hides_workspace_header_and_restore(sculptor_instance_: SculptorInstance) -> None:
     """Maximizing hides the workspace header but keeps the section header; restore brings it back."""

--- a/sculptor/tests/integration/frontend/test_section_active_and_maximize.py
+++ b/sculptor/tests/integration/frontend/test_section_active_and_maximize.py
@@ -99,8 +99,14 @@ def test_toggling_section_open_focuses_it_and_pulses_ring(sculptor_instance_: Sc
     center = PlaywrightWorkspaceSection(page, "center")
     right = PlaywrightWorkspaceSection(page, "right")
 
-    # The right section starts collapsed. Make the center active first so the toggle
-    # has to move the active section for the assertion to mean anything.
+    # Force the precondition rather than trusting the default layout: the right section
+    # must be collapsed so the hotkey below OPENS it. The hotkey is a raw toggle, so an
+    # already-expanded section would collapse instead and invert the assertions.
+    right.collapse_section()
+    expect(right.get_header()).to_have_count(0)
+
+    # Make the center active first so the toggle has to move the active section for the
+    # assertion to mean anything.
     center.get_active_tab().click()
     expect(center.get_active_ring()).to_have_attribute("data-active", "true")
 


### PR DESCRIPTION
## Summary

Two small bug fixes to the workspace **section toggles** (left / right / bottom), reachable from both the keyboard shortcuts and the Cmd+K command palette. Ticket: [SCU-1783](https://linear.app/imbue/issue/SCU-1783).

### Bug 1 — Toggling a section open didn't focus it

Opening a collapsed section (via keybinding or Cmd+K) left focus on the previously-active section. Now the open transition routes through `jumpToSectionAtom` inside `toggleSectionAtom` — the single choke point shared by the keyboard shortcuts and the palette commands — so opening a section makes it the **active section** and pulses the active-section ring, matching the deliberate-jump feedback used by the section-cycle and panel add/drop. Collapsing does not focus.

### Bug 2 — Cmd+K section toggles left the palette open

The "Toggle bottom / left / right section" commands set `keepOpen: true`, so the palette stayed up after triggering and obscured the section the user just toggled. `keepOpen` is removed so they close via the normal run path, like the Maximize toggle.

- The **sidebar** toggle is also updated, since it would otherwise be the lone layout toggle that stays open while its siblings close.
- The **theme** toggle intentionally keeps the palette open — its effect previews live inside the palette itself.

## Changes

- `sections/sectionActions.ts` — `toggleSectionAtom` focuses the section on the open transition.
- `CommandPalette/builtinCommands/panels.ts` — drop `keepOpen` from the three section toggles and the sidebar toggle.

## Tests

- **Unit** (`sectionActions.test.ts`): toggling open focuses + pulses the ring; a split section focuses its primary half; collapsing does not pulse. (`builtinCommands.test.ts`): the section and sidebar toggles close the palette; theme still keeps it open.
- **Integration** (Playwright): toggling a section open focuses it and pulses the ring (`test_section_active_and_maximize.py`); a section toggle from Cmd+K closes the palette (`test_command_palette.py`).
- `just format`, `just check`, and `just test-unit` all pass locally.

_(no outstanding review notes)_

(Sent by Claude)
