### PR TITLE
[SCU-1798] Fix reorder of a tall expanded project in the sidebar

### DIFF
--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.module.scss
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.module.scss
@@ -228,6 +228,42 @@ $row-min-height: 28px;
   }
 }
 
+// The item the dragged element will land against carries a drop-side hint ("before" = it
+// lands above this item, "after" = below) while it is the drop target. There is no floating
+// placeholder — the dragged element slides in place — so draw a small accent insertion line
+// on that edge to show where a release will land.
+//
+// The line must sit at the target's OUTER edge, so it's drawn on the element that spans the
+// target's full height: `.repoGroup` for a group drag (its header carries the hint, but the
+// whole group — header + rows — is what's tall, so a line on the header alone would fall
+// inside a tall group), and `.workspaceRow` for a row drag (rows are uniform height). The
+// two hints use different attribute names so `.repoGroup:has(...)` doesn't also match a row
+// drop-side nested inside it.
+.repoGroup:has([data-sidebar-group-drop-side]),
+.workspaceRow:has([data-sidebar-drop-side]) {
+  position: relative;
+}
+
+.repoGroup:has([data-sidebar-group-drop-side])::after,
+.workspaceRow:has([data-sidebar-drop-side])::after {
+  background: var(--accent-9);
+  border-radius: var(--radius-1);
+  content: "";
+  height: 2px;
+  inset-inline: var(--space-2);
+  position: absolute;
+}
+
+.repoGroup:has([data-sidebar-group-drop-side="before"])::after,
+.workspaceRow:has([data-sidebar-drop-side="before"])::after {
+  top: -1px;
+}
+
+.repoGroup:has([data-sidebar-group-drop-side="after"])::after,
+.workspaceRow:has([data-sidebar-drop-side="after"])::after {
+  bottom: -1px;
+}
+
 .workspaceDot {
   align-items: center;
   display: flex;

--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -13,7 +13,7 @@
 // cross-repo drops structurally impossible rather than merely rejected.
 
 import type { DragEndEvent } from "@dnd-kit/core";
-import { closestCenter, DndContext } from "@dnd-kit/core";
+import { DndContext } from "@dnd-kit/core";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { ContextMenu, DropdownMenu, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
@@ -42,7 +42,7 @@ import { WorkspaceStatusDots } from "~/components/statusDot";
 import { ToastType } from "~/components/Toast.tsx";
 
 import { adjustSidebarDragCountAtom, collapsedRepoGroupsAtom, isRepoCollapsedAtomFamily } from "./navAtoms.ts";
-import { sidebarDndModifiers, useSidebarDndSensors } from "./sidebarDnd.ts";
+import { sidebarCollisionDetection, sidebarDndModifiers, useSidebarDndSensors } from "./sidebarDnd.ts";
 import styles from "./SidebarRepoGroup.module.scss";
 import type { RepoGroup } from "./sidebarWorkspaceOrder.ts";
 import { reorderSidebarWorkspaceAtom } from "./sidebarWorkspaceOrder.ts";
@@ -463,7 +463,7 @@ export const SidebarRepoGroup = ({
         <div className={styles.repoRows}>
           <DndContext
             sensors={rowDndSensors}
-            collisionDetection={closestCenter}
+            collisionDetection={sidebarCollisionDetection}
             modifiers={sidebarDndModifiers}
             onDragStart={beginOwnedDrag}
             onDragEnd={handleRowDragEnd}

--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -89,11 +89,26 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
   onBeginDelete: (workspace: Workspace) => void;
 }): ReactElement {
   const status = useAtomValue(workspaceDotStatusAtomFamily(workspace.objectId));
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging, isOver } =
-    useSortable({
-      id: workspace.objectId,
-      disabled: isRenaming,
-    });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+    activeIndex,
+    overIndex,
+  } = useSortable({
+    id: workspace.objectId,
+    disabled: isRenaming,
+  });
+
+  // Which edge of this row the dragged row will land against, for the drop-indicator
+  // line: "after" (below) when dragging down onto it, "before" (above) when dragging up.
+  // Only meaningful while this row is the drop target (isOver, and not itself dragged).
+  const dropSide = isOver && !isDragging ? (activeIndex < overIndex ? "after" : "before") : undefined;
 
   // Enter navigates from the keyboard, like a click. Space is deliberately NOT
   // handled here: it falls through to the dnd-kit keyboard sensor's activator
@@ -161,6 +176,7 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
               // row whose slot the drag currently targets is marked as the drop target.
               data-sidebar-dragging={isDragging ? "true" : undefined}
               data-sidebar-drop-target={isOver && !isDragging ? "true" : undefined}
+              data-sidebar-drop-side={dropSide}
               data-workspace-tab
               data-tab-id={workspace.objectId}
             >
@@ -287,7 +303,14 @@ export const SidebarRepoGroup = ({
     transition: groupTransition,
     isDragging: isGroupDragging,
     isOver: isGroupOver,
+    activeIndex: groupActiveIndex,
+    overIndex: groupOverIndex,
   } = useSortable({ id: group.projectId });
+
+  // Which edge of this group the dragged group will land against, for the drop-indicator
+  // line (see the row's dropSide). Only meaningful while this group is the drop target.
+  const groupDropSide =
+    isGroupOver && !isGroupDragging ? (groupActiveIndex < groupOverIndex ? "after" : "before") : undefined;
 
   // The rows' own drag context; see the module comment for why it lives per group.
   const rowDndSensors = useSidebarDndSensors();
@@ -396,6 +419,7 @@ export const SidebarRepoGroup = ({
           data-project-id={group.projectId}
           data-sidebar-dragging={isGroupDragging ? "true" : undefined}
           data-sidebar-drop-target={isGroupOver && !isGroupDragging ? "true" : undefined}
+          data-sidebar-group-drop-side={groupDropSide}
         >
           <Chevron size={16} className={styles.repoChevron} />
           <Text className={styles.repoName} truncate>

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
@@ -1,5 +1,5 @@
 import type { DragEndEvent } from "@dnd-kit/core";
-import { closestCenter, DndContext } from "@dnd-kit/core";
+import { DndContext } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { IconButton, Tooltip } from "@radix-ui/themes";
 import { useAtomValue, useSetAtom, useStore } from "jotai";
@@ -37,7 +37,7 @@ import { WorkspacePeekOverlay } from "~/pages/workspace/components/WorkspacePeek
 import { adjustSidebarDragCountAtom, isSidebarDragActiveAtom } from "./navAtoms.ts";
 import navItemStyles from "./NavItem.module.scss";
 import { NavItem } from "./NavItem.tsx";
-import { sidebarDndModifiers, useSidebarDndSensors } from "./sidebarDnd.ts";
+import { sidebarCollisionDetection, sidebarDndModifiers, useSidebarDndSensors } from "./sidebarDnd.ts";
 import { SidebarRepoGroup } from "./SidebarRepoGroup.tsx";
 import { reorderSidebarRepoGroupAtom, sidebarWorkspaceGroupsAtom } from "./sidebarWorkspaceOrder.ts";
 import styles from "./WorkspaceSidebar.module.scss";
@@ -292,7 +292,7 @@ export const WorkspaceSidebar = (): ReactElement | null => {
             "Add repo" button in the bottom actions. */}
           <DndContext
             sensors={groupDndSensors}
-            collisionDetection={closestCenter}
+            collisionDetection={sidebarCollisionDetection}
             modifiers={sidebarDndModifiers}
             onDragStart={beginOwnedDrag}
             onDragEnd={handleGroupDragEnd}

--- a/sculptor/frontend/src/components/nav/sidebarDnd.test.ts
+++ b/sculptor/frontend/src/components/nav/sidebarDnd.test.ts
@@ -1,0 +1,84 @@
+import type { CollisionDetection } from "@dnd-kit/core";
+import { describe, expect, it } from "vitest";
+
+import { sidebarCollisionDetection } from "./sidebarDnd.ts";
+
+type CollisionArgs = Parameters<CollisionDetection>[0];
+type TestRect = { left: number; top: number; width: number; height: number; right: number; bottom: number };
+
+const rect = (left: number, top: number, width: number, height: number): TestRect => ({
+  left,
+  top,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+});
+
+// The collision keys off the dragged element's (modifier-clamped) collisionRect, not the
+// pointer, so each case passes the rect the dragged item currently occupies and a non-null
+// pointer just to select the pointer-drag branch. `rects` is the droppable layout.
+const buildArgs = (
+  collisionRect: TestRect,
+  rects: Map<string, TestRect>,
+  pointer: { x: number; y: number } | null = { x: 0, y: 0 },
+): CollisionArgs =>
+  ({
+    active: { id: "active", rect: { current: { initial: null, translated: collisionRect } }, data: { current: {} } },
+    collisionRect,
+    droppableRects: rects,
+    droppableContainers: [...rects.keys()].map((id) => ({ id, rect: { current: rects.get(id) } })),
+    pointerCoordinates: pointer,
+  }) as unknown as CollisionArgs;
+
+// A tall expanded group (height 400) stacked above a short single-workspace group (height
+// 40). restrictToParentElement lets the tall group slide down by at most the short group's
+// height (40px) before its bottom hits the list bottom.
+const tallOverShort = new Map([
+  ["tall", rect(0, 0, 250, 400)],
+  ["short", rect(0, 400, 250, 40)],
+]);
+
+describe("sidebarCollisionDetection", () => {
+  it("keeps a small drag of a tall group on itself (below the crossover)", () => {
+    // Dragged down 10px: the tall group still covers almost all of its own slot, far more
+    // (as a fraction) than the sliver it covers of the short neighbour. over stays on self,
+    // which the drag-end handler treats as a no-op.
+    const collisions = sidebarCollisionDetection(buildArgs(rect(0, 10, 250, 400), tallOverShort));
+    expect(collisions[0]?.id).toBe("tall");
+  });
+
+  it("flips a tall group onto a short neighbour after about one of the neighbour's rows", () => {
+    // Dragged down to its clamp limit (40px, one short-row): the short neighbour is fully
+    // covered (fraction 1.0) and wins over the tall group's now-vacated slot. closestCenter
+    // could never reach this — the tall group's centre never nears the short one's.
+    const collisions = sidebarCollisionDetection(buildArgs(rect(0, 40, 250, 400), tallOverShort));
+    expect(collisions[0]?.id).toBe("short");
+  });
+
+  it("flips equal-height rows at half a row, like closestCenter", () => {
+    const rows = new Map([
+      ["a", rect(0, 0, 250, 40)],
+      ["b", rect(0, 40, 250, 40)],
+    ]);
+    // Row "a" dragged down 15px (< half): still mostly over its own slot.
+    expect(sidebarCollisionDetection(buildArgs(rect(0, 15, 250, 40), rows))[0]?.id).toBe("a");
+    // Dragged down 25px (> half): now mostly over "b".
+    expect(sidebarCollisionDetection(buildArgs(rect(0, 25, 250, 40), rows))[0]?.id).toBe("b");
+  });
+
+  it("never returns empty: a rect dragged clear of every item falls back to nearest centre", () => {
+    // Overlapping nothing (e.g. clamped into blank space) must still resolve, or `over` goes
+    // null and dnd-kit snaps the dragged item back to its origin. closestCenter resolves to
+    // the nearest item — the short group, whose centre is closest to the rect below it.
+    const collisions = sidebarCollisionDetection(buildArgs(rect(0, 500, 250, 400), tallOverShort));
+    expect(collisions[0]?.id).toBe("short");
+  });
+
+  it("resolves a keyboard drag (no pointer) via closestCenter", () => {
+    // With no pointer coordinates the sortable keyboard getter has already stepped the
+    // dragged rect onto the target slot; closestCenter resolves it by centre distance.
+    const collisions = sidebarCollisionDetection(buildArgs(rect(0, 40, 250, 400), tallOverShort, null));
+    expect(collisions[0]?.id).toBe("tall");
+  });
+});

--- a/sculptor/frontend/src/components/nav/sidebarDnd.ts
+++ b/sculptor/frontend/src/components/nav/sidebarDnd.ts
@@ -4,8 +4,8 @@
 // drag activator, so Playwright drives the real sensor pipeline (focus → Space →
 // arrows → Space) — mirroring the panel-tab drag architecture (PanelDndProvider).
 
-import type { SensorDescriptor, SensorOptions } from "@dnd-kit/core";
-import { KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import type { ClientRect, CollisionDetection, SensorDescriptor, SensorOptions } from "@dnd-kit/core";
+import { closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 
@@ -13,11 +13,65 @@ import { POINTER_DRAG_ACTIVATION_DISTANCE_PX } from "~/components/sections/panel
 
 // Both sidebar lists are vertical, so the dragged element is locked to its lane: it
 // slides only on the y axis and never leaves its container (a row stays inside its
-// group's rows box, a group inside the repo list). This deliberately diverges from
-// panel-tab drags, which must travel freely across sections. Drops still resolve by
-// pointer position even when the pointer itself wanders off the rail — only the
-// element's movement is constrained.
+// group's rows box, a group inside the repo list).
 export const sidebarDndModifiers = [restrictToVerticalAxis, restrictToParentElement];
+
+// The fraction of `target`'s OWN area that the dragged rect currently covers. dnd-kit's
+// built-in rectIntersection normalises the overlap by the UNION area, so a tall item's own
+// slot — which has by far the largest union — always wins and the item can never be dragged
+// onto a short neighbour. Normalising by the TARGET's area instead lets a small nudge flip a
+// large item onto a small one: a short neighbour is fully covered after roughly one of its
+// own rows, while the dragged item's own (equally tall) slot only stays ahead until it has
+// been mostly vacated. For equal-height rows the crossover is half a row — the same feel as
+// closestCenter.
+function coveredFractionOfTarget(dragged: ClientRect, target: ClientRect): number {
+  const overlapWidth =
+    Math.min(dragged.left + dragged.width, target.left + target.width) - Math.max(dragged.left, target.left);
+  const overlapHeight =
+    Math.min(dragged.top + dragged.height, target.top + target.height) - Math.max(dragged.top, target.top);
+  if (overlapWidth <= 0 || overlapHeight <= 0) {
+    return 0;
+  }
+  const targetArea = target.width * target.height;
+  return targetArea > 0 ? (overlapWidth * overlapHeight) / targetArea : 0;
+}
+
+// Resolve the drop target from the dragged element's RECTANGLE, scoring each item by the
+// fraction of its own area the dragged rect covers (see coveredFractionOfTarget). This
+// reorders a tall expanded group after a small drag toward a neighbour, while leaving
+// equal-height rows behaving like closestCenter.
+//
+// It keys off the modifier-clamped collisionRect — restrictToParentElement holds the dragged
+// element inside the list, so its rect always overlaps some item — rather than the raw
+// pointer. A drag past the container edge therefore stays pinned to the extreme item instead
+// of dropping `over`: a null `over` zeroes dnd-kit's active-item transform (it only offsets
+// the dragged item while overIndex is a valid index) and snaps the item back to its origin.
+// closestCenter — which never returns an empty result — is the final safety net.
+//
+// Keyboard drags have no pointer: the sortable keyboard getter steps the dragged rect onto
+// the target slot, so closestCenter resolves it exactly.
+export const sidebarCollisionDetection: CollisionDetection = (args) => {
+  if (args.pointerCoordinates === null) {
+    return closestCenter(args);
+  }
+  const { collisionRect, droppableRects, droppableContainers } = args;
+  const collisions: ReturnType<CollisionDetection> = [];
+  for (const droppableContainer of droppableContainers) {
+    const rect = droppableRects.get(droppableContainer.id);
+    if (rect === undefined) {
+      continue;
+    }
+    const value = coveredFractionOfTarget(collisionRect, rect);
+    if (value > 0) {
+      collisions.push({ id: droppableContainer.id, data: { droppableContainer, value } });
+    }
+  }
+
+  if (collisions.length > 0) {
+    return collisions.sort((first, second) => (second.data?.value ?? 0) - (first.data?.value ?? 0));
+  }
+  return closestCenter(args);
+};
 
 // The pointer sensor's distance constraint keeps plain clicks working on the
 // activator (navigate / toggle collapse); the keyboard sensor's sortable coordinate

--- a/sculptor/sculptor/testing/elements/workspace_sidebar.py
+++ b/sculptor/sculptor/testing/elements/workspace_sidebar.py
@@ -15,6 +15,25 @@ _REORDER_PICKUP_ATTEMPTS = 3
 # slot lights up as the drop target, and this bounds a drag that never gets there.
 _REORDER_MAX_ARROW_PRESSES = 6
 
+# A pointer drag aims at a point past the target's centre in the drag direction but
+# still inside its rect, so `over` resolves to the target (pointerWithin sorts by
+# distance to each containing droppable's centre) without overshooting past the rect
+# into empty space. Expressed as a fraction of the target's height: three-quarters
+# down when dragging downward, one-quarter down when dragging upward.
+_POINTER_DRAG_TARGET_FRACTION_FORWARD = 0.75
+_POINTER_DRAG_TARGET_FRACTION_BACKWARD = 0.25
+
+# The pointer move is broken into this many steps so dnd-kit's PointerSensor clears
+# its activation distance and recomputes `over` on each pointermove; a single jump to
+# the end would skip the intermediate collisions the sensor needs.
+_POINTER_DRAG_MOVE_STEPS = 24
+
+# How far past the target's far edge an overshoot drag drives the pointer — enough to
+# clear the list container so the drag exercises the "pointer past the container" path
+# (where the pointer must be clamped back to the extreme item, since the dragged element
+# is held inside the list but the pointer is not).
+_POINTER_DRAG_OVERSHOOT_PX = 160
+
 
 class PlaywrightWorkspaceSidebarElement(PlaywrightIntegrationTestElement):
     """Page Object Model for the workspace navigation sidebar.
@@ -64,6 +83,16 @@ class PlaywrightWorkspaceSidebarElement(PlaywrightIntegrationTestElement):
         check the wrong element.
         """
         return self.get_repo_groups().filter(has_text=name)
+
+    def get_repo_group_by_project_id(self, project_id: str) -> Locator:
+        """Get a repo-group header by its project id.
+
+        Unambiguous where names could collide or a name is unknown (e.g. the
+        harness's default repo). The header stamps ``data-project-id``; this raw
+        CSS-attribute scope stays inside the POM so the css-locator ratchet is
+        honoured at the call sites.
+        """
+        return self._page.locator(f'[data-testid="{ElementIDs.SIDEBAR_REPO_GROUP}"][data-project-id="{project_id}"]')
 
     def get_no_workspaces_hint(self) -> Locator:
         """The "No workspaces yet" hint shown under a repo group with no workspaces."""
@@ -154,6 +183,74 @@ class PlaywrightWorkspaceSidebarElement(PlaywrightIntegrationTestElement):
 
         # The drop clears the drag flag once the reorder commits; asserting it here
         # keeps callers from racing their order assertions against the commit.
+        expect(item).not_to_have_attribute("data-sidebar-dragging", "true")
+
+    def reorder_via_pointer_drag(self, item: Locator, target: Locator, *, overshoot: bool = False) -> None:
+        """Drag one drag activator past another with a real mouse drag (PointerSensor).
+
+        ``item`` and ``target`` are drag activators of the same sortable list (two
+        repo-group headers, or two workspace rows). Unlike ``reorder_via_keyboard_drag``,
+        this drives the PointerSensor: the pointer drags the element, whose (parent-clamped)
+        rectangle resolves the drop. This is the only path that exercises a drag of a TALL
+        sortable (e.g. an expanded repo group filled with workspaces) — the keyboard getter
+        steps the dragged item's rect straight onto the target slot, so it never depends on
+        the group's height, whereas a pointer drag of a tall group does (the group's
+        collision rect is its full height).
+
+        The move is stepped so dnd-kit's PointerSensor clears its 5px activation distance
+        and recomputes ``over`` on each ``pointermove``. It drags the element far enough past
+        the target's centre that the target's slot wins the collision, then waits for it to
+        light up (``data-sidebar-drop-target``) before releasing — so a caller's order
+        assertion can't race the drop.
+
+        With ``overshoot=True`` the pointer is driven well past the target's far edge — past
+        the list container — instead of landing inside it, to exercise a drag beyond the
+        container: the dragged element is clamped inside the list, so its rectangle still
+        overlaps ``target`` (the extreme item in the drag direction) and keeps it the drop
+        target rather than dropping out.
+        """
+        # Both activators must be on-screen before their box is read: bounding_box() and
+        # page.mouse operate on absolute viewport coordinates and do NOT scroll into view
+        # or wait for actionability (unlike .click()/.drag_to()). A tall group can push an
+        # activator out of the viewport, which would send the pointer to stale pixels.
+        for activator in (item, target):
+            activator.scroll_into_view_if_needed()
+            expect(activator).to_be_visible()
+
+        item_box = item.bounding_box()
+        target_box = target.bounding_box()
+        assert item_box is not None, "drag item has no bounding box (not visible?)"
+        assert target_box is not None, "drag target has no bounding box (not visible?)"
+
+        start_x = item_box["x"] + item_box["width"] / 2
+        start_y = item_box["y"] + item_box["height"] / 2
+        end_x = start_x
+        # `target` is the header activator; the target's droppable rect is the whole group,
+        # which extends further, so a point in the header is safely inside the droppable.
+        is_dragging_down = target_box["y"] >= item_box["y"]
+        if overshoot:
+            end_y = (
+                target_box["y"] + target_box["height"] + _POINTER_DRAG_OVERSHOOT_PX
+                if is_dragging_down
+                else target_box["y"] - _POINTER_DRAG_OVERSHOOT_PX
+            )
+        else:
+            target_fraction = (
+                _POINTER_DRAG_TARGET_FRACTION_FORWARD if is_dragging_down else _POINTER_DRAG_TARGET_FRACTION_BACKWARD
+            )
+            end_y = target_box["y"] + target_box["height"] * target_fraction
+
+        mouse = self._page.mouse
+        mouse.move(start_x, start_y)
+        mouse.down()
+        for step in range(1, _POINTER_DRAG_MOVE_STEPS + 1):
+            mouse.move(end_x, start_y + (end_y - start_y) * step / _POINTER_DRAG_MOVE_STEPS)
+        # The target slot lights up once `over` resolves to it; wait for it so the drop
+        # commits against the intended slot (and the assertion below proves the drag
+        # actually registered a target rather than releasing over empty space).
+        expect(target).to_have_attribute("data-sidebar-drop-target", "true")
+        mouse.up()
+
         expect(item).not_to_have_attribute("data-sidebar-dragging", "true")
 
     # -- Workspace rows (mirrors PlaywrightHomePage.get_workspace_rows) --

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -994,7 +994,9 @@ def wait_for_workspace_list_loaded(page: Page) -> None:
     expect(workspace_rows.or_(sidebar_empty).first).to_be_visible()
 
 
-def create_zero_agent_workspace(page: Page, *, description: str | None = None, source_branch: str = "testing") -> str:
+def create_zero_agent_workspace(
+    page: Page, *, description: str | None = None, source_branch: str = "testing", project_id: str | None = None
+) -> str:
     """Create a WORKTREE workspace with NO agent and navigate to it, returning its id.
 
     The redesign relaxes the old "≥1 agent" invariant, so a
@@ -1004,17 +1006,23 @@ def create_zero_agent_workspace(page: Page, *, description: str | None = None, s
     created — then navigates to ``/ws/<id>`` with a hash change so the WebSocket
     stays alive (mirroring ``navigate_to_workspace_without_agent``).
 
-    Resolves the active project and a unique branch name (via the same
-    ``preview-branch-name`` endpoint the Add Workspace form uses) so the worktree
-    branch never collides across repeated calls.
+    Resolves a unique branch name (via the same ``preview-branch-name`` endpoint
+    the Add Workspace form uses) so the worktree branch never collides across
+    repeated calls. ``project_id`` targets a specific repo; when omitted the first
+    active project is used (the common single-repo case). Passing it lets a test
+    pile many workspaces into one particular repo group — e.g. to make a group
+    tall enough to exercise drag behaviour that depends on group height.
     """
     base_url = resolve_backend_api_url(page)
 
-    projects_response = request_with_retry(page.request.get, f"{base_url}/api/v1/projects/active")
-    assert projects_response.ok, f"list active projects failed: {projects_response.status} {projects_response.text()}"
-    projects = projects_response.json()
-    assert projects, "no active project to create a zero-agent workspace in"
-    project_id = projects[0]["objectId"]
+    if project_id is None:
+        projects_response = request_with_retry(page.request.get, f"{base_url}/api/v1/projects/active")
+        assert projects_response.ok, (
+            f"list active projects failed: {projects_response.status} {projects_response.text()}"
+        )
+        projects = projects_response.json()
+        assert projects, "no active project to create a zero-agent workspace in"
+        project_id = projects[0]["objectId"]
 
     workspace_name = description or f"Zero Agent WS {next(_workspace_name_counter)}"
     preview_response = request_with_retry(
@@ -1041,6 +1049,21 @@ def create_zero_agent_workspace(page: Page, *, description: str | None = None, s
 
     navigate_to_workspace_without_agent(page, workspace_id)
     return workspace_id
+
+
+def get_active_project_id_by_name(page: Page, name: str) -> str:
+    """Return the objectId of the active project whose folder name matches ``name``.
+
+    A project's ``name`` is the folder that contains its git repo (see the Project
+    model), so this resolves the id of a repo added via the settings page — handy
+    for then targeting ``create_zero_agent_workspace(project_id=...)`` at that repo.
+    """
+    base_url = resolve_backend_api_url(page)
+    response = request_with_retry(page.request.get, f"{base_url}/api/v1/projects/active")
+    assert response.ok, f"list active projects failed: {response.status} {response.text()}"
+    matches = [project["objectId"] for project in response.json() if project["name"] == name]
+    assert len(matches) == 1, f"expected exactly one active project named {name!r}, found {len(matches)}"
+    return matches[0]
 
 
 def dispatch_modified_shortcuts_in_one_task(page: Page, shortcuts: Sequence[tuple[str, str]]) -> list[str]:

--- a/sculptor/tests/integration/frontend/test_sidebar_reorder.py
+++ b/sculptor/tests/integration/frontend/test_sidebar_reorder.py
@@ -9,13 +9,17 @@ follows the visible order.
 
 import re
 
+from playwright.sync_api import Locator
 from playwright.sync_api import Page
 from playwright.sync_api import expect
 
+from sculptor.testing.elements.workspace_sidebar import PlaywrightWorkspaceSidebarElement
 from sculptor.testing.pages.add_workspace_page import PlaywrightAddWorkspacePage
 from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 from sculptor.testing.pages.task_page import PlaywrightTaskPage
 from sculptor.testing.playwright_utils import blur_active_element
+from sculptor.testing.playwright_utils import create_zero_agent_workspace
+from sculptor.testing.playwright_utils import get_active_project_id_by_name
 from sculptor.testing.playwright_utils import navigate_to_settings_page
 from sculptor.testing.playwright_utils import navigate_to_workspace
 from sculptor.testing.playwright_utils import open_new_workspace_form
@@ -193,3 +197,119 @@ def test_reorder_repo_groups_via_keyboard_drag(
 
     # Step 3: The group order is swapped.
     expect(groups).to_contain_text([bottom_name, top_name])
+
+
+# Repo groups render expanded by default (isRepoCollapsedAtomFamily defaults to false),
+# independent of workspace count; the count only affects the group's height. This many
+# rows makes the expanded group tall enough that its collision-rect centre sits far past
+# a single-workspace neighbour's — the condition under which closestCenter can never make
+# `over` leave the dragged group, so it never reorders. Eight clears the
+# ~3x-neighbour-height margin with room to spare, without slowing the test by creating
+# needless workspaces.
+_TALL_GROUP_WORKSPACE_COUNT = 8
+
+
+def _build_short_and_tall_repo_groups(
+    page: Page, test_repo_factory: TestRepoFactory, tall_repo_name: str
+) -> tuple[PlaywrightWorkspaceSidebarElement, Locator, str, str, list[str]]:
+    """Build a short repo group (default repo, one workspace) and a tall one.
+
+    The tall group is a second repo piled with ``_TALL_GROUP_WORKSPACE_COUNT`` agent-less
+    workspaces (created straight through the API so it stays cheap), expanded by default so
+    its height dwarfs the short group's. Returns the sidebar POM, the repo-group locator,
+    the tall and short project ids, and the initial top→bottom group-id order.
+    """
+    create_zero_agent_workspace(page, description="Short Repo WS")
+
+    tall_repo = test_repo_factory.create_repo(name=tall_repo_name, branch="main")
+    settings_page = navigate_to_settings_page(page=page)
+    settings_page.click_on_repositories().add_repo(str(tall_repo.base_path.resolve()))
+    tall_project_id = get_active_project_id_by_name(page, tall_repo_name)
+    for index in range(_TALL_GROUP_WORKSPACE_COUNT):
+        create_zero_agent_workspace(page, description=f"Tall Repo WS {index}", project_id=tall_project_id)
+
+    sidebar = PlaywrightTaskPage(page).get_workspace_sidebar()
+    groups = sidebar.get_repo_groups()
+    expect(groups).to_have_count(2)
+    # Pin each group's id before the drag (expect() first so the one-shot reads can't race a
+    # re-render). The short group is simply whichever isn't the tall one.
+    for index in range(2):
+        expect(groups.nth(index)).to_have_attribute("data-project-id", re.compile(r".+"))
+    initial_ids = [groups.nth(index).get_attribute("data-project-id") for index in range(2)]
+    short_project_id = initial_ids[0] if initial_ids[1] == tall_project_id else initial_ids[1]
+    return sidebar, groups, tall_project_id, short_project_id, initial_ids
+
+
+@user_story("to re-order a big expanded repo group by dragging it with the mouse")
+def test_reorder_tall_expanded_repo_group_via_pointer_drag(
+    sculptor_instance_: SculptorInstance, test_repo_factory_: TestRepoFactory
+) -> None:
+    """A pointer drag reorders a repo group that is expanded and full of workspaces.
+
+    This is the pointer-drag counterpart to ``test_reorder_repo_groups_via_keyboard_drag``.
+    The keyboard sensor steps the dragged item's rect straight onto the target slot, so a
+    keyboard drag never depends on the group's height. A mouse drag does — the group's
+    collision rect is its full expanded height — so only this path exercises the collision
+    detection a tall group's reorder relies on. A tall group whose ``over`` never leaves
+    itself can be dragged but never reordered.
+
+    Steps:
+    1. Create a short repo group (default repo, one workspace) and a tall one (a second
+       repo piled with many workspaces, expanded by default).
+    2. Drag the tall group past the short one with the mouse.
+    3. Verify the two groups swapped — the reorder registered.
+    """
+    page = sculptor_instance_.page
+
+    # Step 1: A short group and a tall one.
+    sidebar, groups, tall_project_id, short_project_id, initial_ids = _build_short_and_tall_repo_groups(
+        page, test_repo_factory_, "tall-reorder-repo"
+    )
+
+    # Step 2: Drag the tall group past the short one with the mouse.
+    sidebar.reorder_via_pointer_drag(
+        item=sidebar.get_repo_group_by_project_id(tall_project_id),
+        target=sidebar.get_repo_group_by_project_id(short_project_id),
+    )
+
+    # Step 3: The two groups swapped — dragging the tall group past the short one moved
+    # it into the other slot.
+    expect(groups.nth(0)).to_have_attribute("data-project-id", initial_ids[1])
+    expect(groups.nth(1)).to_have_attribute("data-project-id", initial_ids[0])
+
+
+@user_story("to re-order a big expanded repo group even when I drag past the sidebar")
+def test_reorder_tall_group_when_dragged_past_the_container_edge(
+    sculptor_instance_: SculptorInstance, test_repo_factory_: TestRepoFactory
+) -> None:
+    """A pointer drag that overshoots past the container still reorders (no snap-back).
+
+    The drop resolves from the dragged element's rectangle, which restrictToParentElement
+    holds inside the list, so it always overlaps some group — even when the pointer runs
+    well past the container edge. That keeps ``over`` pinned to the extreme group rather than
+    dropping out; a null ``over`` would zero dnd-kit's active-item transform (it only offsets
+    the dragged item while ``overIndex`` is valid) and snap the item back to its origin.
+
+    Steps:
+    1. Create a short repo group and a tall one.
+    2. Drag the tall group and overshoot well past the short group, beyond the container.
+    3. Verify the two groups still swapped — ``over`` stayed pinned to the extreme group.
+    """
+    page = sculptor_instance_.page
+
+    # Step 1: A short group and a tall one.
+    sidebar, groups, tall_project_id, short_project_id, initial_ids = _build_short_and_tall_repo_groups(
+        page, test_repo_factory_, "tall-overshoot-repo"
+    )
+
+    # Step 2: Drag the tall group and overshoot past the short group / container edge.
+    sidebar.reorder_via_pointer_drag(
+        item=sidebar.get_repo_group_by_project_id(tall_project_id),
+        target=sidebar.get_repo_group_by_project_id(short_project_id),
+        overshoot=True,
+    )
+
+    # Step 3: The groups still swapped — the clamped pointer kept the extreme group as the
+    # drop target instead of dropping out and snapping the dragged group back.
+    expect(groups.nth(0)).to_have_attribute("data-project-id", initial_ids[1])
+    expect(groups.nth(1)).to_have_attribute("data-project-id", initial_ids[0])


### PR DESCRIPTION
## Summary

In the left workspace sidebar, projects (repo groups) can be dragged up/down to reorder. A large project that is **expanded and filled with workspaces** could be picked up and dragged with the mouse, but the drag never triggered a shift in position — it could never be reordered. Small or collapsed groups reordered fine.

Fixes [SCU-1798](https://linear.app/imbue/issue/SCU-1798).

## Root cause

Both sidebar sortable lists (repo groups and workspace rows) resolved dnd-kit drops with `closestCenter`, which keys off the **dragged element's collision-rect centre**. A repo group's measured drag node is the whole group (header + every workspace row), so an expanded, workspace-filled project is very tall — its centre sits deep in its own middle, far from a short neighbour's centre. Combined with `restrictToVerticalAxis` + `restrictToParentElement` clamping how far the element can travel, `closestCenter` could never bring the dragged group's centre closer to a neighbour than to its own slot. So `over` never changed and no reorder committed.

## Fix

Replace `closestCenter` with a small custom collision, `sidebarCollisionDetection`, that scores each item by the **fraction of that item's own area the dragged element's rectangle covers**, and picks the max:

- A **tall group** flips onto a short neighbour after dragging down only ~**one of the neighbour's rows** (the short neighbour is fully covered while the tall group's own, equally tall, slot is only vacated gradually).
- **Equal-height rows** cross over at **half a row** — identical to `closestCenter`.

dnd-kit's built-in `rectIntersection` normalises overlap by the **union** area, so a tall item's own slot always wins (the same failure mode as `closestCenter`); normalising by the **target's** area is what makes a small nudge enough.

Because it keys off the modifier-clamped `collisionRect` (held inside the list by `restrictToParentElement`) rather than the raw pointer, a drag **past the container edge** stays pinned to the extreme item and never nulls `over` — so it can't snap the dragged item back to its origin. `closestCenter` is the never-empty final fallback. Keyboard drags are unchanged (`closestCenter`, since the sortable keyboard getter steps the rect straight onto the target slot).

## Testing

- **Unit** (`sidebarDnd.test.ts`): pins the crossover behaviour — small drag stays on self, a tall group flips after ~one neighbour row, equal rows flip at half a row, never returns empty (falls back to nearest), keyboard uses `closestCenter`.
- **e2e** (`test_sidebar_reorder.py`): a real mouse-drag reorder of a tall expanded group (new `reorder_via_pointer_drag` POM helper), plus a drag that **overshoots past the container edge** and still reorders (no snap-back). The 4 existing keyboard reorder tests are unaffected.
- `just check` and `just test-unit` green.

## Drop indicator

While reordering, the drop target now shows a small **accent insertion line** at the exact edge where the dragged row/group will land (there's no floating placeholder — the element slides in place). The side (above/below) comes from the sortable's active-vs-over index, and the line is drawn on the element that spans the target's full height (`.repoGroup` for groups, `.workspaceRow` for rows) so it sits at the real outer edge rather than inside a tall group. Purely visual, so no automated test (per the layout-only-tests policy).

## Notes

- Test-only plumbing added to build a tall group cheaply: `create_zero_agent_workspace` gains an optional `project_id`, plus `get_active_project_id_by_name` and a `get_repo_group_by_project_id` POM locator.
- Known limitation left out of scope: dragging a group taller than the viewport interacts awkwardly with scrolling — no clean model for it yet.

<sub>The commit history shows the path taken (an initial pointer-position approach, then a snap-back fix, then this rectangle-overlap model). The net diff is the final overlap model.</sub>

(Sent by Claude)
