### PR TITLE
Cherry-pick #277 into 0.42.0: reliable chat scroll restore (SCU-1772)

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/alphaScroll.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/alphaScroll.test.ts
@@ -1,0 +1,61 @@
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { AlphaScrollPosition } from "./alphaScroll";
+import { alphaScrollPositionAtomFamily } from "./alphaScroll";
+
+const position = (overrides?: Partial<AlphaScrollPosition>): AlphaScrollPosition => ({
+  firstVisibleMessageId: "msg-42",
+  pixelOffset: 17,
+  distanceFromBottom: 480,
+  ...overrides,
+});
+
+// The atomFamily caches its atoms for the module's lifetime, and `getOnInit`
+// reads sessionStorage when the atom is *created*. Each test therefore uses a
+// unique taskId, so the atom creation happens inside the test — after that
+// test's sessionStorage setup — matching what a real page load does (fresh
+// module, storage already populated).
+describe("alphaScrollPositionAtomFamily", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("returns null when no position has been stored", () => {
+    const store = createStore();
+    expect(store.get(alphaScrollPositionAtomFamily("fresh-task"))).toBeNull();
+  });
+
+  it("persists writes to sessionStorage under the task-keyed key", () => {
+    const store = createStore();
+    const saved = position();
+
+    store.set(alphaScrollPositionAtomFamily("write-task"), saved);
+
+    expect(JSON.parse(sessionStorage.getItem("sculptor-alpha-scroll:write-task") ?? "")).toEqual(saved);
+  });
+
+  it("rehydrates a stored position on the first read after a reload", () => {
+    const saved = position();
+    sessionStorage.setItem("sculptor-alpha-scroll:reload-task", JSON.stringify(saved));
+
+    // A fresh store stands in for the reloaded page: nothing has been written
+    // through jotai in this "session", so the value can only come from
+    // sessionStorage via getOnInit. Without getOnInit the first synchronous
+    // read — which the pre-paint mount restore depends on — would be null.
+    const store = createStore();
+    expect(store.get(alphaScrollPositionAtomFamily("reload-task"))).toEqual(saved);
+  });
+
+  it("keeps positions isolated per task", () => {
+    const store = createStore();
+    const first = position();
+    const second = position({ firstVisibleMessageId: "msg-7", pixelOffset: 3, distanceFromBottom: 0 });
+
+    store.set(alphaScrollPositionAtomFamily("task-a"), first);
+    store.set(alphaScrollPositionAtomFamily("task-b"), second);
+
+    expect(store.get(alphaScrollPositionAtomFamily("task-a"))).toEqual(first);
+    expect(store.get(alphaScrollPositionAtomFamily("task-b"))).toEqual(second);
+  });
+});

--- a/sculptor/frontend/src/common/state/atoms/alphaScroll.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/alphaScroll.test.ts
@@ -2,23 +2,24 @@ import { createStore } from "jotai";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { AlphaScrollPosition } from "./alphaScroll";
-import { alphaScrollPositionAtomFamily } from "./alphaScroll";
+import { alphaScrollPositionAtomFamily, MAX_PERSISTED_SCROLL_POSITIONS } from "./alphaScroll";
 
 const position = (overrides?: Partial<AlphaScrollPosition>): AlphaScrollPosition => ({
   firstVisibleMessageId: "msg-42",
   pixelOffset: 17,
   distanceFromBottom: 480,
+  savedAtMs: 1_000_000,
   ...overrides,
 });
 
 // The atomFamily caches its atoms for the module's lifetime, and `getOnInit`
-// reads sessionStorage when the atom is *created*. Each test therefore uses a
+// reads localStorage when the atom is *created*. Each test therefore uses a
 // unique taskId, so the atom creation happens inside the test — after that
-// test's sessionStorage setup — matching what a real page load does (fresh
+// test's localStorage setup — matching what a real app start does (fresh
 // module, storage already populated).
 describe("alphaScrollPositionAtomFamily", () => {
   beforeEach(() => {
-    sessionStorage.clear();
+    localStorage.clear();
   });
 
   it("returns null when no position has been stored", () => {
@@ -26,25 +27,25 @@ describe("alphaScrollPositionAtomFamily", () => {
     expect(store.get(alphaScrollPositionAtomFamily("fresh-task"))).toBeNull();
   });
 
-  it("persists writes to sessionStorage under the task-keyed key", () => {
+  it("persists writes to localStorage under the task-keyed key", () => {
     const store = createStore();
     const saved = position();
 
     store.set(alphaScrollPositionAtomFamily("write-task"), saved);
 
-    expect(JSON.parse(sessionStorage.getItem("sculptor-alpha-scroll:write-task") ?? "")).toEqual(saved);
+    expect(JSON.parse(localStorage.getItem("sculptor-alpha-scroll:write-task") ?? "")).toEqual(saved);
   });
 
-  it("rehydrates a stored position on the first read after a reload", () => {
+  it("rehydrates a stored position on the first read after an app restart", () => {
     const saved = position();
-    sessionStorage.setItem("sculptor-alpha-scroll:reload-task", JSON.stringify(saved));
+    localStorage.setItem("sculptor-alpha-scroll:restart-task", JSON.stringify(saved));
 
-    // A fresh store stands in for the reloaded page: nothing has been written
-    // through jotai in this "session", so the value can only come from
-    // sessionStorage via getOnInit. Without getOnInit the first synchronous
+    // A fresh store stands in for the restarted app: nothing has been written
+    // through jotai in this process, so the value can only come from
+    // localStorage via getOnInit. Without getOnInit the first synchronous
     // read — which the pre-paint mount restore depends on — would be null.
     const store = createStore();
-    expect(store.get(alphaScrollPositionAtomFamily("reload-task"))).toEqual(saved);
+    expect(store.get(alphaScrollPositionAtomFamily("restart-task"))).toEqual(saved);
   });
 
   it("keeps positions isolated per task", () => {
@@ -57,5 +58,36 @@ describe("alphaScrollPositionAtomFamily", () => {
 
     expect(store.get(alphaScrollPositionAtomFamily("task-a"))).toEqual(first);
     expect(store.get(alphaScrollPositionAtomFamily("task-b"))).toEqual(second);
+  });
+
+  it("evicts the oldest-saved positions once the cap is exceeded", () => {
+    const store = createStore();
+
+    // Fill to the cap with strictly increasing save times, then write one more.
+    for (let i = 0; i <= MAX_PERSISTED_SCROLL_POSITIONS; i++) {
+      store.set(alphaScrollPositionAtomFamily(`evict-task-${i}`), position({ savedAtMs: i + 1 }));
+    }
+
+    const persistedKeys: Array<string> = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith("sculptor-alpha-scroll:")) persistedKeys.push(key);
+    }
+    expect(persistedKeys).toHaveLength(MAX_PERSISTED_SCROLL_POSITIONS);
+    // The oldest entry made way; the newest write survives.
+    expect(localStorage.getItem("sculptor-alpha-scroll:evict-task-0")).toBeNull();
+    expect(localStorage.getItem(`sculptor-alpha-scroll:evict-task-${MAX_PERSISTED_SCROLL_POSITIONS}`)).not.toBeNull();
+  });
+
+  it("evicts entries missing savedAtMs before timestamped ones", () => {
+    const store = createStore();
+    localStorage.setItem("sculptor-alpha-scroll:legacy-task", JSON.stringify(position({ savedAtMs: undefined })));
+
+    for (let i = 0; i < MAX_PERSISTED_SCROLL_POSITIONS; i++) {
+      store.set(alphaScrollPositionAtomFamily(`fill-task-${i}`), position({ savedAtMs: i + 1 }));
+    }
+
+    expect(localStorage.getItem("sculptor-alpha-scroll:legacy-task")).toBeNull();
+    expect(localStorage.getItem("sculptor-alpha-scroll:fill-task-0")).not.toBeNull();
   });
 });

--- a/sculptor/frontend/src/common/state/atoms/alphaScroll.ts
+++ b/sculptor/frontend/src/common/state/atoms/alphaScroll.ts
@@ -1,6 +1,4 @@
-import type { PrimitiveAtom } from "jotai";
-import { atom } from "jotai";
-import { atomFamily } from "jotai/utils";
+import { atomFamily, atomWithStorage, createJSONStorage } from "jotai/utils";
 
 export type AlphaScrollPosition = {
   firstVisibleMessageId: string;
@@ -11,6 +9,17 @@ export type AlphaScrollPosition = {
   distanceFromBottom: number;
 };
 
-export const alphaScrollPositionAtomFamily = atomFamily<string, PrimitiveAtom<AlphaScrollPosition | undefined>>(() =>
-  atom<AlphaScrollPosition | undefined>(undefined),
+// sessionStorage, not memory or localStorage: a full page reload (mobile PWA
+// relaunch, tab eviction, dev-server reconnect) must not lose the reading
+// position — with a memory-only atom the restore falls back to the first-visit
+// landing and leaves the reader a page above the live tail once measurements
+// settle. Per-tab and gone on tab close, so positions never go stale across
+// sessions. `getOnInit` makes the saved value available on the very first
+// read, which the pre-paint mount restore depends on.
+const alphaScrollStorage = createJSONStorage<AlphaScrollPosition | null>(() => sessionStorage);
+
+export const alphaScrollPositionAtomFamily = atomFamily((taskId: string) =>
+  atomWithStorage<AlphaScrollPosition | null>(`sculptor-alpha-scroll:${taskId}`, null, alphaScrollStorage, {
+    getOnInit: true,
+  }),
 );

--- a/sculptor/frontend/src/common/state/atoms/alphaScroll.ts
+++ b/sculptor/frontend/src/common/state/atoms/alphaScroll.ts
@@ -7,19 +7,69 @@ export type AlphaScrollPosition = {
    *  virtualizer's paddingEnd excluded); negative when the viewport sits past
    *  the content, inside the tail padding. */
   distanceFromBottom: number;
+  /** When this position was saved (epoch ms). Only orders the LRU eviction of
+   *  persisted positions; entries missing it are treated as oldest. */
+  savedAtMs?: number;
 };
 
-// sessionStorage, not memory or localStorage: a full page reload (mobile PWA
-// relaunch, tab eviction, dev-server reconnect) must not lose the reading
-// position — with a memory-only atom the restore falls back to the first-visit
-// landing and leaves the reader a page above the live tail once measurements
-// settle. Per-tab and gone on tab close, so positions never go stale across
-// sessions. `getOnInit` makes the saved value available on the very first
-// read, which the pre-paint mount restore depends on.
-const alphaScrollStorage = createJSONStorage<AlphaScrollPosition | null>(() => sessionStorage);
+const STORAGE_KEY_PREFIX = "sculptor-alpha-scroll:";
+
+/**
+ * Cap on how many tasks keep a persisted scroll position. Positions are ~100
+ * bytes each, so the cap is about hygiene, not quota: without it every task
+ * ever visited would leave a localStorage key behind forever. Oldest-saved
+ * entries are evicted first.
+ */
+export const MAX_PERSISTED_SCROLL_POSITIONS = 50;
+
+/** Evict the oldest persisted positions (by savedAtMs) until the count fits
+ *  the cap. The just-written key is never a candidate, so a write is always
+ *  retained even if its payload carries no timestamp. */
+const prunePersistedPositions = (justWrittenKey: string): void => {
+  const candidates: Array<{ key: string; savedAtMs: number }> = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key === null || !key.startsWith(STORAGE_KEY_PREFIX) || key === justWrittenKey) continue;
+    let savedAtMs = 0;
+    try {
+      savedAtMs = (JSON.parse(localStorage.getItem(key) ?? "null") as AlphaScrollPosition | null)?.savedAtMs ?? 0;
+    } catch {
+      // Unparseable entry: leave savedAtMs at 0 so it is evicted first.
+    }
+    candidates.push({ key, savedAtMs });
+  }
+  const excess = candidates.length + 1 - MAX_PERSISTED_SCROLL_POSITIONS;
+  if (excess <= 0) return;
+  candidates.sort((a, b) => a.savedAtMs - b.savedAtMs);
+  for (const { key } of candidates.slice(0, excess)) {
+    localStorage.removeItem(key);
+  }
+};
+
+// localStorage, not memory or sessionStorage: restoring where the reader left
+// off must survive not just an in-tab reload (mobile PWA relaunch, tab
+// eviction) but a full app restart — on desktop, quitting the Electron app
+// ends the session, so sessionStorage would forget every position on quit.
+// The concerns that usually argue for a narrower scope are covered here:
+// cross-session staleness by the restore semantics themselves (an at-bottom
+// reader re-lands at the *live* tail via the signed distance, a scrolled-up
+// reader re-anchors to a stable message id with a distance fallback),
+// concurrent tabs by last-writer-wins — the same policy as the other
+// task-keyed localStorage state (prompt drafts, draft agent settings) — and
+// unbounded key growth by the LRU prune above. `getOnInit` makes the saved
+// value available on the very first read, which the pre-paint mount restore
+// depends on.
+const alphaScrollStorage = createJSONStorage<AlphaScrollPosition | null>(() => ({
+  getItem: (key: string): string | null => localStorage.getItem(key),
+  setItem: (key: string, value: string): void => {
+    localStorage.setItem(key, value);
+    prunePersistedPositions(key);
+  },
+  removeItem: (key: string): void => localStorage.removeItem(key),
+}));
 
 export const alphaScrollPositionAtomFamily = atomFamily((taskId: string) =>
-  atomWithStorage<AlphaScrollPosition | null>(`sculptor-alpha-scroll:${taskId}`, null, alphaScrollStorage, {
+  atomWithStorage<AlphaScrollPosition | null>(`${STORAGE_KEY_PREFIX}${taskId}`, null, alphaScrollStorage, {
     getOnInit: true,
   }),
 );

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -338,7 +338,8 @@ describe("useAlphaAutoScroll", () => {
     // User was at bottom, sent a message which grew scrollHeight, pushing them
     // slightly above the old bottom. The streaming-start effect should read the
     // live scroll position (still within threshold) and engage.
-    const el = createMockScrollContainer(1300, 2000, 500); // distance=200, at bottom
+    // Desktop-height container (>= 700px), where the at-bottom threshold is 200px.
+    const el = createMockScrollContainer(1200, 2000, 800); // distance=0, at bottom
     const ref = { current: el };
     const virtualizer = createMockVirtualizer();
 
@@ -350,7 +351,7 @@ describe("useAlphaAutoScroll", () => {
     // User was pinned to bottom (distance=0). New message adds ~100px to
     // scrollHeight, pushing distance to 100 — still within the 200px threshold.
     // No scroll event fires, so isAtBottom state reflects the initial value.
-    setScrollPosition(el, 1500, 2100); // distance = 2100 - 1500 - 500 = 100 ≤ 200
+    setScrollPosition(el, 1200, 2100); // distance = 2100 - 1200 - 800 = 100 ≤ 200
 
     // No scroll event fired — isAtBottom state reflects initial value, not live position
     expect(result.current.isAtBottom).toBe(true);
@@ -424,6 +425,27 @@ describe("useAlphaAutoScroll", () => {
       });
       expect(el.scrollTop).toBe(1540);
     });
+  });
+
+  it("does not auto-engage at streaming start 100px above the bottom on a short viewport", () => {
+    // Same scenario as above, but the scroll container is short (< 700px), so
+    // the at-bottom threshold tightens to 80px (BE2): 100px above the bottom is
+    // NOT "at bottom" on mobile, and streaming must not yank the view down.
+    const el = createMockScrollContainer(1500, 2000, 500); // distance=0, at bottom
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer();
+
+    const { result, rerender } = renderHook(
+      ({ isStreaming }) => useAlphaAutoScroll(ref, isStreaming, 10, virtualizer, null, -1, "test-task"),
+      { initialProps: { isStreaming: false } },
+    );
+
+    // Content grew by 100px with no scroll event — the same growth the desktop
+    // test treats as still-at-bottom (100 ≤ 200).
+    setScrollPosition(el, 1500, 2100); // distance = 2100 - 1500 - 500 = 100 > 80
+
+    rerender({ isStreaming: true });
+    expect(result.current.isEngaged).toBe(false);
   });
 
   it("scrolls to bottom when messageCount increases while at bottom (pin-to-bottom)", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -429,7 +429,7 @@ describe("useAlphaAutoScroll", () => {
 
   it("does not auto-engage at streaming start 100px above the bottom on a short viewport", () => {
     // Same scenario as above, but the scroll container is short (< 700px), so
-    // the at-bottom threshold tightens to 80px (BE2): 100px above the bottom is
+    // the at-bottom threshold tightens to 80px: 100px above the bottom is
     // NOT "at bottom" on mobile, and streaming must not yank the view down.
     const el = createMockScrollContainer(1500, 2000, 500); // distance=0, at bottom
     const ref = { current: el };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
@@ -44,6 +44,9 @@ const wrapperFor = (store: ReturnType<typeof createStore>) => {
 describe("useAlphaScrollPersistence", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // The scroll-position atom is sessionStorage-backed (survives page
+    // reloads); clear it so saves from one test don't leak into the next.
+    sessionStorage.clear();
   });
 
   afterEach(() => {
@@ -113,7 +116,9 @@ describe("useAlphaScrollPersistence", () => {
   });
 
   it("restores to the saved distance from the content bottom when near the bottom", () => {
-    const el = createMockScrollContainer(0, 2000, 500);
+    // Desktop-height container (>= 700px), where the at-bottom threshold is
+    // 200px — so the saved 100px distance takes the near-bottom restore path.
+    const el = createMockScrollContainer(0, 2000, 800);
     const ref = { current: el };
     const virtualItems = [createMockVirtualItem(0, 0, 200)];
     const virtualizer = createMockVirtualizer(virtualItems);
@@ -135,10 +140,10 @@ describe("useAlphaScrollPersistence", () => {
       vi.advanceTimersByTime(16);
     });
 
-    // Restored 100px above the content bottom (2000 - paddingEnd 0 - 500 - 100),
+    // Restored 100px above the content bottom (2000 - paddingEnd 0 - 800 - 100),
     // relative to the *current* content bottom so content that grew while away
     // stays in view.
-    expect(el.scrollTop).toBe(1400);
+    expect(el.scrollTop).toBe(1100);
   });
 
   it("round-trips a position inside the tail padding (negative distance)", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
@@ -44,9 +44,9 @@ const wrapperFor = (store: ReturnType<typeof createStore>) => {
 describe("useAlphaScrollPersistence", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    // The scroll-position atom is sessionStorage-backed (survives page
-    // reloads); clear it so saves from one test don't leak into the next.
-    sessionStorage.clear();
+    // The scroll-position atom is localStorage-backed (survives app
+    // restarts); clear it so saves from one test don't leak into the next.
+    localStorage.clear();
   });
 
   afterEach(() => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -12,6 +12,7 @@ import { ChatMessageRole } from "~/api";
 
 import {
   bottomPinOffset,
+  bottomThresholdFor,
   distanceFromContentBottom,
   FOOTER_REVEAL_WINDOW_MS,
   PIN_BOTTOM_GAP,
@@ -24,7 +25,6 @@ import {
   type ScrollStateMachine,
 } from "../scroll/scrollStateMachine.ts";
 
-const BOTTOM_THRESHOLD = 200;
 // Tighter threshold for re-engaging auto-scroll. The user must scroll to
 // essentially the very bottom — not just "near" it — to opt back in.
 const REENGAGE_THRESHOLD = 5;
@@ -297,7 +297,7 @@ export const useAlphaAutoScroll = (
       const distance = distanceFromContentBottom(el, virtualizer);
       // Sample at-bottness for the projection. projectAtBottom applies the
       // anchoring/following phase override, so no special-case guard is needed.
-      machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
+      machine.setGeometryAtBottom(distance <= bottomThresholdFor(el));
 
       if (isProgrammaticScroll.current) {
         isProgrammaticScroll.current = false;
@@ -385,7 +385,7 @@ export const useAlphaAutoScroll = (
 
       if (previous.kind === "restoring" && next.kind === "userControlled" && isStreamingRef.current) {
         const el = scrollContainerRef.current;
-        if (el !== null && distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD) {
+        if (el !== null && distanceFromContentBottom(el, virtualizer) <= bottomThresholdFor(el)) {
           machine.dispatch({ kind: "reachedBottom" });
         }
       }
@@ -525,7 +525,7 @@ export const useAlphaAutoScroll = (
       // effect already entered the anchoring phase.
       if (!isAnchoring()) {
         const el = scrollContainerRef.current;
-        if (el && distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD) {
+        if (el && distanceFromContentBottom(el, virtualizer) <= bottomThresholdFor(el)) {
           machine.dispatch({ kind: "reachedBottom" });
         }
       }
@@ -595,7 +595,7 @@ export const useAlphaAutoScroll = (
           isProgrammaticScroll.current = true;
           el.scrollTop = desired;
         }
-        machine.setGeometryAtBottom(distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD);
+        machine.setGeometryAtBottom(distanceFromContentBottom(el, virtualizer) <= bottomThresholdFor(el));
       });
     },
     [scrollContainerRef, virtualizer, machine, isProgrammaticScroll],
@@ -617,7 +617,7 @@ export const useAlphaAutoScroll = (
         case "pinBottom": {
           // Following the live tail — keep the last message's content bottom in
           // view. A user actively scrolling away during a stream hands control back.
-          if (distance > BOTTOM_THRESHOLD && isUserScrollingRef.current) {
+          if (distance > bottomThresholdFor(el) && isUserScrollingRef.current) {
             machine.dispatch({ kind: "userScrolled" });
             return;
           }
@@ -671,7 +671,7 @@ export const useAlphaAutoScroll = (
     const observer = new ResizeObserver(() => {
       if (messageCount === 0) return;
       const distance = distanceFromContentBottom(el, virtualizer);
-      machine.setGeometryAtBottom(distance <= BOTTOM_THRESHOLD);
+      machine.setGeometryAtBottom(distance <= bottomThresholdFor(el));
       // Reveal the turn footer that grew the content just after a followed turn ended:
       // re-pin (down-only) to the grown content bottom, within the window opened at
       // streaming stop. The two non-obvious guards: still userControlled (a new turn
@@ -693,7 +693,7 @@ export const useAlphaAutoScroll = (
     // further resize would otherwise fire the pin. Only `following` yields
     // pinBottom, so idle reconnects fall through untouched.
     if (isStreaming && messageCount > 0 && projectReflow(machine.getState()).kind === "pinBottom") {
-      if (distanceFromContentBottom(el, virtualizer) <= BOTTOM_THRESHOLD) {
+      if (distanceFromContentBottom(el, virtualizer) <= bottomThresholdFor(el)) {
         pinToBottom();
       }
     }

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -65,6 +65,7 @@ export const useAlphaScrollPersistence = (
           // reader follows content that grew while away and a position inside
           // the padding (the anchored rest / a max scroll) round-trips.
           distanceFromBottom: distanceFromContentBottom(el, virtualizer),
+          savedAtMs: Date.now(),
         });
       });
     };

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -5,7 +5,12 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { alphaScrollPositionAtomFamily } from "~/common/state/atoms/alphaScroll.ts";
 
-import { contentBottomOffset, distanceFromContentBottom, maxScrollOffset } from "../scroll/geometry.ts";
+import {
+  bottomThresholdFor,
+  contentBottomOffset,
+  distanceFromContentBottom,
+  maxScrollOffset,
+} from "../scroll/geometry.ts";
 import type { ScrollStateMachine } from "../scroll/scrollStateMachine.ts";
 
 /** Cancel all pending rAFs tracked in the set and clear it. */
@@ -13,8 +18,6 @@ const cancelPendingRafs = (ids: Set<number>): void => {
   for (const id of ids) cancelAnimationFrame(id);
   ids.clear();
 };
-
-const BOTTOM_THRESHOLD = 200;
 
 type MessageRef = { id: string };
 
@@ -90,7 +93,7 @@ export const useAlphaScrollPersistence = (
       return;
     }
 
-    if (scrollPosition.distanceFromBottom <= BOTTOM_THRESHOLD) {
+    if (scrollPosition.distanceFromBottom <= bottomThresholdFor(el)) {
       // At (or past) the bottom: re-land at the saved distance from the
       // *current* content bottom, not at the saved message anchor — when
       // content grew while away, an at-bottom reader should see the new
@@ -173,8 +176,13 @@ export const useAlphaScrollPersistence = (
     }
   }, [taskId, restore]);
 
-  // Initial restore on mount; cancel pending rAFs on unmount
-  useEffect(() => {
+  // Initial restore on mount; cancel pending rAFs on unmount. A layout effect
+  // for the same reason as the task-switch restore above: on mobile every
+  // navigation REMOUNTS the chat, and a post-paint restore would flash the
+  // pin-to-bottom position (painted by useAlphaAutoScroll's mount effects)
+  // before jumping to the saved one. Running after that pin in the same
+  // layout-effect queue (this hook is called later), the restore wins pre-paint.
+  useLayoutEffect(() => {
     restore();
     const rafs = pendingRafsRef.current;
     return (): void => cancelPendingRafs(rafs);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaVirtualizer.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaVirtualizer.ts
@@ -20,6 +20,19 @@ const OVERSCAN = 5;
 const MAX_CACHED_TASKS = 20;
 
 /**
+ * Per-task caches: item heights (for estimateSize) and tail content height.
+ * MODULE-scoped, not refs: the mobile shell unmounts the whole chat on every
+ * navigation (home ↔ workspace), so a ref-held cache restarts cold on each
+ * return visit. Cold caches mean estimateSize falls back to the generic 120px
+ * guess for every item, and the scroll-position restore first lands far from
+ * the saved spot, then visibly leaps as real measurements land — for seconds
+ * on a phone. Keyed by task id, so surviving the component is safe: a return
+ * visit reads the same task's own heights from its last visit.
+ */
+const heightCacheByTask = new Map<string, Array<number>>();
+const tailCacheByTask = new Map<string, number>();
+
+/**
  * Vertical padding above the virtualised list.
  *
  * Using `paddingStart` (and `paddingEnd` below) is the correct TanStack Virtual
@@ -134,17 +147,13 @@ export const useAlphaVirtualizer = (
   isStreaming: boolean = false,
 ): Virtualizer<HTMLDivElement, Element> => {
   const [containerHeight, setContainerHeight] = useState(0);
-  const [tailContentHeight, setTailContentHeight] = useState(0);
-  const tailContentHeightRef = useRef(0);
+  // Seed from the module-level caches so a REMOUNT of a previously-visited
+  // task starts with its real heights and tail from the first render — the
+  // task-switch branch below only handles taskId changing while mounted.
+  const [tailContentHeight, setTailContentHeight] = useState(() => tailCacheByTask.get(taskId) ?? 0);
+  const tailContentHeightRef = useRef(tailCacheByTask.get(taskId) ?? 0);
   const prevTaskIdRef = useRef(taskId);
-
-  // Per-task caches: item heights (for estimateSize) and tail content height.
-  // When switching away from a task we save these; when switching back we
-  // restore them so items start at approximately-correct positions instead of
-  // the generic 120px estimate and 64px padding fallback.
-  const heightCacheRef = useRef<Map<string, Array<number>>>(new Map());
-  const tailCacheRef = useRef<Map<string, number>>(new Map());
-  const currentEstimatesRef = useRef<Array<number>>([]);
+  const currentEstimatesRef = useRef<Array<number>>(heightCacheByTask.get(taskId) ?? []);
 
   // The settle window (per-item scroll-adjustment suppression after a task
   // switch) is owned by the scroll state machine's layout phase: `measuring`
@@ -269,8 +278,8 @@ export const useAlphaVirtualizer = (
       setIsTailSettling(false);
 
       // Restore saved state for the incoming task.
-      currentEstimatesRef.current = heightCacheRef.current.get(taskId) ?? [];
-      const savedTail = tailCacheRef.current.get(taskId);
+      currentEstimatesRef.current = heightCacheByTask.get(taskId) ?? [];
+      const savedTail = tailCacheByTask.get(taskId);
 
       if (savedTail != null) {
         // Return visit: use the exact tail height from last time.
@@ -351,10 +360,10 @@ export const useAlphaVirtualizer = (
       const item = virtualizer.measurementsCache[i];
       if (item) heights[i] = item.size;
     }
-    heightCacheRef.current.set(taskId, heights);
-    tailCacheRef.current.set(taskId, tailContentHeightRef.current);
-    touchLRU(heightCacheRef.current, taskId, MAX_CACHED_TASKS);
-    touchLRU(tailCacheRef.current, taskId, MAX_CACHED_TASKS);
+    heightCacheByTask.set(taskId, heights);
+    tailCacheByTask.set(taskId, tailContentHeightRef.current);
+    touchLRU(heightCacheByTask, taskId, MAX_CACHED_TASKS);
+    touchLRU(tailCacheByTask, taskId, MAX_CACHED_TASKS);
   });
 
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = buildShouldAdjustScrollPositionOnItemSizeChange(

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
@@ -62,7 +62,7 @@ const SHORT_VIEWPORT_PX = 700;
  * reading-anchor restore, the streaming-start engage) must use this one
  * function: during streaming the ResizeObserver re-samples on every token, so
  * a single site using a looser threshold overrides the others and re-engages
- * pin-to-bottom too early on short viewports (BE2).
+ * pin-to-bottom too early on short viewports.
  */
 export const bottomThresholdFor = (el: HTMLElement): number =>
   el.clientHeight < SHORT_VIEWPORT_PX ? MOBILE_BOTTOM_THRESHOLD : BOTTOM_THRESHOLD;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/scroll/geometry.ts
@@ -47,6 +47,26 @@ export const STREAMING_TAIL_PADDING = PIN_BOTTOM_GAP + TURN_END_SHRINK_SLACK;
  */
 export const FOOTER_REVEAL_WINDOW_MS = 1200;
 
+/** How close to the content bottom (px) counts as "at the bottom". */
+export const BOTTOM_THRESHOLD = 200;
+// On short (mobile) viewports, 200px is ~1/4 of the screen, so at-bottom (and
+// with it pin-to-bottom) engages "too early" when scrolling down — require
+// getting closer to the actual bottom there. Keyed off the scroll container's
+// own height so it's driven by the layout, not a separate mobile flag.
+const MOBILE_BOTTOM_THRESHOLD = 80;
+const SHORT_VIEWPORT_PX = 700;
+
+/**
+ * The at-bottom threshold for this scroll container. Every site that samples
+ * `geometryAtBottom` (the scroll handler, the content ResizeObserver, the
+ * reading-anchor restore, the streaming-start engage) must use this one
+ * function: during streaming the ResizeObserver re-samples on every token, so
+ * a single site using a looser threshold overrides the others and re-engages
+ * pin-to-bottom too early on short viewports (BE2).
+ */
+export const bottomThresholdFor = (el: HTMLElement): number =>
+  el.clientHeight < SHORT_VIEWPORT_PX ? MOBILE_BOTTOM_THRESHOLD : BOTTOM_THRESHOLD;
+
 /** The largest scrollTop the browser will allow: the very end of the padded
  *  scroll range. For a chat whose last turn is short, the dynamic `paddingEnd`
  *  makes this exactly the anchored-turn rest position (last user message at


### PR DESCRIPTION
Cherry-picks #277 (SCU-1772) into the 0.42.0 release branch — reliable chat scroll restore across remounts and reloads, plus persisting scroll positions in localStorage so app restarts restore them.

## Included (full commit set from #277's merge)
- `5b97a3d7340` fix(chat): reliable scroll restore across remounts and reloads
- `18af05fc3fb` Address Copilot review: drop (BE2) shorthand, test sessionStorage rehydration
- `19f617d2f12` Persist chat scroll positions in localStorage so app restarts restore them

Each SHA is the original commit on `main`. Clean cherry-pick, no conflicts — all in the alpha-chat scroll subsystem, which had zero intervening changes on the 0.42 branch since the cut.

After this merges, `just fixup` on the release branch will tag rc2.

(Sent by Claude)