### PR TITLE
Serialize pi completion wake-ups through Sculptor's FIFO (SCU-1776)

### DIFF
--- a/agent_docs/scu-1776-pi-wake-serialization/design.md
+++ b/agent_docs/scu-1776-pi-wake-serialization/design.md
@@ -1,0 +1,132 @@
+# SCU-1776: Serialize pi completion wake-ups through Sculptor's message FIFO
+
+## Problem
+
+When a pi sub-agent or background task completes, the pinned extensions
+(`sculptor_subagent.ts`, `sculptor_background.ts`) wake the agent with
+`pi.sendUserMessage(..., {deliverAs: "followUp"})`. If the completion lands
+while a run is in flight (routine for fast children that finish during the
+launch run), pi queues the wake-up **inside the run** and drains it at the next
+turn boundary — the run continues with reaction turns instead of ending.
+`agent_end`, the only turn boundary Sculptor's wrapper recognizes, is deferred
+until the whole reaction chain finishes. Consequences (all observed in the
+SCU-1776 incident logs and reproduced against real pi 0.80.2):
+
+- Queued user messages wait indefinitely (`_process_message_queue` services one
+  message per `agent_end`) — "the message to the outer agent is queued and
+  waiting".
+- The in-flight request cycle swallows the reaction turns, so the UI shows one
+  endless "thinking" turn.
+- `abort` (Stop) kills only the current *turn*; pi then drains the next queued
+  wake-up, so no `agent_end` arrives within the 5s escalation grace window and
+  Sculptor SIGTERMs a healthy pi.
+
+Root cause, one sentence: **the extension wake-up is a second turn-initiator
+inside pi, racing Sculptor's prompt pump; Sculptor's design assumes it is the
+only initiator.**
+
+## Fix
+
+Make Sculptor the only turn-initiator. The `notify` data channel (completion
+payloads) is unchanged; only the wake-up moves.
+
+### 1. Extensions: remove the pi-side wake-up
+
+Delete the `pi.sendUserMessage(...)` call (and its comment) from
+`sculptor_subagent.ts` and `sculptor_background.ts`. The extensions still:
+spawn children, stream/accumulate events, fire the completion `notify`, and
+kill children on `session_shutdown`. Update both file headers: completion is
+reported out-of-band via notify; *Sculptor* initiates the reaction turn.
+
+### 2. Wrapper: enqueue a wake message on the input FIFO
+
+New module-private message type in `agent_wrapper.py`:
+
+```python
+@dataclass
+class _ReactionWakeMessage:
+    text: str  # the wake prompt sent to pi verbatim
+```
+
+At the single seam where each completion is reconciled — the end of
+`_handle_subagent_completion` and `_handle_background_completion` (both are
+reached from the in-turn notify path AND the idle-drain path) — build the wake
+text and `self._input_agent_messages.put(_ReactionWakeMessage(text=...))`.
+
+Wake text (parity with what the extensions used to send, so model-visible
+behavior is preserved):
+
+- Sub-agents: `Your delegated sub-agent task ({label}) finished: {status} —
+  {done}/{total} done, {failed} failed.` with `label` = the single child's
+  label, or `{N} sub-agents` for a batch — derived from
+  `SubagentCompletion.children`.
+- Background: `Your background task finished: {status}{ (exit {code})}.`
+  (The extension interpolated a label it held locally;
+  `BackgroundTaskCompletion` does not carry one, and extending the notify wire
+  contract just for the label is not worth it — the model still has the
+  launching tool call in context.)
+
+### 3. Wrapper: service the wake from the FIFO
+
+`_process_message_queue` gets a `_ReactionWakeMessage` branch that calls
+`_run_wake_turn(message)`:
+
+- Emit `RequestStartedAgentMessage` with a fresh request id (the wake is not a
+  reply to any user message).
+- Send `{"type": "prompt", "id": <fresh>, "message": wake.text}` and consume
+  with `_consume_until_turn_end(prompt_id)`.
+- Non-fatal error handling, mirroring today's `_consume_reaction_turn`: a
+  `PiCrashError` is logged and the cycle resolves `interrupted=True`; it must
+  not tear down the agent.
+- Emit terminal `RequestSuccessAgentMessage`.
+
+FIFO ordering gives the fix its guarantees: a user message queued before the
+completion is answered *first* (the ticket's expected behavior); a Stop ends
+the current turn and pi is genuinely idle afterwards (nothing queued pi-side),
+so interrupts resolve within the grace window.
+
+### 4. Delete the reaction-window machinery
+
+With no pi-initiated runs left, remove:
+
+- `_note_awaiting_reaction`, `_is_awaiting_reaction`,
+  `_awaiting_reaction_count`, `_awaiting_reaction_deadline`,
+  `_REACTION_WINDOW_SECONDS`
+- `_consume_reaction_turn` and the idle-drain's `ParsedAgentStart` arm.
+  Replace the arm with a loud `logger.warning` (a pi-initiated run now
+  indicates a protocol violation; its events would otherwise silently corrupt
+  the next turn).
+- The `_is_awaiting_reaction()` term in `_has_background_tasks`.
+
+Update stale prose: `agent_wrapper.py` module docstring + the notify-path
+comments, `harness.py` capability comments, `subagent.py` / `background.py`
+module docstrings, `sculptor_subagent.ts` / `sculptor_background.ts` headers.
+
+## Behavior deltas (accepted)
+
+- Reaction ordering: previously a mid-run wake ran *before* queued user
+  messages (pi drained followUps first); now user messages win. This is the
+  bug fix.
+- A Stop no longer implicitly cancels pending reactions mid-chain (it never
+  cleanly did); queued wakes still run afterwards as individually stoppable,
+  bounded turns.
+- A wake enqueued but not yet serviced is lost on process restart — parity
+  with today (pi's in-memory followUp queue is equally lost).
+- Background wake text loses its `({label})` interpolation.
+
+## Test plan
+
+- **Failing-first unit tests** (`agent_wrapper_test.py`): completion (subagent
+  + background, in-turn + idle-drain) enqueues a `_ReactionWakeMessage`; FIFO
+  order puts an already-queued user message first; `_run_wake_turn` sends the
+  wake prompt RPC and wraps the turn in its own request cycle; a wake-turn
+  `PiCrashError` is non-fatal.
+- **Updated tests**: `agent_wrapper_test.py` reaction-machinery tests;
+  `fake_pi.py` loses `_emit_reaction_turn` + `reaction` directive args (the
+  wake now arrives as a real prompt fake_pi answers with its default echo);
+  `test_pi_sub_agents.py` / `test_pi_background_tasks.py` assert the wake turn
+  via the echoed wake text instead of scripted reactions.
+- **Real-pi verification (Phase 4)**: run `real_pi/test_sub_agents.py` and
+  `real_pi/test_background_tasks.py`; drive the incident shape via
+  `/auto-qa-changes` (instant children + long launch run + mid-run user
+  message + Stop) and capture before/after evidence.

--- a/agent_docs/scu-1776-pi-wake-serialization/design.simplified.md
+++ b/agent_docs/scu-1776-pi-wake-serialization/design.simplified.md
@@ -1,0 +1,227 @@
+# SCU-1776: Serialize pi completion wake-ups through Sculptor's message FIFO (simplified)
+
+## Simplification memo
+
+The original design's core cut is correct and kept: the bug is a **when/where +
+who complect** — two turn-initiators (Sculptor's prompt pump and the pi-side
+extension wake-up) braided through one event stream that has a single boundary
+marker (`agent_end`). The fix un-braids by making Sculptor the only initiator.
+This pass found three residual braids in the original design and cut them, and
+records the guard-deletion audit.
+
+**Ledger:**
+
+1. **Wake text: a third rendering of the same fact** *(why/policy scattered)*.
+   The original kept "parity with the extension's phrasing", introducing a
+   bespoke wake string alongside the existing `_format_subagent_completion` /
+   `_format_background_completion` renderings of the same completion fact.
+   "Parity" is an *easy* claim (familiar/comparable), not a *simple* one. Cut:
+   **one rendering per completion type, shared by the UI notification and the
+   wake prompt** — one place to change how a completion reads. Artifact bonus:
+   the background wake now carries the summary (output tail) the notification
+   already carries, so the model learns the result, not just "finished". The
+   original's "(label) is lost" delta dissolves — the shared rendering never
+   had one.
+
+2. **Wake turn: a second, hand-synced turn lifecycle** *(modular but
+   complected)*. The original said "mirror today's `_consume_reaction_turn`" —
+   copying a subset of the turn lifecycle (in-flight id, `_turn_in_flight`,
+   interrupt-state clearing, escalation cancel, answer finalization) into a
+   second site that must stay in sync with `_run_prompt_turn` by hand; a Stop
+   landing during a wake turn exercises whichever flags the copy remembered to
+   set. Cut: **one turn-driving lifecycle** used by both user turns and wake
+   turns, parameterized by exactly the two genuine differences — payload
+   construction (rich user payload vs bare wake prompt) and failure policy
+   (user turn failures propagate; wake turn failures log and resolve the cycle
+   `interrupted=True`). "Copy the 12 lines" was *easy*; one lifecycle is
+   *simple*.
+
+3. **Wake message type: keep it out of the wire union** *(data +
+   representation)*. Reusing `ChatInputUserMessage` for the wake (considered)
+   would be *easy* (no new type) but braids internal scheduling into
+   user-chat semantics (plan-mode flags, request-id derivation, persistence
+   expectations). Adding the wake to the serializable `Message` union would
+   leak an internal concern into a shared contract. Cut: a module-private
+   dataclass; the FIFO's element type widens to the internal union
+   `Message | _ReactionWakeMessage`. The wake is not a user message; nothing
+   should be able to treat it as one.
+
+**Guard-deletion audit (Check A):**
+
+- *Extension `sendUserMessage` deleted.* Invariant "the agent reacts to
+  completions" is now enforced by the wrapper enqueueing the wake at the same
+  seam that parses the completion notify (both the in-turn and idle-drain
+  paths call `_handle_*_completion`). Tests that asserted the pi-initiated
+  reaction are rewritten to assert the wake prompt turn.
+- *Idle-drain `ParsedAgentStart` arm (and `_consume_reaction_turn`) deleted.*
+  Invariant "pi never self-starts a run" is enforced by (a) removing the only
+  cause — the extension wake-up — and (b) `--no-extensions -e <pinned>`, which
+  prevents any foreign extension from loading. A `logger.warning` tripwire
+  replaces the arm. **Factual precondition to verify in Phase 4 against real
+  pi:** nothing else in pi 0.80.2 self-starts runs between prompts (the
+  real-pi suite plus the incident-shape auto-qa run would surface a
+  violation as this warning).
+- *`_REACTION_WINDOW_SECONDS` / awaiting-reaction bookkeeping deleted.* Its
+  job (keep the idle-drain polling until the pi-initiated reaction arrived)
+  has no successor because the wake is enqueued synchronously when the notify
+  is parsed; the drain still runs while `_background_tasks` /
+  `_subagent_tasks` are non-empty, which is the only window completions can
+  arrive in. Unit tests around awaiting-reaction are replaced by FIFO-enqueue
+  assertions.
+- *Terminal-only wake:* no guard needed — the extensions' `finish()` is the
+  sole notify emitter and only sends `"completed" | "failed"` (wire
+  contract), so every parsed completion is terminal. (Permissive parsing of a
+  malformed status is a pre-existing property of the notification path; the
+  wake adds no new decision on it.)
+
+**Check B (inert-claim scan):** no field in this design is claimed
+documentation-only. `_ReactionWakeMessage.text` is read to build the prompt;
+completion payload fields keep their existing readers.
+
+**Left alone (inherent complexity):** pi's followUp-drain semantics and the
+single `agent_end` boundary are the environment, not the design's fault; the
+in-turn vs idle-drain duality of completion surfacing is inherent to
+completions racing turns and stays.
+
+---
+
+## Problem
+
+When a pi sub-agent or background task completes, the pinned extensions
+(`sculptor_subagent.ts`, `sculptor_background.ts`) wake the agent with
+`pi.sendUserMessage(..., {deliverAs: "followUp"})`. If the completion lands
+while a run is in flight (routine for fast children that finish during the
+launch run), pi queues the wake-up **inside the run** and drains it at the next
+turn boundary — the run continues with reaction turns instead of ending.
+`agent_end`, the only turn boundary Sculptor's wrapper recognizes, is deferred
+until the whole reaction chain finishes. Consequences (all observed in the
+SCU-1776 incident logs and reproduced against real pi 0.80.2):
+
+- Queued user messages wait indefinitely (`_process_message_queue` services one
+  message per `agent_end`) — "the message to the outer agent is queued and
+  waiting".
+- The in-flight request cycle swallows the reaction turns, so the UI shows one
+  endless "thinking" turn.
+- `abort` (Stop) kills only the current *turn*; pi then drains the next queued
+  wake-up, so no `agent_end` arrives within the 5s escalation grace window and
+  Sculptor SIGTERMs a healthy pi.
+
+Root cause, one sentence: **the extension wake-up is a second turn-initiator
+inside pi, racing Sculptor's prompt pump; Sculptor's design assumes it is the
+only initiator.**
+
+## Fix
+
+Make Sculptor the only turn-initiator. The `notify` data channel (completion
+payloads) is unchanged; only the wake-up moves. Each concern below is one
+strand.
+
+### 1. Extensions: stop initiating turns
+
+Delete the `pi.sendUserMessage(...)` call (and its comment) from
+`sculptor_subagent.ts` and `sculptor_background.ts`. The extensions still:
+spawn children, stream/accumulate events, fire the completion `notify`, and
+kill children on `session_shutdown`. Update both headers: completion is
+reported via notify; *Sculptor* initiates the reaction turn.
+
+### 2. Wrapper: schedule the reaction on the input FIFO
+
+Module-private, not part of the `Message` wire union:
+
+```python
+@dataclass
+class _ReactionWakeMessage:
+    text: str  # sent to pi verbatim as the wake prompt
+```
+
+`_input_agent_messages` widens to `Queue[Message | _ReactionWakeMessage]`.
+
+At the end of `_handle_subagent_completion` and
+`_handle_background_completion` (the single seam both the in-turn notify path
+and the idle-drain path go through), enqueue
+`_ReactionWakeMessage(text=<the same summary string the completion
+notification carries>)` — i.e. the existing `_format_subagent_completion` /
+`_format_background_completion` output. One completion fact, one rendering,
+two consumers (UI notification and model wake).
+
+FIFO ordering gives the fix its guarantees: a user message queued before the
+completion is answered *first*; after a Stop, pi is genuinely idle (nothing
+queued pi-side), so interrupts resolve within the grace window.
+
+### 3. Wrapper: one turn lifecycle, two entry points
+
+`_process_message_queue` gets a `_ReactionWakeMessage` branch. Both user
+messages and wakes drive the **same turn lifecycle** (today's
+`_run_prompt_turn` body: in-flight request id, interrupt-state reset,
+`_turn_in_flight`, escalation cancel, pending-answer finalization, transient
+retry), parameterized by the only two genuine differences:
+
+- **Payload**: user turns build the rich payload
+  (`_build_prompt_payload`: attachments, images, plan-mode prefix); a wake
+  turn sends `{"type": "prompt", "id": <fresh>, "message": wake.text}`.
+- **Failure policy and request cycle**: user turns keep the existing
+  `_handle_user_message` wrapper (errors serialize to the user / propagate).
+  A wake turn wraps in its own minimal cycle — `RequestStarted(fresh id)` →
+  consume → `RequestSuccess` — and a turn failure is logged and resolved
+  `interrupted=True`; it must never tear down the agent.
+
+No second hand-synced lifecycle: an interrupt during a wake turn behaves
+exactly like an interrupt during a user turn because it runs the same code.
+
+### 4. Delete the reaction-window machinery
+
+With no pi-initiated runs left, remove:
+
+- `_note_awaiting_reaction`, `_is_awaiting_reaction`,
+  `_awaiting_reaction_count`, `_awaiting_reaction_deadline`,
+  `_REACTION_WINDOW_SECONDS`
+- `_consume_reaction_turn` and the idle-drain's `ParsedAgentStart` arm,
+  replaced by a `logger.warning` tripwire (a pi-initiated run is now a
+  protocol violation; see memo for the surviving enforcement).
+- The `_is_awaiting_reaction()` term in `_has_background_tasks`.
+
+Update stale prose: `agent_wrapper.py` module docstring + notify-path
+comments, `harness.py` capability comments, `subagent.py` / `background.py`
+module docstrings, both extension headers.
+
+## Behavior deltas (accepted)
+
+- Reaction ordering: previously a mid-run wake ran *before* queued user
+  messages (pi drained followUps first); now user messages win. This is the
+  bug fix.
+- Wake prompt text changes from the extensions' phrasing to the notification
+  summary (`Sub-agents completed: 1 done, 0 failed (of 1).` /
+  `Background task completed (exit code 0).\n\n<output tail>`); the model now
+  sees the background output tail it previously had no access to.
+- A Stop no longer implicitly cancels pending reactions; queued wakes run
+  afterwards as individually stoppable, bounded turns (parity with pi's old
+  drain behavior, minus the wedge).
+- A wake enqueued but not yet serviced is lost on process restart — parity
+  with today (pi's in-memory followUp queue is equally lost).
+
+## Test plan
+
+- **Failing-first unit tests** (`agent_wrapper_test.py`):
+  - a surfaced sub-agent completion (in-turn and idle-drain) enqueues a
+    `_ReactionWakeMessage` whose text is the notification summary;
+  - same for a background completion;
+  - FIFO order: a user message queued before the completion is serviced
+    before the wake;
+  - servicing a wake sends the wake prompt RPC bracketed by its own
+    `RequestStarted`/`RequestSuccess` cycle;
+  - a wake turn hitting `PiCrashError` resolves `interrupted=True` without
+    raising (the agent survives).
+- **Updated tests** (follow the deletions): the awaiting-reaction /
+  auto-resume wrapper tests are rewritten against the wake contract;
+  `fake_pi.py` loses `_emit_reaction_turn` + the `reaction` directive arg (the
+  wake now arrives as a real prompt fake_pi answers with its default echo);
+  `test_pi_sub_agents.py` / `test_pi_background_tasks.py` assert the wake turn
+  via the echoed wake text, and gain the ticket's scenario: a user message
+  sent while children run is answered independently of (and never blocked by)
+  the wake.
+- **Real-pi verification (Phase 4)**: run `real_pi/test_sub_agents.py` and
+  `real_pi/test_background_tasks.py`; drive the incident shape via
+  `/auto-qa-changes` (instant children + long launch run + mid-run user
+  message + Stop) and capture before/after evidence. This also verifies the
+  memo's precondition that pi never self-starts runs (the tripwire warning
+  must not fire).

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -557,11 +557,10 @@ class _ReactionWakeMessage:
     Enqueued on `_input_agent_messages` when a completion is surfaced, and
     serviced by `_run_wake_turn` as an ordinary prompt turn. Deliberately NOT a
     `Message` union member: the wake is internal scheduling, not user chat, and
-    it must never reach pi through any channel but this FIFO. Sculptor being the
-    ONLY turn-initiator is the SCU-1776 fix — the extensions' pi-side
-    `sendUserMessage` wake-up spliced reaction turns into an in-flight run,
-    deferring `agent_end` (the sole turn boundary) so queued user messages
-    starved and Stop escalated to SIGTERM.
+    it must never reach pi through any channel but this FIFO — Sculptor is the
+    only turn-initiator. A pi-side wake-up (`sendUserMessage`) queues into an
+    in-flight run and defers `agent_end`, the wrapper's sole turn boundary,
+    starving queued user messages (SCU-1776).
     """
 
     text: str

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -42,6 +42,7 @@ import os
 import random
 import re
 import time
+from collections.abc import Callable
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -247,20 +248,14 @@ The user's request follows:
 # (ChatInput.tsx `wsTimeout`) so a wedged `new_session` fails rather than hanging the UI.
 _CLEAR_CONTEXT_TIMEOUT_SECONDS: float = 10.0
 
-# After a background/sub-agent completion, the extension wakes the agent with
-# `sendUserMessage`; Sculptor keeps the idle-drain alive this long to consume the
-# resulting reaction turn. Bounds the wait so a reaction that never arrives (the
-# wake-up errored) cannot keep the drain polling forever.
-_REACTION_WINDOW_SECONDS: float = 120.0
-
 # How long each blocking read of pi's stdout queue waits before the drain loop
 # re-checks shutdown / process-exit; small so an exit is noticed promptly.
 _STDOUT_QUEUE_POLL_SECONDS: float = 0.1
 
-# Input-queue wait between turns. While async tasks/reactions are pending, poll
-# briefly so their out-of-band completions surface promptly; when idle, wait
-# longer to avoid busy-polling (a new user message wakes the queue immediately
-# either way, and the longer wait bounds shutdown latency).
+# Input-queue wait between turns. While async tasks are pending, poll briefly so
+# their out-of-band completions surface promptly; when idle, wait longer to
+# avoid busy-polling (a new user message wakes the queue immediately either way,
+# and the longer wait bounds shutdown latency).
 _TASK_POLL_SECONDS: float = 0.1
 _IDLE_WAIT_SECONDS: float = 1.0
 
@@ -555,6 +550,23 @@ class _PiTransientTurnError(Exception):
         self.reason = reason
 
 
+@dataclass
+class _ReactionWakeMessage:
+    """A Sculptor-initiated reaction to a completed sub-agent / background task.
+
+    Enqueued on `_input_agent_messages` when a completion is surfaced, and
+    serviced by `_run_wake_turn` as an ordinary prompt turn. Deliberately NOT a
+    `Message` union member: the wake is internal scheduling, not user chat, and
+    it must never reach pi through any channel but this FIFO. Sculptor being the
+    ONLY turn-initiator is the SCU-1776 fix — the extensions' pi-side
+    `sendUserMessage` wake-up spliced reaction turns into an in-flight run,
+    deferring `agent_end` (the sole turn boundary) so queued user messages
+    starved and Stop escalated to SIGTERM.
+    """
+
+    text: str
+
+
 class PiAgent(DefaultAgentWrapper):
     # Narrows the inherited `harness: Harness` field — the registry owns
     # construction, so no agent↔harness import cycle exists.
@@ -569,12 +581,18 @@ class PiAgent(DefaultAgentWrapper):
     # first turn and the switcher does not flicker back to pi's own default. None when
     # the switcher has no persisted selection yet (pi's default is used).
     preselected_model: ModelOption | None = None
-    # Carries chat turns AND between-turns control messages (context reset,
-    # model switch) through one FIFO so each runs strictly after any in-flight
-    # turn — the sole-reader window where the control RPCs' responses can be
-    # consumed safely (see _process_message_queue).
+    # Carries chat turns, between-turns control messages (context reset, model
+    # switch), AND Sculptor-initiated reaction wakes through one FIFO so each
+    # runs strictly after any in-flight turn — the sole-reader window where the
+    # control RPCs' responses can be consumed safely (see
+    # _process_message_queue). One FIFO is the SCU-1776 serialization guarantee:
+    # a user message queued before a completion's wake is serviced first.
     _input_agent_messages: Queue[
-        ChatInputUserMessage | ClearContextUserMessage | SetModelUserMessage | RefreshModelsUserMessage
+        ChatInputUserMessage
+        | ClearContextUserMessage
+        | SetModelUserMessage
+        | RefreshModelsUserMessage
+        | _ReactionWakeMessage
     ] = PrivateAttr(default_factory=Queue)
     _shutdown_event: Event = PrivateAttr(default_factory=Event)
     _message_processing_thread: ObservableThread | None = PrivateAttr(default=None)
@@ -647,12 +665,6 @@ class PiAgent(DefaultAgentWrapper):
     # protects both task dicts).
     _subagent_tasks: dict[str, tuple[int, ...]] = PrivateAttr(default_factory=dict)
     _background_tasks_lock: Lock = PrivateAttr(default_factory=Lock)
-    # Count of surfaced completions whose auto-resume reaction turn (the
-    # extension's `sendUserMessage`) has not yet been consumed, with a deadline.
-    # Keeps the idle-drain alive to catch the reaction. Mutated only on the
-    # message-processing thread.
-    _awaiting_reaction_count: int = PrivateAttr(default=0)
-    _awaiting_reaction_deadline: float = PrivateAttr(default=0.0)
     # The curated model catalog surfaced at start (`_fetch_models_into_state`),
     # cached so a `set_model` switch can re-emit it with the new current model in
     # its `ModelsAvailableAgentMessage` carrier. Set and read on the
@@ -1547,32 +1559,17 @@ class PiAgent(DefaultAgentWrapper):
                 # _handle_refresh_models).
                 self._handle_refresh_models(message)
                 continue
+            if isinstance(message, _ReactionWakeMessage):
+                # A completion's Sculptor-initiated reaction: an ordinary prompt
+                # turn in its own request cycle, FIFO-serialized behind any
+                # user message queued before it (see _ReactionWakeMessage).
+                self._run_wake_turn(message)
+                continue
             self._run_prompt_turn(message)
 
     def _has_background_tasks(self) -> bool:
         with self._background_tasks_lock:
-            if self._background_tasks or self._subagent_tasks:
-                return True
-        return self._is_awaiting_reaction()
-
-    def _is_awaiting_reaction(self) -> bool:
-        """True while a completion's auto-resume reaction turn is still expected.
-
-        Bounded by a deadline so a reaction that never arrives (the wake-up
-        errored) cannot keep the idle-drain polling forever.
-        """
-        if self._awaiting_reaction_count <= 0:
-            return False
-        if time.monotonic() >= self._awaiting_reaction_deadline:
-            self._awaiting_reaction_count = 0
-            return False
-        return True
-
-    def _note_awaiting_reaction(self) -> None:
-        """Record a surfaced completion so the idle-drain stays alive to consume the
-        reaction turn the extension triggers via `sendUserMessage`."""
-        self._awaiting_reaction_count += 1
-        self._awaiting_reaction_deadline = time.monotonic() + _REACTION_WINDOW_SECONDS
+            return bool(self._background_tasks or self._subagent_tasks)
 
     def _run_prompt_turn(self, message: ChatInputUserMessage) -> None:
         # Track this turn's request id so an interrupt arriving with no turn in
@@ -1583,34 +1580,72 @@ class PiAgent(DefaultAgentWrapper):
         self._update_plan_mode_from_message(message)
         self._ensure_diff_baseline()
         with self._handle_user_message(message):
-            # A fresh turn starts un-interrupted: clear interrupt state left by an
-            # interrupt that raced in with no turn in flight, which would otherwise
-            # mis-mark this turn as interrupted.
+            self._drive_turn(lambda prompt_id: self._build_prompt_payload(prompt_id, message))
+
+    def _run_wake_turn(self, wake: _ReactionWakeMessage) -> None:
+        """Run a completion's Sculptor-initiated reaction as its own request cycle.
+
+        The wake is an ordinary prompt turn through the SAME lifecycle as a user
+        turn (`_drive_turn`), so interrupts and transient retries behave
+        identically. It differs only in its payload (the bare wake text) and its
+        failure policy: the wake is not a reply to any user message, so a
+        turn-level failure (`PiCrashError` / exhausted-retry
+        `AgentTransientError`) is logged and resolves the cycle
+        `interrupted=True` instead of tearing down the agent.
+        """
+        request_id = AgentMessageID()
+        self._in_flight_request_id = request_id
+        self._ensure_diff_baseline()
+        self._output_messages.put(RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=request_id))
+        turn_failed = False
+        try:
+            self._drive_turn(lambda prompt_id: {"type": "prompt", "id": prompt_id, "message": wake.text})
+        except (PiCrashError, AgentTransientError) as error:
+            logger.info("PiAgent reaction wake turn failed: {}", error)
+            turn_failed = True
+        finally:
+            was_interrupted = self._was_interrupted.is_set()
             self._was_interrupted.clear()
+            self._output_messages.put(
+                RequestSuccessAgentMessage(
+                    message_id=AgentMessageID(),
+                    request_id=request_id,
+                    interrupted=turn_failed or was_interrupted,
+                )
+            )
+
+    def _drive_turn(self, build_payload: Callable[[str], dict[str, Any]]) -> None:
+        """One turn lifecycle, shared by user turns and reaction wake turns.
+
+        Owns the interrupt-state machine around a single prompt→agent_end cycle:
+        a fresh turn starts un-interrupted (clearing state left by an interrupt
+        that raced in with no turn in flight, which would otherwise mis-mark this
+        turn as interrupted), `_turn_in_flight` gates the interrupt escalation,
+        and on exit — success or failure — escalation stands down and any
+        backchannel answer delivered mid-turn is finalized (its RequestSuccess
+        was deferred so the post-answer content reached the frontend first;
+        mirrors Claude).
+        """
+        self._was_interrupted.clear()
+        self._interrupt_pending.clear()
+        self._cancel_interrupt_escalation()
+        self._turn_in_flight.set()
+        turn_failed = False
+        try:
+            self._consume_turn_with_transient_retry(build_payload)
+        except BaseException:
+            turn_failed = True
+            raise
+        finally:
+            # Turn over: stand down escalation and drop interrupt-pending so a
+            # late grace-window thread can't SIGTERM the next turn's pi.
+            self._turn_in_flight.clear()
             self._interrupt_pending.clear()
             self._cancel_interrupt_escalation()
-            self._turn_in_flight.set()
-            turn_failed = False
-            try:
-                self._consume_turn_with_transient_retry(message)
-            except BaseException:
-                turn_failed = True
-                raise
-            finally:
-                # Turn over: stand down escalation and drop interrupt-pending so a
-                # late grace-window thread can't SIGTERM the next turn's pi.
-                self._turn_in_flight.clear()
-                self._interrupt_pending.clear()
-                self._cancel_interrupt_escalation()
-                # Finalize any backchannel answer delivered mid-turn (its
-                # RequestSuccess was deferred to here so the post-answer content
-                # reached the frontend first). Runs on the failure path too, so the
-                # answer's request resolves instead of pinning the frontend
-                # "thinking" (mirrors Claude).
-                self._finalize_pending_answers(interrupted=turn_failed)
+            self._finalize_pending_answers(interrupted=turn_failed)
 
-    def _consume_turn_with_transient_retry(self, message: ChatInputUserMessage) -> None:
-        """Drive one user turn, retrying KNOWN-TRANSIENT provider failures with backoff.
+    def _consume_turn_with_transient_retry(self, build_payload: Callable[[str], dict[str, Any]]) -> None:
+        """Drive one turn, retrying KNOWN-TRANSIENT provider failures with backoff.
 
         A turn whose assistant run ends in a transient provider error
         (`_PiTransientTurnError` — overloaded / rate-limit / 5xx / timeout) is
@@ -1623,7 +1658,7 @@ class PiAgent(DefaultAgentWrapper):
         instead of `PiCrashError`. A non-transient error still raises `PiCrashError`
         from the dispatcher and is not retried here.
         """
-        payload = self._build_prompt_payload(generate_id(), message)
+        payload = build_payload(generate_id())
         attempt = 0
         while True:
             self._send_rpc(payload)
@@ -2404,6 +2439,10 @@ class PiAgent(DefaultAgentWrapper):
                 summary=_format_subagent_completion(completion),
             )
         )
+        # Schedule the Sculptor-initiated reaction turn: same rendering as the
+        # notification (one completion fact, one presentation), FIFO-serialized
+        # behind any user message queued before this completion (SCU-1776).
+        self._input_agent_messages.put(_ReactionWakeMessage(text=_format_subagent_completion(completion)))
 
     def _emit_subagent_completion_out_of_band(self, completion: SubagentCompletion) -> None:
         """Surface a sub-agent completion that arrived between turns, live.
@@ -2491,6 +2530,10 @@ class PiAgent(DefaultAgentWrapper):
                 content=summary_blocks,
             )
         )
+        # Schedule the Sculptor-initiated reaction turn: same rendering as the
+        # summary block above (one completion fact, one presentation),
+        # FIFO-serialized behind any queued user message (SCU-1776).
+        self._input_agent_messages.put(_ReactionWakeMessage(text=_format_background_completion(completion)))
 
     def _emit_background_completion_out_of_band(self, completion: BackgroundTaskCompletion) -> None:
         """Surface a background completion that arrived between turns, live.
@@ -2510,15 +2553,19 @@ class PiAgent(DefaultAgentWrapper):
             )
 
     def _drain_idle_background_events(self) -> None:
-        """Between turns, surface task completions and consume any auto-resume turn.
+        """Between turns, surface task completions from pi's stdout.
 
         Sculptor drains pi's stdout only during a turn, so a completion `notify`
-        (and the reaction turn the extension triggers via `sendUserMessage`) firing
-        while the user is idle would otherwise sit unseen. While a task is in flight
-        — or a completion is awaiting its reaction turn — `_process_message_queue`
-        calls this between user messages: a completion is surfaced out-of-band, and a
-        pi-initiated turn (the auto-resume reaction) is consumed in its own request
-        cycle. Runs on the message-processing thread (the sole stdout reader).
+        firing while the user is idle would otherwise sit unseen. While a task is
+        in flight, `_process_message_queue` calls this between user messages: a
+        completion is surfaced out-of-band, and its `_handle_*_completion` seam
+        enqueues the Sculptor-initiated reaction wake on the input FIFO. Runs on
+        the message-processing thread (the sole stdout reader).
+
+        Pi never self-starts a run: Sculptor is the only turn-initiator (the
+        extensions report completions via notify only, and `--no-extensions -e
+        <pinned>` keeps foreign extensions out), so an `agent_start` seen here is
+        a protocol violation — logged loud, not consumed.
         """
         process = self._process
         if process is None:
@@ -2542,44 +2589,16 @@ class PiAgent(DefaultAgentWrapper):
                 continue
             parsed = parse_rpc_message(event)
             if isinstance(parsed, ParsedAgentStart):
-                # The extension woke the agent (`sendUserMessage`) after a completion;
-                # consume its reaction turn in its own request cycle.
-                self._awaiting_reaction_count = max(0, self._awaiting_reaction_count - 1)
-                self._consume_reaction_turn()
+                logger.error("PiAgent saw a pi-initiated agent_start between turns — protocol violation")
                 continue
             if isinstance(parsed, ExtensionUiRequest) and parsed.method == "notify":
                 completion = parse_background_completion(parsed.message)
                 if completion is not None:
                     self._emit_background_completion_out_of_band(completion)
-                    self._note_awaiting_reaction()
                     continue
                 sub_completion = parse_subagent_completion(parsed.message)
                 if sub_completion is not None:
                     self._emit_subagent_completion_out_of_band(sub_completion)
-                    self._note_awaiting_reaction()
-
-    def _consume_reaction_turn(self) -> None:
-        """Consume a pi-initiated turn — the auto-resume reaction the extension
-        triggered via `sendUserMessage` on completion — in its own request cycle so
-        it renders as a standalone assistant turn. The triggering `agent_start` has
-        already been read; `_consume_until_turn_end` consumes the rest through
-        `agent_end`. A turn-level failure is logged, not raised: an auto-resume
-        reaction must not tear down the session.
-        """
-        request_id = AgentMessageID()
-        self._output_messages.put(RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=request_id))
-        self._turn_in_flight.set()
-        interrupted = False
-        try:
-            self._consume_until_turn_end()
-        except PiCrashError as error:
-            logger.info("PiAgent auto-resume reaction turn failed: {}", error)
-            interrupted = True
-        finally:
-            self._turn_in_flight.clear()
-            self._output_messages.put(
-                RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=request_id, interrupted=interrupted)
-            )
 
     def _cancel_all_background_tasks(self) -> None:
         """SIGTERM every still-running background and sub-agent child by signalling its process group.
@@ -2791,15 +2810,14 @@ class PiAgent(DefaultAgentWrapper):
             completion = parse_background_completion(parsed.message)
             if completion is not None:
                 # A task that completes while a user turn is in flight is reconciled
-                # into that turn; the reaction the extension triggers (deliverAs
-                # "followUp") runs after this turn and is consumed by the idle-drain.
+                # into that turn; the completion seam enqueues the Sculptor-initiated
+                # reaction wake, serviced from the FIFO after this turn (and any
+                # earlier-queued user messages).
                 self._handle_background_completion(completion)
-                self._note_awaiting_reaction()
                 return
             sub_completion = parse_subagent_completion(parsed.message)
             if sub_completion is not None:
                 self._handle_subagent_completion(sub_completion)
-                self._note_awaiting_reaction()
                 return
             logger.debug("PiAgent ignoring non-task notify extension_ui_request")
             return

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -487,16 +487,6 @@ def _subagent_launch_events() -> list:
     ]
 
 
-def _reaction_turn_events(ack: str) -> list:
-    """A pi-initiated reaction turn (the extension's `sendUserMessage` wake-up):
-    `agent_start` with NO preceding `response` ack, then the assistant reaction."""
-    return [
-        _event({"type": "agent_start"}),
-        _event({"type": "message_end", "message": _assistant_msg(ack)}),
-        _event({"type": "agent_end", "messages": [_assistant_msg(ack)], "willRetry": False}),
-    ]
-
-
 def _main_agent_texts(emitted: list) -> list[str]:
     return [
         block.text
@@ -3043,53 +3033,28 @@ class TestSubagents:
         _assert_killed_pgid(agent, 777)
         _assert_killed_pgid(agent, 888)
 
-    def test_subagent_completion_triggers_auto_resume_reaction(self) -> None:
-        """After a sub-agent completion the extension wakes the agent (sendUserMessage);
-        the idle-drain consumes the pi-initiated reaction turn out-of-band so the agent's
-        reaction renders, and the await-reaction guard clears."""
+    def test_idle_drain_rejects_pi_initiated_agent_start(self) -> None:
+        """Pi never self-starts a run (Sculptor is the only turn-initiator — the
+        SCU-1776 invariant), so an `agent_start` between turns is a protocol
+        violation: logged loud, not consumed as a turn. The completion before it
+        still surfaces normally and its wake still enqueues."""
         agent = _make_agent()
         agent._subagent_tasks[_SA_TASK_ID] = _SA_PGIDS
-        ack = "Acknowledged: my sub-agent finished — continuing the work."
         agent._process = _make_process(
-            [_event(_subagent_notify([_subagent_child("c0", "done", _read_child_events())]))]
-            + _reaction_turn_events(ack)
+            [
+                _event(_subagent_notify([_subagent_child("c0", "done", _read_child_events())])),
+                _event({"type": "agent_start"}),
+            ]
         )
-        agent._drain_idle_background_events()
+        with expect_exact_logged_errors(["PiAgent saw a pi-initiated agent_start between turns"]):
+            agent._drain_idle_background_events()
         emitted = _drain(agent._output_messages)
 
         assert len(_bg_notifications(emitted)) == 1
-        assert any(ack in text for text in _main_agent_texts(emitted)), _main_agent_texts(emitted)
+        # Exactly the completion's own request cycle — no reaction turn was consumed.
         types = [type(m).__name__ for m in emitted]
-        assert "RequestStartedAgentMessage" in types and "RequestSuccessAgentMessage" in types
-        assert agent._awaiting_reaction_count == 0
-
-
-class TestAutoResumeReaction:
-    """Auto-resume reaction turns after task completion."""
-
-    def test_background_completion_triggers_auto_resume_reaction(self) -> None:
-        """After a background-task completion the extension wakes the agent; the idle-drain
-        consumes the pi-initiated reaction turn so the agent's reaction renders."""
-        agent = _make_agent()
-        agent._background_tasks[_BG_TASK_ID] = _BG_PGID
-        ack = "Acknowledged: my background task finished — continuing the work."
-        agent._process = _make_process([_event(_background_notify())] + _reaction_turn_events(ack))
-        agent._drain_idle_background_events()
-        emitted = _drain(agent._output_messages)
-
-        assert len(_bg_notifications(emitted)) == 1
-        assert any(ack in text for text in _main_agent_texts(emitted)), _main_agent_texts(emitted)
-        assert agent._awaiting_reaction_count == 0
-
-    def test_idle_drain_gives_up_awaiting_reaction_past_deadline(self) -> None:
-        """A completion whose reaction never arrives must not keep the drain awaiting
-        forever: once the window elapses, `_has_background_tasks` reports no work."""
-        agent = _make_agent()
-        agent._note_awaiting_reaction()
-        assert agent._has_background_tasks() is True
-        agent._awaiting_reaction_deadline = 0.0  # force the window to have elapsed
-        assert agent._has_background_tasks() is False
-        assert agent._awaiting_reaction_count == 0
+        assert types.count("RequestStartedAgentMessage") == 1
+        assert types.count("RequestSuccessAgentMessage") == 1
 
 
 class TestBackgroundTasks:

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import pytest
 
+from sculptor.agents.pi_agent import agent_wrapper as agent_wrapper_module
 from sculptor.agents.pi_agent.agent_wrapper import PI_PROBE_SESSION_DIR_NAME
 from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_DIR_NAME
 from sculptor.agents.pi_agent.agent_wrapper import PI_SESSION_ID_STATE_FILE
@@ -30,6 +31,8 @@ from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_BASE_DELA
 from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS
 from sculptor.agents.pi_agent.agent_wrapper import _TurnState
 from sculptor.agents.pi_agent.agent_wrapper import _curate_models
+from sculptor.agents.pi_agent.agent_wrapper import _format_background_completion
+from sculptor.agents.pi_agent.agent_wrapper import _format_subagent_completion
 from sculptor.agents.pi_agent.agent_wrapper import _model_option_from_pi
 from sculptor.agents.pi_agent.agent_wrapper import _render_synthesized_skill
 from sculptor.agents.pi_agent.agent_wrapper import _rewrite_skill_invocation
@@ -38,6 +41,7 @@ from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
 from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_HEADER
 from sculptor.agents.pi_agent.background import BACKGROUND_NOTIFY_MARKER
 from sculptor.agents.pi_agent.background import BACKGROUND_PAYLOAD_VERSION
+from sculptor.agents.pi_agent.background import parse_background_completion
 from sculptor.agents.pi_agent.harness import PI_HARNESS
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import ParsedAgentEnd
@@ -45,6 +49,7 @@ from sculptor.agents.pi_agent.output_processor import ParsedUnknownEvent
 from sculptor.agents.pi_agent.output_processor import extract_tool_call_blocks
 from sculptor.agents.pi_agent.output_processor import parse_rpc_message
 from sculptor.agents.pi_agent.subagent import SUBAGENT_NOTIFY_MARKER
+from sculptor.agents.pi_agent.subagent import parse_subagent_completion
 from sculptor.foundation.async_monkey_patches_test import expect_exact_logged_errors
 from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
 from sculptor.interfaces.agents.agent import AutoCompactingAgentMessage
@@ -3646,3 +3651,161 @@ class TestTurnFooterMetrics:
         assert first is not None
         assert agent._diff_tracker is first
         tracker_cls.assert_called_once_with(agent.environment)
+
+
+class TestSculptorInitiatedWake:
+    """SCU-1776: completion wake-ups are Sculptor-initiated, serialized on the input FIFO.
+
+    The extensions' pi-side `sendUserMessage(deliverAs:"followUp")` wake-up raced
+    Sculptor's prompt pump: landing mid-run it spliced reaction turns into the run,
+    deferring `agent_end` (the wrapper's only turn boundary) indefinitely — queued
+    user messages starved and Stop escalated to SIGTERM. The fix makes Sculptor the
+    only turn-initiator: surfacing a completion enqueues a `_ReactionWakeMessage`
+    onto the same FIFO as user messages, and servicing it drives an ordinary
+    prompt turn in its own request cycle.
+
+    `_ReactionWakeMessage` / `_run_wake_turn` are resolved via `getattr` so that,
+    before the fix exists, exactly these tests fail with AttributeError at
+    runtime — a static reference would fail module collection and `just
+    typecheck` for the whole file on the failing-test commit.
+    """
+
+    @staticmethod
+    def _wake_message(text: str) -> Any:
+        wake_cls = getattr(agent_wrapper_module, "_ReactionWakeMessage")  # noqa: B009
+        return wake_cls(text=text)
+
+    @staticmethod
+    def _is_wake(message: Any) -> bool:
+        return type(message).__name__ == "_ReactionWakeMessage"
+
+    def test_subagent_completion_from_idle_drain_enqueues_wake_on_input_fifo(self) -> None:
+        """A sub-agent completion surfaced by the idle-drain enqueues one wake message
+        on the input FIFO, carrying the same summary text the completion notification
+        renders (one completion fact, one rendering)."""
+        agent = _make_agent()
+        agent._subagent_tasks[_SA_TASK_ID] = _SA_PGIDS
+        notify = _subagent_notify([_subagent_child("c0", "done", _read_child_events())])
+        agent._process = _make_process([_event(notify)])
+
+        agent._drain_idle_background_events()
+
+        queued = _drain(agent._input_agent_messages)
+        wakes = [m for m in queued if self._is_wake(m)]
+        assert len(wakes) == 1
+        completion = parse_subagent_completion(notify["message"])
+        assert completion is not None
+        assert wakes[0].text == _format_subagent_completion(completion)
+
+    def test_subagent_completion_in_turn_enqueues_wake_on_input_fifo(self) -> None:
+        """A completion that reconciles into an in-flight turn also enqueues the wake:
+        it is serviced from the FIFO after this turn (and any earlier-queued user
+        messages), never spliced into the current run."""
+        agent = _make_agent()
+        agent._subagent_tasks[_SA_TASK_ID] = _SA_PGIDS
+        agent._process = _make_process(
+            [
+                _event({"type": "agent_start"}),
+                _event(_subagent_notify([_subagent_child("c0", "done", _read_child_events())])),
+                _event({"type": "agent_end", "messages": [_assistant_msg("done")], "willRetry": False}),
+            ]
+        )
+
+        agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+        queued = _drain(agent._input_agent_messages)
+        assert len(queued) == 1 and self._is_wake(queued[0]), queued
+
+    def test_background_completion_enqueues_wake_on_input_fifo(self) -> None:
+        """A background-task completion enqueues a wake whose text is the notification
+        summary (which carries the output tail), mirroring the sub-agent contract."""
+        agent = _make_agent()
+        agent._background_tasks[_BG_TASK_ID] = _BG_PGID
+        notify = _background_notify()
+        agent._process = _make_process([_event(notify)])
+
+        agent._drain_idle_background_events()
+
+        queued = _drain(agent._input_agent_messages)
+        wakes = [m for m in queued if self._is_wake(m)]
+        assert len(wakes) == 1
+        completion = parse_background_completion(notify["message"])
+        assert completion is not None
+        assert wakes[0].text == _format_background_completion(completion)
+
+    def test_wake_enqueues_behind_already_queued_user_message(self) -> None:
+        """FIFO serialization is the fix's core guarantee: a user message queued before
+        the completion is serviced FIRST; the wake lands behind it (the old pi-side
+        followUp ran reaction turns ahead of queued user messages — the bug)."""
+        agent = _make_agent()
+        agent._subagent_tasks[_SA_TASK_ID] = _SA_PGIDS
+        user_message = ChatInputUserMessage(text="answer me first")
+        assert agent._push_message(user_message) is True
+        agent._process = _make_process(
+            [_event(_subagent_notify([_subagent_child("c0", "done", _read_child_events())]))]
+        )
+
+        agent._drain_idle_background_events()
+
+        queued = _drain(agent._input_agent_messages)
+        assert len(queued) == 2, queued
+        assert queued[0] is user_message
+        assert self._is_wake(queued[1])
+
+    def test_wake_turn_sends_prompt_in_own_request_cycle(self) -> None:
+        """Servicing a wake sends its text verbatim as an ordinary `prompt` RPC and
+        brackets the consumed turn in its own RequestStarted → RequestSuccess cycle
+        (a fresh request id — the wake is not a reply to any user message)."""
+        agent = _make_agent()
+        ack = "Both sub-agents finished; continuing."
+        agent._process = _make_process(
+            [
+                _event({"type": "agent_start"}),
+                _event(_text_delta_update(ack, ack)),
+                _event({"type": "message_end", "message": _assistant_msg(ack)}),
+                _event({"type": "agent_end", "messages": [_assistant_msg(ack)], "willRetry": False}),
+            ]
+        )
+        wake = self._wake_message("Sub-agents completed: 1 done, 0 failed (of 1).")
+
+        getattr(agent, "_run_wake_turn")(wake)  # noqa: B009
+
+        sent = [json.loads(call.args[0]) for call in agent._process.write_stdin.call_args_list]
+        prompts = [payload for payload in sent if payload.get("type") == "prompt"]
+        assert len(prompts) == 1
+        assert prompts[0]["message"] == wake.text
+
+        emitted = _drain(agent._output_messages)
+        assert isinstance(emitted[0], RequestStartedAgentMessage)
+        assert isinstance(emitted[-1], RequestSuccessAgentMessage)
+        assert emitted[-1].request_id == emitted[0].request_id
+        assert emitted[-1].interrupted is False
+        assert any(ack in text for text in _main_agent_texts(emitted))
+
+    def test_wake_turn_pi_crash_is_nonfatal(self) -> None:
+        """A wake turn that fails (PiCrashError) must not tear down the agent: the
+        failure is logged and its request cycle resolves interrupted=True, so the
+        message-processing loop lives on to serve the next user message."""
+        agent = _make_agent()
+        # An unexpected stopReason:"aborted" (no interrupt pending) raises
+        # PiCrashError inside the consume loop — the crash shape from the field.
+        agent._process = _make_process(
+            [
+                _event({"type": "agent_start"}),
+                _event(
+                    {
+                        "type": "agent_end",
+                        "messages": [_assistant_msg("boom", stop_reason="aborted")],
+                        "willRetry": False,
+                    }
+                ),
+            ]
+        )
+        wake = self._wake_message("Background task completed (exit code 0).")
+
+        getattr(agent, "_run_wake_turn")(wake)  # must NOT raise  # noqa: B009
+
+        emitted = _drain(agent._output_messages)
+        assert isinstance(emitted[0], RequestStartedAgentMessage)
+        assert isinstance(emitted[-1], RequestSuccessAgentMessage)
+        assert emitted[-1].interrupted is True

--- a/sculptor/sculptor/agents/pi_agent/extensions/sculptor_background.ts
+++ b/sculptor/sculptor/agents/pi_agent/extensions/sculptor_background.ts
@@ -170,7 +170,11 @@ export default function sculptorBackgroundExtension(pi: ExtensionAPI): void {
 				const summary = truncateSummary(output.trim());
 				// Out-of-band completion: a fire-and-forget notify carrying the
 				// structured marker. Sculptor's adapter maps it onto
-				// BackgroundTaskNotification (background.py / agent_wrapper).
+				// BackgroundTaskNotification (background.py / agent_wrapper) and
+				// initiates the reaction turn itself — this extension must NOT wake
+				// the agent (a pi-side sendUserMessage landing mid-run splices
+				// reaction turns into the run and defers agent_end indefinitely;
+				// SCU-1776).
 				try {
 					sessionCtx?.ui.notify(
 						JSON.stringify({
@@ -188,17 +192,6 @@ export default function sculptorBackgroundExtension(pi: ExtensionAPI): void {
 					);
 				} catch {
 					/* session torn down between completion and notify; nothing to surface */
-				}
-				// Wake the calling agent so it can react to the completion. sendUserMessage
-				// triggers a turn when the agent is idle; deliverAs "followUp" queues it
-				// behind an in-flight user turn instead of interrupting it.
-				try {
-					pi.sendUserMessage(
-						`Your background task (${label}) finished: ${status}${exitCode === null ? "" : ` (exit ${exitCode})`}.`,
-						{ deliverAs: "followUp" },
-					);
-				} catch {
-					/* session torn down; nothing to deliver */
 				}
 			};
 

--- a/sculptor/sculptor/agents/pi_agent/extensions/sculptor_subagent.ts
+++ b/sculptor/sculptor/agents/pi_agent/extensions/sculptor_subagent.ts
@@ -351,13 +351,14 @@ export default function sculptorSubagentExtension(pi: ExtensionAPI): void {
 			liveTasks.set(taskId, { taskId, kill: killAll });
 
 			// Out-of-band completion: when the whole batch settles, fire a single
-			// fire-and-forget notify carrying the full per-child snapshot. The turn
-			// has already ended, so Sculptor surfaces this via its idle-drain.
+			// fire-and-forget notify carrying the full per-child snapshot. Sculptor
+			// surfaces it (in-turn or via its idle-drain) and initiates the
+			// reaction turn itself — this extension must NOT wake the agent
+			// (a pi-side sendUserMessage landing mid-run splices reaction turns
+			// into the run and defers agent_end indefinitely; SCU-1776).
 			void Promise.all(handles.map((h) => h.done)).then(() => {
 				liveTasks.delete(taskId);
 				const status = children.some((c) => c.status === "error") ? "failed" : "completed";
-				const done = children.filter((c) => c.status === "done").length;
-				const failed = children.filter((c) => c.status === "error").length;
 				try {
 					sessionCtx?.ui.notify(
 						JSON.stringify({
@@ -373,17 +374,6 @@ export default function sculptorSubagentExtension(pi: ExtensionAPI): void {
 					);
 				} catch {
 					/* session torn down between completion and notify; nothing to surface */
-				}
-				// Wake the calling agent so it can react to the completion. sendUserMessage
-				// triggers a turn when the agent is idle; deliverAs "followUp" queues it
-				// behind an in-flight user turn instead of interrupting it.
-				try {
-					pi.sendUserMessage(
-						`Your delegated sub-agent task (${label}) finished: ${status} — ${done}/${children.length} done, ${failed} failed.`,
-						{ deliverAs: "followUp" },
-					);
-				} catch {
-					/* session torn down; nothing to deliver */
 				}
 			});
 

--- a/sculptor/sculptor/testing/fake_pi.py
+++ b/sculptor/sculptor/testing/fake_pi.py
@@ -439,20 +439,6 @@ def _emit_agent_end(text: str) -> None:
     )
 
 
-def _emit_reaction_turn(ack: str) -> None:
-    """Emit the out-of-band reaction turn pi runs when the extension wakes the agent
-    via `sendUserMessage` after a completion: an assistant acknowledgement bracketed
-    by agent_start/agent_end, so Sculptor consumes it as the auto-resume reaction."""
-    _emit({"type": "agent_start"})
-    _emit(
-        {
-            "type": "message_end",
-            "message": {"role": "assistant", "content": [{"type": "text", "text": ack}], "stopReason": "stop"},
-        }
-    )
-    _emit_agent_end(ack)
-
-
 def _emit_aborted_agent_end(text: str) -> None:
     """Emit the interrupted-turn boundary: an `agent_end` whose assistant message
     carries `stopReason:"aborted"` plus the partial text streamed so far.
@@ -720,14 +706,12 @@ def _handle_subagent(args: dict, builder: _TurnBuilder, abort_event: Event, stat
         "notifyType": "info" if status == "completed" else "warning",
         "message": json.dumps({"sculptorSubagentTask": completion}, separators=(",", ":")),
     }
-    # Optionally script the auto-resume reaction turn pi runs when the extension
-    # wakes the agent (sendUserMessage) after the completion notify.
-    reaction = args.get("reaction")
+    # No reaction turn is scripted here: real pi never self-starts a run after a
+    # completion — Sculptor initiates the reaction by sending a wake prompt,
+    # which FakePi answers like any other prompt (SCU-1776).
 
     def _emit_completion() -> None:
         _emit(notify_event)
-        if isinstance(reaction, str) and reaction:
-            _emit_reaction_turn(reaction)
 
     wait_path = args.get("wait_path")
     if wait_path:
@@ -841,14 +825,12 @@ def _handle_background(args: dict, builder: _TurnBuilder, abort_event: Event, st
         "notifyType": "info" if status == "completed" else "warning",
         "message": json.dumps({"sculptorBackgroundTask": completion}, separators=(",", ":")),
     }
-    # Optionally script the auto-resume reaction turn pi runs when the extension
-    # wakes the agent (sendUserMessage) after the completion notify.
-    reaction = args.get("reaction")
+    # No reaction turn is scripted here: real pi never self-starts a run after a
+    # completion — Sculptor initiates the reaction by sending a wake prompt,
+    # which FakePi answers like any other prompt (SCU-1776).
 
     def _emit_completion() -> None:
         _emit(notify_event)
-        if isinstance(reaction, str) and reaction:
-            _emit_reaction_turn(reaction)
 
     wait_path = args.get("wait_path")
     if wait_path:

--- a/sculptor/tests/integration/frontend/test_pi_background_tasks.py
+++ b/sculptor/tests/integration/frontend/test_pi_background_tasks.py
@@ -155,12 +155,13 @@ def test_pi_background_task_survives_stop(sculptor_instance_: SculptorInstance) 
 
 @user_story("to see the calling agent auto-resume when its background task finishes under pi")
 def test_pi_background_task_completion_auto_resumes_the_agent(sculptor_instance_: SculptorInstance) -> None:
-    """When a background task finishes, the extension wakes the calling agent and it
-    reacts in a new turn (auto-resume): the reaction surfaces after the launch yielded."""
+    """When a background task finishes, Sculptor wakes the calling agent with its own
+    prompt (SCU-1776: pi never self-starts a run) and the reaction surfaces as a new
+    turn after the launch yielded — FakePi answers the wake prompt with its default
+    text, which is the reaction turn this asserts on."""
     page = sculptor_instance_.page
     install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
     release_path = Path(tempfile.gettempdir()) / f"pi_bg_autoresume_{uuid.uuid4().hex}"
-    ack = "BG-AUTORESUME-ACK-77311"
     try:
         task_page = start_task_and_wait_for_ready(
             sculptor_page=page,
@@ -169,7 +170,7 @@ def test_pi_background_task_completion_auto_resumes_the_agent(sculptor_instance_
             agent_type="pi",
             prompt=(
                 'fake_pi:background `{"command": "true", "label": "build", "pgid": 0, '
-                + f'"summary": "done", "wait_path": "{release_path}", "reaction": "{ack}"}}`'
+                + f'"summary": "done", "wait_path": "{release_path}"}}`'
             ),
             wait_for_agent_to_finish=True,
         )
@@ -177,5 +178,6 @@ def test_pi_background_task_completion_auto_resumes_the_agent(sculptor_instance_
     finally:
         release_path.touch()
 
-    # The task completes, the agent is woken, and its reaction turn surfaces.
-    expect(chat_panel.get_messages().filter(has_text=ack).first).to_be_visible(timeout=30000)
+    # The task completes; Sculptor sends the wake prompt and the reaction turn
+    # surfaces (FakePi's default reply to the wake).
+    expect(chat_panel.get_messages().filter(has_text="[FakePi] Task completed.").first).to_be_visible(timeout=30000)

--- a/sculptor/tests/integration/frontend/test_pi_sub_agents.py
+++ b/sculptor/tests/integration/frontend/test_pi_sub_agents.py
@@ -143,25 +143,29 @@ def test_pi_subagent_survives_stop(sculptor_instance_: SculptorInstance) -> None
 
 @user_story("to see the calling agent auto-resume when its sub-agent finishes under pi")
 def test_pi_subagent_completion_auto_resumes_the_agent(sculptor_instance_: SculptorInstance) -> None:
-    """When a sub-agent finishes, the extension wakes the calling agent and it reacts in
-    a new turn (auto-resume): the reaction surfaces after the launch turn yielded."""
+    """When a sub-agent finishes, Sculptor wakes the calling agent with its own prompt
+    (SCU-1776: pi never self-starts a run) and the reaction surfaces as a new turn
+    after the launch turn yielded — FakePi answers the wake prompt with its default
+    text, which is the reaction turn this asserts on."""
     page = sculptor_instance_.page
     install_fake_pi_binary(sculptor_instance_.fake_bin_dir)
     release_path = Path(tempfile.gettempdir()) / f"pi_sa_autoresume_{uuid.uuid4().hex}"
-    ack = "SA-AUTORESUME-ACK-77310"
     try:
         task_page = start_task_and_wait_for_ready(
             sculptor_page=page,
             workspace_name="Pi Sub-Agent Auto-Resume",
             model_name=None,
             agent_type="pi",
-            prompt=f'fake_pi:subagent `{{"children": [{_DONE_CHILD}], "wait_path": "{release_path}", "reaction": "{ack}"}}`',
+            prompt=f'fake_pi:subagent `{{"children": [{_DONE_CHILD}], "wait_path": "{release_path}"}}`',
             wait_for_agent_to_finish=True,
         )
         chat_panel = task_page.get_chat_panel()
     finally:
         release_path.touch()
 
-    # The sub-agent completes, the agent is woken, and its reaction turn surfaces.
-    expect(chat_panel.get_assistant_messages().filter(has_text=ack).first).to_be_visible(timeout=30000)
+    # The sub-agent completes; Sculptor sends the wake prompt and the reaction turn
+    # surfaces (FakePi's default reply to the wake).
+    expect(chat_panel.get_assistant_messages().filter(has_text="[FakePi] Task completed.").first).to_be_visible(
+        timeout=30000
+    )
     expect(page.get_by_test_id(ElementIDs.ALPHA_CHAT_SUBAGENT_PILL).first).to_be_visible(timeout=30000)


### PR DESCRIPTION
## Original bug

[SCU-1776](https://linear.app/imbue/issue/SCU-1776): on the pi harness, dispatch 2 sub-agents for a minor task, then keep talking to the outer agent.

- **Expected:** communication with the outer agent continues while the sub-agents complete their work.
- **Actual:** the message to the outer agent is queued and waiting, indefinitely. Stop only settles one activity at a time and eventually Sculptor SIGTERMs a healthy pi.

## Root cause

The pinned sub-agent/background extensions woke pi after a completion with `pi.sendUserMessage(..., {deliverAs: "followUp"})` — a **second turn-initiator inside pi**, racing Sculptor's own prompt pump.

When a completion lands while a run is in flight (routine: "minor task" children finish while the launch run is still going), pi queues the wake-up **inside the run** and drains it before going idle — the run continues with reaction turns instead of ending. `agent_end` — the only turn boundary `PiAgent._consume_until_turn_end` recognizes — is deferred until the whole reaction chain finishes. Consequences:

- `_process_message_queue` services one message per `agent_end`, so queued user messages starve ("queued and waiting").
- `abort` (Stop) kills only the current *turn*; with another wake queued, pi resumes the run, so no `agent_end` arrives within the 5s escalation grace window and `_escalate_interrupt` SIGTERMs pi.

The design comment at the notify path explicitly assumed the reaction "runs after this turn and is consumed by the idle-drain" — false whenever the completion lands mid-run.

### Diagnosis provenance

An initial hypothesis (bare re-prompt rejected with pi's "Agent is already processing" → fatal `PiCrashError` → dead message thread) was **refuted** by excavating the incident's backend logs: zero occurrences of that rejection, zero crashes. The logs instead showed the wedge directly — a continuous stream of assistant turns with interrupt escalation logging `abort grace window (5.0s) expired without agent_end`, followed by the SIGTERM. The splice was then reproduced wire-for-wire against real pi 0.80.2 (below). (That rejection crash is real but distinct — filed separately, see Deferred follow-ups.)

### Wire-level reproduction (real pi 0.80.2, before the fix)

Prompt dispatches 2 instant children, then keeps counting (launch run outlives the children):

```
[  6.20s] tool_execution_end   tool=subagent          # yield-early launch
[  9.50s] extension_ui_request method=notify          # children done, MID-RUN
[  9.50s] queue_update  followUp=["Your delegated sub-agent task (2 sub-agents) finished..."]
[ 12.94s] message_end   (launch turn's text ends)
[ 12.94s] turn_end
[ 12.94s] turn_start                                  # queued wake DRAINS INTO THE SAME RUN
[ 14.43s] message_end   "Both sub-agents have finished — ..."
[ 14.44s] agent_end                                   # boundary deferred until the reaction finished
```

## Fix

Make Sculptor the **only** turn-initiator. The `notify` data channel is unchanged; only the wake-up moves.

- `sculptor_subagent.ts` / `sculptor_background.ts`: drop `sendUserMessage` — completions are report-only.
- `PiAgent`: surfacing a completion (in-turn or idle-drain, via the shared `_handle_*_completion` seam) enqueues a module-private `_ReactionWakeMessage` on the **same input FIFO as user messages**, carrying the completion notification's own summary text. `_process_message_queue` services it as an ordinary prompt turn in its own request cycle.
- One turn lifecycle: `_run_prompt_turn` and the new `_run_wake_turn` share `_drive_turn` (interrupt-state machine, escalation, transient retry, answer finalization), differing only in payload and failure policy (wake-turn failures log and resolve `interrupted=True`; they never tear down the agent).
- The reaction-window machinery is deleted (`_note_awaiting_reaction`, `_awaiting_reaction_*`, `_REACTION_WINDOW_SECONDS`, `_consume_reaction_turn`, the idle-drain's `agent_start` arm). A pi-initiated `agent_start` between turns is now a loudly-logged protocol violation.
- FakePi drops its scripted reaction turns to match real pi (the wake now arrives as a real prompt it answers normally); the two auto-resume integration tests assert the wake-driven reaction instead.

FIFO ordering is the guarantee: a user message queued before a completion is answered *first*, and after a Stop pi is genuinely idle (nothing queued pi-side), so interrupts resolve within the grace window.

Design notes (including the simplification pass and guard-deletion audit) are committed under `agent_docs/scu-1776-pi-wake-serialization/`.

## Proof the fix works

**TDD:** failing tests committed first — `b1b3bbfc` (6 tests pinning the wake contract; 4 fail on behavioral assertions, 2 on the not-yet-existing API). Fix commit: `070f9fbb`.

Before the fix:

```
FAILED ...::TestSculptorInitiatedWake::test_subagent_completion_from_idle_drain_enqueues_wake_on_input_fifo
FAILED ...::TestSculptorInitiatedWake::test_subagent_completion_in_turn_enqueues_wake_on_input_fifo
FAILED ...::TestSculptorInitiatedWake::test_background_completion_enqueues_wake_on_input_fifo
FAILED ...::TestSculptorInitiatedWake::test_wake_enqueues_behind_already_queued_user_message
FAILED ...::TestSculptorInitiatedWake::test_wake_turn_sends_prompt_in_own_request_cycle
FAILED ...::TestSculptorInitiatedWake::test_wake_turn_pi_crash_is_nonfatal
6 failed in 0.18s
```

After the fix:

```
6 passed in 0.07s          (TestSculptorInitiatedWake)
201 passed in 3.28s        (full agent_wrapper_test.py)
test-unit-backend/frontend/foundation/sculpt: OK   (just test-unit)
```

**Wire level (real pi 0.80.2, fixed extension, same incident-shape prompt):** the completion notify arrives mid-run with **no** `queue_update` followUp, and the launch run ends at its natural boundary — no spliced reaction turn:

```
[  9.55s] extension_ui_request method=notify          # children done, MID-RUN
[ 12.95s] message_end   (launch turn's text ends)
[ 12.95s] turn_end
[ 12.95s] agent_end                                   # boundary NOT deferred
```

**Real-pi integration suite** (`just test-real-pi`, real pi + real model): all 6 sub-agent/background tests pass, including `test_pi_subagent_yields_interactive_and_completes` (the ticket's exact flow: a follow-up message answered while a child runs) and both `survives_stop` tests. One trailing orphan-child check flaked on the first batch run (after the core assertions had passed) and passed clean on re-run.

**Live UI verification** (headless Sculptor + real pi + qwen/qwen3.7-max, the reporter's model): dispatched 2 sub-agents from chat with a long launch turn, sent a mid-flow message — answered promptly; no stuck queued message; agent idle afterwards; the protocol-violation tripwire logged zero hits.

## Behavior deltas (intentional)

- A mid-run wake used to run reaction turns *before* queued user messages; now user messages win (this is the bug fix).
- The wake prompt text is the completion notification's rendering (`Sub-agents completed: 1 done, 0 failed (of 1).` / `Background task completed (exit code 0).` + output tail) instead of the extensions' bespoke phrasing — one rendering per completion fact, and the model now sees the background output tail.
- A wake enqueued but not yet serviced is lost on process restart — parity with the old in-memory pi-side queue.

## Deferred follow-ups

- [SCU-1784](https://linear.app/imbue/issue/SCU-1784/pi-agent-crashes-when-sculptors-transient-re-prompt-races-pis-own-auto) — pre-existing: Sculptor's transient re-prompt can race pi's own auto-retry; the bare re-prompt is rejected ("Agent is already processing") and today that is a fatal `PiCrashError` that kills the message thread. Witnessed live during verification under a provider overload.
- [SCU-1785](https://linear.app/imbue/issue/SCU-1785/pi-completion-notifies-are-dropped-if-they-arrive-during-a-control) — pre-existing: a completion notify arriving during a between-turns control-command window (`new_session` / `set_model`) is consumed and dropped by `_consume_until_command_response`.

## Review notes

- Declined: replacing the `"[FakePi] Task completed."` literal in the two integration tests with an import of FakePi's private `_DEFAULT_RESPONSE_TEXT` — the underscore import would trip the `no-underscore-imports` ratchet, and the adjacent comments already name it as FakePi's default reply.

(Sent by Claude)
