### PR TITLE
Fix pi model-picker login-CTA flash during authenticated startup (SCU-1583)

### DIFF
--- a/offload.toml
+++ b/offload.toml
@@ -8,7 +8,6 @@
 [offload]
 max_parallel = 200
 test_timeout_secs = 900
-stream_output = true
 sandbox_project_root = "/app/sculptor"
 sandbox_repo_root = "/app"
 # Finalize the cached base image: install deps, write tool stubs, seed

--- a/sculptor/frontend/src/common/state/hooks/useTaskHelpers.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useTaskHelpers.test.ts
@@ -5,6 +5,7 @@ import { createElement, useRef } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { CodingAgentTaskView, ModelOption } from "../../../api";
+import { ModelCatalogState } from "../../../api";
 import { queryClient, syncTasksToQueryCache } from "../../queryClient.ts";
 import { useTaskAvailableModels, useTaskStatus } from "./useTaskHelpers.ts";
 
@@ -92,14 +93,15 @@ describe("useTaskStatus", () => {
 });
 
 describe("useTaskAvailableModels", () => {
-  it("returns a referentially stable empty list across unrelated updates", async () => {
-    // No backend catalog (Claude): availableModels is absent, so the select must
-    // fall back to the shared EMPTY constant — one stable array identity rather
-    // than a fresh `[]` each frame.
+  it("returns the stable NOT_FETCHED_YET sentinel while the catalog is absent", async () => {
+    // Catalog not fetched yet: availableModels is absent, so the select must fall
+    // back to NOT_FETCHED_YET (a stable primitive) rather than an empty array —
+    // distinguishing "not fetched" from "fetched, empty" is what lets the switcher
+    // show a loading state instead of flashing the login CTA at startup.
     const task = createMockTask({ id: "task-1", availableModels: undefined, status: "RUNNING" });
     await writeTasksAndFlush({ "task-1": task });
 
-    const seen: Array<ReadonlyArray<ModelOption>> = [];
+    const seen: Array<ReadonlyArray<ModelOption> | ModelCatalogState> = [];
     renderHook(
       () => {
         seen.push(useTaskAvailableModels("task-1"));
@@ -110,10 +112,10 @@ describe("useTaskAvailableModels", () => {
 
     await writeTasksAndFlush({ "task-1": { ...task, status: "WAITING" } as CodingAgentTaskView });
 
-    // Every observed value is the same reference (both the absent-data coalesce
-    // and the select fallback return the shared EMPTY constant).
+    // Every observed value is the same sentinel (both the absent-data coalesce
+    // and the select fallback yield NOT_FETCHED_YET).
     const first = seen[0];
-    expect(first).toEqual([]);
+    expect(first).toBe(ModelCatalogState.NOT_FETCHED_YET);
     seen.forEach((value) => expect(value).toBe(first));
   });
 });

--- a/sculptor/frontend/src/common/state/hooks/useTaskHelpers.ts
+++ b/sculptor/frontend/src/common/state/hooks/useTaskHelpers.ts
@@ -1,6 +1,7 @@
 import { skipToken, useQuery } from "@tanstack/react-query";
 
 import type { CodingAgentTaskView, ModelOption, TaskStatus } from "../../../api";
+import { ModelCatalogState } from "../../../api";
 import { taskQueryKey } from "../../queryClient.ts";
 export { useTask } from "./useTask";
 
@@ -12,11 +13,6 @@ export { useTask } from "./useTask";
 // selector families used to provide. These hooks are the narrow accessors for
 // `harnessCapabilities.<field>`: a mistyped capability key would read
 // `undefined` and gate open, so every capability read goes through one here.
-
-// A stable reference for the "no backend catalog" case (Claude), so the
-// availableModels select keeps one identity across unrelated task updates
-// instead of yielding a fresh array each recompute.
-const EMPTY_MODEL_OPTIONS: ReadonlyArray<ModelOption> = [];
 
 // Subscribe to a single task, projecting one field through `pick`. The cache is
 // subscription-only (`skipToken`), matching useTask; `pick` runs on every cached
@@ -47,9 +43,10 @@ export const useTaskModel = (taskId: string): string | undefined =>
 export const useTaskWorkspaceId = (taskId: string): string | undefined =>
   useTaskField(taskId, (task) => task?.workspaceId ?? undefined);
 
-/** Subscribe to the harness's backend-sourced model list (pi); empty for Claude. */
-export const useTaskAvailableModels = (taskId: string): ReadonlyArray<ModelOption> =>
-  useTaskField(taskId, (task) => task?.availableModels ?? EMPTY_MODEL_OPTIONS);
+/** Subscribe to the harness's backend-sourced model catalog (pi): the fetched
+ *  list (empty for Claude), or NOT_FETCHED_YET while the start-time probe runs. */
+export const useTaskAvailableModels = (taskId: string): ReadonlyArray<ModelOption> | ModelCatalogState =>
+  useTaskField(taskId, (task) => task?.availableModels ?? ModelCatalogState.NOT_FETCHED_YET);
 
 /** Subscribe to the model_id the switcher should show selected for a backend list (pi). */
 export const useTaskSelectedModelId = (taskId: string): string | undefined =>

--- a/sculptor/frontend/src/components/ModelSelector.test.tsx
+++ b/sculptor/frontend/src/components/ModelSelector.test.tsx
@@ -4,7 +4,7 @@ import { createStore, Provider } from "jotai";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { ElementIds, LlmModel, type ModelOption } from "~/api";
+import { ElementIds, LlmModel, ModelCatalogState, type ModelOption } from "~/api";
 import { groupModelsByProvider, routeModelChange } from "~/common/modelConstants.ts";
 
 import { ModelSelectOptions } from "./ModelSelectOptions";
@@ -188,6 +188,28 @@ describe("ModelSelector", () => {
     expect(emptyState).toHaveTextContent("No models available — please log in to authenticate");
     expect(screen.getByTestId(ElementIds.PI_PICKER_LOGIN_CTA)).toBeInTheDocument();
     expect(screen.queryByTestId(ElementIds.MODEL_SELECTOR)).not.toBeInTheDocument();
+  });
+
+  it("shows a loading state, not the login CTA, while the pi catalog is not yet fetched", () => {
+    render(
+      withStore(
+        <ModelSelector
+          model={LlmModel.CLAUDE_4_OPUS_200K}
+          onModelChange={() => {}}
+          capabilityValue={true}
+          sourcesBackendModels={true}
+          backendModels={ModelCatalogState.NOT_FETCHED_YET}
+          onAuthenticate={() => {}}
+        />,
+      ),
+    );
+    // Until the start-time probe lands, an authenticated user's catalog is
+    // NOT_FETCHED_YET — the switcher shows a loading placeholder and must NOT flash
+    // the "please log in" CTA (that empty-state is reserved for a fetched-but-empty
+    // catalog, i.e. real no-auth).
+    expect(screen.getByTestId(ElementIds.PI_PICKER_LOADING)).toBeInTheDocument();
+    expect(screen.queryByTestId(ElementIds.PI_PICKER_EMPTY_STATE)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ElementIds.PI_PICKER_LOGIN_CTA)).not.toBeInTheDocument();
   });
 
   it("invokes onAuthenticate when the login CTA is clicked", () => {

--- a/sculptor/frontend/src/components/ModelSelector.tsx
+++ b/sculptor/frontend/src/components/ModelSelector.tsx
@@ -2,7 +2,7 @@ import { Button, DropdownMenu, Flex, Select, Text, Tooltip } from "@radix-ui/the
 import type { ReactElement } from "react";
 
 import type { LlmModel, ModelOption } from "~/api";
-import { ElementIds } from "~/api";
+import { ElementIds, ModelCatalogState } from "~/api";
 import {
   getModelShortName,
   getProviderDisplayName,
@@ -22,9 +22,10 @@ type ModelSelectorProps = {
   /** The active task's `supports_model_selection` capability. When false the
    *  switcher renders disabled-with-tooltip (the current model still shows). */
   capabilityValue?: boolean;
-  /** A harness-supplied model list (pi). Options are keyed by model_id and
-   *  `selectedModelId` is shown selected. */
-  backendModels?: ReadonlyArray<ModelOption>;
+  /** The pi catalog for the switcher: the fetched list (keyed by model_id, with
+   *  `selectedModelId` shown selected), or `NOT_FETCHED_YET` while the start-time
+   *  probe is still in flight — which renders a loading state, not the login CTA. */
+  backendModels?: ReadonlyArray<ModelOption> | ModelCatalogState;
   /** The model_id to show selected when the harness sources a backend list (pi). */
   selectedModelId?: string;
   /** The out-of-band change handler for a backend model list (pi). Called with
@@ -54,7 +55,8 @@ export const ModelSelector = ({
 }: ModelSelectorProps): ReactElement => {
   const gate = useCapabilityGate(capabilityValue, ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION);
 
-  const models = backendModels ?? [];
+  const models = Array.isArray(backendModels) ? backendModels : [];
+  const isCatalogNotFetched = backendModels === ModelCatalogState.NOT_FETCHED_YET;
   const hasBackendModels = sourcesBackendModels && models.length > 0;
   const providerGroups = hasBackendModels ? groupModelsByProvider(models) : [];
 
@@ -82,6 +84,24 @@ export const ModelSelector = ({
           </Select.Root>
         </span>
       </Tooltip>
+    );
+  }
+
+  if (sourcesBackendModels && isCatalogNotFetched) {
+    // The start-time catalog probe is still in flight (catalog NOT_FETCHED_YET):
+    // show a quiet, disabled placeholder — never the login CTA, which would
+    // otherwise flash for an authenticated user until the real catalog lands. Only
+    // a fetched-but-empty catalog (below) means "no providers, please log in".
+    return (
+      <Select.Root size="1" value="" disabled>
+        <Select.Trigger className={styles.trigger} data-testid={ElementIds.PI_PICKER_LOADING} variant="ghost">
+          <Flex align="center">
+            <Text size="1" color="gray">
+              Loading models…
+            </Text>
+          </Flex>
+        </Select.Trigger>
+      </Select.Root>
     );
   }
 

--- a/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
@@ -254,10 +254,15 @@ export type CodingAgentTaskView = {
 	/**
 	 * Availablemodels
 	 *
-	 * The models the harness offers in its switcher (empty when it sources
-	 * none and the frontend falls back to its built-in list).
+	 * The switcher's catalog as the frontend gates on it: NOT_FETCHED_YET
+	 * until the start-time probe lands, then the fetched list (empty = the
+	 * harness sources none and the frontend falls back to its built-in list, or
+	 * pi is authenticated with no providers and shows the login CTA). Runtime
+	 * callers that only offer models use `get_available_models`, which coalesces
+	 * the sentinel to []; the switcher needs the distinction so it can show a
+	 * loading state instead of flashing the CTA while the catalog loads.
 	 */
-	readonly availableModels: Array<ModelOption>;
+	readonly availableModels: Array<ModelOption> | ModelCatalogState;
 	/**
 	 * Selectedmodelid
 	 *
@@ -443,6 +448,22 @@ declare const LlmModel: {
  * LLMModel
  */
 export type LlmModel = typeof LlmModel[keyof typeof LlmModel];
+declare const ModelCatalogState: {
+	readonly NOT_FETCHED_YET: "not_fetched_yet";
+};
+/**
+ * ModelCatalogState
+ *
+ * The catalog states a plain `list[ModelOption]` cannot express.
+ *
+ * `NOT_FETCHED_YET` is the birth state of a backend (pi) catalog on task state,
+ * before the start-time probe runs — distinct from a fetched-but-empty `[]`
+ * (authenticated, but no providers), which is what drives the login CTA. Keeping
+ * the two apart is what stops the switcher flashing that CTA during startup. A
+ * StrEnum member is a value-less, interned singleton that survives serialization
+ * by identity, so read sites use `is` rather than overloading `None`.
+ */
+export type ModelCatalogState = typeof ModelCatalogState[keyof typeof ModelCatalogState];
 /**
  * ModelOption
  *

--- a/sculptor/sculptor/agents/pi_agent/harness.py
+++ b/sculptor/sculptor/agents/pi_agent/harness.py
@@ -45,7 +45,9 @@ from sculptor.interfaces.agents.harness import HarnessCapabilities
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
 from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.chat_state import ToolUseBlock
+from sculptor.state.messages import ModelCatalog
 from sculptor.state.messages import ModelOption
+from sculptor.state.messages import NOT_FETCHED_YET
 
 # Pi has no MCP / AskUserQuestion / ExitPlanMode surface; the Claude
 # prompt's tool-instructions block is deliberately absent. Names Sculptor
@@ -161,11 +163,20 @@ class PiHarness(Harness):
     def get_available_models(self, task_state: AgentTaskStateV2 | None) -> list[ModelOption]:
         # The agent fetches and curates pi's catalog at start and persists it on
         # the task state (agent_wrapper._fetch_models_into_state); the switcher
-        # reads it from here. Empty until the agent has run, or when task_state
-        # is absent — the frontend then falls back to its built-in list.
+        # reads it from here. Coalesce a not-yet-fetched catalog to [] for callers
+        # that only offer models (agent runtime, the set-model endpoint) — the
+        # NOT_FETCHED_YET distinction is preserved by get_model_catalog for the UI.
+        catalog = self.get_model_catalog(task_state)
+        return list(catalog) if isinstance(catalog, list) else []
+
+    def get_model_catalog(self, task_state: AgentTaskStateV2 | None) -> ModelCatalog:
+        # The raw catalog: NOT_FETCHED_YET until the start-time probe persists a
+        # list (possibly [] = authenticated but no providers). Preserved so the
+        # switcher shows a loading state during startup rather than flashing the
+        # login CTA. Also NOT_FETCHED_YET when task_state is absent (nothing known).
         if task_state is None:
-            return []
-        return list(task_state.available_models)
+            return NOT_FETCHED_YET
+        return task_state.available_models
 
     def get_selected_model_id(self, task_state: AgentTaskStateV2 | None) -> str | None:
         # The model_id pi reported as current at start (get_state.model), or None

--- a/sculptor/sculptor/agents/pi_agent/harness_test.py
+++ b/sculptor/sculptor/agents/pi_agent/harness_test.py
@@ -10,6 +10,7 @@ from sculptor.primitives.ids import ToolUseID
 from sculptor.primitives.ids import WorkspaceID
 from sculptor.state.chat_state import ToolUseBlock
 from sculptor.state.messages import ModelOption
+from sculptor.state.messages import NOT_FETCHED_YET
 
 
 def test_pi_harness_capabilities() -> None:
@@ -147,6 +148,22 @@ def test_pi_harness_get_available_models_empty_when_unpopulated_or_none() -> Non
     # Empty until the agent has run, and empty when there is no task state.
     assert PI_HARNESS.get_available_models(_task_state_with_models([], current_model=None)) == []
     assert PI_HARNESS.get_available_models(None) == []
+
+
+def test_pi_harness_distinguishes_not_fetched_catalog_from_fetched_empty() -> None:
+    # Before the start-time probe runs, a fresh task's catalog is NOT_FETCHED_YET
+    # — distinct from a fetched-but-empty [] (authenticated, but no providers).
+    # get_available_models coalesces both to [] for runtime callers that only
+    # offer models; get_model_catalog keeps them apart so the switcher can show a
+    # loading state instead of flashing the login CTA during startup.
+    fresh = AgentTaskStateV2(workspace_id=WorkspaceID())
+    assert fresh.available_models is NOT_FETCHED_YET
+    assert PI_HARNESS.get_model_catalog(fresh) is NOT_FETCHED_YET
+    assert PI_HARNESS.get_available_models(fresh) == []
+
+    fetched_empty = _task_state_with_models([], current_model=None)
+    assert PI_HARNESS.get_model_catalog(fetched_empty) == []
+    assert PI_HARNESS.get_available_models(fetched_empty) == []
 
 
 def test_pi_harness_sources_backend_models_is_true() -> None:

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -437,6 +437,9 @@ class ElementIDs(StrEnum):
     # Model-picker empty state when a pi agent has no authenticated providers.
     PI_PICKER_EMPTY_STATE = "pi-picker-empty-state"
     PI_PICKER_LOGIN_CTA = "pi-picker-login-cta"
+    # Model-picker placeholder while the start-time catalog probe is still in
+    # flight (catalog NOT_FETCHED_YET), shown instead of the empty-state CTA.
+    PI_PICKER_LOADING = "pi-picker-loading"
     # Failed-turn error block CTA that deep-links into the pi login flow.
     PI_ERROR_LOGIN_CTA = "pi-error-login-cta"
 

--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -2724,6 +2724,14 @@
     "current_state": {
       "AgentTaskStateV2": {
         "$defs": {
+          "ModelCatalogState": {
+            "description": "The catalog states a plain `list[ModelOption]` cannot express.\n\n`NOT_FETCHED_YET` is the birth state of a backend (pi) catalog on task state,\nbefore the start-time probe runs \u2014 distinct from a fetched-but-empty `[]`\n(authenticated, but no providers), which is what drives the login CTA. Keeping\nthe two apart is what stops the switcher flashing that CTA during startup. A\nStrEnum member is a value-less, interned singleton that survives serialization\nby identity, so read sites use `is` rather than overloading `None`.",
+            "enum": [
+              "not_fetched_yet"
+            ],
+            "title": "ModelCatalogState",
+            "type": "string"
+          },
           "ModelOption": {
             "additionalProperties": true,
             "description": "One model a harness offers in its switcher.\n\n`provider` and `model_id` identify the model on the harness's own terms\n(pi sends them back as a `set_model` selection; for the Claude harness\n`model_id` is the `LLMModel` value). `display_name` is the selector label.",
@@ -2754,12 +2762,19 @@
         "description": "The state of a run_agent server task.\nThis is used to snapshot the state of the task at various points in time so that the agent can be resumed.",
         "properties": {
           "availableModels": {
-            "default": [],
-            "items": {
-              "$ref": "#/$defs/ModelOption"
-            },
-            "title": "Availablemodels",
-            "type": "array"
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/$defs/ModelOption"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/$defs/ModelCatalogState"
+              }
+            ],
+            "default": "not_fetched_yet",
+            "title": "Availablemodels"
           },
           "currentModel": {
             "anyOf": [

--- a/sculptor/sculptor/database/models.py
+++ b/sculptor/sculptor/database/models.py
@@ -26,7 +26,9 @@ from sculptor.primitives.ids import UserSettingsID
 from sculptor.primitives.ids import WorkspaceID
 from sculptor.state.messages import AgentMessageSource
 from sculptor.state.messages import LLMModel
+from sculptor.state.messages import ModelCatalog
 from sculptor.state.messages import ModelOption
+from sculptor.state.messages import NOT_FETCHED_YET
 
 TaskID = AgentTaskID
 
@@ -202,8 +204,11 @@ class AgentTaskStateV2(BaseTaskState):
     terminal_shell_pid: int | None = None
     # pi agents only: the curated model catalog the agent fetched from pi at
     # start (get_available_models), surfaced by the pi harness's
-    # get_available_models so the chat switcher offers pi's real models.
-    available_models: list[ModelOption] = []
+    # get_available_models so the chat switcher offers pi's real models. Defaults
+    # to NOT_FETCHED_YET (the probe has not run) — distinct from a fetched-but-
+    # empty [] (authenticated, no providers), so the switcher can tell a loading
+    # catalog from a genuinely empty one instead of flashing the login CTA.
+    available_models: ModelCatalog = NOT_FETCHED_YET
     # pi agents only: the model pi reported as current at start (get_state.model),
     # surfaced by the pi harness's get_selected_model_id as the switcher's value.
     current_model: ModelOption | None = None

--- a/sculptor/sculptor/interfaces/agents/harness.py
+++ b/sculptor/sculptor/interfaces/agents/harness.py
@@ -50,6 +50,7 @@ from sculptor.state.chat_state import ContentBlock
 from sculptor.state.chat_state import ToolInput
 from sculptor.state.chat_state import ToolInteractiveRole
 from sculptor.state.chat_state import ToolUseBlock
+from sculptor.state.messages import ModelCatalog
 from sculptor.state.messages import ModelOption
 
 
@@ -155,6 +156,16 @@ class Harness(BaseModel, abc.ABC):
         base offers nothing, mirroring the all-`False` `capabilities()` default.
         """
         return []
+
+    def get_model_catalog(self, task_state: AgentTaskStateV2 | None) -> ModelCatalog:
+        """The raw switcher catalog, preserving lifecycle states a plain list
+        cannot express (e.g. `NOT_FETCHED_YET`, before a dynamic catalog's probe
+        has run). `get_available_models` coalesces those to `[]` for callers that
+        only need to offer models; the frontend reads this to tell a still-loading
+        catalog from a fetched-but-empty one. A harness that sources no backend
+        catalog has nothing to load, so its resolved list is authoritative.
+        """
+        return self.get_available_models(task_state)
 
     def get_selected_model_id(self, task_state: AgentTaskStateV2 | None) -> str | None:
         """The `model_id` of the task's currently-selected model, or `None` when

--- a/sculptor/sculptor/state/messages.py
+++ b/sculptor/sculptor/state/messages.py
@@ -47,6 +47,28 @@ class ModelOption(SerializableModel):
     display_name: str
 
 
+class ModelCatalogState(StrEnum):
+    """The catalog states a plain `list[ModelOption]` cannot express.
+
+    `NOT_FETCHED_YET` is the birth state of a backend (pi) catalog on task state,
+    before the start-time probe runs — distinct from a fetched-but-empty `[]`
+    (authenticated, but no providers), which is what drives the login CTA. Keeping
+    the two apart is what stops the switcher flashing that CTA during startup. A
+    StrEnum member is a value-less, interned singleton that survives serialization
+    by identity, so read sites use `is` rather than overloading `None`.
+    """
+
+    NOT_FETCHED_YET = "not_fetched_yet"
+
+
+# Canonical singleton, so call sites read `NOT_FETCHED_YET` not the dotted form.
+NOT_FETCHED_YET = ModelCatalogState.NOT_FETCHED_YET
+
+# A backend model catalog as stored on task state and surfaced to the switcher:
+# the fetched list (possibly empty = no providers), or a lifecycle sentinel.
+ModelCatalog = list[ModelOption] | ModelCatalogState
+
+
 class AgentMessageSource(StrEnum):
     """
     Messages can come from the AGENT (in-container LLM), USER (chat messages & direct interactions), SCULPTOR_SYSTEM (multifaceted sculptor app and service code) and RUNNER (the process controlling a task on the server.)

--- a/sculptor/sculptor/state/test_messages.py
+++ b/sculptor/sculptor/state/test_messages.py
@@ -1,9 +1,14 @@
 from syrupy import SnapshotAssertion
 
+from sculptor.database.models import AgentTaskStateV2
 from sculptor.primitives.ids import AssistantMessageID
+from sculptor.primitives.ids import WorkspaceID
 from sculptor.state.chat_state import TextBlock
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import LLMModel
+from sculptor.state.messages import ModelCatalogState
+from sculptor.state.messages import ModelOption
+from sculptor.state.messages import NOT_FETCHED_YET
 from sculptor.state.messages import ResponseBlockAgentMessage
 
 
@@ -19,3 +24,41 @@ def test_create_messages(snapshot: SnapshotAssertion) -> None:
             model_name=LLMModel.CLAUDE_4_OPUS,
         ),
     ]
+
+
+def test_not_fetched_yet_is_the_interned_catalog_singleton() -> None:
+    # A StrEnum member is the singleton: the alias IS the member, and a value
+    # lookup (what pydantic does on parse) returns that same object — so read
+    # sites can rely on `is`, no validator and no `None` overload required.
+    assert NOT_FETCHED_YET is ModelCatalogState.NOT_FETCHED_YET
+    assert ModelCatalogState("not_fetched_yet") is NOT_FETCHED_YET
+
+
+def test_catalog_sentinel_survives_task_state_serialization_by_identity() -> None:
+    # The DB path is model_dump -> JSON -> model_validate. NOT_FETCHED_YET must
+    # come back as the SAME member (not a str, not None), so the switcher's
+    # "still loading" gate holds after a reload / backend restart.
+    fresh = AgentTaskStateV2(workspace_id=WorkspaceID())
+    assert fresh.available_models is NOT_FETCHED_YET
+    from_dict = AgentTaskStateV2.model_validate(fresh.model_dump())
+    assert from_dict.available_models is NOT_FETCHED_YET
+    from_json = AgentTaskStateV2.model_validate_json(fresh.model_dump_json())
+    assert from_json.available_models is NOT_FETCHED_YET
+
+
+def test_legacy_empty_catalog_deserializes_as_fetched_empty() -> None:
+    # Rows written before the sentinel existed store available_models as a bare
+    # []; those must read as fetched-empty (the no-auth CTA case), NOT as the new
+    # not-fetched default. This is why no migration shim is needed — but only as
+    # long as the field keeps serializing explicitly (no exclude_defaults).
+    legacy = AgentTaskStateV2.model_validate(
+        {"object_type": "AgentTaskStateV2", "workspace_id": str(WorkspaceID()), "available_models": []}
+    )
+    assert legacy.available_models == []
+    assert not isinstance(legacy.available_models, ModelCatalogState)
+
+    opus = ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Opus")
+    fetched = AgentTaskStateV2.model_validate_json(
+        AgentTaskStateV2(workspace_id=WorkspaceID(), available_models=[opus]).model_dump_json()
+    )
+    assert fetched.available_models == [opus]

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -861,21 +861,21 @@ def _eager_fetch_pi_models_into_state(
 
     `run_agent_task_v1` keeps a prompt-less agent READY without calling
     `agent_wrapper.start()` until a message arrives, so pi's start-time
-    `_fetch_models_into_state` has not run and the task carries no
-    `available_models` — the switcher then shows the built-in Claude list. Here,
-    once the environment is ready, we run a short-lived pi probe
+    `_fetch_models_into_state` has not run and the task's catalog is still
+    `NOT_FETCHED_YET` — the switcher shows a loading state, not the login CTA.
+    Here, once the environment is ready, we run a short-lived pi probe
     (`PiAgent.fetch_available_models_probe`) and persist its curated catalog onto
     task state so the switcher reflects pi's models immediately.
 
-    Returns the task state, evolved with the catalog when the probe found one, so
-    the caller carries it forward — otherwise `finalize_task_setup`'s later
-    evolve-and-upsert (from the in-memory state) would write the catalog back
-    out. Restricted to pi: the `supports_model_selection` check skips harnesses
-    that cannot select a model at all, and the `PiAgent` check below skips the
-    rest — only pi sources a dynamic catalog via the probe (Claude supports model
+    Returns the task state evolved with the probe's result, so the caller carries
+    it forward — otherwise `finalize_task_setup`'s later evolve-and-upsert (from
+    the in-memory state) would write the stale `NOT_FETCHED_YET` back out.
+    Restricted to pi: the `supports_model_selection` check skips harnesses that
+    cannot select a model at all, and the `PiAgent` check below skips the rest —
+    only pi sources a dynamic catalog via the probe (Claude supports model
     selection but with a static built-in list). Best-effort: on any failure the
-    probe returns an empty catalog and the task state is returned unchanged, so
-    the switcher falls back exactly as before.
+    probe returns an empty catalog, which is persisted as a fetched-but-empty `[]`
+    (the switcher then shows the login CTA) rather than left not-fetched.
     """
     if not get_harness_for_config(task_data.agent_config).capabilities().supports_model_selection:
         return task_state
@@ -896,8 +896,10 @@ def _eager_fetch_pi_models_into_state(
         return task_state
     secrets = _build_agent_secrets(settings=settings, task=task, task_state=task_state, project=project)
     available_models, current_model = agent_wrapper.fetch_available_models_probe(secrets)
-    if not available_models and current_model is None:
-        return task_state
+    # Persist even the empty result: it records that the probe COMPLETED, moving the
+    # catalog off NOT_FETCHED_YET to a fetched-but-empty [] (authenticated with no
+    # providers — or a best-effort probe failure, which today falls back the same
+    # way). Returning early here would strand the switcher on "loading" forever.
     return _persist_available_models(
         available_models=available_models,
         current_model=current_model,

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -32,6 +32,7 @@ from sculptor.interfaces.agents.artifacts import ArtifactType
 from sculptor.interfaces.agents.artifacts import FileAgentArtifact
 from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_FROM_SIGTERM
 from sculptor.interfaces.agents.errors import AgentClientError
+from sculptor.interfaces.environments.agent_execution_environment import AgentExecutionEnvironment
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import AssistantMessageID
 from sculptor.primitives.ids import TaskID
@@ -47,12 +48,16 @@ from sculptor.state.chat_state import TextBlock
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import LLMModel
 from sculptor.state.messages import Message
+from sculptor.state.messages import ModelCatalogState
+from sculptor.state.messages import ModelOption
+from sculptor.state.messages import NOT_FETCHED_YET
 from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.tasks.handlers.run_agent.setup import _drop_already_processed_messages
 from sculptor.tasks.handlers.run_agent.setup import _resolve_title_prediction_thread
 from sculptor.tasks.handlers.run_agent.setup import load_initial_task_state
 from sculptor.tasks.handlers.run_agent.v1 import AgentPaused
 from sculptor.tasks.handlers.run_agent.v1 import _build_agent_path
+from sculptor.tasks.handlers.run_agent.v1 import _eager_fetch_pi_models_into_state
 from sculptor.tasks.handlers.run_agent.v1 import _run_agent_in_environment
 from sculptor.tasks.handlers.run_agent.v1 import _save_messages
 from sculptor.tasks.handlers.run_agent.v1 import _send_user_input_message
@@ -1401,6 +1406,60 @@ def _read_persisted_task_state(local_task: Task, services: ServiceCollectionForT
         task_row = transaction.get_task(local_task.object_id)
         assert task_row is not None
         return AgentTaskStateV2.model_validate(task_row.current_state)
+
+
+class _EmptyProbePiAgent:
+    """Stands in for a PiAgent whose start-time catalog probe finds no models."""
+
+    def fetch_available_models_probe(self, secrets: object) -> tuple[list[ModelOption], None]:
+        return [], None
+
+
+def test_eager_pi_probe_records_fetched_empty_when_no_models(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: AgentExecutionEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A start-time pi probe that finds no models records fetched-empty [], moving
+    the catalog off its NOT_FETCHED_YET default so the switcher shows the login CTA
+    rather than spinning on 'loading' forever. (The probe returns ([], None) for a
+    genuinely unauthenticated user AND for a best-effort probe failure; both land
+    on the same fetched-empty result, matching today's behavior — distinguishing
+    them is a separate future catalog state.)
+    """
+    task_data = local_task.input_data
+    assert isinstance(task_data, AgentTaskInputsV2)
+    fresh = AgentTaskStateV2(workspace_id=WorkspaceID())
+    assert fresh.available_models is NOT_FETCHED_YET
+    _set_task_state(local_task, fresh, services)
+
+    harness_stub = MagicMock()
+    harness_stub.capabilities.return_value.supports_model_selection = True
+    with (
+        patch("sculptor.tasks.handlers.run_agent.v1.get_harness_for_config", return_value=harness_stub),
+        patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=_EmptyProbePiAgent()),
+        patch("sculptor.tasks.handlers.run_agent.v1._build_agent_secrets", return_value={}),
+        patch("sculptor.tasks.handlers.run_agent.v1.PiAgent", _EmptyProbePiAgent),
+    ):
+        evolved = _eager_fetch_pi_models_into_state(
+            task=local_task,
+            task_data=task_data,
+            task_state=fresh,
+            environment=environment,
+            project=project,
+            settings=test_settings,
+            services=services,
+            in_testing=True,
+        )
+
+    # The carried-forward state AND the persisted row are fetched-empty [], not the
+    # NOT_FETCHED_YET sentinel — otherwise finalize_task_setup would later write the
+    # in-memory sentinel back over the DB.
+    assert evolved.available_models == []
+    assert not isinstance(evolved.available_models, ModelCatalogState)
+    assert _read_persisted_task_state(local_task, services).available_models == []
 
 
 def test_queued_followup_is_dispatched_after_resumed_turn_completes(

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -67,7 +67,7 @@ from sculptor.state.messages import AgentMessageSource
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import LLMModel
 from sculptor.state.messages import Message
-from sculptor.state.messages import ModelOption
+from sculptor.state.messages import ModelCatalog
 from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.state.workflow_state import WorkflowTaskState
 from sculptor.utils.functional import first
@@ -432,10 +432,15 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
 
     @computed_field
     @property
-    def available_models(self) -> list[ModelOption]:
-        """The models the harness offers in its switcher (empty when it sources
-        none and the frontend falls back to its built-in list)."""
-        return self._resolve_harness().get_available_models(self.task_state)
+    def available_models(self) -> ModelCatalog:
+        """The switcher's catalog as the frontend gates on it: NOT_FETCHED_YET
+        until the start-time probe lands, then the fetched list (empty = the
+        harness sources none and the frontend falls back to its built-in list, or
+        pi is authenticated with no providers and shows the login CTA). Runtime
+        callers that only offer models use `get_available_models`, which coalesces
+        the sentinel to []; the switcher needs the distinction so it can show a
+        loading state instead of flashing the CTA while the catalog loads."""
+        return self._resolve_harness().get_model_catalog(self.task_state)
 
     @computed_field
     @property


### PR DESCRIPTION
## Summary

Fixes **SCU-1583**: an authenticated pi user starting a new agent briefly saw the model picker flash its empty-state *"No models available — please log in to authenticate"* CTA for ~1–3s, until the start-time model-catalog probe landed.

### Root cause

The task-state catalog was an empty list in **both** "the probe hasn't run yet" and "probed, genuinely no providers" — so nothing downstream could tell *loading* from *empty*. The picker renders for any non-ERROR task, so it showed the login CTA during that loading window.

### Fix

Give the catalog an explicit "not fetched yet" state instead of overloading the empty list (value + time, disentangled):

- **`ModelCatalogState.NOT_FETCHED_YET`** — a `StrEnum` singleton that survives serialization by identity (read sites use `is`, no `None` overload). The task-state catalog is now `list[ModelOption] | ModelCatalogState`, defaulting to `NOT_FETCHED_YET`.
- The harness coalesces the sentinel to `[]` for runtime callers (`get_available_models`) and exposes the raw state to the UI (`get_model_catalog`); the task view surfaces the union.
- **`ModelSelector`** shows a quiet *"Loading models…"* placeholder while the catalog is `NOT_FETCHED_YET`, and reserves the login CTA for a genuinely fetched-but-empty catalog.
- The start-time probe now records a fetched-but-empty `[]` even when it finds no providers, so a real no-auth user still gets the CTA rather than spinning on "loading" forever.

No DB migration is needed: existing rows persist `available_models` explicitly as `[]`, which reads as fetched-empty.

### Also included

- A small, unrelated Offload config tweak (`stream_output` removed from `offload.toml`) that was already present on this branch.

## Testing

- New tests: catalog sentinel serialization + singleton-by-identity + legacy-`[]` compat; harness loading-vs-empty distinction; the start-time probe recording fetched-empty; and `ModelSelector` showing the loading placeholder (no CTA) while not-fetched.
- Backend affected suites + `app_basic_test` pass; full frontend suite passes (2813 tests).
- `ruff`, `pyrefly`, `tsc`, `eslint`, and `ratchets` all pass.

(Sent by Claude)
