### PR TITLE
Steer OpenHost preview launches into the switcher pill's 51000-51099 band

### DIFF
--- a/.claude/skills/openhost-frontend-preview/SKILL.md
+++ b/.claude/skills/openhost-frontend-preview/SKILL.md
@@ -67,14 +67,25 @@ does not apply — use normal `pnpm run dev` / `just frontend` there instead.
 
 ## Run a preview
 
-Pick a free port in 51000-59999, preferring the 51000-51099 range: the
-`/proxy/` switchboard page (openhost-preview-fallback.html) quick-scans that
-range on load, so previews there are found without a full-band scan. Launch it
-**DETACHED** — do NOT use a tracked background task; this Sculptor will not
-release your turn to the user while one is alive:
+Use a port in the 51000-51099 band. The preview-switcher pill in the
+deployed app only auto-discovers that range (and the `/proxy/` switchboard page,
+openhost-preview-fallback.html, quick-scans it on load), so a preview there shows
+up without a full-band scan. A higher port (51100-59999) still works, but it will
+**not** appear in the pill — you'd reach it only via the switchboard's full-band
+scan or a direct `/proxy/<port>/` URL, so don't reach for a random high port. The
+zero-friction way to get a valid one is to let the script pick: run
+`launch-preview.sh` with **no argument** and it auto-selects a free 51000-51099
+port (printed to the log).
+
+Launch it **DETACHED** — do NOT use a tracked background task; this Sculptor will
+not release your turn to the user while one is alive:
 
     cd <frontend-dir>
     setsid bash launch-preview.sh 51042 >/tmp/vite-51042.log 2>&1 </dev/null &
+
+(or `setsid bash launch-preview.sh >/tmp/vite-preview.log 2>&1 </dev/null &` with
+no port to auto-pick a free 510xx one — then read the chosen port and the
+`ready in` line from the log.)
 
 `<frontend-dir>` is either:
 - **`/app/sculptor/frontend`** — preview the deployed UI as-is (its `node_modules`
@@ -83,9 +94,11 @@ release your turn to the user while one is alive:
   worktree has no `node_modules`, so run `pnpm install` there once first (slow),
   then launch.
 
-`launch-preview.sh <port>` sets `SCULPTOR_FRONTEND_PORT` + `SCULPTOR_OPENHOST_PROXY`
-and runs `pnpm run dev -- --base=/proxy/<port>/` (base is a native Vite flag; the
-env var only drives the OpenHost wss/HMR override). First start pre-bundles deps
+`launch-preview.sh [port]` sets `SCULPTOR_FRONTEND_PORT` + `SCULPTOR_OPENHOST_PROXY`
+and runs `pnpm run dev` — the `/proxy/<port>/` base AND the OpenHost wss/HMR
+override are both derived from those env vars in `vite.base.config.ts`, so do NOT
+pass `--base` yourself (pnpm forwards a stray `--` that Vite reads as
+end-of-options and silently drops the flag). First start pre-bundles deps
 (~tens of seconds) — watch
 `/tmp/vite-<port>.log` for `ready in`. Then open, on any logged-in browser:
 

--- a/sculptor/frontend/launch-preview.sh
+++ b/sculptor/frontend/launch-preview.sh
@@ -18,15 +18,49 @@
 #     on one origin (the session cookie would collide).
 set -euo pipefail
 
+# The preview-switcher pill in the deployed app only auto-discovers previews in
+# the 51000-51099 quick band (a browser can't scan the whole 9000-port band on
+# every open — the /proxy/ switchboard's full-band scan covers the rest). So
+# default to a free port in that band when none is given, and warn on an explicit
+# port outside it: otherwise the preview is reachable only by a direct URL or the
+# switchboard, never the pill. Keep this band in sync with QUICK_BAND_* in
+# plugins/openhost-preview-switcher/src/scan.ts.
+quick_band_start=51000
+quick_band_end=51099
+
+pick_free_quick_port() {
+  # Ports currently bound (listening), one per line, from a single ss snapshot.
+  local used
+  used="$(ss -tlnH 2>/dev/null | grep -oE ':[0-9]+' | tr -d ':' | sort -u)"
+  local p
+  for ((p = quick_band_start; p <= quick_band_end; p++)); do
+    grep -qx "$p" <<<"$used" || { echo "$p"; return 0; }
+  done
+  return 1
+}
+
 port="${1:-}"
+if [[ -z "$port" ]]; then
+  if ! port="$(pick_free_quick_port)"; then
+    echo "no free port in $quick_band_start-$quick_band_end; pass an explicit port in 51000-59999" >&2
+    exit 1
+  fi
+  echo "auto-selected free port $port (in the preview-switcher pill's $quick_band_start-$quick_band_end scan band)"
+fi
+
 case "$port" in
   5[1-9][0-9][0-9][0-9]) ;;   # 51000-59999, the nginx preview band
   *)
-    echo "usage: $(basename "$0") <port in 51000-59999>" >&2
-    echo "  prefer 51000-51099: the /proxy/ switchboard quick-scans that range" >&2
+    echo "usage: $(basename "$0") [port in 51000-59999]   (default: a free port in $quick_band_start-$quick_band_end)" >&2
+    echo "  the preview-switcher pill only auto-discovers $quick_band_start-$quick_band_end; higher ports need the /proxy/ switchboard or a direct URL" >&2
     exit 1
     ;;
 esac
+
+if (( port < quick_band_start || port > quick_band_end )); then
+  echo "WARNING: port $port is outside $quick_band_start-$quick_band_end, so the preview-switcher pill will NOT list it." >&2
+  echo "         Reach it via the /proxy/ switchboard (full-band scan) or the direct /proxy/$port/ URL — or use a $quick_band_start-$quick_band_end port to get the pill." >&2
+fi
 
 cd "$(dirname "$0")"
 export SCULPTOR_FRONTEND_PORT="$port"

--- a/sculptor/frontend/launch-preview.sh
+++ b/sculptor/frontend/launch-preview.sh
@@ -24,14 +24,16 @@ set -euo pipefail
 # default to a free port in that band when none is given, and warn on an explicit
 # port outside it: otherwise the preview is reachable only by a direct URL or the
 # switchboard, never the pill. Keep this band in sync with QUICK_BAND_* in
-# plugins/openhost-preview-switcher/src/scan.ts.
+# sculptor/frontend/plugins/openhost-preview-switcher/src/scan.ts.
 quick_band_start=51000
 quick_band_end=51099
 
 pick_free_quick_port() {
   # Ports currently bound (listening), one per line, from a single ss snapshot.
+  # grep matches nothing when there are no listeners at all; tolerate that
+  # (|| true) rather than letting the empty match trip pipefail under set -e.
   local used
-  used="$(ss -tlnH 2>/dev/null | grep -oE ':[0-9]+' | tr -d ':' | sort -u)"
+  used="$(ss -tlnH 2>/dev/null | grep -oE ':[0-9]+' | tr -d ':' | sort -u)" || true
   local p
   for ((p = quick_band_start; p <= quick_band_end; p++)); do
     grep -qx "$p" <<<"$used" || { echo "$p"; return 0; }


### PR DESCRIPTION
## What & why

The OpenHost preview-switcher pill in the deployed web app only auto-discovers dev previews in **51000–51099** — a browser can't rescan the whole 9000-port `/proxy` band on every open, so the pill scans just that quick band and the `/proxy/` switchboard's full-band scan covers the rest.

But `launch-preview.sh` accepted any port in 51000–59999, and the `openhost-frontend-preview` skill only *softly* "preferred" the quick band. In practice a launch could land on a high port (e.g. 519xx) that never shows up in the pill — so the discovery mechanism and the launch guidance had drifted apart. This reconciles them by steering launches into the band the pill actually scans.

## Changes

- **`launch-preview.sh`** now auto-selects a free 51000–51099 port when called with **no argument** (single `ss` snapshot, first free port), and prints a clear `WARNING` when given an explicit port outside that band — still allowed, since nginx proxies the full 51000–59999 band, but only reachable via the switchboard or a direct `/proxy/<port>/` URL. The band is documented as kept in sync with `QUICK_BAND_*` in the switcher plugin's `scan.ts`.
- **`openhost-frontend-preview` skill** now leads with the 51000–51099 band and spells out the pill consequence, and documents the no-arg auto-pick.
- **Doc fix:** the skill no longer tells readers to run `pnpm run dev -- --base=…` — the script deliberately avoids that (pnpm swallows the stray `--`); the base is derived from env in `vite.base.config.ts`.

## Testing

- `shellcheck --severity=warning` clean on the script (same invocation as the `check-shellcheck` CI recipe).
- File hygiene: no trailing whitespace, final newlines present.
- Dry-ran the port picker (correctly skipped a live listener and returned the first free port) and the out-of-band warning gate.

No Python/JS/TS/SCSS changed, so the format/typecheck/unit-test recipes don't apply.

(Sent by Claude)