### PR TITLE
[SCU-1790] fix(chat): hold scroll restore for late-arriving messages; don't persist programmatic scrolls

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/AlphaChatInterface.tsx
@@ -176,7 +176,9 @@ export const AlphaChatInterface = ({
 
   // Set true before any programmatic scroll of the chat container so
   // ChatScrollProvider doesn't dismiss popovers on it. Cleared by
-  // useAlphaAutoScroll.handleScroll after it consumes the scroll event.
+  // useAlphaAutoScroll.handleScroll in a microtask after the flagged scroll
+  // event, so every listener of that event (including the persistence save
+  // handler) sees the classification.
   const isProgrammaticScrollRef = useRef(false);
 
   // Single owner of scroll state (authority + layout settle + suppression).
@@ -214,7 +216,14 @@ export const AlphaChatInterface = ({
 
   // Scroll position persistence per task
   const filteredMessageRefs = useMemo(() => filteredNodes.map((n) => ({ id: n.message.id })), [filteredNodes]);
-  useAlphaScrollPersistence(scrollContainerRef, virtualizer, taskID, filteredMessageRefs, scrollMachine);
+  useAlphaScrollPersistence(
+    scrollContainerRef,
+    virtualizer,
+    taskID,
+    filteredMessageRefs,
+    scrollMachine,
+    isProgrammaticScrollRef,
+  );
 
   // Prompt navigation: ArrowUp/Down to cycle through user prompts
   const filteredChatMessages = useMemo(() => filteredNodes.map((n) => n.message), [filteredNodes]);

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaAutoScroll.test.ts
@@ -647,7 +647,7 @@ describe("useAlphaAutoScroll", () => {
     expect(virtualizer.scrollToIndex).not.toHaveBeenCalled();
   });
 
-  it("re-engages when user scrolls to exact bottom during streaming", () => {
+  it("re-engages when user scrolls to exact bottom during streaming", async () => {
     // After disengaging, if the user scrolls all the way to the bottom
     // (distance ≈ 0), auto-scroll should re-engage — this is an intentional
     // gesture to resume following the stream.
@@ -660,9 +660,12 @@ describe("useAlphaAutoScroll", () => {
     // Engaged via isStreaming effect
     expect(result.current.isEngaged).toBe(true);
 
-    // User scrolls away → disengage
+    // User scrolls away → disengage. Async act: the engage pin flagged a
+    // programmatic scroll which swallows this first scroll event; the flag
+    // clears in a microtask, so the await provides the task boundary that
+    // separates real browser scroll events.
     setScrollPosition(el, 500, 2000);
-    act(() => {
+    await act(async () => {
       el.dispatchEvent(new Event("wheel"));
       el.dispatchEvent(new Event("scroll"));
     });
@@ -911,7 +914,7 @@ describe("useAlphaAutoScroll", () => {
       expect(result.current.isJumpSuppressed).toBe(true);
     });
 
-    it("filling phase exits on user scroll", () => {
+    it("filling phase exits on user scroll", async () => {
       const el = createMockScrollContainer(1500, 2000, 500);
       const ref = { current: el };
       const virtualizer = createMockVirtualizerWithFilling(300, 100);
@@ -948,7 +951,9 @@ describe("useAlphaAutoScroll", () => {
 
       // The scroll-to-top effect sets isProgrammaticScrollRef. Consume it
       // with a bare scroll event so it doesn't swallow the real user scroll.
-      act(() => {
+      // Async act: the flag clears in a microtask after the event, so the
+      // await provides the task boundary real browser scroll events have.
+      await act(async () => {
         el.dispatchEvent(new Event("scroll"));
       });
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
@@ -17,6 +17,11 @@ const createMockScrollContainer = (scrollTop: number, scrollHeight: number, clie
   return el;
 };
 
+const setScrollPosition = (el: HTMLDivElement, scrollTop: number, scrollHeight: number): void => {
+  Object.defineProperty(el, "scrollTop", { value: scrollTop, writable: true, configurable: true });
+  Object.defineProperty(el, "scrollHeight", { value: scrollHeight, writable: true, configurable: true });
+};
+
 const createMockVirtualItem = (index: number, start: number, size: number): VirtualItem => ({
   index,
   start,
@@ -64,9 +69,13 @@ describe("useAlphaScrollPersistence", () => {
     const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
     const store = createStore();
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     // Initial mount triggers restore
     act(() => {
@@ -89,9 +98,13 @@ describe("useAlphaScrollPersistence", () => {
     const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
     const store = createStore();
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     // Wait for restore to complete (double rAF) so the machine leaves `restoring`.
     act(() => {
@@ -132,9 +145,13 @@ describe("useAlphaScrollPersistence", () => {
       distanceFromBottom: 100, // within threshold
     });
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     act(() => {
       vi.advanceTimersByTime(16);
@@ -162,9 +179,13 @@ describe("useAlphaScrollPersistence", () => {
       distanceFromBottom: -300,
     });
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     act(() => {
       vi.advanceTimersByTime(16);
@@ -190,9 +211,13 @@ describe("useAlphaScrollPersistence", () => {
       distanceFromBottom: -600,
     });
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     act(() => {
       vi.advanceTimersByTime(16);
@@ -217,9 +242,13 @@ describe("useAlphaScrollPersistence", () => {
       distanceFromBottom: 800,
     });
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     act(() => {
       vi.advanceTimersByTime(16);
@@ -236,7 +265,7 @@ describe("useAlphaScrollPersistence", () => {
     const store = createStore();
     const machine = createScrollStateMachine();
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine), {
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }), {
       wrapper: wrapperFor(store),
     });
 
@@ -262,9 +291,13 @@ describe("useAlphaScrollPersistence", () => {
       distanceFromBottom: 800,
     });
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine()), {
-      wrapper: wrapperFor(store),
-    });
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, createScrollStateMachine(), { current: false }),
+      {
+        wrapper: wrapperFor(store),
+      },
+    );
 
     expect(virtualizer.scrollToIndex).toHaveBeenCalledTimes(1); // initial apply
     act(() => {
@@ -286,7 +319,7 @@ describe("useAlphaScrollPersistence", () => {
     });
     const machine = createScrollStateMachine();
 
-    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine), {
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }), {
       wrapper: wrapperFor(store),
     });
 
@@ -301,5 +334,151 @@ describe("useAlphaScrollPersistence", () => {
     // Re-assert skipped — the user's scroll is not clobbered.
     expect(virtualizer.scrollToIndex).toHaveBeenCalledTimes(1);
     expect(machine.getState().authority.kind).toBe("userControlled");
+  });
+
+  it("holds the restore pending until messages arrive, then applies it", () => {
+    // Right after a task switch the task-detail atom can still be cold: the
+    // chat renders with zero messages while the unified stream fills it in.
+    // The restore must wait for the messages instead of being skipped.
+    const el = createMockScrollContainer(0, 2000, 500);
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer([createMockVirtualItem(1, 200, 200)]);
+    const store = createStore();
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-2",
+      pixelOffset: 50,
+      distanceFromBottom: 800,
+    });
+    const machine = createScrollStateMachine();
+    const loadedMessages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: Array<{ id: string }> }) =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }),
+      { wrapper: wrapperFor(store), initialProps: { messages: [] as Array<{ id: string }> } },
+    );
+
+    // The wait is armed: the machine already owns the window (suppressing
+    // saves), but nothing has been applied against the empty list.
+    expect(machine.getState().authority.kind).toBe("restoring");
+    expect(virtualizer.scrollToIndex).not.toHaveBeenCalled();
+    expect(el.scrollTop).toBe(0);
+
+    // Messages arrive — the pending restore fires against them.
+    rerender({ messages: loadedMessages });
+    expect(virtualizer.scrollToIndex).toHaveBeenCalledWith(1, { align: "start" });
+
+    act(() => {
+      vi.advanceTimersByTime(48);
+    });
+    expect(machine.getState().authority.kind).toBe("userControlled");
+  });
+
+  it("does not overwrite the saved position while the restore is pending", () => {
+    // The interim landing before messages arrive (content mounting, pins
+    // against estimates) fires scroll events; none of them may clobber the
+    // saved position the pending restore has yet to read.
+    const el = createMockScrollContainer(0, 2000, 500);
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer([createMockVirtualItem(0, 0, 200)]);
+    const store = createStore();
+    const saved = {
+      firstVisibleMessageId: "msg-2",
+      pixelOffset: 50,
+      distanceFromBottom: 800,
+    };
+    store.set(alphaScrollPositionAtomFamily("task-1"), saved);
+
+    renderHook(
+      () => useAlphaScrollPersistence(ref, virtualizer, "task-1", [], createScrollStateMachine(), { current: false }),
+      { wrapper: wrapperFor(store) },
+    );
+
+    act(() => {
+      setScrollPosition(el, 700, 2000);
+      el.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(48);
+    });
+
+    expect(store.get(alphaScrollPositionAtomFamily("task-1"))).toEqual(saved);
+  });
+
+  it("skips the pending restore when the user scrolls during the wait", () => {
+    const el = createMockScrollContainer(0, 2000, 500);
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer([createMockVirtualItem(1, 200, 200)]);
+    const store = createStore();
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-2",
+      pixelOffset: 50,
+      distanceFromBottom: 800,
+    });
+    const machine = createScrollStateMachine();
+
+    const { rerender } = renderHook(
+      ({ messages }: { messages: Array<{ id: string }> }) =>
+        useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }),
+      { wrapper: wrapperFor(store), initialProps: { messages: [] as Array<{ id: string }> } },
+    );
+
+    // The user takes over before the messages land.
+    act(() => {
+      machine.dispatch({ kind: "userScrolled" });
+    });
+
+    rerender({ messages: [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }] });
+
+    // Their position wins: the late restore never fires.
+    expect(virtualizer.scrollToIndex).not.toHaveBeenCalled();
+    expect(machine.getState().authority.kind).toBe("userControlled");
+  });
+
+  it("does not save positions produced by programmatic scrolls", () => {
+    const el = createMockScrollContainer(300, 2000, 500);
+    const ref = { current: el };
+    const virtualItems = [
+      createMockVirtualItem(0, 0, 200),
+      createMockVirtualItem(1, 200, 200),
+      createMockVirtualItem(2, 400, 200),
+    ];
+    const virtualizer = createMockVirtualizer(virtualItems);
+    const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+    const store = createStore();
+    const isProgrammaticScrollRef = { current: false };
+
+    renderHook(
+      () =>
+        useAlphaScrollPersistence(
+          ref,
+          virtualizer,
+          "task-1",
+          messages,
+          createScrollStateMachine(),
+          isProgrammaticScrollRef,
+        ),
+      { wrapper: wrapperFor(store) },
+    );
+
+    // Let the mount restore settle so the machine no longer suppresses saves.
+    act(() => {
+      vi.advanceTimersByTime(48);
+    });
+
+    // A pin / TanStack compensation scroll: flagged programmatic — not saved.
+    act(() => {
+      isProgrammaticScrollRef.current = true;
+      setScrollPosition(el, 300, 2000);
+      el.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(16);
+    });
+    expect(store.get(alphaScrollPositionAtomFamily("task-1"))).toBeNull();
+
+    // The same scroll from the user is saved.
+    act(() => {
+      isProgrammaticScrollRef.current = false;
+      el.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(16);
+    });
+    expect(store.get(alphaScrollPositionAtomFamily("task-1"))?.firstVisibleMessageId).toBe("msg-2");
   });
 });

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaAutoScroll.ts
@@ -300,7 +300,15 @@ export const useAlphaAutoScroll = (
       machine.setGeometryAtBottom(distance <= bottomThresholdFor(el));
 
       if (isProgrammaticScroll.current) {
-        isProgrammaticScroll.current = false;
+        // Clear in a microtask, not synchronously: other scroll listeners on
+        // this element (the persistence save handler) classify the SAME event
+        // by reading this flag, and listener order isn't guaranteed — both
+        // hooks re-register independently. A microtask runs after every
+        // listener of this event and before the next event's task, so the
+        // flag stays visible exactly for the one event it describes.
+        queueMicrotask(() => {
+          isProgrammaticScroll.current = false;
+        });
         return;
       }
 

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -1,6 +1,6 @@
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { useAtom } from "jotai";
-import type { RefObject } from "react";
+import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { alphaScrollPositionAtomFamily } from "~/common/state/atoms/alphaScroll.ts";
@@ -27,10 +27,14 @@ export const useAlphaScrollPersistence = (
   taskId: string,
   filteredMessages: ReadonlyArray<MessageRef>,
   machine: ScrollStateMachine,
+  isProgrammaticScrollRef: MutableRefObject<boolean>,
 ): void => {
   const [scrollPosition, setScrollPosition] = useAtom(alphaScrollPositionAtomFamily(taskId));
   const prevTaskIdRef = useRef(taskId);
   const pendingRafsRef = useRef(new Set<number>());
+  // A restore that arrived before the task's messages did (cold task-detail
+  // atom right after a switch). Held until the first non-empty message list.
+  const pendingRestoreRef = useRef(false);
 
   // Save scroll position (rAF-debounced)
   useEffect(() => {
@@ -43,6 +47,15 @@ export const useAlphaScrollPersistence = (
       // Don't record positions the restore itself produces — the machine is in
       // `restoring` for the whole restore window.
       if (machine.getState().authority.kind === "restoring") return;
+      // Nor positions produced by other programmatic scrolls: pin-to-bottom
+      // writes and TanStack's per-item scroll compensation flag themselves
+      // here, and mid-measurement compensation in particular lands at
+      // positions the user never chose — recording one overwrites the real
+      // reading position. The flag is cleared in a microtask (after every
+      // listener of this event has run), so this read is safe regardless of
+      // listener registration order. Sampled at event time: the rAF below
+      // runs after the microtask clear.
+      if (isProgrammaticScrollRef.current) return;
 
       if (rafId !== null) cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => {
@@ -75,7 +88,7 @@ export const useAlphaScrollPersistence = (
       el.removeEventListener("scroll", handleScroll);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [scrollContainerRef, virtualizer, filteredMessages, setScrollPosition, machine]);
+  }, [scrollContainerRef, virtualizer, filteredMessages, setScrollPosition, machine, isProgrammaticScrollRef]);
 
   // Apply the saved scroll position to the container. Resolves the saved anchor
   // (message index + pixel offset, or distance-from-bottom) against the
@@ -126,13 +139,26 @@ export const useAlphaScrollPersistence = (
   // Restore scroll position on task switch
   const restore = useCallback(() => {
     const el = scrollContainerRef.current;
-    if (!el || filteredMessages.length === 0) return;
+    if (!el) return;
 
     // Cancel any in-flight rAFs from a previous restore call
     cancelPendingRafs(pendingRafsRef.current);
     // Enter `restoring`: the machine now owns "a restore is in flight", which
     // suppresses position saves and is reflected to the DOM as data-scroll-phase.
     machine.dispatch({ kind: "taskSwitched", taskId });
+
+    // The task's messages may not have arrived yet (the task-detail atom is
+    // cold right after a switch and the unified stream fills it a beat later).
+    // There is nothing to resolve the saved anchor against, so hold the
+    // restore pending — the message-arrival effect below fires it on the first
+    // non-empty list. Entering `restoring` above is what makes the wait safe:
+    // the interim landing (content mounting, estimate-based pins) fires scroll
+    // events that must not overwrite the saved position we have yet to read.
+    if (filteredMessages.length === 0) {
+      pendingRestoreRef.current = true;
+      return;
+    }
+    pendingRestoreRef.current = false;
 
     // First apply: resolves the anchor against the virtualizer's *estimated*
     // heights — on a task switch the virtualizer is mid-settle and the items
@@ -176,6 +202,18 @@ export const useAlphaScrollPersistence = (
       restore();
     }
   }, [taskId, restore]);
+
+  // Fire a pending restore the moment the task's messages arrive. Pre-paint
+  // for the same reason as the restores above. Skipped (and cleared) if the
+  // user already scrolled during the wait: their position wins over the saved
+  // one, exactly like the settled restore's re-assert courtesy.
+  useLayoutEffect(() => {
+    if (!pendingRestoreRef.current || filteredMessages.length === 0) return;
+    pendingRestoreRef.current = false;
+    if (machine.getState().authority.kind === "restoring") {
+      restore();
+    }
+  }, [filteredMessages, machine, restore]);
 
   // Initial restore on mount; cancel pending rAFs on unmount. A layout effect
   // for the same reason as the task-switch restore above: on mobile every


### PR DESCRIPTION
## Summary

Follow-up to #277 (SCU-1772), fixing [SCU-1790](https://linear.app/imbue/issue/SCU-1790/chat-scroll-restore-skipped-when-messages-load-after-a-task-switch): persistent wrong scroll landings when switching between long-conversation workspaces — the view lands several prompts above the bottom, the broken state survives clicking Jump, and each affected workspace reproduces it on every visit. Diagnosed from a live repro; the mechanism is three compounding legs, two of which this PR closes.

### 1. The restore was silently skipped when messages hadn't loaded yet — and never retried

`useAlphaScrollPersistence.restore()` early-returned on an empty message list *before* entering `restoring`. Right after a workspace switch the task-detail atom is cold and the unified stream fills it a beat later, so the chat's first renders have zero messages — the whole visit then ran **unrestored**: the saved position (including a correct at-bottom one that Jump just wrote) was never read, and the interim landing (a one-shot pin against cold 120px height estimates that real measurements then outgrow) stranded the view mid-history.

The restore now dispatches `taskSwitched` immediately — suppressing saves for the wait — and holds **pending** until the first non-empty message list, applied pre-paint on the render where messages arrive. If the user scrolls during the wait, their position wins and the pending restore is dropped, mirroring the settled restore's re-assert courtesy. A genuinely empty task simply stays in `restoring` until its first message (a user's first prompt exits via `newUserTurn` → anchoring, as before).

### 2. Programmatic scrolls were saved as reading positions

The save handler skipped scroll events only while `restoring`. Pin-to-bottom writes and TanStack's per-item scroll compensation fire scroll events indistinguishable from user input, and mid-measurement compensation lands at positions the user never chose — recording one **overwrites the real reading position**. That's what made the broken state sticky: every unrestored visit re-poisoned the store, defeating Jump.

Saves now skip events flagged by `isProgrammaticScrollRef` (already set by every pin site and the virtualizer's compensation wrapper). The flag's consume-once clear in `useAlphaAutoScroll` moves to a microtask so all listeners of the flagged event see the classification regardless of registration order — the two hooks re-register their listeners independently, so order isn't stable. Real scroll events are separate tasks, so the microtask always runs between events; two auto-scroll tests that compressed two scroll events into one synchronous block gain the task boundary via `await act(async ...)`.

### Leg 3 (not in this PR)

Cold-first-visit landings can still be off before the double-rAF re-assert converges — that's the SCU-1686 settle-sweep work. With legs 1–2 fixed, that residue no longer gets *persisted*.

Ruled out during diagnosis: localStorage/sessionStorage pollution from older builds (sessionStorage-era entries are orphaned and never read; pre-SCU-1673 unsigned `distanceFromBottom` values restore correctly under the signed arithmetic).

## Testing

- New unit tests: pending restore applies when messages arrive (and the machine owns the window meanwhile), saves suppressed while pending, user scroll during the wait wins, programmatic scroll events are not saved.
- Full frontend suite: 2899 passed / 1 skipped; `tsc`, `eslint`, pre-commit `just` checks green.

(Sent by Claude)
