### PR TITLE
Show workspace title in the top bar when the left sidebar is collapsed

### DIFF
--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.module.scss
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.module.scss
@@ -10,20 +10,12 @@
   padding: var(--space-1) var(--space-4);
 }
 
-// Workspace title in the header (shown only when the sidebar is collapsed).
-// Mirrors the branch pill's text metrics (same font-size and inherited
-// line-height) so the two read as one row: the header centers its items, and
-// matching type metrics make that center-alignment coincide with a shared
-// baseline. min-width:0 + ellipsis so it truncates instead of pushing the rest
-// of the bar.
+// Type and truncation come from the Radix <Text size weight truncate>; this
+// only adds the flex-specific min-width:0 so the title can shrink and ellipsize
+// (a flex item's default min-width:auto would otherwise let it push the rest of
+// the bar off the overflow-hidden header).
 .workspaceTitle {
-  color: var(--gray-12);
-  font-size: var(--font-size-1);
-  font-weight: var(--font-weight-medium);
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 // A <button>, so neutralize the UA button chrome; the inner spans carry their

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.module.scss
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.module.scss
@@ -12,6 +12,22 @@
 
 // A <button>, so neutralize the UA button chrome; the inner spans carry their
 // own colors and the mono font.
+// Workspace title in the header (shown only when the sidebar is collapsed).
+// Mirrors the branch pill's text metrics (same font-size and inherited
+// line-height) so the two read as one row: the header centers its items, and
+// matching type metrics make that center-alignment coincide with a shared
+// baseline. min-width:0 + ellipsis so it truncates instead of pushing the rest
+// of the bar.
+.workspaceTitle {
+  color: var(--gray-12);
+  font-size: var(--font-size-1);
+  font-weight: var(--font-weight-medium);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .branchSection {
   align-items: center;
   background: transparent;

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.module.scss
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.module.scss
@@ -10,8 +10,6 @@
   padding: var(--space-1) var(--space-4);
 }
 
-// A <button>, so neutralize the UA button chrome; the inner spans carry their
-// own colors and the mono font.
 // Workspace title in the header (shown only when the sidebar is collapsed).
 // Mirrors the branch pill's text metrics (same font-size and inherited
 // line-height) so the two read as one row: the header centers its items, and
@@ -28,6 +26,8 @@
   white-space: nowrap;
 }
 
+// A <button>, so neutralize the UA button chrome; the inner spans carry their
+// own colors and the mono font.
 .branchSection {
   align-items: center;
   background: transparent;

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
@@ -232,7 +232,7 @@ const WorkspaceHeaderComponent = (): ReactElement | null => {
         <Text
           as="span"
           size="1"
-          weight="medium"
+          weight="bold"
           truncate
           className={styles.workspaceTitle}
           data-testid={ElementIds.WORKSPACE_HEADER_TITLE}

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
@@ -227,12 +227,13 @@ const WorkspaceHeaderComponent = (): ReactElement | null => {
       </Flex>
 
       {/* Workspace title — only when the left sidebar is collapsed, since the sidebar
-          otherwise shows the workspace name. Mirrors the sidebar's label source and
-          "Untitled" fallback. Allowed to shrink/truncate so a long name doesn't push
-          the branch pill and right-side controls out of the overflow-hidden bar. */}
+          otherwise shows the workspace name. Mirrors the sidebar's label source, and
+          falls back to "Untitled" for a null/blank name so this prominent slot never
+          renders empty. Allowed to shrink/truncate so a long name doesn't push the
+          branch pill and right-side controls out of the overflow-hidden bar. */}
       {isSidebarCollapsed && (
         <span className={styles.workspaceTitle} data-testid={ElementIds.WORKSPACE_HEADER_TITLE}>
-          {workspace.description ?? "Untitled"}
+          {(workspace.description ?? "").trim() || "Untitled"}
         </span>
       )}
 

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
@@ -226,6 +226,16 @@ const WorkspaceHeaderComponent = (): ReactElement | null => {
         />
       </Flex>
 
+      {/* Workspace title — only when the left sidebar is collapsed, since the sidebar
+          otherwise shows the workspace name. Mirrors the sidebar's label source and
+          "Untitled" fallback. Allowed to shrink/truncate so a long name doesn't push
+          the branch pill and right-side controls out of the overflow-hidden bar. */}
+      {isSidebarCollapsed && (
+        <span className={styles.workspaceTitle} data-testid={ElementIds.WORKSPACE_HEADER_TITLE}>
+          {workspace.description ?? "Untitled"}
+        </span>
+      )}
+
       {/* Branch pill: a real button so it is focusable and Enter/Space-activatable
           for free; the visible label is the branch name, so the aria-label spells
           out what pressing it does. */}

--- a/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspaceHeader.tsx
@@ -1,4 +1,4 @@
-import { Badge, Flex, Skeleton, Tooltip } from "@radix-ui/themes";
+import { Badge, Flex, Skeleton, Text, Tooltip } from "@radix-ui/themes";
 import { useAtomValue, useSetAtom } from "jotai";
 import { GitBranchIcon, PanelBottom, PanelLeft, PanelRight } from "lucide-react";
 import type { ReactElement } from "react";
@@ -226,15 +226,19 @@ const WorkspaceHeaderComponent = (): ReactElement | null => {
         />
       </Flex>
 
-      {/* Workspace title — only when the left sidebar is collapsed, since the sidebar
-          otherwise shows the workspace name. Mirrors the sidebar's label source, and
-          falls back to "Untitled" for a null/blank name so this prominent slot never
-          renders empty. Allowed to shrink/truncate so a long name doesn't push the
-          branch pill and right-side controls out of the overflow-hidden bar. */}
+      {/* Only shown when the sidebar is collapsed — it otherwise carries the name.
+          "Untitled" guards a blank name so this slot never renders empty. */}
       {isSidebarCollapsed && (
-        <span className={styles.workspaceTitle} data-testid={ElementIds.WORKSPACE_HEADER_TITLE}>
+        <Text
+          as="span"
+          size="1"
+          weight="medium"
+          truncate
+          className={styles.workspaceTitle}
+          data-testid={ElementIds.WORKSPACE_HEADER_TITLE}
+        >
           {(workspace.description ?? "").trim() || "Untitled"}
-        </span>
+        </Text>
       )}
 
       {/* Branch pill: a real button so it is focusable and Enter/Space-activatable

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -619,6 +619,9 @@ class ElementIDs(StrEnum):
     # Workspace header (the simplified top bar above the section grid): branch
     # pill + section collapse/expand toggles + re-homed PR button / diff summary.
     WORKSPACE_HEADER = "WORKSPACE_HEADER"
+    # The workspace title shown in the header. Only rendered when the left sidebar
+    # is collapsed (the sidebar otherwise carries the workspace name).
+    WORKSPACE_HEADER_TITLE = "WORKSPACE_HEADER_TITLE"
     HEADER_SECTION_TOGGLE_LEFT = "HEADER_SECTION_TOGGLE_LEFT"
     HEADER_SECTION_TOGGLE_RIGHT = "HEADER_SECTION_TOGGLE_RIGHT"
     HEADER_SECTION_TOGGLE_BOTTOM = "HEADER_SECTION_TOGGLE_BOTTOM"


### PR DESCRIPTION
## What

When the left sidebar is collapsed, the workspace name is no longer visible anywhere in the UI. This surfaces the current workspace title in the workspace top bar (`WorkspaceHeader`) so the user always knows which workspace they're in — but **only when the sidebar is collapsed**, since an open sidebar already shows the name.

## Details

- The title renders in the header's left cluster, right after the sidebar toggle and before the branch pill, gated on the existing `sidebarCollapsedAtom`.
- It reuses the sidebar's label source (`workspace.description`) and falls back to `"Untitled"` for a null/blank name, so this prominent slot never renders empty.
- Its text metrics mirror the adjacent branch pill (`font-size-1`, medium weight) so the two labels share a baseline and read as one row.
- It truncates with an ellipsis (`min-width: 0`) so a long name can't push the branch pill and right-side controls off the overflow-hidden bar.
- Adds a `WORKSPACE_HEADER_TITLE` element id for testing.

## Behavior

| Sidebar state | Header title |
|---|---|
| Open | Hidden (name shown in the sidebar) |
| Collapsed | Workspace title shown |

## Testing

- Verified end-to-end in the headless-browser QA harness: title absent with the sidebar open, present when collapsed, sharing a baseline with the branch name, and truncating cleanly at a narrow (760px) viewport with all controls still reachable.
- `just format`, `just check`, and `just test-unit` all pass.

Ticket: SCU-1794

(Sent by Claude)