### PR TITLE
FakeClaude: test-timed background completions and reaction turns (SCU-1680)

### DIFF
--- a/.claude/skills/write-integration-test/SKILL.md
+++ b/.claude/skills/write-integration-test/SKILL.md
@@ -48,6 +48,19 @@ If your test needs the agent to perform specific actions — e.g., writing files
 | `multi_step` | Execute multiple commands sequentially | `fake_claude:multi_step \`{"steps": [...]}\`` |
 | `parallel_tools` | Execute multiple tools in parallel | `fake_claude:parallel_tools \`{"tools": [...]}\`` |
 | `warning` | Surface a warning message | `fake_claude:warning \`{"message": "..."}\`` |
+| `start_background_task` | Arm a background task; the arming turn ends and the process lingers | `fake_claude:start_background_task \`{"trigger_path": "...", "reaction_text": "..."}\`` |
+| `complete_background_task` | Inside a borrowed turn, complete an armed task inline mid-cycle | `fake_claude:complete_background_task \`{"task_id": "..."}\`` |
+
+**Test-timed background completions.** `start_background_task` arms a background
+task without completing it — the arming turn ends (its `result` is emitted) and
+the process lingers. Pass `trigger_path` from a `FakeClaudeTrigger`
+(`sculptor/testing/fake_claude_pause.py`) and call `trigger.fire()` when the test
+wants completion: FakeClaude then emits `task_updated` + `task_notification`
+followed by a scripted reaction cycle (`reaction_text` / `reaction_steps`),
+without any user frame prompting it. To complete a task *during* a follow-up turn
+instead (so the notification interleaves mid-cycle), put a
+`complete_background_task` step with the same `task_id` in that turn's
+`multi_step` script; its reaction cycle then runs after the turn finishes.
 
 ## CRITICAL: Use `/run-integration-test` to Run Tests
 

--- a/sculptor/sculptor/agents/testing/fake_claude.py
+++ b/sculptor/sculptor/agents/testing/fake_claude.py
@@ -9,6 +9,7 @@ import html
 import json
 import os
 import re
+import select
 import signal
 import sys
 import time
@@ -19,7 +20,11 @@ from sculptor.agents.default.claude_code_sdk.harness import compute_claude_jsonl
 from sculptor.agents.testing.fake_claude_commands import COMMAND_REGISTRY
 from sculptor.agents.testing.fake_claude_commands import UnknownFakeClaudeCommandError
 from sculptor.agents.testing.fake_claude_commands import dispatch_handler
+from sculptor.agents.testing.fake_claude_commands import emit_pending_task_reaction
 from sculptor.agents.testing.fake_claude_commands import handle_default
+from sculptor.agents.testing.fake_claude_commands import pending_background_task_count
+from sculptor.agents.testing.fake_claude_commands import take_reaction_ready_background_task
+from sculptor.agents.testing.fake_claude_commands import take_triggered_background_task
 from sculptor.agents.testing.fake_claude_jsonl import generate_id
 from sculptor.agents.testing.fake_claude_jsonl import make_end_message
 from sculptor.agents.testing.fake_claude_jsonl import make_init_message
@@ -233,6 +238,124 @@ def _read_prompt_from_stream_json_stdin() -> str | None:
     return None
 
 
+# Poll interval for the between-cycle linger loop: how often it re-checks the
+# pending tasks' trigger sentinels. Small enough that a fired trigger is picked
+# up promptly; the sentinel file — not the interval — is the synchronization
+# point, so this is latency, never a race window.
+_LINGER_POLL_INTERVAL_SECONDS: float = 0.05
+
+# Safety cap on how long the linger loop waits for a trigger once stdin is at
+# EOF. With stdin closed no borrowed frame can arrive, so only a trigger can
+# advance the loop; a forgotten trigger then fails loudly instead of hanging the
+# runner. While stdin is open there is no deadline — the process is under the
+# caller's control and exits on interrupt / SIGTERM / stdin close.
+_LINGER_EOF_SAFETY_TIMEOUT_SECONDS: float = 120.0
+
+
+def _read_one_stdin_frame() -> tuple[str, str | None]:
+    """Read and classify a single stdin line during the linger loop.
+
+    Returns ``("prompt", content)`` for a user frame, ``("interrupt", None)``
+    for a Stop interrupt control_request, ``("eof", None)`` when stdin has
+    closed, and ``("ignore", None)`` for anything else (control responses,
+    context-usage requests, blank or unparseable lines).
+
+    Reads exactly one line — unlike ``_read_prompt_from_stream_json_stdin``,
+    which loops until a user frame — so the linger loop stays free to re-check
+    the background-task triggers between frames. Kept independent of that reader
+    so its stdin-reader rework (mid-turn absorption) and this reaction-emission
+    path can evolve separately.
+    """
+    line = sys.stdin.readline()
+    if not line:
+        return ("eof", None)
+    line = line.strip()
+    if not line:
+        return ("ignore", None)
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return ("ignore", None)
+    if not isinstance(data, dict):
+        return ("ignore", None)
+    if (
+        data.get("type") == "control_request"
+        and isinstance(data.get("request"), dict)
+        and data["request"].get("subtype") == "interrupt"
+    ):
+        return ("interrupt", None)
+    if data.get("type") == "user":
+        message = data.get("message", {})
+        content = message.get("content", "")
+        return ("prompt", html.unescape(content).strip() if isinstance(content, str) else "")
+    return ("ignore", None)
+
+
+def _run_background_task_linger_loop(
+    session_id: str,
+    cwd: str,
+    emit_streaming: bool,
+    plugin_dir: str | None,
+) -> str | None:
+    """Wait between cycles while background tasks are pending.
+
+    Emits each armed task's reaction cycle as its completion fires, and returns
+    the next borrowed turn's prompt read from stdin — or ``None`` once stdin is
+    at EOF and every pending task has drained, letting ``main`` exit.
+
+    Two completion paths feed the same reaction emission:
+      * a task a ``complete_background_task`` step already completed inline
+        mid-cycle — its reaction runs here, without re-emitting the
+        task_updated/task_notification; and
+      * a task still awaiting its trigger sentinel — when the sentinel appears
+        this loop emits task_updated + task_notification, then the reaction cycle.
+
+    The loop returns ``None`` only once nothing is pending AND stdin is closed,
+    so the lingering window extends until every scripted task has fired and its
+    reaction has been consumed — including tasks a borrowed turn itself armed.
+    """
+    stdin_at_eof = False
+    eof_deadline: float | None = None
+    while True:
+        ready = take_reaction_ready_background_task()
+        if ready is not None:
+            emit_pending_task_reaction(ready, session_id, cwd, emit_streaming, plugin_dir, emit_notification=False)
+            eof_deadline = None
+            continue
+        triggered = take_triggered_background_task()
+        if triggered is not None:
+            emit_pending_task_reaction(triggered, session_id, cwd, emit_streaming, plugin_dir, emit_notification=True)
+            eof_deadline = None
+            continue
+        if pending_background_task_count() == 0:
+            # All tasks drained: resume normal between-cycle reading.
+            if stdin_at_eof:
+                return None
+            return _read_prompt_from_stream_json_stdin()
+        # Tasks still pending with triggers unfired. Wait for a trigger sentinel
+        # or (while stdin is open) a borrowed frame / interrupt.
+        if stdin_at_eof:
+            if eof_deadline is None:
+                eof_deadline = time.monotonic() + _LINGER_EOF_SAFETY_TIMEOUT_SECONDS
+            elif time.monotonic() > eof_deadline:
+                raise RuntimeError(
+                    f"FakeClaude lingered past {_LINGER_EOF_SAFETY_TIMEOUT_SECONDS}s waiting for background "
+                    + f"task trigger(s) with stdin closed; {pending_background_task_count()} task(s) never fired"
+                )
+            time.sleep(_LINGER_POLL_INTERVAL_SECONDS)
+            continue
+        ready_fds, _, _ = select.select([sys.stdin], [], [], _LINGER_POLL_INTERVAL_SECONDS)
+        if not ready_fds:
+            continue
+        frame_kind, prompt = _read_one_stdin_frame()
+        if frame_kind == "prompt":
+            return prompt
+        if frame_kind == "interrupt":
+            sys.exit(AGENT_EXIT_CODE_FROM_SIGTERM)
+        if frame_kind == "eof":
+            stdin_at_eof = True
+
+
 def _maybe_delay_for_compact_indicator(prompt: str, resume_id: str | None) -> None:
     """Stall a resumed ``/compact`` so tests can observe the Compacting indicator.
 
@@ -358,9 +481,16 @@ def main(argv: list[str] | None = None) -> int:
     if parsed.input_format == "stream-json":
         is_first_cycle = True
         while True:
-            prompt = _read_prompt_from_stream_json_stdin()
+            # While background tasks armed by a prior cycle are still pending,
+            # the linger loop drives the between-cycle wait: it emits their
+            # reaction cycles as they complete and, meanwhile, returns any
+            # borrowed turn's frame. Otherwise read the next frame plainly.
+            if pending_background_task_count() > 0:
+                prompt = _run_background_task_linger_loop(session_id, cwd, emit_streaming, plugin_dir)
+            else:
+                prompt = _read_prompt_from_stream_json_stdin()
             if prompt is None:
-                # stdin closed while idle between cycles — exit silently.
+                # stdin closed and no background task pending — exit silently.
                 return 0
             _maybe_delay_for_compact_indicator(prompt, parsed.resume)
             cycle_system_commands = system_commands if is_first_cycle else []

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -4,6 +4,7 @@ Each handler takes parsed arguments and returns a list of JSONL dicts to emit
 between the init and end messages.
 """
 
+import dataclasses
 import glob as glob_module
 import inspect
 import json
@@ -1844,6 +1845,264 @@ def handle_background_subagent(args: dict, emit_streaming: bool) -> list[dict]:
     return messages
 
 
+@dataclasses.dataclass
+class _PendingBackgroundTask:
+    """A background task armed by ``start_background_task``, awaiting completion.
+
+    ``trigger_path`` is the sentinel whose creation completes the task.
+    ``reaction_steps`` is the reaction cycle's body (multi_step-shaped steps).
+    ``notification_emitted`` flips to True once a ``complete_background_task``
+    step has emitted this task's task_updated/task_notification inline mid-cycle;
+    the linger loop then runs only its reaction cycle, without re-emitting them.
+    """
+
+    task_id: str
+    tool_use_id: str
+    trigger_path: str
+    reaction_steps: list[dict]
+    notification_summary: str
+    notification_status: str
+    notification_emitted: bool = False
+
+
+# Background tasks armed in this process but not yet completed. Module-global so
+# it survives across cycles within one FakeClaude invocation: the arming cycle
+# registers a task here, later cycles / the between-cycle linger loop drain it.
+# A fresh process starts empty; tests sharing a process (the pure-function unit
+# tests) must reset it via ``reset_pending_background_tasks``.
+_PENDING_BACKGROUND_TASKS: list[_PendingBackgroundTask] = []
+
+
+def register_pending_background_task(task: _PendingBackgroundTask) -> None:
+    """Record an armed background task awaiting its completion trigger."""
+    _PENDING_BACKGROUND_TASKS.append(task)
+
+
+def pending_background_task_count() -> int:
+    """Return how many armed background tasks have not yet drained."""
+    return len(_PENDING_BACKGROUND_TASKS)
+
+
+def find_pending_background_task(task_id: str) -> _PendingBackgroundTask | None:
+    """Return the armed task with ``task_id`` (still in the registry), or None."""
+    for task in _PENDING_BACKGROUND_TASKS:
+        if task.task_id == task_id:
+            return task
+    return None
+
+
+def take_reaction_ready_background_task() -> _PendingBackgroundTask | None:
+    """Remove and return a task whose notification already fired inline.
+
+    These are tasks a ``complete_background_task`` step completed mid-cycle
+    (scenario 2): their reaction cycle still needs to run, but their
+    task_updated/task_notification were already emitted, so the linger loop must
+    not emit them again.
+    """
+    for index, task in enumerate(_PENDING_BACKGROUND_TASKS):
+        if task.notification_emitted:
+            return _PENDING_BACKGROUND_TASKS.pop(index)
+    return None
+
+
+def take_triggered_background_task() -> _PendingBackgroundTask | None:
+    """Remove and return a task whose trigger sentinel has appeared.
+
+    Only considers tasks not yet completed inline; the caller emits their full
+    completion (task_updated + task_notification + reaction cycle).
+    """
+    for index, task in enumerate(_PENDING_BACKGROUND_TASKS):
+        if not task.notification_emitted and Path(task.trigger_path).exists():
+            return _PENDING_BACKGROUND_TASKS.pop(index)
+    return None
+
+
+def reset_pending_background_tasks() -> None:
+    """Clear the registry. For tests that exercise handlers in-process."""
+    _PENDING_BACKGROUND_TASKS.clear()
+
+
+def handle_start_background_task(args: dict, emit_streaming: bool) -> list[dict]:
+    """Arm a background task whose completion the test triggers later.
+
+    Emits a realistic launch — assistant text + an Agent ``tool_use`` + the
+    immediate "launched" ``tool_result`` + ``system/task_started`` — and
+    registers the task in the process-global registry. The handler does NOT
+    block or emit any completion event: the arming cycle ends normally (``main``
+    appends its ``result``), the process lingers, and the reaction cycle is
+    emitted later — either spontaneously when the trigger sentinel appears while
+    the process is idle between cycles, or after a borrowed turn's
+    ``complete_background_task`` step fired the notification inline.
+
+    The task_started ``tool_use_id`` matches the launching Agent tool_use so the
+    output processor links the task to its tool call, and is reused as the
+    eventual task_notification's ``tool_use_id``.
+
+    Args:
+        trigger_path (required): sentinel file whose creation completes the task
+            (use ``FakeClaudeTrigger`` from sculptor/testing/fake_claude_pause.py).
+        task_id: stable id so a ``complete_background_task`` step can reference
+            this task (default: generated).
+        tool_use_id: the launching tool call's id (default: generated).
+        description / prompt: Agent tool metadata for the launch.
+        launched_text: assistant text emitted with the launch.
+        task_type: task_started ``task_type``. Defaults to ``local_agent`` — the
+            subagent type whose task_updated -> task_notification -> reaction
+            ordering the output processor keeps the turn open for.
+        notification_summary: the completion's task_notification summary.
+        notification_status: terminal status for both task_updated.patch.status
+            and task_notification.status (default "completed").
+        reaction_steps: the reaction cycle body as multi_step-shaped steps.
+        reaction_text: shorthand for a single-text-message reaction body (used
+            only when ``reaction_steps`` is absent).
+    """
+    trigger_path = args["trigger_path"]
+    task_id = str(args.get("task_id", generate_id("task")))
+    tool_use_id = args.get("tool_use_id", generate_id("toolu"))
+    description = args.get("description", "Explore the codebase")
+    prompt = args.get("prompt", "Find relevant files")
+    launched_text = args.get("launched_text", "Background task launched. I'll continue while it runs.")
+    task_type = args.get("task_type", "local_agent")
+    notification_summary = args.get("notification_summary", f'Agent "{description}" completed')
+    notification_status = args.get("notification_status", "completed")
+
+    reaction_steps = args.get("reaction_steps")
+    if reaction_steps is None:
+        reaction_text = args.get("reaction_text", f'[FakeClaude] Background task "{description}" completed.')
+        reaction_steps = [{"command": "text", "args": {"text": reaction_text}}]
+
+    register_pending_background_task(
+        _PendingBackgroundTask(
+            task_id=task_id,
+            tool_use_id=tool_use_id,
+            trigger_path=str(trigger_path),
+            reaction_steps=reaction_steps,
+            notification_summary=notification_summary,
+            notification_status=notification_status,
+        )
+    )
+
+    main_msg_id = generate_id("msg")
+    launched_msg_id = generate_id("msg")
+
+    agent_tool_block = make_tool_use_block(
+        tool_id=tool_use_id,
+        tool_name="Agent",
+        tool_input={"prompt": prompt, "description": description, "run_in_background": True},
+    )
+    messages = _make_tool_assistant_message(
+        message_id=main_msg_id,
+        tool_blocks=[agent_tool_block],
+        emit_streaming=emit_streaming,
+        text_prefix="I'll start a background task and keep working.",
+    )
+    messages.append(
+        make_tool_result_message(
+            tool_use_id=tool_use_id,
+            content=f"Async agent launched successfully.\nagentId: {task_id}",
+        )
+    )
+    messages.append(
+        make_task_started_message(
+            task_id=task_id,
+            tool_use_id=tool_use_id,
+            description=description,
+            task_type=task_type,
+        )
+    )
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=launched_msg_id, text=launched_text))
+    messages.append(
+        make_assistant_message(message_id=launched_msg_id, content_blocks=[make_text_block(launched_text)])
+    )
+    return messages
+
+
+def handle_complete_background_task(args: dict, emit_streaming: bool) -> list[dict]:
+    """Complete an armed background task inline, mid-cycle.
+
+    Placed inside a borrowed turn's script (scenario 2). Looks up the task armed
+    earlier by ``start_background_task`` with the same ``task_id``, blocks on its
+    registered trigger sentinel (interrupt-aware, like ``wait_for_file``), then
+    emits ``task_updated`` followed by ``task_notification`` WITHOUT ending the
+    turn — so the completion interleaves into the in-flight turn with no
+    premature ``result``. The task stays in the registry marked reaction-ready,
+    so the linger loop runs its reaction cycle after this turn's result.
+
+    Belongs to ``_INLINE_EMITTING_COMMANDS`` so a wrapping ``multi_step`` flushes
+    the prior steps' messages before this one parks on the trigger.
+
+    Args:
+        task_id (required): the armed task to complete.
+        timeout_seconds: safety cap on the trigger wait (default 120).
+    """
+    task_id = str(args["task_id"])
+    timeout_seconds: float = args.get("timeout_seconds", 120)
+    task = find_pending_background_task(task_id)
+    if task is None:
+        raise UnknownFakeClaudeCommandError(
+            f"complete_background_task: no armed background task with id {task_id!r} "
+            + "(start_background_task must run first with the same task_id)"
+        )
+    sentinel = Path(task.trigger_path)
+    if not _wait_until(timeout_seconds=timeout_seconds, poll_interval=0.05, done=sentinel.exists):
+        raise RuntimeError(
+            f"complete_background_task timed out after {timeout_seconds}s waiting for trigger {sentinel}"
+        )
+    task.notification_emitted = True
+    return [
+        make_task_updated_message(task_id=task.task_id, status=task.notification_status),
+        make_task_notification_message(
+            task_id=task.task_id,
+            tool_use_id=task.tool_use_id,
+            status=task.notification_status,
+            summary=task.notification_summary,
+        ),
+    ]
+
+
+def emit_pending_task_reaction(
+    task: _PendingBackgroundTask,
+    session_id: str,
+    cwd: str,
+    emit_streaming: bool,
+    plugin_dir: str | None,
+    emit_notification: bool,
+) -> None:
+    """Emit a completed background task's reaction turn directly to stdout.
+
+    With ``emit_notification`` True (the trigger fired while idle between
+    cycles), emit ``task_updated`` then ``task_notification`` first — the
+    completion ordering the real CLI uses. With it False (a
+    ``complete_background_task`` step already emitted them inline), go straight
+    to the reaction cycle.
+
+    The reaction cycle is a full ``init -> <reaction body> -> result`` bracket in
+    the invocation's own session: every real-CLI turn, including a spontaneous
+    reaction turn, opens with its own ``system/init``. The body is dispatched
+    through ``handle_multi_step`` so a reaction can itself run tools or ask
+    questions (and so its own inline-emitting steps flush correctly).
+    """
+    if emit_notification:
+        _emit_messages_to_stdout(
+            [
+                make_task_updated_message(task_id=task.task_id, status=task.notification_status),
+                make_task_notification_message(
+                    task_id=task.task_id,
+                    tool_use_id=task.tool_use_id,
+                    status=task.notification_status,
+                    summary=task.notification_summary,
+                ),
+            ]
+        )
+    _emit_messages_to_stdout([make_init_message(session_id=session_id)])
+    body = handle_multi_step(
+        args={"steps": task.reaction_steps}, cwd=cwd, emit_streaming=emit_streaming, plugin_dir=plugin_dir
+    )
+    _emit_messages_to_stdout(body)
+    _emit_messages_to_stdout([make_end_message(session_id=session_id)])
+
+
 def handle_workflow_run(args: dict, emit_streaming: bool) -> list[dict]:
     """Simulate the Workflow tool's full background-task lifecycle.
 
@@ -2254,6 +2513,11 @@ _INLINE_EMITTING_COMMANDS: frozenset[str] = frozenset(
         # otherwise the in-flight turn has no partial response to resume from
         # (see v1.py's is_partial_agent_response walk).
         "wait_for_file",
+        # complete_background_task blocks on a trigger sentinel like wait_for_file,
+        # so the prior steps must be flushed before it parks — otherwise the
+        # in-flight turn's earlier content isn't visible while the harness waits
+        # for the background completion.
+        "complete_background_task",
     }
 )
 
@@ -2834,6 +3098,8 @@ COMMAND_REGISTRY: dict[str, Callable[..., list[dict]]] = {
     "auto_compact_mid_stream": handle_auto_compact_mid_stream,
     "background_task_started": handle_background_task_started,
     "background_task_notification": handle_background_task_notification,
+    "start_background_task": handle_start_background_task,
+    "complete_background_task": handle_complete_background_task,
     "emit_task_notification": handle_emit_task_notification,
     "emit_task_updated": handle_emit_task_updated,
     "emit_result": handle_emit_result,

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -3,8 +3,13 @@
 import io
 import json
 import os
+import queue
 import subprocess
 import sys
+import threading
+import time
+from collections.abc import Callable
+from collections.abc import Generator
 from pathlib import Path
 from uuid import uuid4
 
@@ -12,21 +17,27 @@ import pytest
 
 from sculptor.agents.testing.fake_claude import _parse_prompt
 from sculptor.agents.testing.fake_claude import _read_prompt_from_stream_json_stdin
+from sculptor.agents.testing.fake_claude_commands import UnknownFakeClaudeCommandError
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_response_text
+from sculptor.agents.testing.fake_claude_commands import emit_pending_task_reaction
+from sculptor.agents.testing.fake_claude_commands import find_pending_background_task
 from sculptor.agents.testing.fake_claude_commands import handle_ask_user_question
 from sculptor.agents.testing.fake_claude_commands import handle_background_task_notification
 from sculptor.agents.testing.fake_claude_commands import handle_background_task_started
 from sculptor.agents.testing.fake_claude_commands import handle_bash
+from sculptor.agents.testing.fake_claude_commands import handle_complete_background_task
 from sculptor.agents.testing.fake_claude_commands import handle_default
 from sculptor.agents.testing.fake_claude_commands import handle_edit_file
 from sculptor.agents.testing.fake_claude_commands import handle_multi_step
 from sculptor.agents.testing.fake_claude_commands import handle_parallel_tools
+from sculptor.agents.testing.fake_claude_commands import handle_start_background_task
 from sculptor.agents.testing.fake_claude_commands import handle_stream_text
 from sculptor.agents.testing.fake_claude_commands import handle_task_create
 from sculptor.agents.testing.fake_claude_commands import handle_task_update
 from sculptor.agents.testing.fake_claude_commands import handle_text
 from sculptor.agents.testing.fake_claude_commands import handle_wait_for_file
 from sculptor.agents.testing.fake_claude_commands import handle_write_file
+from sculptor.agents.testing.fake_claude_commands import reset_pending_background_tasks
 from sculptor.agents.testing.fake_claude_jsonl import generate_id
 from sculptor.agents.testing.fake_claude_jsonl import make_assistant_message
 from sculptor.agents.testing.fake_claude_jsonl import make_end_message
@@ -46,6 +57,20 @@ from sculptor.state.claude_state import ParsedTaskNotificationResponse
 from sculptor.state.claude_state import ParsedTaskStartedResponse
 from sculptor.state.claude_state import ParsedToolResultResponseSimple
 from sculptor.state.claude_state import parse_claude_code_json_lines_simple
+from sculptor.testing.fake_claude_pause import FakeClaudeTrigger
+
+
+@pytest.fixture(autouse=True)
+def _reset_background_task_registry() -> Generator[None, None, None]:
+    """Clear the process-global background-task registry around every test.
+
+    The registry is module-global so it survives across cycles within one
+    FakeClaude invocation; the pure-function tests here share this process, so
+    reset it so one test's armed tasks can't leak into the next.
+    """
+    reset_pending_background_tasks()
+    yield
+    reset_pending_background_tasks()
 
 
 def test_init_message_roundtrip() -> None:
@@ -1047,3 +1072,432 @@ def test_read_mcp_control_response_surfaces_response_after_buffered_control_requ
         os.close(w_fd)
 
     assert result == "MCP error -32602: Invalid params"
+
+
+# --- Test-timed background completions and reaction turns ---
+#
+# ``start_background_task`` arms a task whose completion the test triggers via a
+# sentinel file; ``complete_background_task`` completes an armed task inline
+# mid-cycle. The handler-level tests below check the pieces; the subprocess
+# tests drive FakeClaude's stdin the way a lingering CLI is fed and trigger
+# completions with real sentinel files, asserting the emitted byte stream for
+# each borrowing-model scenario.
+
+
+def test_handle_start_background_task_registers_and_emits_launch(tmp_path: Path) -> None:
+    """The arm command emits a realistic launch and records the task's completion
+    details for later, without emitting any completion event itself."""
+    trigger = tmp_path / "trigger"
+    messages = handle_start_background_task(
+        args={
+            "trigger_path": str(trigger),
+            "task_id": "bg-1",
+            "description": "Find files",
+            "launched_text": "LAUNCHED",
+            "reaction_text": "REACTED",
+            "notification_summary": "all done",
+        },
+        emit_streaming=False,
+    )
+
+    kinds = [(m.get("type"), m.get("subtype", "")) for m in messages]
+    assert kinds == [("assistant", ""), ("user", ""), ("system", "task_started"), ("assistant", "")]
+    assert messages[0]["message"]["content"][1]["name"] == "Agent"
+    assert messages[2]["task_id"] == "bg-1"
+    assert messages[2]["task_type"] == "local_agent"
+    assert messages[3]["message"]["content"][0]["text"] == "LAUNCHED"
+
+    task = find_pending_background_task("bg-1")
+    assert task is not None
+    assert task.trigger_path == str(trigger)
+    assert task.notification_summary == "all done"
+    assert task.notification_emitted is False
+    assert task.reaction_steps == [{"command": "text", "args": {"text": "REACTED"}}]
+
+
+def test_handle_complete_background_task_emits_notification_and_marks_ready(tmp_path: Path) -> None:
+    """Completing an armed task inline emits task_updated + task_notification and
+    leaves the task registered but reaction-ready (so the linger loop runs only
+    its reaction cycle later)."""
+    trigger = tmp_path / "trigger"
+    handle_start_background_task(
+        args={"trigger_path": str(trigger), "task_id": "bg-2", "description": "d", "notification_summary": "s"},
+        emit_streaming=False,
+    )
+    # Pre-create the sentinel so the wait returns immediately (no stdin polling).
+    trigger.touch()
+
+    messages = handle_complete_background_task(args={"task_id": "bg-2"}, emit_streaming=False)
+    kinds = [(m.get("type"), m.get("subtype", "")) for m in messages]
+    assert kinds == [("system", "task_updated"), ("system", "task_notification")]
+    assert messages[0]["task_id"] == "bg-2"
+    assert messages[0]["patch"]["status"] == "completed"
+    assert messages[1]["summary"] == "s"
+
+    task = find_pending_background_task("bg-2")
+    assert task is not None
+    assert task.notification_emitted is True
+
+
+def test_handle_complete_background_task_unknown_task_raises() -> None:
+    """Completing a task that was never armed fails loudly."""
+    with pytest.raises(UnknownFakeClaudeCommandError):
+        handle_complete_background_task(args={"task_id": "never-armed"}, emit_streaming=False)
+
+
+def test_emit_pending_task_reaction_with_notification(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A spontaneous completion emits task_updated + task_notification, then a
+    full init -> reaction -> result cycle in the given session."""
+    handle_start_background_task(
+        args={
+            "trigger_path": str(tmp_path / "t"),
+            "task_id": "bg-3",
+            "description": "d",
+            "notification_summary": "sum",
+            "reaction_text": "REACTED",
+        },
+        emit_streaming=False,
+    )
+    task = find_pending_background_task("bg-3")
+    assert task is not None
+
+    emit_pending_task_reaction(
+        task, session_id="sess-x", cwd=str(tmp_path), emit_streaming=False, plugin_dir=None, emit_notification=True
+    )
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    kinds = [(e.get("type"), e.get("subtype", "")) for e in events]
+    assert kinds == [
+        ("system", "task_updated"),
+        ("system", "task_notification"),
+        ("system", "init"),
+        ("assistant", ""),
+        ("result", "success"),
+    ]
+    assert events[1]["summary"] == "sum"
+    assert events[2]["session_id"] == "sess-x"
+    assert events[3]["message"]["content"][0]["text"] == "REACTED"
+
+
+def test_emit_pending_task_reaction_without_notification(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """When the notification already fired inline, the reaction is just an
+    init -> reaction -> result cycle (no task_updated / task_notification)."""
+    handle_start_background_task(
+        args={"trigger_path": str(tmp_path / "t"), "task_id": "bg-4", "description": "d", "reaction_text": "REACTED"},
+        emit_streaming=False,
+    )
+    task = find_pending_background_task("bg-4")
+    assert task is not None
+
+    emit_pending_task_reaction(
+        task, session_id="sess-y", cwd=str(tmp_path), emit_streaming=False, plugin_dir=None, emit_notification=False
+    )
+
+    events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    kinds = [(e.get("type"), e.get("subtype", "")) for e in events]
+    assert kinds == [("system", "init"), ("assistant", ""), ("result", "success")]
+    assert events[1]["message"]["content"][0]["text"] == "REACTED"
+
+
+def test_fake_claude_trigger_fire_creates_sentinel() -> None:
+    """FakeClaudeTrigger mints a unique sentinel path and creates it on fire()."""
+    trigger = FakeClaudeTrigger()
+    assert not trigger.trigger_path.exists()
+    trigger.fire()
+    assert trigger.trigger_path.exists()
+    trigger.trigger_path.unlink()
+
+
+class _FakeClaudeProcess:
+    """Drive a live FakeClaude stream-json process the way a lingering CLI is fed.
+
+    Writes user frames onto stdin one at a time and reads top-level (non
+    ``stream_event``) events off stdout on a background thread, so a test can
+    synchronize on emitted content — waiting for a turn's ``result`` before
+    firing a trigger — rather than on wall-clock time.
+    """
+
+    def __init__(self, *, include_partial: bool = False) -> None:
+        argv = [
+            sys.executable,
+            "-m",
+            "sculptor.agents.testing.fake_claude",
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--input-format",
+            "stream-json",
+        ]
+        if include_partial:
+            argv.append("--include-partial-messages")
+        self._proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(Path(__file__).parents[3]),
+        )
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._reader = threading.Thread(target=self._pump_stdout, daemon=True)
+        self._reader.start()
+
+    def _pump_stdout(self) -> None:
+        assert self._proc.stdout is not None
+        for line in self._proc.stdout:
+            self._lines.put(line)
+        self._lines.put(None)
+
+    def __enter__(self) -> "_FakeClaudeProcess":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._proc.poll() is None:
+            self._proc.kill()
+        self._proc.wait(timeout=15.0)
+
+    def write_frame(self, content: str) -> None:
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(_user_frame(content))
+        self._proc.stdin.flush()
+
+    def close_stdin(self) -> None:
+        assert self._proc.stdin is not None
+        self._proc.stdin.close()
+
+    def read_top_level_until(self, predicate: Callable[[dict], bool], *, timeout: float = 15.0) -> list[dict]:
+        """Collect top-level events until one satisfies ``predicate`` (inclusive)."""
+        collected: list[dict] = []
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError(
+                    f"timed out; collected {[(e.get('type'), e.get('subtype', '')) for e in collected]}"
+                )
+            try:
+                line = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                raise AssertionError("timed out waiting for a stdout line")
+            if line is None:
+                raise AssertionError(
+                    "stdout closed before match; collected "
+                    + f"{[(e.get('type'), e.get('subtype', '')) for e in collected]}, stderr={self._read_stderr()}"
+                )
+            line = line.strip()
+            if not line:
+                continue
+            event = json.loads(line)
+            if event.get("type") == "stream_event":
+                continue
+            collected.append(event)
+            if predicate(event):
+                return collected
+
+    def _read_stderr(self) -> str:
+        assert self._proc.stderr is not None
+        return self._proc.stderr.read()
+
+    def wait(self, *, timeout: float = 15.0) -> int:
+        return self._proc.wait(timeout=timeout)
+
+
+def _is_result(event: dict) -> bool:
+    return event.get("type") == "result"
+
+
+def _assistant_text(event: dict) -> str | None:
+    if event.get("type") != "assistant":
+        return None
+    content = event["message"]["content"]
+    return content[0].get("text") if content and content[0].get("type") == "text" else None
+
+
+def test_scenario_idle_completion_emits_reaction_turn() -> None:
+    """Scenario 1: a cycle arms a background task and ends; the process lingers;
+    a sentinel fires completion; FakeClaude spontaneously emits
+    task_updated + task_notification then a full reaction cycle — with no user
+    frame in between."""
+    trigger = FakeClaudeTrigger()
+    arm = json.dumps(
+        {
+            "trigger_path": str(trigger.trigger_path),
+            "task_id": "bg-idle",
+            "launched_text": "LAUNCHED",
+            "reaction_text": "REACTION",
+            "notification_summary": "background done",
+        }
+    )
+    with _FakeClaudeProcess() as proc:
+        proc.write_frame(f"fake_claude:start_background_task `{arm}`")
+
+        # The arming cycle runs to its own result and the process then lingers.
+        cycle = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in cycle] == [
+            ("system", "init"),
+            ("assistant", ""),  # "I'll start..." + Agent tool_use
+            ("user", ""),  # "Async agent launched" tool_result
+            ("system", "task_started"),
+            ("assistant", ""),  # LAUNCHED
+            ("result", "success"),
+        ]
+
+        # Nothing more can be emitted until the trigger sentinel appears: the
+        # first event after the arming result is the completion's task_updated,
+        # which proves the reaction was gated on fire().
+        trigger.fire()
+        reaction = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in reaction] == [
+            ("system", "task_updated"),
+            ("system", "task_notification"),
+            ("system", "init"),
+            ("assistant", ""),
+            ("result", "success"),
+        ]
+        assert reaction[0]["task_id"] == "bg-idle"
+        assert reaction[1]["task_id"] == "bg-idle"
+        assert reaction[1]["summary"] == "background done"
+        assert _assistant_text(reaction[3]) == "REACTION"
+
+        proc.close_stdin()
+        assert proc.wait() == 0
+
+
+def test_scenario_borrowed_turn_completion_is_mid_cycle() -> None:
+    """Scenario 2: with a task pending, a borrowed user turn is in flight when
+    the test fires completion; the task_updated + task_notification are emitted
+    mid-cycle (before that turn's result), and the reaction cycle runs after the
+    borrowed turn completes."""
+    trigger = FakeClaudeTrigger()
+    arm = json.dumps(
+        {
+            "trigger_path": str(trigger.trigger_path),
+            "task_id": "bg-borrow",
+            "launched_text": "LAUNCHED",
+            "reaction_text": "REACTION",
+            "notification_summary": "background done",
+        }
+    )
+    borrowed = json.dumps(
+        {
+            "steps": [
+                {"command": "text", "args": {"text": "BORROWED_WORKING"}},
+                {"command": "complete_background_task", "args": {"task_id": "bg-borrow"}},
+                {"command": "text", "args": {"text": "BORROWED_DONE"}},
+            ]
+        }
+    )
+    with _FakeClaudeProcess() as proc:
+        proc.write_frame(f"fake_claude:start_background_task `{arm}`")
+        proc.read_top_level_until(_is_result)  # arming cycle ends; process lingers
+
+        # A borrowed turn arrives during the lingering window and parks in
+        # complete_background_task after flushing its "working" text.
+        proc.write_frame(f"fake_claude:multi_step `{borrowed}`")
+        proc.read_top_level_until(lambda e: _assistant_text(e) == "BORROWED_WORKING")
+
+        # Fire completion while the borrowed turn is mid-flight.
+        trigger.fire()
+        borrowed_tail = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in borrowed_tail] == [
+            ("system", "task_updated"),
+            ("system", "task_notification"),
+            ("assistant", ""),  # BORROWED_DONE — the turn continues past the notification
+            ("result", "success"),  # no premature result before the notification
+        ]
+        assert borrowed_tail[1]["task_id"] == "bg-borrow"
+        assert _assistant_text(borrowed_tail[2]) == "BORROWED_DONE"
+
+        # The reaction cycle runs after the borrowed turn's result, and does NOT
+        # re-emit the notification (already delivered inline).
+        reaction = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in reaction] == [
+            ("system", "init"),
+            ("assistant", ""),
+            ("result", "success"),
+        ]
+        assert _assistant_text(reaction[1]) == "REACTION"
+
+        proc.close_stdin()
+        assert proc.wait() == 0
+
+
+def test_scenario_borrowed_turn_arms_second_task_extends_window() -> None:
+    """Scenario 3: a borrowed turn completes the first task and arms a second;
+    the lingering window stays open until the second task is also triggered and
+    its reaction consumed."""
+    trigger_a = FakeClaudeTrigger()
+    trigger_b = FakeClaudeTrigger()
+    arm_a = json.dumps(
+        {
+            "trigger_path": str(trigger_a.trigger_path),
+            "task_id": "bg-a",
+            "launched_text": "LAUNCHED_A",
+            "reaction_text": "REACTION_A",
+            "notification_summary": "a done",
+        }
+    )
+    borrowed = json.dumps(
+        {
+            "steps": [
+                {"command": "complete_background_task", "args": {"task_id": "bg-a"}},
+                {
+                    "command": "start_background_task",
+                    "args": {
+                        "trigger_path": str(trigger_b.trigger_path),
+                        "task_id": "bg-b",
+                        "launched_text": "LAUNCHED_B",
+                        "reaction_text": "REACTION_B",
+                        "notification_summary": "b done",
+                    },
+                },
+            ]
+        }
+    )
+    with _FakeClaudeProcess() as proc:
+        proc.write_frame(f"fake_claude:start_background_task `{arm_a}`")
+        proc.read_top_level_until(_is_result)  # A armed; process lingers
+
+        # Borrowed turn: its first step parks on A's trigger straight after the
+        # cycle's init, so sync on that init before firing A.
+        proc.write_frame(f"fake_claude:multi_step `{borrowed}`")
+        proc.read_top_level_until(lambda e: e.get("subtype") == "init")
+
+        trigger_a.fire()
+        borrowed_tail = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in borrowed_tail] == [
+            ("system", "task_updated"),  # A completes inline
+            ("system", "task_notification"),
+            ("assistant", ""),  # "I'll start..." + Agent tool_use for B
+            ("user", ""),  # B's launched tool_result
+            ("system", "task_started"),  # B armed
+            ("assistant", ""),  # LAUNCHED_B
+            ("result", "success"),
+        ]
+        assert borrowed_tail[1]["task_id"] == "bg-a"
+        assert borrowed_tail[4]["task_id"] == "bg-b"
+
+        # A's reaction runs immediately after the borrowed turn's result.
+        reaction_a = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in reaction_a] == [
+            ("system", "init"),
+            ("assistant", ""),
+            ("result", "success"),
+        ]
+        assert _assistant_text(reaction_a[1]) == "REACTION_A"
+
+        # B is still pending — the window stayed open. Fire it and drain.
+        trigger_b.fire()
+        reaction_b = proc.read_top_level_until(_is_result)
+        assert [(e.get("type"), e.get("subtype", "")) for e in reaction_b] == [
+            ("system", "task_updated"),
+            ("system", "task_notification"),
+            ("system", "init"),
+            ("assistant", ""),
+            ("result", "success"),
+        ]
+        assert reaction_b[1]["task_id"] == "bg-b"
+        assert _assistant_text(reaction_b[3]) == "REACTION_B"
+
+        proc.close_stdin()
+        assert proc.wait() == 0

--- a/sculptor/sculptor/testing/fake_claude_pause.py
+++ b/sculptor/sculptor/testing/fake_claude_pause.py
@@ -28,3 +28,26 @@ class FakeClaudePause:
     def release(self) -> None:
         """Let fake_claude's current turn finish naturally."""
         self.release_path.touch()
+
+
+class FakeClaudeTrigger:
+    """A signaled completion trigger for a fake_claude background task.
+
+    Pass ``trigger_path`` to a ``start_background_task`` command to arm a
+    background task whose completion the test controls. Call ``fire()`` when
+    the test wants the task to complete: fake_claude then emits the task's
+    ``task_updated`` + ``task_notification`` and runs its scripted reaction
+    cycle. The same path can be handed to a ``complete_background_task`` step so
+    a borrowed turn completes the task inline mid-cycle instead.
+
+    Mirrors ``FakeClaudePause``: a unique sentinel file plus a method that
+    creates it, so completion timing is signaled rather than raced against a
+    wall-clock.
+    """
+
+    def __init__(self) -> None:
+        self.trigger_path = Path(tempfile.gettempdir()) / f"fake_claude_trigger_{uuid.uuid4().hex}"
+
+    def fire(self) -> None:
+        """Complete the armed background task now."""
+        self.trigger_path.touch()

--- a/sculptor/tests/integration/frontend/test_background_task_reaction_turn.py
+++ b/sculptor/tests/integration/frontend/test_background_task_reaction_turn.py
@@ -1,0 +1,76 @@
+"""Integration test for a test-timed background completion that fires a
+spontaneous reaction turn.
+
+The ``start_background_task`` FakeClaude command arms a background task and ends
+the arming turn (its ``result`` is emitted, the process lingers). When the test
+creates the trigger sentinel, FakeClaude emits ``task_updated`` +
+``task_notification`` and then a full ``init -> reaction -> result`` cycle —
+without any user frame prompting it, matching the real CLI's spontaneous
+reaction turn on background-task completion.
+
+Unlike ``background_subagent`` (whose notification + reaction are baked into the
+same cycle as the launch), here the reaction is a genuinely separate cycle
+emitted while the process idles between cycles, so completion timing is fully
+test-controlled via ``FakeClaudeTrigger``.
+"""
+
+import json
+
+from playwright.sync_api import expect
+
+from sculptor.testing.fake_claude_pause import FakeClaudeTrigger
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+
+@user_story("to verify a background task completing while idle fires a spontaneous reaction turn")
+def test_idle_background_completion_fires_reaction_turn(sculptor_instance_: SculptorInstance) -> None:
+    """Flow:
+    1. Start a turn with ``start_background_task``; the arming turn ends and the
+       harness lingers waiting for the background completion.
+    2. Once the "launched" text is visible, assert the pill shows the
+       ``waiting_for_background`` lifecycle state.
+    3. ``fire()`` the trigger; FakeClaude emits the completion and its reaction
+       cycle. Assert the reaction summary appears and the pill returns to idle.
+    """
+    page = sculptor_instance_.page
+    trigger = FakeClaudeTrigger()
+
+    arm_command = (
+        "fake_claude:start_background_task `"
+        + json.dumps(
+            {
+                "description": "Find Python files",
+                "reaction_text": "[SCU-1680] reaction turn complete",
+                "notification_summary": "background task done",
+                "trigger_path": str(trigger.trigger_path),
+            }
+        )
+        + "`"
+    )
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=arm_command,
+        wait_for_agent_to_finish=False,
+    )
+    chat_panel = task_page.get_chat_panel()
+
+    # The "launched" text marks the end of the arming turn: FakeClaude has
+    # emitted task_started + result and is now lingering on the trigger sentinel.
+    messages = chat_panel.get_messages()
+    expect(messages.filter(has_text="Background task launched").first).to_be_visible()
+
+    # The harness is idle with a pending background task — the pill must show the
+    # waiting state, not an active label.
+    pill = chat_panel.get_status_pill()
+    expect(pill).to_have_attribute("data-agent-state", "waiting_for_background")
+    expect(chat_panel.get_status_pill_label()).to_contain_text("Waiting")
+
+    # Fire the completion. The spontaneous task_updated + task_notification +
+    # reaction cycle should stream through and the turn complete.
+    trigger.fire()
+
+    expect(messages.filter(has_text="[SCU-1680] reaction turn complete").first).to_be_visible()
+    expect(chat_panel.get_thinking_indicator()).not_to_be_visible()


### PR DESCRIPTION
## What & why

Part of the **In-turn messages** epic (SCU-1675), Phase 0. Sub-ticket [SCU-1680].

FakeClaude could emit `task_started`/`task_notification` only as pre-baked, single-cycle sequences (`background_task_notification`, `background_subagent`/`workflow_run` with `pause_path`). The *timing* of a background task's completion relative to other turns was not test-controllable, and there was no true post-result asynchronous behavior — which is exactly what the borrowing-model scenarios hinge on.

This adds a small background-task registry so a scripted cycle can **arm** a task and end (its `result` is emitted, the process lingers), and the completion is **triggered later** by the test via a sentinel file. The reaction turn is then a genuinely separate, spontaneous cycle — matching the real CLI, where every turn (including a spontaneous reaction turn) opens with its own `system/init`, and completion ordering is `task_updated` → `task_notification` → a fresh `init → … → result` reaction cycle.

## What's added

- **`start_background_task`** — arms a task: emits a realistic launch (assistant text + Agent `tool_use` + "launched" `tool_result` + `system/task_started`) and registers a trigger path + scripted reaction. Does **not** block; the arming turn ends normally.
- **`complete_background_task`** — inside a borrowed turn's `multi_step`, blocks on the armed task's trigger and emits `task_updated` + `task_notification` **inline mid-cycle** (no premature `result`), marking the task reaction-ready.
- **Between-cycle linger loop** (`fake_claude.py`) — while tasks are pending, it emits each completed task's reaction cycle as its trigger fires (or as an inline completion becomes reaction-ready), and meanwhile returns any borrowed turn's frame. It exits only once stdin is closed **and** every task has drained, so the lingering window extends until all scripted tasks fire and their reactions are consumed.
- **`FakeClaudeTrigger`** (`sculptor/testing/fake_claude_pause.py`) — a unique sentinel path + `fire()`, mirroring `FakeClaudePause`.

## Behavior scenarios

All three epic scenarios are exercised deterministically, triggering completion via real sentinel files (**no sleeps-as-synchronization** — the tests synchronize by reading emitted `result` lines off stdout):

1. **Completion while idle → reaction turn** — subprocess test + an end-to-end integration test (`test_background_task_reaction_turn.py`) that also asserts the status pill shows `waiting_for_background` during the lingering window and returns to idle after the reaction.
2. **Completion during a borrowed turn** — subprocess test asserting `task_updated`/`task_notification` land mid-cycle (before the borrowed turn's `result`) and the reaction cycle runs after it.
3. **Multiple tasks / extended window** — subprocess test where a borrowed turn completes the first task and arms a second; the window stays open until the second fires.

## Testing

`just format` / `just check` / `just test-unit` all green. 66 FakeClaude unit tests pass; the new integration test passes end-to-end (`1 passed in 21.41s`).

## Deviations & notes

- **Scenarios 2 & 3 are covered at the FakeClaude byte-stream level (subprocess tests), not as full end-to-end integration tests.** Borrowed turns dispatched onto a lingering CLI's stdin require Phase 1's turn-yield/dispatch, which isn't implemented yet. Scenario 1 works end-to-end today because the current output processor already lingers while a background task is pending. The FakeClaude capability for 2 & 3 exists now, so they become expressible as end-to-end integration tests once Phase 1 lands — matching the ticket's acceptance.
- **Mid-cycle notification (scenario 2) is emitted by an explicit `complete_background_task` step in the borrowed turn's script**, rather than by the linger loop. This is deliberate: for the notification to interleave *mid-cycle* (as the real CLI does when a task completes while busy), the in-flight turn must be where it's emitted; the linger loop only runs the reaction cycle afterward.
- **`task_type` defaults to `local_agent`** so the reaction flows through the output processor's subagent task_updated → task_notification → reaction deferral path; it's configurable per task.
- **Coordination with SCU-1679** (concurrent mid-turn stdin-reader rework): I kept my changes to the reaction-turn emission path. The linger loop uses a new, independent `_read_one_stdin_frame` (single-line read) rather than touching `_read_prompt_from_stream_json_stdin`, so the two paths can evolve/merge separately. Merge surface: both read `sys.stdin`; `complete_background_task` relies on the same "don't queue a follow-up frame mid-cycle" contract (`_wait_until` drops non-interrupt lines) that SCU-1679 owns. If SCU-1679 changes frame buffering/classification, the two readers may want a shared classifier.

[SCU-1680]: https://linear.app/imbue/issue/SCU-1680

(Sent by Claude)