### PR TITLE
Fix confusing Pi first-agent settings in the new-workspace modal

### DIFF
--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.ts
@@ -1,0 +1,138 @@
+import { renderHook } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactElement, ReactNode } from "react";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as api from "~/api";
+import { EffortLevel, LlmModel, WorkspaceInitializationStrategy } from "~/api";
+import type { StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
+
+import { useCreateWorkspace } from "./useCreateWorkspace.ts";
+
+// Stub the two create endpoints so we can inspect exactly what the hook sends
+// for each agent type (the gating between Claude / pi / terminal is the unit
+// under test).
+const { mockCreateWorkspaceV2, mockCreateWorkspaceAgent } = vi.hoisted(() => ({
+  mockCreateWorkspaceV2: vi.fn(),
+  mockCreateWorkspaceAgent: vi.fn(),
+}));
+
+vi.mock("~/api", async () => {
+  const actual = await vi.importActual<typeof api>("~/api");
+  return {
+    ...actual,
+    createWorkspaceV2: mockCreateWorkspaceV2,
+    createWorkspaceAgent: mockCreateWorkspaceAgent,
+  };
+});
+
+vi.mock("~/common/NavigateUtils.ts", () => ({
+  useImbueNavigate: (): Record<string, unknown> => ({ navigateToAgent: vi.fn() }),
+}));
+
+vi.mock("posthog-js", () => ({ posthog: { capture: vi.fn() } }));
+
+const makeWrapper =
+  (store: ReturnType<typeof createStore>) =>
+  ({ children }: { children: ReactNode }): ReactElement =>
+    createElement(Provider, { store }, children);
+
+type CreateArgs = Parameters<ReturnType<typeof useCreateWorkspace>["createWorkspace"]>[0];
+
+const baseArgs = (overrides: Partial<CreateArgs>): CreateArgs => ({
+  projectId: "project-1",
+  workspaceName: "My workspace",
+  prompt: "",
+  mode: WorkspaceInitializationStrategy.WORKTREE,
+  sourceBranch: "main",
+  branchName: "feature/branch",
+  agentTypeValue: "claude" as StoredAgentType,
+  registrations: [],
+  defaultModel: LlmModel.CLAUDE_4_OPUS,
+  effort: EffortLevel.HIGH,
+  fastMode: false,
+  enterPlanMode: false,
+  ...overrides,
+});
+
+const getAgentRequestBody = (): Record<string, unknown> =>
+  mockCreateWorkspaceAgent.mock.calls[0][0].body as Record<string, unknown>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateWorkspaceV2.mockResolvedValue({ data: { objectId: "workspace-1" } });
+  mockCreateWorkspaceAgent.mockResolvedValue({ data: { id: "agent-1" } });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useCreateWorkspace agent-type gating", () => {
+  it("sends prompt, model, effort, fast, and plan for a Claude agent", async () => {
+    const store = createStore();
+    const { result } = renderHook(() => useCreateWorkspace(), { wrapper: makeWrapper(store) });
+
+    await result.current.createWorkspace(
+      baseArgs({ agentTypeValue: "claude" as StoredAgentType, prompt: "do a thing", enterPlanMode: true }),
+    );
+
+    const body = getAgentRequestBody();
+    expect(body.agentType).toBe("claude");
+    expect(body.prompt).toBe("do a thing");
+    expect(body.model).toBe(LlmModel.CLAUDE_4_OPUS);
+    expect(body.effort).toBe(EffortLevel.HIGH);
+    expect(body.fastMode).toBe(false);
+    expect(body.enterPlanMode).toBe(true);
+  });
+
+  it("sends the prompt (and a placeholder model) for a pi agent, but omits effort/fast/plan", async () => {
+    const store = createStore();
+    const { result } = renderHook(() => useCreateWorkspace(), { wrapper: makeWrapper(store) });
+
+    await result.current.createWorkspace(
+      baseArgs({ agentTypeValue: "pi" as StoredAgentType, prompt: "help me get started", enterPlanMode: true }),
+    );
+
+    const body = getAgentRequestBody();
+    expect(body.agentType).toBe("pi");
+    // The prompt the user typed must reach pi, not be silently dropped.
+    expect(body.prompt).toBe("help me get started");
+    // pi ignores the model (it picks from its own in-task catalog), but the
+    // backend requires one alongside a prompt, so a placeholder default rides along.
+    expect(body.model).toBe(LlmModel.CLAUDE_4_OPUS);
+    // These Claude-only per-prompt settings do not apply to a pi create.
+    expect(body.effort).toBeUndefined();
+    expect(body.fastMode).toBeUndefined();
+    expect(body.enterPlanMode).toBeUndefined();
+  });
+
+  it("omits the prompt and model for a pi agent when no prompt was typed", async () => {
+    const store = createStore();
+    const { result } = renderHook(() => useCreateWorkspace(), { wrapper: makeWrapper(store) });
+
+    await result.current.createWorkspace(baseArgs({ agentTypeValue: "pi" as StoredAgentType, prompt: "   " }));
+
+    const body = getAgentRequestBody();
+    expect(body.agentType).toBe("pi");
+    expect(body.prompt).toBeUndefined();
+    // No prompt → the backend does not require a model, so pi starts on its own default.
+    expect(body.model).toBeUndefined();
+  });
+
+  it("never sends a prompt or model for a terminal agent", async () => {
+    const store = createStore();
+    const { result } = renderHook(() => useCreateWorkspace(), { wrapper: makeWrapper(store) });
+
+    await result.current.createWorkspace(
+      baseArgs({ agentTypeValue: "terminal" as StoredAgentType, prompt: "this should be ignored" }),
+    );
+
+    const body = getAgentRequestBody();
+    expect(body.agentType).toBe("terminal");
+    // The backend rejects a prompt for terminal/registered agents (422), so it must never be sent.
+    expect(body.prompt).toBeUndefined();
+    expect(body.model).toBeUndefined();
+  });
+});

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as api from "~/api";
 import { EffortLevel, LlmModel, WorkspaceInitializationStrategy } from "~/api";
-import type { StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
+import { encodeRegisteredAgentType, type StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
 
 import { useCreateWorkspace } from "./useCreateWorkspace.ts";
 
@@ -134,5 +134,60 @@ describe("useCreateWorkspace agent-type gating", () => {
     // The backend rejects a prompt for terminal/registered agents (422), so it must never be sent.
     expect(body.prompt).toBeUndefined();
     expect(body.model).toBeUndefined();
+  });
+
+  it("omits the prompt and model for a registered agent whose registration exists", async () => {
+    const store = createStore();
+    const { result } = renderHook(() => useCreateWorkspace(), { wrapper: makeWrapper(store) });
+
+    const registration: api.TerminalAgentRegistration = {
+      registrationId: "reg-1",
+      displayName: "My Agent",
+      launchCommand: "my-agent",
+    };
+    await result.current.createWorkspace(
+      baseArgs({
+        agentTypeValue: encodeRegisteredAgentType("reg-1"),
+        registrations: [registration],
+        prompt: "this should be ignored",
+      }),
+    );
+
+    const body = getAgentRequestBody();
+    // A registered agent is terminal-like: the backend rejects a prompt for it,
+    // and it carries no model / per-prompt settings.
+    expect(body.agentType).toBe("registered");
+    expect(body.registrationId).toBe("reg-1");
+    expect(body.prompt).toBeUndefined();
+    expect(body.model).toBeUndefined();
+    expect(body.effort).toBeUndefined();
+    expect(body.fastMode).toBeUndefined();
+    expect(body.enterPlanMode).toBeUndefined();
+  });
+
+  it("falls back to Claude (prompt + model + settings) when the registered agent's registration was deleted", async () => {
+    const store = createStore();
+    const { result } = renderHook(() => useCreateWorkspace(), { wrapper: makeWrapper(store) });
+
+    // The stored type references a registration that no longer exists, so
+    // resolveEffectiveAgentType falls back to Claude — which must send the prompt
+    // and settings, not silently drop them.
+    await result.current.createWorkspace(
+      baseArgs({
+        agentTypeValue: encodeRegisteredAgentType("reg-deleted"),
+        registrations: [],
+        prompt: "help me get started",
+        enterPlanMode: true,
+      }),
+    );
+
+    const body = getAgentRequestBody();
+    expect(body.agentType).toBe("claude");
+    expect(body.registrationId).toBeUndefined();
+    expect(body.prompt).toBe("help me get started");
+    expect(body.model).toBe(LlmModel.CLAUDE_4_OPUS);
+    expect(body.effort).toBe(EffortLevel.HIGH);
+    expect(body.fastMode).toBe(false);
+    expect(body.enterPlanMode).toBe(true);
   });
 });

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
@@ -118,26 +118,29 @@ export const useCreateWorkspace = (): UseCreateWorkspaceReturn => {
             ? encodeRegisteredAgentType(effectiveRegistrationId)
             : effectiveAgentType;
 
-        // Only Claude consumes a creation-time prompt, model, and the per-prompt
-        // agent settings (effort / fast / plan): terminal/registered agents have
-        // no model concept, and pi selects from its own catalog in-task, so it
-        // starts on pi's defaults rather than Claude settings it would ignore.
-        // The prompt gate mirrors the backend, which rejects a prompt for
-        // terminal/registered agents and requires a model alongside any prompt —
-        // sending one would fail the agent create after the workspace already
-        // exists, orphaning an agentless workspace. Non-Claude agents start in
-        // the waiting state instead.
+        // Claude and pi both take an initial prompt; terminal/registered agents
+        // do not — the backend rejects a prompt for them (422), which would fail
+        // the agent create after the workspace already exists and orphan it.
         const isClaudeAgent = effectiveAgentType === "claude";
+        const isPiAgent = effectiveAgentType === "pi";
+        const initialPrompt = isClaudeAgent || isPiAgent ? args.prompt.trim() || undefined : undefined;
+        // Claude seeds its model at create and consumes the per-prompt agent
+        // settings (effort / fast / plan). pi ignores all of them: it picks its
+        // model from its own in-task catalog and enters plan mode from the chat.
+        // The backend still requires a model whenever a prompt is present, so pi
+        // rides a placeholder default in that case only — the same Claude
+        // model_name every live pi message already carries and pi discards.
+        const shouldSendModel = isClaudeAgent || (isPiAgent && initialPrompt !== undefined);
         const agentResponse = await createWorkspaceAgent({
           path: { workspace_id: workspaceId },
           body: {
-            model: isClaudeAgent ? (args.defaultModel as LlmModel) : undefined,
+            model: shouldSendModel ? (args.defaultModel as LlmModel) : undefined,
             effort: isClaudeAgent ? args.effort : undefined,
             fastMode: isClaudeAgent ? args.fastMode : undefined,
             enterPlanMode: isClaudeAgent ? args.enterPlanMode : undefined,
             agentType: effectiveAgentType,
             registrationId: effectiveRegistrationId,
-            prompt: isClaudeAgent ? args.prompt.trim() || undefined : undefined,
+            prompt: initialPrompt,
           },
         });
 

--- a/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.test.tsx
@@ -46,28 +46,15 @@ const defaultProps = {
   onPlanModeToggle: (): void => {},
 };
 
-describe("AgentSettingsControls canSelectModel", () => {
-  it("renders an enabled model picker when canSelectModel defaults to true", () => {
+describe("AgentSettingsControls", () => {
+  it("renders the full Claude control cluster with an enabled model picker", () => {
     render(withStore(<AgentSettingsControls {...defaultProps} />));
-    expect(screen.getByTestId(ElementIds.MODEL_SELECTOR)).toBeTruthy();
-    expect(screen.queryByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeNull();
-  });
-
-  it("renders a disabled model picker when canSelectModel is false", () => {
-    render(withStore(<AgentSettingsControls {...defaultProps} canSelectModel={false} />));
-    expect(screen.queryByTestId(ElementIds.MODEL_SELECTOR)).toBeNull();
-    expect(screen.getByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeTruthy();
-  });
-});
-
-describe("AgentSettingsControls canUseFastMode", () => {
-  it("hides the fast-mode toggle when canUseFastMode is false", () => {
-    render(withStore(<AgentSettingsControls {...defaultProps} canUseFastMode={false} />));
-    expect(screen.queryByTestId(ElementIds.FAST_MODE_TOGGLE)).toBeNull();
-  });
-
-  it("shows the fast-mode toggle when the model supports it and canUseFastMode is true", () => {
-    render(withStore(<AgentSettingsControls {...defaultProps} canUseFastMode={true} />));
+    expect(screen.getByTestId(ElementIds.PLAN_MODE_TOGGLE)).toBeTruthy();
+    // Opus supports fast mode, so its toggle shows.
     expect(screen.getByTestId(ElementIds.FAST_MODE_TOGGLE)).toBeTruthy();
+    expect(screen.getByTestId(ElementIds.MODEL_SELECTOR)).toBeTruthy();
+    // This cluster is Claude-only, so the model picker is never the disabled
+    // capability-tooltip treatment.
+    expect(screen.queryByTestId(ElementIds.CAPABILITY_DISABLED_MODEL_SELECTION)).toBeNull();
   });
 });

--- a/sculptor/frontend/src/components/AgentSettingsControls.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.tsx
@@ -19,33 +19,18 @@ type AgentSettingsControlsProps = {
   onFastModeToggle: () => void;
   isPlanMode: boolean;
   onPlanModeToggle: () => void;
-  /**
-   * Hide the plan-mode toggle when the active harness can't honor a
-   * mid-turn interactive backchannel (pi). Defaults to `true` so callsites
-   * without a task yet (e.g. the new-workspace modal) show it.
-   */
-  canEnterPlanMode?: boolean;
-  /**
-   * Gate the fast-mode toggle on harness support in addition to the
-   * model's own `supportsFastMode` capability. Defaults to `true`.
-   */
-  canUseFastMode?: boolean;
-  /**
-   * Gate the model picker on harness support. When false, the picker renders
-   * disabled with a capability-tooltip. Defaults to `true`.
-   */
-  canSelectModel?: boolean;
 };
 
 /**
- * The right-side toolbar block of agent settings — plan mode, fast mode
- * (when the model supports it), thinking effort, model. Lives standalone
- * so the new-workspace modal can render the same controls beneath its
- * prompt textarea without duplicating ChatInput's wiring. The fast-mode
- * toggle is gated on `getModelCapabilities(model).supportsFastMode`
- * here (rather than at every callsite) so consumers only have to pass
- * the selected model. The model picker is gated on `canSelectModel` (false
- * disables it with a capability tooltip).
+ * The right-side toolbar block of a Claude first agent's per-prompt settings —
+ * plan mode, fast mode (when the model supports it), thinking effort, and model.
+ * The new-workspace modal renders this beneath its prompt textarea for a Claude
+ * first agent. Non-Claude harnesses don't consume any of these at create (pi
+ * picks its model from its own in-task catalog and plans from the chat; terminal
+ * agents have no model), so the modal renders its own hint in place of this
+ * block rather than gating the controls one by one. The fast-mode toggle is
+ * gated on `getModelCapabilities(model).supportsFastMode` here (rather than at
+ * every callsite) so consumers only have to pass the selected model.
  *
  * ChatInput renders a parallel copy of this toolbar block that adds
  * capability-gated disabled states and a backend-model selector it needs in
@@ -61,43 +46,34 @@ export const AgentSettingsControls = ({
   onFastModeToggle,
   isPlanMode,
   onPlanModeToggle,
-  canEnterPlanMode = true,
-  canUseFastMode = true,
-  canSelectModel = true,
 }: AgentSettingsControlsProps): ReactElement => {
   const { supportsFastMode: doesSupportFastMode } = getModelCapabilities(model);
   const { navigateToGlobalSettings } = useImbueNavigate();
-  // ModelSelector's no-providers CTA (pi with an empty backend catalog) sends
-  // the user to the pi login flow under Settings -> Pi, matching ChatInput.
+  // ModelSelector requires an authenticate handler for its no-providers CTA. That
+  // CTA is a pi-only state that never fires for this Claude cluster, but the prop
+  // is required, so route it to the pi login flow to match ChatInput.
   const handleAuthenticate = useCallback((): void => {
     navigateToGlobalSettings(SettingsSection.PI);
   }, [navigateToGlobalSettings]);
   return (
     <Flex align="center" flexShrink="0">
-      {canEnterPlanMode && (
-        <Tooltip content={isPlanMode ? "Leave plan mode" : "Enter plan mode"}>
-          <IconButton
-            variant="ghost"
-            size="3"
-            onClick={onPlanModeToggle}
-            aria-label="Toggle plan first mode"
-            data-testid={ElementIds.PLAN_MODE_TOGGLE}
-            data-active={isPlanMode}
-            style={isPlanMode ? { color: "var(--button-primary-bg)", margin: 0 } : { margin: 0 }}
-          >
-            <ListChecks size={16} />
-          </IconButton>
-        </Tooltip>
-      )}
-      {doesSupportFastMode && canUseFastMode && <FastModeToggle isActive={isFastMode} onToggle={onFastModeToggle} />}
+      <Tooltip content={isPlanMode ? "Leave plan mode" : "Enter plan mode"}>
+        <IconButton
+          variant="ghost"
+          size="3"
+          onClick={onPlanModeToggle}
+          aria-label="Toggle plan first mode"
+          data-testid={ElementIds.PLAN_MODE_TOGGLE}
+          data-active={isPlanMode}
+          style={isPlanMode ? { color: "var(--button-primary-bg)", margin: 0 } : { margin: 0 }}
+        >
+          <ListChecks size={16} />
+        </IconButton>
+      </Tooltip>
+      {doesSupportFastMode && <FastModeToggle isActive={isFastMode} onToggle={onFastModeToggle} />}
       <EffortSelector effort={effort} onEffortChange={onEffortChange} />
       <Flex pr="1">
-        <ModelSelector
-          model={model}
-          onModelChange={onModelChange}
-          capabilityValue={canSelectModel}
-          onAuthenticate={handleAuthenticate}
-        />
+        <ModelSelector model={model} onModelChange={onModelChange} onAuthenticate={handleAuthenticate} />
       </Flex>
     </Flex>
   );

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Skeleton, Switch, Tooltip } from "@radix-ui/themes";
+import { Button, Skeleton, Switch, Text, Tooltip } from "@radix-ui/themes";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { ReactElement } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -121,10 +121,11 @@ export const NewWorkspaceForm = ({
 
   // State and hooks — external
   const { registrations } = useTerminalAgentRegistrations();
-  // Fast mode and model selection are Claude-only. Resolve through the same
-  // helper the create flow uses so a registered agent whose registration was
-  // deleted (and therefore creates a Claude agent) still shows Claude's controls.
-  const isNonClaudeHarness = resolveEffectiveAgentType(agentTypeValue, registrations).agentType !== "claude";
+  // The per-prompt agent settings (model / effort / plan / fast) are consumed at
+  // create only for Claude. Resolve through the same helper the create flow uses
+  // so a registered agent whose registration was deleted (and therefore creates a
+  // Claude agent) still shows Claude's controls.
+  const effectiveAgentType = resolveEffectiveAgentType(agentTypeValue, registrations).agentType;
   const { repoInfo, fetchRepoInfo, fetchCurrentBranch } = useRepoInfo(selectedProjectId);
   const { isCreating, createWorkspace } = useCreateWorkspace();
   const nameInputRef = useRef<HTMLInputElement>(null);
@@ -467,23 +468,30 @@ export const NewWorkspaceForm = ({
             rows={2}
           />
 
-          {/* Per-prompt agent settings (plan / fast / effort / model). Always
-              rendered so the row reserves its space; hidden via `visibility`
-              until the user has typed a prompt so the modal doesn't jump. */}
+          {/* Per-prompt agent settings. The row is always laid out so it reserves
+              its space; it is hidden via `visibility` until the user has typed a
+              prompt so the modal doesn't jump. Only Claude consumes model / effort
+              / plan / fast at create, so it gets the full control cluster. pi
+              ignores all of them — it picks its model from its own in-task catalog
+              and enters plan mode from the chat — so it gets a hint instead.
+              Terminal/registered agents configure nothing here. */}
           <div className={styles.agentSettings} data-visible={!isPromptEmpty} aria-hidden={isPromptEmpty}>
-            {/* Pi supports interactive backchannel, so plan mode stays enabled. */}
-            <AgentSettingsControls
-              model={agentModel}
-              onModelChange={setAgentModel}
-              effort={agentEffort}
-              onEffortChange={setAgentEffort}
-              isFastMode={isAgentFastMode}
-              onFastModeToggle={(): void => setIsAgentFastMode((v) => !v)}
-              isPlanMode={isAgentPlanMode}
-              onPlanModeToggle={(): void => setIsAgentPlanMode((v) => !v)}
-              canUseFastMode={!isNonClaudeHarness}
-              canSelectModel={!isNonClaudeHarness}
-            />
+            {effectiveAgentType === "claude" ? (
+              <AgentSettingsControls
+                model={agentModel}
+                onModelChange={setAgentModel}
+                effort={agentEffort}
+                onEffortChange={setAgentEffort}
+                isFastMode={isAgentFastMode}
+                onFastModeToggle={(): void => setIsAgentFastMode((v) => !v)}
+                isPlanMode={isAgentPlanMode}
+                onPlanModeToggle={(): void => setIsAgentPlanMode((v) => !v)}
+              />
+            ) : effectiveAgentType === "pi" ? (
+              <Text size="1" color="gray" data-testid={ElementIds.NEW_WORKSPACE_PI_SETTINGS_HINT}>
+                Select your model after the workspace starts
+              </Text>
+            ) : null}
           </div>
         </div>
 

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -37,6 +37,10 @@ class ElementIDs(StrEnum):
     NEW_WORKSPACE_CONTEXT_PILL = "NEW_WORKSPACE_CONTEXT_PILL"
     NEW_WORKSPACE_KEEP_OPEN_SWITCH = "NEW_WORKSPACE_KEEP_OPEN_SWITCH"
     NEW_WORKSPACE_CREATE_BUTTON = "NEW_WORKSPACE_CREATE_BUTTON"
+    # Shown in place of the per-prompt agent-settings controls when the first
+    # agent is pi: model / effort / plan / fast do not apply to a pi create
+    # (pi picks its model from its own in-task catalog), so a hint replaces them.
+    NEW_WORKSPACE_PI_SETTINGS_HINT = "NEW_WORKSPACE_PI_SETTINGS_HINT"
     WORKSPACE_SELECTOR = "WORKSPACE_SELECTOR"
     WORKSPACE_OPTION_NAME = "WORKSPACE_OPTION_NAME"
     HOME_PAGE_SYSTEM_PROMPT_OPEN_BUTTON = "HOME_PAGE_SYSTEM_PROMPT_OPEN_BUTTON"


### PR DESCRIPTION
## What & why

On the create-workspace modal, choosing **Pi** as the first agent surfaced Claude's per-prompt settings, none of which apply to a Pi create:

- the **model picker** rendered *disabled* with a generic "Not supported by this agent harness" tooltip;
- **effort** and **plan-mode** toggles rendered as normal but silently did nothing.

Pi selects its model from its own in-task catalog once the session starts, and enters plan mode from the chat — so at create time there is nothing to configure there. A prior partial fix only gated the model picker and fast-mode toggle, leaving the misleading disabled picker and the inert effort/plan controls.

This PR:

1. **Replaces the whole cluster, for a Pi first agent, with one hint:** _"Select your model after the workspace starts."_ Claude keeps the full control cluster; terminal/registered agents show nothing.
2. **Stops silently dropping the typed prompt for a Pi create.** The flow gated the prompt (and model/effort/fast/plan) on "is this Claude?", so a Pi workspace started empty and discarded the user's first task. The backend already accepts a prompt for Pi (it rejects prompts only for terminal/registered agents) and requires a model alongside any prompt, so Pi now sends the prompt plus the default model as a placeholder it ignores — the same `model_name` every live Pi message already carries and discards.
3. **Simplifies `AgentSettingsControls`** to a Claude-only control cluster: the superseded per-control capability gates are removed, along with a stale comment that claimed Pi both does and does not support a mid-turn interactive backchannel (the harness declares it does).

## Before / After (create modal — Pi selected, prompt typed)

**Before:** the model picker is shown _disabled_ with a "Not supported by this agent harness" tooltip; the effort and plan-mode toggles are shown but inert; the typed prompt is discarded on create.

**After:** the settings row shows a single muted hint — _"Select your model after the workspace starts"_ — with the disabled picker and inert toggles gone; the typed prompt is delivered to Pi.

Verified in a live headless-browser QA session: the Claude path is unchanged (enabled "Opus (1M)" picker + plan-mode toggle, no hint), and the Pi path shows only the hint with the `CAPABILITY_DISABLED_MODEL_SELECTION` element absent.

## Test plan

- New unit test `useCreateWorkspace.test.ts` covers the create-flow gating across agent types — Claude sends prompt+model+effort+fast+plan; Pi sends prompt + placeholder model and omits effort/fast/plan; Pi without a prompt sends neither; terminal sends neither. It fails without the prompt fix.
- Updated `AgentSettingsControls.test.tsx` for the Claude-only cluster.
- `just format`, `just check` (typecheck + lint + ratchets), and the full frontend unit suite pass.

## Notes / follow-ups

- Pi isn't installed in CI, so the _live_ Pi-with-prompt flow isn't covered by an automated end-to-end test. It's verified by the unit-tested payload, the backend contract, and the existing first-run intro-message precedent that already ships a Claude `model_name` to Pi (which Pi discards). An integration test could be added if/when Pi is available in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
