### PR TITLE
Tint selected sidebar icon with the accent color (SCU-1797)

### DIFF
--- a/sculptor/frontend/src/components/nav/NavItem.module.scss
+++ b/sculptor/frontend/src/components/nav/NavItem.module.scss
@@ -53,9 +53,10 @@
   color: var(--accent-11);
 }
 
-// Dim the leading icon in step with the disabled label. Kept flat (and after
-// `.navIcon`, at equal specificity to the active rule so disabled wins) so
-// selector specificity stays in source order for stylelint.
+// Dim the leading icon in step with the disabled label. The `:disabled`
+// pseudo-class makes this more specific than `.navItemActive .navIcon`, so it
+// wins for an active-and-disabled row. Kept flat and after the active rule so
+// specificity stays non-descending in source order for stylelint.
 .navItem:disabled .navIcon {
   color: var(--gray-8);
 }

--- a/sculptor/frontend/src/components/nav/NavItem.module.scss
+++ b/sculptor/frontend/src/components/nav/NavItem.module.scss
@@ -46,8 +46,16 @@
   flex-shrink: 0;
 }
 
+// Tint the leading icon with the accent color when the row is selected, matching
+// the accent label. The icon sets an explicit color (rather than inheriting
+// currentColor), so the active state has to restate it here.
+.navItemActive .navIcon {
+  color: var(--accent-11);
+}
+
 // Dim the leading icon in step with the disabled label. Kept flat (and after
-// `.navIcon`) so selector specificity stays in source order for stylelint.
+// `.navIcon`, at equal specificity to the active rule so disabled wins) so
+// selector specificity stays in source order for stylelint.
 .navItem:disabled .navIcon {
   color: var(--gray-8);
 }


### PR DESCRIPTION
## Summary

When a sidebar item is selected, its icon stayed gray while the label turned accent-tinted. This fixes the icon to use the same accent color as the selected label.

Fixes SCU-1797.

## Root cause

In `NavItem.module.scss`, the leading `.navIcon` sets an explicit `color: var(--gray-11)`, which overrides the inherited `currentColor`. The selected state (`.navItemActive`) switches the label to `var(--accent-11)` — the label inherits it via `currentColor` — but there was no active-state override for the icon, so it stayed pinned to gray.

## Fix

Add a `.navItemActive .navIcon` rule that restates the icon color as `var(--accent-11)`, matching the selected label. It's placed after `.navIcon` and before the existing `:disabled` icon rule so source-order specificity is preserved (stylelint) and disabled still wins when a row is both active and disabled.

## Verification

Verified end-to-end in the browser QA harness by reading computed styles. Note the harness build ships a **gray accent** (`data-accent-color="gray"`), so `--accent-11` equals `--gray-11` there and the change is invisible under that theme. Forcing a non-gray (violet) accent proves it:

- Selected icon and label both compute to the accent color (`#baa7ff`).
- Unselected icons stay gray (`#606060`).

Before/after screenshots (rendered under a violet accent so the accent-vs-gray difference is visible) are attached to SCU-1797.

(Sent by Claude)