### PR TITLE
FakeClaude: absorb mid-turn frames as steering (SCU-1679)

### DIFF
--- a/sculptor/sculptor/agents/testing/fake_claude.py
+++ b/sculptor/sculptor/agents/testing/fake_claude.py
@@ -12,17 +12,21 @@ import re
 import signal
 import sys
 import time
-from pathlib import Path
 from uuid import uuid4
 
-from sculptor.agents.default.claude_code_sdk.harness import compute_claude_jsonl_directory
 from sculptor.agents.testing.fake_claude_commands import COMMAND_REGISTRY
 from sculptor.agents.testing.fake_claude_commands import UnknownFakeClaudeCommandError
+from sculptor.agents.testing.fake_claude_commands import clear_absorbed_frames
+from sculptor.agents.testing.fake_claude_commands import configure_stdin_router
 from sculptor.agents.testing.fake_claude_commands import dispatch_handler
 from sculptor.agents.testing.fake_claude_commands import handle_default
+from sculptor.agents.testing.fake_claude_commands import read_next_user_prompt
+from sculptor.agents.testing.fake_claude_jsonl import append_transcript_entry
 from sculptor.agents.testing.fake_claude_jsonl import generate_id
 from sculptor.agents.testing.fake_claude_jsonl import make_end_message
 from sculptor.agents.testing.fake_claude_jsonl import make_init_message
+from sculptor.agents.testing.fake_claude_jsonl import make_plain_user_transcript_entry
+from sculptor.agents.testing.fake_claude_jsonl import make_user_frame_echo
 from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_FROM_SIGTERM
 
 _FAKE_CLAUDE_PREFIX = "fake_claude:"
@@ -45,6 +49,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dangerously-skip-permissions", action="store_true")
     parser.add_argument("--include-partial-messages", action="store_true")
     parser.add_argument("--include-hook-events", action="store_true")
+    # Echo each accepted user frame back on stdout (delivery confirmation). When
+    # set, turn-starting frames are echoed just after their init and absorbed
+    # frames are echoed inside the open turn — matching the real CLI's
+    # --replay-user-messages, whose only discriminator is echo position.
+    parser.add_argument("--replay-user-messages", action="store_true")
     parser.add_argument("--resume", default=None)
     parser.add_argument("--append-system-prompt", default=None)
     parser.add_argument("--model", default=None)
@@ -117,24 +126,6 @@ def _get_session_id(resume_id: str | None) -> str:
     return f"session_fakeclaude_{uuid4().hex}"
 
 
-def _get_session_file_path(session_id: str) -> Path:
-    """Compute the session file path matching the Claude harness's layout.
-
-    Uses the resolved CWD, which matches `ClaudeCodeHarness.get_jsonl_path`
-    since the process is launched with get_working_directory() as its CWD.
-    """
-    resolved_cwd = Path(os.path.realpath(os.getcwd()))
-    return compute_claude_jsonl_directory(Path.home(), resolved_cwd) / f"{session_id}.jsonl"
-
-
-def _write_session_file(session_id: str) -> None:
-    """Write the session history file so is_session_id_valid() passes."""
-    session_path = _get_session_file_path(session_id)
-    session_path.parent.mkdir(parents=True, exist_ok=True)
-    session_data = {"sessionId": session_id, "type": "user", "message": {"role": "user", "content": "test"}}
-    session_path.write_text(json.dumps(session_data) + "\n")
-
-
 def _emit_jsonl(messages: list[dict]) -> None:
     """Write JSONL messages to stdout."""
     for msg in messages:
@@ -181,56 +172,22 @@ def _install_sigterm_handler() -> None:
 
 
 def _read_prompt_from_stream_json_stdin() -> str | None:
-    """Read the next user message from stdin in stream-json format.
+    """Read the next turn-starting user message from stdin (stream-json mode).
 
-    Reads lines until a JSON object with ``"type": "user"`` is found, then
-    returns its (HTML-unescaped, stripped) message content. An empty-content
-    user frame returns ``""`` so the default handler still runs for a
-    genuinely empty prompt.
+    Delegates to the unified stdin router's between-cycle reader (see
+    ``read_next_user_prompt``). Returns the frame's (HTML-unescaped, stripped)
+    content — ``""`` for an empty-content frame so the default handler still
+    runs — or ``None`` when stdin closes first, so the caller exits cleanly
+    rather than running a turn the user never sent. An ``interrupt``
+    control_request seen while idle exits with the SIGTERM code.
 
-    Returns ``None`` when stdin closes before another user frame arrives. The
-    caller treats that as EOF and exits cleanly with nothing further emitted,
-    matching the real CLI, which lingers on stdin between turns and exits only
-    on EOF. (Returning ``""`` here instead would spuriously run the default
-    handler for a turn the user never sent.)
-
-    An ``interrupt`` control_request seen while idle between cycles exits with
-    ``AGENT_EXIT_CODE_FROM_SIGTERM``, mirroring the graceful-interrupt exit the
-    in-cycle handlers perform. Other non-user frames (context-usage requests,
-    control responses, etc.) are ignored.
-
-    ``sys.stdin`` is its own iterator, so successive *between-cycle* reads
-    resume where the previous one stopped and share one read buffer: frames
-    delivered while FakeClaude is idle between cycles are neither dropped nor
-    reordered. That guarantee is scoped to idle delivery only. A frame written
-    while a cycle's handler is itself polling stdin can be consumed and
-    discarded by that handler before this reader ever sees it — ``_wait_until``
-    drops non-interrupt lines and the raw-fd ``_read_mcp_control_response_text``
-    drops non-matching lines (with the SCU-783 buffering interplay on top) — so
-    tests must not queue a follow-up frame mid-cycle. (Mid-cycle absorption is
-    SCU-1679's concern, not this reader's.)
+    The router owns a single stdin buffer shared with the in-cycle readers, so
+    a frame that lands while a cycle's handler is polling stdin is absorbed as
+    steering there (not lost, and not misread as a turn-start here); whatever a
+    handler pulled off stdin but did not consume stays buffered and is seen here
+    at the cycle boundary.
     """
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(data, dict):
-            continue
-        if (
-            data.get("type") == "control_request"
-            and isinstance(data.get("request"), dict)
-            and data["request"].get("subtype") == "interrupt"
-        ):
-            sys.exit(AGENT_EXIT_CODE_FROM_SIGTERM)
-        if data.get("type") == "user":
-            message = data.get("message", {})
-            content = message.get("content", "")
-            return html.unescape(content).strip() if isinstance(content, str) else ""
-    return None
+    return read_next_user_prompt()
 
 
 def _maybe_delay_for_compact_indicator(prompt: str, resume_id: str | None) -> None:
@@ -249,22 +206,27 @@ def _run_cycle(
     emit_streaming: bool,
     plugin_dir: str | None,
     system_commands: list[str],
-    write_session_file: bool,
+    persist_session: bool,
+    replay_user_messages: bool,
 ) -> int | None:
     """Run one full ``init → messages → result`` cycle for a single user frame.
 
     Emits the cycle's own ``init`` first — an init per cycle mirrors the real
     CLI and is the shape Sculptor's output processor expects for every turn —
-    then dispatches the frame's ``fake_claude:`` directives, then the
-    terminating ``result``. Emitting ``init`` up front also means the output
-    processor has the session id before any handler blocks (e.g.
-    ask_user_question waiting on an MCP response).
+    then records this turn-starting frame, then dispatches the frame's
+    ``fake_claude:`` directives, then the terminating ``result``. Emitting
+    ``init`` up front also means the output processor has the session id before
+    any handler blocks (e.g. ask_user_question waiting on an MCP response).
 
-    ``write_session_file`` writes the ``--resume`` history file just before the
-    first init. The caller sets it only on the first cycle (and only when
-    session persistence is enabled), so it runs exactly once per invocation and
-    — crucially — never when stdin is already at EOF: an immediate-EOF exit runs
-    no cycle at all and therefore leaves nothing on disk.
+    ``persist_session`` appends this frame to the on-disk transcript as a plain
+    user message — the turn-starting shape, distinct from the ``queued_command``
+    attachment an absorbed mid-cycle frame gets. It doubles as the ``--resume``
+    validity record. Writing happens inside the cycle, so an immediate-EOF exit
+    (no cycle) leaves nothing on disk; ``--no-session-persistence`` skips it.
+
+    ``replay_user_messages`` echoes this frame on stdout right after ``init``
+    (the turn-starting replay position), the counterpart to an absorbed frame's
+    echo inside the open turn.
 
     ``system_commands`` (directives extracted from ``--append-system-prompt``)
     run before the frame's own directives. The caller passes them only for the
@@ -274,10 +236,16 @@ def _run_cycle(
     Returns an exit code if the cycle terminates the whole process (an unknown
     command → 1), or ``None`` to signal the caller may run further cycles.
     """
-    if write_session_file:
-        _write_session_file(session_id)
+    # Start the turn's absorption record fresh so a reference_absorbed directive
+    # in this cycle sees only frames absorbed during this turn.
+    clear_absorbed_frames()
 
     _emit_jsonl([make_init_message(session_id)])
+
+    if persist_session:
+        append_transcript_entry(session_id, make_plain_user_transcript_entry(session_id, prompt))
+    if replay_user_messages:
+        _emit_jsonl([make_user_frame_echo(prompt)])
 
     all_messages: list[dict] = []
     end_result = ""
@@ -336,9 +304,13 @@ def main(argv: list[str] | None = None) -> int:
 
     # `--no-session-persistence` (used by /btw's forked invocation) means we
     # must leave the resumed session file untouched and not write a new one.
-    # The write itself is deferred into the first cycle (see `_run_cycle`) so an
-    # immediate-EOF exit leaves no orphan session file on disk.
+    # The transcript write is deferred into the first cycle (see `_run_cycle`)
+    # so an immediate-EOF exit leaves no orphan session file on disk.
     persist_session = not parsed.no_session_persistence
+
+    # Hand the stdin router its launch-time flags before any cycle runs: it owns
+    # every stdin read and decides how a mid-cycle frame is absorbed.
+    configure_stdin_router(replay_user_messages=parsed.replay_user_messages, persist_session=persist_session)
 
     # fake_claude: directives embedded in the appended system prompt are a
     # launch-time input, so they run once — on the first cycle only.
@@ -349,7 +321,14 @@ def main(argv: list[str] | None = None) -> int:
     if isinstance(parsed.p_flag, str):
         _maybe_delay_for_compact_indicator(parsed.p_flag, parsed.resume)
         exit_code = _run_cycle(
-            parsed.p_flag, session_id, cwd, emit_streaming, plugin_dir, system_commands, persist_session
+            parsed.p_flag,
+            session_id,
+            cwd,
+            emit_streaming,
+            plugin_dir,
+            system_commands,
+            persist_session=persist_session,
+            replay_user_messages=parsed.replay_user_messages,
         )
         return exit_code if exit_code is not None else 0
 
@@ -371,7 +350,8 @@ def main(argv: list[str] | None = None) -> int:
                 emit_streaming,
                 plugin_dir,
                 cycle_system_commands,
-                write_session_file=is_first_cycle and persist_session,
+                persist_session=persist_session,
+                replay_user_messages=parsed.replay_user_messages,
             )
             if exit_code is not None:
                 return exit_code
@@ -380,7 +360,16 @@ def main(argv: list[str] | None = None) -> int:
     # Non-stream-json single-shot: a plain piped prompt, or nothing on a tty.
     prompt = html.unescape(sys.stdin.read()).strip() if not sys.stdin.isatty() else ""
     _maybe_delay_for_compact_indicator(prompt, parsed.resume)
-    exit_code = _run_cycle(prompt, session_id, cwd, emit_streaming, plugin_dir, system_commands, persist_session)
+    exit_code = _run_cycle(
+        prompt,
+        session_id,
+        cwd,
+        emit_streaming,
+        plugin_dir,
+        system_commands,
+        persist_session=persist_session,
+        replay_user_messages=parsed.replay_user_messages,
+    )
     return exit_code if exit_code is not None else 0
 
 

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -5,6 +5,7 @@ between the init and end messages.
 """
 
 import glob as glob_module
+import html
 import inspect
 import json
 import os
@@ -17,6 +18,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
+from sculptor.agents.testing.fake_claude_jsonl import append_transcript_entry
 from sculptor.agents.testing.fake_claude_jsonl import generate_id
 from sculptor.agents.testing.fake_claude_jsonl import get_last_session_id
 from sculptor.agents.testing.fake_claude_jsonl import make_assistant_message
@@ -26,6 +28,7 @@ from sculptor.agents.testing.fake_claude_jsonl import make_compact_summary_user_
 from sculptor.agents.testing.fake_claude_jsonl import make_end_message
 from sculptor.agents.testing.fake_claude_jsonl import make_hook_callback_control_request
 from sculptor.agents.testing.fake_claude_jsonl import make_init_message
+from sculptor.agents.testing.fake_claude_jsonl import make_queued_command_attachment_entry
 from sculptor.agents.testing.fake_claude_jsonl import make_streaming_interleaved_events
 from sculptor.agents.testing.fake_claude_jsonl import make_streaming_text_events
 from sculptor.agents.testing.fake_claude_jsonl import make_streaming_tool_events
@@ -36,6 +39,7 @@ from sculptor.agents.testing.fake_claude_jsonl import make_task_updated_message
 from sculptor.agents.testing.fake_claude_jsonl import make_text_block
 from sculptor.agents.testing.fake_claude_jsonl import make_tool_result_message
 from sculptor.agents.testing.fake_claude_jsonl import make_tool_use_block
+from sculptor.agents.testing.fake_claude_jsonl import make_user_frame_echo
 from sculptor.agents.testing.fake_claude_jsonl import make_workflow_agent_entry
 from sculptor.agents.testing.fake_claude_jsonl import make_workflow_phase_entry
 from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_FROM_SIGTERM
@@ -138,68 +142,230 @@ def _emit_mcp_tool_call_and_wait_for_response(
     return _read_mcp_control_response_text(request_id, tool_use_id, timeout_seconds, expect_error=expect_error)
 
 
-# Bytes pulled off stdin by a response reader after its final match. A single
-# os.read can swallow lines destined for a LATER reader in the same process
-# (the SCU-783 buffering flake); parking them here keeps sequential readers
-# (e.g. two AUQ waits in one handler) from losing responses.
-_STDIN_UNCONSUMED: bytes = b""
+# --- Unified stdin router ---------------------------------------------------
+#
+# Every stdin read in FakeClaude funnels through one router so a frame that
+# arrives while a cycle is held open is classified exactly once and never
+# silently dropped. It reads the raw fd (via ``sys.stdin.fileno()``) into a
+# single buffer: mixing ``sys.stdin``'s BufferedReader with raw ``os.read``
+# splits complete lines across two invisible buffers, the flake behind SCU-783
+# (a matching control_response stranded in Python's buffer where ``select`` on
+# the fd can't see it). With one buffer, whatever a mid-cycle reader pulls off
+# stdin but doesn't itself consume — a later reader's response, a frame to
+# absorb — stays available to the next reader across the cycle boundary.
+#
+# Classification is uniform, mirroring the real CLI:
+#   * an ``interrupt`` control_request exits the process (SIGTERM code);
+#   * a ``control_response`` goes to whichever handler is waiting on its id;
+#   * a ``user`` frame arriving mid-cycle is *absorbed* — recorded as a
+#     ``queued_command`` attachment and, under ``--replay-user-messages``,
+#     echoed on stdout (the real CLI's mid-turn steering);
+#   * anything else (a ``get_context_usage`` request, injected chrome events)
+#     is ignored.
+# A ``user`` frame read *between* cycles is turn-starting instead, so the
+# between-cycle reader classifies it itself rather than absorbing it.
+
+# Launch-time flags governing absorption, set by ``configure_stdin_router``.
+_REPLAY_USER_MESSAGES: bool = False
+_PERSIST_SESSION: bool = True
+
+# Contents of frames absorbed mid-cycle in the current turn, in arrival order.
+# ``handle_reference_absorbed`` reads this so a scripted cycle can prove it saw
+# the steered content; ``clear_absorbed_frames`` resets it per cycle.
+_ABSORBED_FRAMES: list[str] = []
+
+# Sentinels returned by ``_StdinRouter.next_frame`` when no frame is available.
+_STDIN_TIMEOUT = object()
+_STDIN_EOF = object()
+
+
+class _StdinRouter:
+    """Sole owner of FakeClaude's stdin fd (see the module comment above)."""
+
+    def __init__(self) -> None:
+        self._buffer: bytes = b""
+        self._eof: bool = False
+
+    def reset(self) -> None:
+        """Drop buffered bytes and clear EOF (unit tests reuse one process)."""
+        self._buffer = b""
+        self._eof = False
+
+    def _pop_frame(self) -> dict | None:
+        """Return the next complete, parseable JSON object already buffered.
+
+        Blank and unparseable lines (and non-object JSON) are skipped; a
+        partial trailing line stays buffered for the next read.
+        """
+        while b"\n" in self._buffer:
+            raw_line, _, self._buffer = self._buffer.partition(b"\n")
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict):
+                return data
+        return None
+
+    def _fill(self, timeout: float) -> None:
+        """Block up to ``timeout`` seconds for more stdin bytes into the buffer."""
+        if self._eof:
+            return
+        try:
+            fd = sys.stdin.fileno()
+        except (ValueError, OSError):
+            # No real fd (closed stream / non-fd stdin) — treat as end of input.
+            self._eof = True
+            return
+        ready, _, _ = select.select([fd], [], [], timeout)
+        if not ready:
+            return
+        chunk = os.read(fd, 8192)
+        if not chunk:
+            self._eof = True
+            return
+        self._buffer += chunk
+
+    def next_frame(self, timeout: float) -> dict | object:
+        """Return the next parsed JSON frame, else ``_STDIN_TIMEOUT`` (nothing
+        arrived within ``timeout``) or ``_STDIN_EOF`` (stdin closed)."""
+        frame = self._pop_frame()
+        if frame is not None:
+            return frame
+        if self._eof:
+            return _STDIN_EOF
+        self._fill(timeout)
+        frame = self._pop_frame()
+        if frame is not None:
+            return frame
+        return _STDIN_EOF if (self._eof and b"\n" not in self._buffer) else _STDIN_TIMEOUT
+
+
+_STDIN_ROUTER = _StdinRouter()
+
+
+def configure_stdin_router(replay_user_messages: bool, persist_session: bool) -> None:
+    """Apply launch-time flags and start each invocation from a clean slate."""
+    global _REPLAY_USER_MESSAGES, _PERSIST_SESSION
+    _REPLAY_USER_MESSAGES = replay_user_messages
+    _PERSIST_SESSION = persist_session
+    _STDIN_ROUTER.reset()
+    _ABSORBED_FRAMES.clear()
+
+
+def clear_absorbed_frames() -> None:
+    """Reset the absorbed-frame record at the start of a cycle so each turn's
+    ``reference_absorbed`` sees only the frames absorbed during that turn."""
+    _ABSORBED_FRAMES.clear()
+
+
+def _user_frame_content(frame: dict) -> str:
+    """Extract a user frame's message content, HTML-unescaped and stripped
+    (the same normalization the between-cycle reader applies to a prompt)."""
+    content = frame.get("message", {}).get("content", "")
+    return html.unescape(content).strip() if isinstance(content, str) else ""
+
+
+def _exit_if_interrupt(frame: dict) -> None:
+    """Exit with the SIGTERM code if ``frame`` is an interrupt control_request.
+
+    Mirrors real Claude's event loop: a Stop-button click arrives as an
+    ``interrupt`` control_request and tears the turn down promptly.
+    """
+    if (
+        frame.get("type") == "control_request"
+        and isinstance(frame.get("request"), dict)
+        and frame["request"].get("subtype") == "interrupt"
+    ):
+        sys.exit(AGENT_EXIT_CODE_FROM_SIGTERM)
+
+
+def _absorb_user_frame(frame: dict) -> None:
+    """Record a mid-cycle user frame the way the real CLI absorbs steering.
+
+    Appends a ``queued_command`` attachment to the session transcript (so the
+    on-disk shape distinguishes an absorbed frame from a turn-starting plain
+    user message) and, under ``--replay-user-messages``, echoes the frame on
+    stdout — emitted here, inside the open turn before its ``result``, which is
+    the steered replay position the spike pinned (as opposed to a turn-starting
+    frame's echo, which lands just after a fresh ``init``).
+    """
+    content = _user_frame_content(frame)
+    _ABSORBED_FRAMES.append(content)
+    session_id = get_last_session_id()
+    if _PERSIST_SESSION and session_id is not None:
+        append_transcript_entry(session_id, make_queued_command_attachment_entry(session_id, content))
+    if _REPLAY_USER_MESSAGES:
+        _emit_event(make_user_frame_echo(content))
+
+
+def _route_mid_cycle_frame(frame: dict) -> None:
+    """Apply the universal side effects for a frame a mid-cycle reader is not
+    itself consuming: an interrupt exits, a user frame is absorbed, everything
+    else is ignored."""
+    _exit_if_interrupt(frame)
+    if frame.get("type") == "user":
+        _absorb_user_frame(frame)
+
+
+def read_next_user_prompt() -> str | None:
+    """Block *between* cycles for the next turn-starting user frame.
+
+    Returns the frame's (HTML-unescaped, stripped) content, or ``None`` when
+    stdin closes first (EOF) so the caller exits instead of running a turn the
+    user never sent. An ``interrupt`` control_request seen while idle exits with
+    the SIGTERM code. A user frame here is turn-starting — it is NOT absorbed
+    (absorption applies only to frames that land while a cycle is held open);
+    control responses and other non-user frames are ignored while scanning.
+    """
+    while True:
+        frame = _STDIN_ROUTER.next_frame(timeout=3600.0)
+        if frame is _STDIN_TIMEOUT:
+            continue
+        if frame is _STDIN_EOF:
+            return None
+        assert isinstance(frame, dict)
+        _exit_if_interrupt(frame)
+        if frame.get("type") == "user":
+            return _user_frame_content(frame)
 
 
 def _read_mcp_control_responses(expected_request_ids: set[str], timeout_seconds: float) -> dict[str, dict]:
-    """Block reading stdin until an MCP ``control_response`` has arrived for
-    every id in ``expected_request_ids``. Returns ``{request_id: mcp_response}``.
+    """Block until an MCP ``control_response`` has arrived for every id in
+    ``expected_request_ids``. Returns ``{request_id: mcp_response}``.
 
-    Reads from stdin's raw file descriptor rather than ``sys.stdin.readline``
-    to avoid a flake (SCU-783) where Sculptor writes a non-matching control
-    request (e.g. ``get_context_usage``) and the matching control_response
-    back-to-back: ``readline``'s underlying ``read1`` then pulls BOTH lines
-    into Python's ``BufferedReader`` buffer in a single syscall, returns only
-    the first, and leaves the response in the buffer where the next
-    ``select.select`` on stdin's fd cannot see it — the helper would spin
-    until its 180s timeout while the agent's status pill stayed visible.
+    Runs on the unified router, so a user frame that lands while the handler
+    waits for its answer is absorbed rather than discarded, and a non-matching
+    control_response batched into the same read stays buffered for the next
+    reader instead of being lost (SCU-783).
     """
-    global _STDIN_UNCONSUMED
-    fd = sys.stdin.fileno()
-    results: dict[str, dict] = {}
     remaining_ids = set(expected_request_ids)
-    pending = _STDIN_UNCONSUMED
-    _STDIN_UNCONSUMED = b""
+    results: dict[str, dict] = {}
     deadline = time.monotonic() + timeout_seconds
-    try:
-        while True:
-            while b"\n" in pending:
-                raw_line, _, pending = pending.partition(b"\n")
-                line = raw_line.decode("utf-8", errors="replace").strip()
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(data, dict) or data.get("type") != "control_response":
-                    continue
-                response = data.get("response", {})
-                request_id = response.get("request_id")
-                if request_id not in remaining_ids:
-                    continue
+    while remaining_ids:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        frame = _STDIN_ROUTER.next_frame(timeout=min(remaining, 0.1))
+        if frame is _STDIN_TIMEOUT:
+            continue
+        if frame is _STDIN_EOF:
+            break
+        assert isinstance(frame, dict)
+        if frame.get("type") == "control_response":
+            response = frame.get("response", {})
+            request_id = response.get("request_id")
+            if request_id in remaining_ids:
                 results[request_id] = response.get("response", {}).get("mcp_response", {})
                 remaining_ids.discard(request_id)
-                if not remaining_ids:
-                    return results
-
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-            ready, _, _ = select.select([fd], [], [], min(remaining, 0.1))
-            if not ready:
-                continue
-            chunk = os.read(fd, 8192)
-            if not chunk:
-                break
-            pending += chunk
+            continue
+        _route_mid_cycle_frame(frame)
+    if remaining_ids:
         raise RuntimeError(f"Timed out waiting for MCP control_response(s) for request_ids={sorted(remaining_ids)}")
-    finally:
-        _STDIN_UNCONSUMED = pending
+    return results
 
 
 def _extract_mcp_response_text(mcp_response: dict) -> str:
@@ -498,11 +664,13 @@ def _wait_until(
 ) -> bool:
     """Wait until ``done()`` returns true or ``timeout_seconds`` elapses.
 
-    Polls stdin throughout: a Stop-button click arrives as an interrupt
-    ``control_request`` and exits the process with the SIGTERM exit code,
-    mirroring real Claude's event loop and keeping interrupt tests fast.
-    SIGTERM itself still terminates via the signal handler installed in
-    ``main()`` — including on ``-p``-mode callers whose stdin is closed.
+    Polls stdin throughout via the unified router: a Stop-button click arrives
+    as an ``interrupt`` control_request and exits with the SIGTERM code
+    (mirroring real Claude's event loop and keeping interrupt tests fast),
+    while a user frame that lands during the wait is absorbed as steering
+    rather than dropped. SIGTERM itself still terminates via the signal handler
+    installed in ``main()`` — including on ``-p``-mode callers whose stdin is
+    closed.
 
     With ``done`` omitted, simply waits out the full timeout. Returns whether
     ``done()`` fired before the timeout.
@@ -512,25 +680,15 @@ def _wait_until(
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return False
-        ready, _, _ = select.select([sys.stdin], [], [], min(remaining, poll_interval))
-        if not ready:
+        frame = _STDIN_ROUTER.next_frame(timeout=min(remaining, poll_interval))
+        if frame is _STDIN_TIMEOUT:
             continue
-        line = sys.stdin.readline()
-        if not line:
-            # stdin closed (e.g. -p mode) — keep waiting without it.
-            time.sleep(poll_interval)
+        if frame is _STDIN_EOF:
+            # stdin closed (e.g. -p mode) — keep polling done()/timeout without it.
+            time.sleep(min(remaining, poll_interval))
             continue
-        try:
-            data = json.loads(line.strip())
-        except json.JSONDecodeError:
-            continue
-        if (
-            isinstance(data, dict)
-            and data.get("type") == "control_request"
-            and isinstance(data.get("request"), dict)
-            and data["request"].get("subtype") == "interrupt"
-        ):
-            sys.exit(AGENT_EXIT_CODE_FROM_SIGTERM)
+        assert isinstance(frame, dict)
+        _route_mid_cycle_frame(frame)
     return True
 
 
@@ -560,6 +718,30 @@ def handle_wait_for_file(args: dict, emit_streaming: bool) -> list[dict]:
     if not _wait_until(timeout_seconds=timeout_seconds, poll_interval=0.05, done=sentinel.exists):
         raise RuntimeError(f"fake_claude:wait_for_file timed out after {timeout_seconds}s waiting for {sentinel}")
     return []
+
+
+def handle_reference_absorbed(args: dict, emit_streaming: bool) -> list[dict]:
+    """Emit assistant text referencing the frames absorbed so far this cycle.
+
+    A scripted way to prove the held cycle actually saw the steered content
+    (scenario 1's "a scripted directive controls whether/how the fake assistant
+    references the absorbed content in its remaining output"): pair it after a
+    held handler in a ``multi_step`` so absorption happens during the hold and
+    this step quotes it. ``prefix`` / ``separator`` shape the text; with nothing
+    absorbed the body is ``empty`` (default ``"(none)"``).
+    """
+    prefix: str = args.get("prefix", "Absorbed: ")
+    separator: str = args.get("separator", " | ")
+    empty: str = args.get("empty", "(none)")
+    body = separator.join(_ABSORBED_FRAMES) if _ABSORBED_FRAMES else empty
+    text = prefix + body
+
+    message_id = generate_id("msg")
+    messages: list[dict] = []
+    if emit_streaming:
+        messages.extend(make_streaming_text_events(message_id=message_id, text=text))
+    messages.append(make_assistant_message(message_id=message_id, content_blocks=[make_text_block(text)]))
+    return messages
 
 
 _TASK_DEFAULTS: dict = {
@@ -1055,37 +1237,30 @@ def handle_auto_compact(args: dict, plugin_dir: str | None, emit_streaming: bool
 
 
 def _read_control_response_from_stdin(expected_request_id: str, timeout_seconds: float = 5.0) -> None:
-    """Read stdin until we get a ``control_response`` for the given request ID.
+    """Read stdin until a ``control_response`` for ``expected_request_id`` arrives.
 
-    Falls back silently after ``timeout_seconds`` so FakeClaude doesn't hang
-    if the output processor doesn't respond (e.g. during unit tests that mock
-    stdin).
+    Runs on the unified router (so a mid-wait user frame is absorbed and an
+    interrupt exits), but falls back silently after ``timeout_seconds`` — unlike
+    the MCP reader — so FakeClaude doesn't hang if the output processor never
+    acks the hook (e.g. during unit tests that mock stdin).
     """
     deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
+    while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            break
-        # Use select to avoid blocking indefinitely on stdin
-        ready, _, _ = select.select([sys.stdin], [], [], min(remaining, 0.1))
-        if not ready:
+            return
+        frame = _STDIN_ROUTER.next_frame(timeout=min(remaining, 0.1))
+        if frame is _STDIN_TIMEOUT:
             continue
-        line = sys.stdin.readline()
-        if not line:
-            break
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+        if frame is _STDIN_EOF:
+            return
+        assert isinstance(frame, dict)
         if (
-            isinstance(data, dict)
-            and data.get("type") == "control_response"
-            and data.get("response", {}).get("request_id") == expected_request_id
+            frame.get("type") == "control_response"
+            and frame.get("response", {}).get("request_id") == expected_request_id
         ):
             return
+        _route_mid_cycle_frame(frame)
 
 
 def handle_auto_compact_no_summary(args: dict, plugin_dir: str | None, emit_streaming: bool) -> list[dict]:
@@ -2817,6 +2992,7 @@ COMMAND_REGISTRY: dict[str, Callable[..., list[dict]]] = {
     "text_and_bash": handle_text_and_bash,
     "sleep": handle_sleep,
     "wait_for_file": handle_wait_for_file,
+    "reference_absorbed": handle_reference_absorbed,
     "task_create": handle_task_create,
     "task_update": handle_task_update,
     "task_list": handle_task_list,

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -142,7 +142,7 @@ def _emit_mcp_tool_call_and_wait_for_response(
     return _read_mcp_control_response_text(request_id, tool_use_id, timeout_seconds, expect_error=expect_error)
 
 
-# --- Unified stdin router ---------------------------------------------------
+# Unified stdin router.
 #
 # Every stdin read in FakeClaude funnels through one router so a frame that
 # arrives while a cycle is held open is classified exactly once and never
@@ -150,13 +150,15 @@ def _emit_mcp_tool_call_and_wait_for_response(
 # single buffer: mixing ``sys.stdin``'s BufferedReader with raw ``os.read``
 # splits complete lines across two invisible buffers, the flake behind SCU-783
 # (a matching control_response stranded in Python's buffer where ``select`` on
-# the fd can't see it). With one buffer, whatever a mid-cycle reader pulls off
-# stdin but doesn't itself consume — a later reader's response, a frame to
-# absorb — stays available to the next reader across the cycle boundary.
+# the fd can't see it). With one buffer, whatever a reader pulls off stdin but
+# doesn't itself consume stays available: unparsed bytes remain in the buffer,
+# and a parsed control_response destined for a different reader is stashed for
+# it (see ``stash_control_response``) rather than discarded.
 #
 # Classification is uniform, mirroring the real CLI:
 #   * an ``interrupt`` control_request exits the process (SIGTERM code);
-#   * a ``control_response`` goes to whichever handler is waiting on its id;
+#   * a ``control_response`` goes to whichever reader is waiting on its id,
+#     stashed until that reader asks for it;
 #   * a ``user`` frame arriving mid-cycle is *absorbed* — recorded as a
 #     ``queued_command`` attachment and, under ``--replay-user-messages``,
 #     echoed on stdout (the real CLI's mid-turn steering);
@@ -185,11 +187,25 @@ class _StdinRouter:
     def __init__(self) -> None:
         self._buffer: bytes = b""
         self._eof: bool = False
+        # control_responses read by a reader that wasn't waiting on them, kept
+        # for whichever reader is (keyed by request id). FakeClaude waits for
+        # each response synchronously, so this is usually empty; it exists so a
+        # response is never dropped when one reader pulls another's off stdin.
+        self._stashed_control_responses: dict[str, dict] = {}
 
     def reset(self) -> None:
-        """Drop buffered bytes and clear EOF (unit tests reuse one process)."""
+        """Drop buffered bytes, stashed responses, and EOF (tests reuse one process)."""
         self._buffer = b""
         self._eof = False
+        self._stashed_control_responses = {}
+
+    def stash_control_response(self, request_id: str, envelope: dict) -> None:
+        """Hold a control_response envelope for the reader awaiting ``request_id``."""
+        self._stashed_control_responses[request_id] = envelope
+
+    def pop_stashed_response(self, request_id: str) -> dict | None:
+        """Return and remove a previously stashed response for ``request_id``, if any."""
+        return self._stashed_control_responses.pop(request_id, None)
 
     def _pop_frame(self, flush_partial: bool = False) -> dict | None:
         """Return the next complete, parseable JSON object already buffered.
@@ -310,11 +326,19 @@ def _absorb_user_frame(frame: dict) -> None:
 
 def _route_mid_cycle_frame(frame: dict) -> None:
     """Apply the universal side effects for a frame a mid-cycle reader is not
-    itself consuming: an interrupt exits, a user frame is absorbed, everything
-    else is ignored."""
+    itself consuming: an interrupt exits, a user frame is absorbed, a
+    control_response meant for a different reader is stashed for that reader,
+    and anything else (a ``get_context_usage`` request, chrome events) is
+    ignored."""
     _exit_if_interrupt(frame)
-    if frame.get("type") == "user":
+    frame_type = frame.get("type")
+    if frame_type == "user":
         _absorb_user_frame(frame)
+    elif frame_type == "control_response":
+        envelope = frame.get("response", {})
+        request_id = envelope.get("request_id")
+        if request_id is not None:
+            _STDIN_ROUTER.stash_control_response(request_id, envelope)
 
 
 def read_next_user_prompt() -> str | None:
@@ -344,12 +368,19 @@ def _read_mcp_control_responses(expected_request_ids: set[str], timeout_seconds:
     ``expected_request_ids``. Returns ``{request_id: mcp_response}``.
 
     Runs on the unified router, so a user frame that lands while the handler
-    waits for its answer is absorbed rather than discarded, and a non-matching
-    control_response batched into the same read stays buffered for the next
-    reader instead of being lost (SCU-783).
+    waits for its answer is absorbed rather than discarded, and a
+    control_response meant for a different waiter (batched into the same read,
+    or already seen by an earlier reader) is stashed for that waiter instead of
+    being lost — the SCU-783 guarantee, extended from raw bytes to parsed frames.
     """
     remaining_ids = set(expected_request_ids)
     results: dict[str, dict] = {}
+    # A response for one of our ids may already be waiting from an earlier read.
+    for request_id in list(remaining_ids):
+        stashed = _STDIN_ROUTER.pop_stashed_response(request_id)
+        if stashed is not None:
+            results[request_id] = stashed.get("response", {}).get("mcp_response", {})
+            remaining_ids.discard(request_id)
     deadline = time.monotonic() + timeout_seconds
     while remaining_ids:
         remaining = deadline - time.monotonic()
@@ -367,7 +398,9 @@ def _read_mcp_control_responses(expected_request_ids: set[str], timeout_seconds:
             if request_id in remaining_ids:
                 results[request_id] = response.get("response", {}).get("mcp_response", {})
                 remaining_ids.discard(request_id)
-            continue
+                continue
+        # Not one of ours (a user frame, an interrupt, or another waiter's
+        # response) — route it so it is absorbed / stashed, never dropped.
         _route_mid_cycle_frame(frame)
     if remaining_ids:
         raise RuntimeError(f"Timed out waiting for MCP control_response(s) for request_ids={sorted(remaining_ids)}")
@@ -1245,11 +1278,15 @@ def handle_auto_compact(args: dict, plugin_dir: str | None, emit_streaming: bool
 def _read_control_response_from_stdin(expected_request_id: str, timeout_seconds: float = 5.0) -> None:
     """Read stdin until a ``control_response`` for ``expected_request_id`` arrives.
 
-    Runs on the unified router (so a mid-wait user frame is absorbed and an
-    interrupt exits), but falls back silently after ``timeout_seconds`` — unlike
-    the MCP reader — so FakeClaude doesn't hang if the output processor never
-    acks the hook (e.g. during unit tests that mock stdin).
+    Runs on the unified router (so a mid-wait user frame is absorbed, an
+    interrupt exits, and a control_response for a *different* waiter is stashed
+    for it rather than dropped), but falls back silently after
+    ``timeout_seconds`` — unlike the MCP reader — so FakeClaude doesn't hang if
+    the output processor never acks the hook (e.g. during unit tests that mock
+    stdin).
     """
+    if _STDIN_ROUTER.pop_stashed_response(expected_request_id) is not None:
+        return
     deadline = time.monotonic() + timeout_seconds
     while True:
         remaining = deadline - time.monotonic()

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -191,14 +191,20 @@ class _StdinRouter:
         self._buffer = b""
         self._eof = False
 
-    def _pop_frame(self) -> dict | None:
+    def _pop_frame(self, flush_partial: bool = False) -> dict | None:
         """Return the next complete, parseable JSON object already buffered.
 
         Blank and unparseable lines (and non-object JSON) are skipped; a
-        partial trailing line stays buffered for the next read.
+        partial trailing line normally stays buffered for the next read. Pass
+        ``flush_partial`` at EOF to also consume a final line that arrived
+        without a trailing newline, so a last frame isn't dropped (the old
+        ``for line in sys.stdin`` iterator yielded it).
         """
-        while b"\n" in self._buffer:
-            raw_line, _, self._buffer = self._buffer.partition(b"\n")
+        while b"\n" in self._buffer or (flush_partial and self._buffer):
+            if b"\n" in self._buffer:
+                raw_line, _, self._buffer = self._buffer.partition(b"\n")
+            else:
+                raw_line, self._buffer = self._buffer, b""
             line = raw_line.decode("utf-8", errors="replace").strip()
             if not line:
                 continue
@@ -235,13 +241,13 @@ class _StdinRouter:
         frame = self._pop_frame()
         if frame is not None:
             return frame
-        if self._eof:
-            return _STDIN_EOF
-        self._fill(timeout)
-        frame = self._pop_frame()
+        if not self._eof:
+            self._fill(timeout)
+        # At EOF, flush a final newline-less line so a last frame isn't dropped.
+        frame = self._pop_frame(flush_partial=self._eof)
         if frame is not None:
             return frame
-        return _STDIN_EOF if (self._eof and b"\n" not in self._buffer) else _STDIN_TIMEOUT
+        return _STDIN_EOF if self._eof else _STDIN_TIMEOUT
 
 
 _STDIN_ROUTER = _StdinRouter()
@@ -353,7 +359,7 @@ def _read_mcp_control_responses(expected_request_ids: set[str], timeout_seconds:
         if frame is _STDIN_TIMEOUT:
             continue
         if frame is _STDIN_EOF:
-            break
+            raise RuntimeError(f"stdin closed before MCP control_response(s) for request_ids={sorted(remaining_ids)}")
         assert isinstance(frame, dict)
         if frame.get("type") == "control_response":
             response = frame.get("response", {})

--- a/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
@@ -69,11 +69,13 @@ def make_queued_command_attachment_entry(session_id: str, prompt: str) -> dict:
     The real CLI records a frame that arrives while a turn is in flight as a
     ``queued_command`` attachment rather than a plain user message; this is the
     on-disk marker that distinguishes steering from a turn-starting follow-up.
+    ``commandMode: "prompt"`` matches the real CLI's attachment shape (a queued
+    plain prompt, as opposed to a queued slash command).
     """
     return {
         "type": "attachment",
         "sessionId": session_id,
-        "attachment": {"type": "queued_command", "prompt": prompt},
+        "attachment": {"type": "queued_command", "prompt": prompt, "commandMode": "prompt"},
     }
 
 

--- a/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_jsonl.py
@@ -2,7 +2,11 @@
 
 import itertools
 import json
+import os
 from collections.abc import Sequence
+from pathlib import Path
+
+from sculptor.agents.default.claude_code_sdk.harness import compute_claude_jsonl_directory
 
 _id_counter = itertools.count(1)
 
@@ -17,6 +21,70 @@ def generate_id(prefix: str = "msg") -> str:
 def get_last_session_id() -> str | None:
     """Return the session id from the most recent make_init_message call."""
     return _LAST_SESSION_ID
+
+
+def session_transcript_path(session_id: str) -> Path:
+    """Path of the on-disk session JSONL for ``session_id``.
+
+    Mirrors ``ClaudeCodeHarness.get_jsonl_path``: the CLI is launched with the
+    working directory as its CWD, so the transcript lands under the slugged
+    projects tree that ``compute_claude_jsonl_directory`` derives from HOME and
+    that CWD. Read HOME/CWD at call time so a test that pins ``$HOME`` gets the
+    path it expects.
+    """
+    resolved_cwd = Path(os.path.realpath(os.getcwd()))
+    return compute_claude_jsonl_directory(Path.home(), resolved_cwd) / f"{session_id}.jsonl"
+
+
+def append_transcript_entry(session_id: str, entry: dict) -> None:
+    """Append one JSONL entry to ``session_id``'s on-disk transcript.
+
+    Creating the projects directory on first write mirrors the real CLI, which
+    materializes the transcript lazily once a turn actually runs — so a session
+    that emits nothing (immediate EOF) leaves no file behind.
+    """
+    path = session_transcript_path(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as transcript:
+        transcript.write(json.dumps(entry) + "\n")
+
+
+def make_plain_user_transcript_entry(session_id: str, content: str) -> dict:
+    """Transcript entry for a turn-starting user frame (a plain user message).
+
+    The top-level ``sessionId`` (camelCase, matching the real CLI's on-disk
+    shape) is what ``is_session_id_valid`` scans for, so writing this per turn
+    also keeps the session resumable.
+    """
+    return {
+        "type": "user",
+        "sessionId": session_id,
+        "message": {"role": "user", "content": content},
+    }
+
+
+def make_queued_command_attachment_entry(session_id: str, prompt: str) -> dict:
+    """Transcript entry for a frame absorbed mid-cycle (the steering shape).
+
+    The real CLI records a frame that arrives while a turn is in flight as a
+    ``queued_command`` attachment rather than a plain user message; this is the
+    on-disk marker that distinguishes steering from a turn-starting follow-up.
+    """
+    return {
+        "type": "attachment",
+        "sessionId": session_id,
+        "attachment": {"type": "queued_command", "prompt": prompt},
+    }
+
+
+def make_user_frame_echo(content: str) -> dict:
+    """Stdout echo of an accepted user frame (the ``--replay-user-messages`` shape).
+
+    The real CLI, launched with ``--replay-user-messages``, re-emits each
+    accepted frame as a ``type:"user"`` event whose message content is a plain
+    string — the same shape the wrapper writes on stdin.
+    """
+    return {"type": "user", "message": {"role": "user", "content": content}}
 
 
 def make_init_message(session_id: str) -> dict:

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -19,6 +19,7 @@ from sculptor.agents.testing.fake_claude import _read_prompt_from_stream_json_st
 from sculptor.agents.testing.fake_claude_commands import _ABSORBED_FRAMES
 from sculptor.agents.testing.fake_claude_commands import _STDIN_EOF
 from sculptor.agents.testing.fake_claude_commands import _STDIN_ROUTER
+from sculptor.agents.testing.fake_claude_commands import _read_control_response_from_stdin
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_response_text
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_responses
 from sculptor.agents.testing.fake_claude_commands import configure_stdin_router
@@ -926,43 +927,53 @@ def test_stream_json_interrupt_between_cycles_exits_with_sigterm_code() -> None:
     assert len([e for e in events if e.get("type") == "result"]) == 1
 
 
-def _feed_stdin_pipe(payload: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point ``sys.stdin`` at a real pipe carrying ``payload`` then EOF.
+@pytest.fixture
+def feed_stdin_pipe(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[[str], None]]:
+    """Point ``sys.stdin`` at a real pipe carrying a payload then EOF.
 
     The unified stdin router reads the raw fd (``sys.stdin.fileno()``), so the
     between-cycle reader tests need a genuine file descriptor rather than an
     ``io.StringIO`` (which has no fileno). Closing the write end after the
-    payload gives the reader a clean EOF.
+    payload gives the reader a clean EOF; the read end is closed at teardown so
+    the suite doesn't leak descriptors.
     """
-    read_fd, write_fd = os.pipe()
-    os.write(write_fd, payload.encode("utf-8"))
-    os.close(write_fd)
-    fake_stdin = os.fdopen(read_fd, "r")
-    monkeypatch.setattr(sys, "stdin", fake_stdin)
+    streams: list[IO[str]] = []
+
+    def _feed(payload: str) -> None:
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, payload.encode("utf-8"))
+        os.close(write_fd)
+        fake_stdin = os.fdopen(read_fd, "r")
+        streams.append(fake_stdin)
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    yield _feed
+    for stream in streams:
+        stream.close()
 
 
-def test_read_prompt_returns_none_on_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_prompt_returns_none_on_eof(feed_stdin_pipe: Callable[[str], None]) -> None:
     """EOF (empty stdin) yields None so the caller exits instead of running the
     default handler for a turn the user never sent."""
-    _feed_stdin_pipe("", monkeypatch)
+    feed_stdin_pipe("")
     assert _read_prompt_from_stream_json_stdin() is None
 
 
-def test_read_prompt_returns_empty_string_for_empty_content_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_prompt_returns_empty_string_for_empty_content_frame(feed_stdin_pipe: Callable[[str], None]) -> None:
     """An explicit empty-content user frame is distinct from EOF: it returns ""
     so the default handler still runs for a genuinely empty prompt."""
     frame = json.dumps({"type": "user", "message": {"role": "user", "content": ""}}) + "\n"
-    _feed_stdin_pipe(frame, monkeypatch)
+    feed_stdin_pipe(frame)
     assert _read_prompt_from_stream_json_stdin() == ""
 
 
-def test_read_prompt_returns_content_for_user_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_prompt_returns_content_for_user_frame(feed_stdin_pipe: Callable[[str], None]) -> None:
     frame = json.dumps({"type": "user", "message": {"role": "user", "content": "hello there"}}) + "\n"
-    _feed_stdin_pipe(frame, monkeypatch)
+    feed_stdin_pipe(frame)
     assert _read_prompt_from_stream_json_stdin() == "hello there"
 
 
-def test_read_prompt_skips_non_user_frames_until_user_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_prompt_skips_non_user_frames_until_user_frame(feed_stdin_pipe: Callable[[str], None]) -> None:
     """Non-user frames (control responses, context-usage requests) are ignored
     while scanning for the next user frame."""
     lines = (
@@ -973,14 +984,14 @@ def test_read_prompt_skips_non_user_frames_until_user_frame(monkeypatch: pytest.
         + json.dumps({"type": "user", "message": {"role": "user", "content": "actual prompt"}})
         + "\n"
     )
-    _feed_stdin_pipe(lines, monkeypatch)
+    feed_stdin_pipe(lines)
     assert _read_prompt_from_stream_json_stdin() == "actual prompt"
 
 
-def test_read_prompt_exits_on_idle_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_read_prompt_exits_on_idle_interrupt(feed_stdin_pipe: Callable[[str], None]) -> None:
     """An interrupt control_request read between cycles exits with the SIGTERM code."""
     frame = json.dumps({"type": "control_request", "request_id": "r", "request": {"subtype": "interrupt"}}) + "\n"
-    _feed_stdin_pipe(frame, monkeypatch)
+    feed_stdin_pipe(frame)
     with pytest.raises(SystemExit) as exc_info:
         _read_prompt_from_stream_json_stdin()
     assert exc_info.value.code == AGENT_EXIT_CODE_FROM_SIGTERM
@@ -1092,7 +1103,7 @@ def test_read_mcp_control_response_surfaces_response_after_buffered_control_requ
     assert result == "MCP error -32602: Invalid params"
 
 
-# --- Mid-turn absorption + --replay-user-messages (SCU-1679) ---
+# Mid-turn absorption + --replay-user-messages (SCU-1679).
 #
 # The real CLI absorbs a user frame that lands while a turn is in flight as a
 # ``queued_command`` attachment (steering), distinct from a between-turns frame
@@ -1335,6 +1346,43 @@ def test_mcp_reader_absorbs_user_frame_while_awaiting_response(
     assert results[request_id]["result"]["content"][0]["text"] == "ANSWER"
     assert _ABSORBED_FRAMES == [steer]
     assert _queued_command_prompts(_read_transcript_from_home(tmp_path)) == [steer]
+
+
+def test_reader_stashes_control_response_for_a_different_waiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A control_response a reader isn't waiting on is stashed for the reader
+    that is, not dropped: the hook-ack reader (waiting on A) parks an MCP
+    response for B, and the later MCP reader picks B up from the stash without
+    needing another stdin read."""
+    _STDIN_ROUTER.reset()
+    hook_request_id = "hook_req_A"
+    mcp_request_id = "mcp_req_B"
+    mcp_response = json.dumps(
+        {
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": mcp_request_id,
+                "response": {"mcp_response": {"result": {"content": [{"type": "text", "text": "B-ANSWER"}]}}},
+            },
+        }
+    )
+    hook_response = json.dumps(
+        {"type": "control_response", "response": {"subtype": "success", "request_id": hook_request_id}}
+    )
+    read_fd, write_fd = os.pipe()
+    # B's response arrives first, while the hook-ack wait (for A) is reading.
+    os.write(write_fd, (mcp_response + "\n" + hook_response + "\n").encode("utf-8"))
+    os.close(write_fd)
+    fake_stdin = os.fdopen(read_fd, "r")
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+    try:
+        _read_control_response_from_stdin(hook_request_id, timeout_seconds=2.0)
+        # stdin now holds no more responses; B must come from the stash.
+        results = _read_mcp_control_responses({mcp_request_id}, timeout_seconds=2.0)
+    finally:
+        fake_stdin.close()
+
+    assert results[mcp_request_id]["result"]["content"][0]["text"] == "B-ANSWER"
 
 
 class _BackgroundLineReader:

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -1,18 +1,26 @@
 """Unit tests for FakeClaude script."""
 
-import io
 import json
 import os
 import subprocess
 import sys
+import threading
+import time
+from collections.abc import Callable
+from collections.abc import Iterator
 from pathlib import Path
+from typing import IO
 from uuid import uuid4
 
 import pytest
 
 from sculptor.agents.testing.fake_claude import _parse_prompt
 from sculptor.agents.testing.fake_claude import _read_prompt_from_stream_json_stdin
+from sculptor.agents.testing.fake_claude_commands import _ABSORBED_FRAMES
+from sculptor.agents.testing.fake_claude_commands import _STDIN_ROUTER
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_response_text
+from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_responses
+from sculptor.agents.testing.fake_claude_commands import configure_stdin_router
 from sculptor.agents.testing.fake_claude_commands import handle_ask_user_question
 from sculptor.agents.testing.fake_claude_commands import handle_background_task_notification
 from sculptor.agents.testing.fake_claude_commands import handle_background_task_started
@@ -46,6 +54,21 @@ from sculptor.state.claude_state import ParsedTaskNotificationResponse
 from sculptor.state.claude_state import ParsedTaskStartedResponse
 from sculptor.state.claude_state import ParsedToolResultResponseSimple
 from sculptor.state.claude_state import parse_claude_code_json_lines_simple
+
+
+@pytest.fixture(autouse=True)
+def _reset_stdin_router() -> Iterator[None]:
+    """Clear the module-level stdin router between tests.
+
+    The router is a process-wide singleton whose buffer/EOF state persists
+    across tests in one pytest process; resetting keeps a prior test's leftover
+    bytes or EOF from leaking into the next reader.
+    """
+    _STDIN_ROUTER.reset()
+    _ABSORBED_FRAMES.clear()
+    yield
+    _STDIN_ROUTER.reset()
+    _ABSORBED_FRAMES.clear()
 
 
 def test_init_message_roundtrip() -> None:
@@ -750,6 +773,7 @@ def _run_fake_claude_stream_json(
     *,
     include_partial: bool = False,
     append_system_prompt: str | None = None,
+    replay_user_messages: bool = False,
     home: Path | None = None,
     timeout: float = 30.0,
 ) -> subprocess.CompletedProcess[str]:
@@ -771,6 +795,8 @@ def _run_fake_claude_stream_json(
     ]
     if include_partial:
         argv.append("--include-partial-messages")
+    if replay_user_messages:
+        argv.append("--replay-user-messages")
     if append_system_prompt is not None:
         argv.extend(["--append-system-prompt", append_system_prompt])
     env = {**os.environ, "HOME": str(home)} if home is not None else None
@@ -898,10 +924,25 @@ def test_stream_json_interrupt_between_cycles_exits_with_sigterm_code() -> None:
     assert len([e for e in events if e.get("type") == "result"]) == 1
 
 
+def _feed_stdin_pipe(payload: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``sys.stdin`` at a real pipe carrying ``payload`` then EOF.
+
+    The unified stdin router reads the raw fd (``sys.stdin.fileno()``), so the
+    between-cycle reader tests need a genuine file descriptor rather than an
+    ``io.StringIO`` (which has no fileno). Closing the write end after the
+    payload gives the reader a clean EOF.
+    """
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, payload.encode("utf-8"))
+    os.close(write_fd)
+    fake_stdin = os.fdopen(read_fd, "r")
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+
 def test_read_prompt_returns_none_on_eof(monkeypatch: pytest.MonkeyPatch) -> None:
     """EOF (empty stdin) yields None so the caller exits instead of running the
     default handler for a turn the user never sent."""
-    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    _feed_stdin_pipe("", monkeypatch)
     assert _read_prompt_from_stream_json_stdin() is None
 
 
@@ -909,13 +950,13 @@ def test_read_prompt_returns_empty_string_for_empty_content_frame(monkeypatch: p
     """An explicit empty-content user frame is distinct from EOF: it returns ""
     so the default handler still runs for a genuinely empty prompt."""
     frame = json.dumps({"type": "user", "message": {"role": "user", "content": ""}}) + "\n"
-    monkeypatch.setattr(sys, "stdin", io.StringIO(frame))
+    _feed_stdin_pipe(frame, monkeypatch)
     assert _read_prompt_from_stream_json_stdin() == ""
 
 
 def test_read_prompt_returns_content_for_user_frame(monkeypatch: pytest.MonkeyPatch) -> None:
     frame = json.dumps({"type": "user", "message": {"role": "user", "content": "hello there"}}) + "\n"
-    monkeypatch.setattr(sys, "stdin", io.StringIO(frame))
+    _feed_stdin_pipe(frame, monkeypatch)
     assert _read_prompt_from_stream_json_stdin() == "hello there"
 
 
@@ -930,14 +971,14 @@ def test_read_prompt_skips_non_user_frames_until_user_frame(monkeypatch: pytest.
         + json.dumps({"type": "user", "message": {"role": "user", "content": "actual prompt"}})
         + "\n"
     )
-    monkeypatch.setattr(sys, "stdin", io.StringIO(lines))
+    _feed_stdin_pipe(lines, monkeypatch)
     assert _read_prompt_from_stream_json_stdin() == "actual prompt"
 
 
 def test_read_prompt_exits_on_idle_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
     """An interrupt control_request read between cycles exits with the SIGTERM code."""
     frame = json.dumps({"type": "control_request", "request_id": "r", "request": {"subtype": "interrupt"}}) + "\n"
-    monkeypatch.setattr(sys, "stdin", io.StringIO(frame))
+    _feed_stdin_pipe(frame, monkeypatch)
     with pytest.raises(SystemExit) as exc_info:
         _read_prompt_from_stream_json_stdin()
     assert exc_info.value.code == AGENT_EXIT_CODE_FROM_SIGTERM
@@ -1047,3 +1088,311 @@ def test_read_mcp_control_response_surfaces_response_after_buffered_control_requ
         os.close(w_fd)
 
     assert result == "MCP error -32602: Invalid params"
+
+
+# --- Mid-turn absorption + --replay-user-messages (SCU-1679) ---
+#
+# The real CLI absorbs a user frame that lands while a turn is in flight as a
+# ``queued_command`` attachment (steering), distinct from a between-turns frame
+# which starts a plain new turn. FakeClaude reproduces both, keyed on whether
+# the frame arrives while a cycle is held open. The transcript shape is checked
+# with the same detectors the real-CLI delivery-matrix canary uses.
+
+# A cycle held open on a 1s sleep (long enough for the router to absorb a
+# buffered frame during the hold), then a directive that quotes what it absorbed.
+_HELD_THEN_REFERENCE_STEPS = [
+    {"command": "sleep", "args": {"seconds": 1.0}},
+    {"command": "reference_absorbed", "args": {}},
+]
+
+
+def _held_then_reference_frame() -> str:
+    """A frame whose cycle holds open, absorbs a buffered frame, then references it."""
+    return _user_frame("fake_claude:multi_step `" + json.dumps({"steps": _HELD_THEN_REFERENCE_STEPS}) + "`")
+
+
+def _read_transcript_from_home(home: Path) -> list[dict]:
+    """Parse every JSONL transcript FakeClaude wrote under a pinned ``$HOME``.
+
+    One session runs per process, so this is the single session file; parsing
+    all of them keeps the helper robust to the slugged projects path.
+    """
+    entries: list[dict] = []
+    claude_dir = home / ".claude"
+    if not claude_dir.exists():
+        return entries
+    for path in claude_dir.rglob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def _queued_command_prompts(entries: list[dict]) -> list[str]:
+    """Prompts of ``queued_command`` attachment entries (the steering shape)."""
+    prompts = []
+    for entry in entries:
+        attachment = entry.get("attachment")
+        if (
+            entry.get("type") == "attachment"
+            and isinstance(attachment, dict)
+            and attachment.get("type") == "queued_command"
+        ):
+            prompts.append(attachment.get("prompt", ""))
+    return prompts
+
+
+def _plain_user_texts(entries: list[dict]) -> list[str]:
+    """Text of ordinary (turn-starting) user messages in the transcript."""
+    texts = []
+    for entry in entries:
+        if entry.get("type") != "user":
+            continue
+        content = entry.get("message", {}).get("content", "")
+        if isinstance(content, str):
+            texts.append(content)
+    return texts
+
+
+def _string_user_echoes(events: list[dict], needle: str) -> list[str]:
+    """Stdout user-frame echoes (string content) containing ``needle``."""
+    echoes = []
+    for event in events:
+        if event.get("type") != "user":
+            continue
+        content = event.get("message", {}).get("content")
+        if isinstance(content, str) and needle in content:
+            echoes.append(content)
+    return echoes
+
+
+def test_mid_cycle_frame_absorbed_as_queued_command(tmp_path: Path) -> None:
+    """Scenario 1: a frame that lands while a cycle is held open is absorbed.
+
+    The held cycle does NOT start a second turn; it records the frame as a
+    ``queued_command`` attachment (not a plain user message) and a scripted
+    ``reference_absorbed`` step proves the cycle saw the absorbed content.
+    """
+    steer = f"STEER-{uuid4().hex}"
+    result = _run_fake_claude_stream_json(_held_then_reference_frame() + _user_frame(steer), home=tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    events = _top_level_events(result.stdout)
+    # Absorbed mid-cycle → exactly one turn, not a second init/result cycle.
+    assert len([e for e in events if e.get("type") == "result"]) == 1
+    assert len([e for e in events if e.get("subtype") == "init"]) == 1
+
+    # The held cycle referenced the absorbed content in its remaining output.
+    assistant_texts = [e["message"]["content"][0]["text"] for e in events if e.get("type") == "assistant"]
+    assert any(steer in text for text in assistant_texts), assistant_texts
+
+    # Transcript: absorbed frame = queued_command; the turn-starting frame stays plain.
+    entries = _read_transcript_from_home(tmp_path)
+    assert _queued_command_prompts(entries) == [steer]
+    plain = _plain_user_texts(entries)
+    assert steer not in plain
+    assert any("multi_step" in text for text in plain), plain
+
+
+def test_absorbed_frame_not_replayed_on_stdout_without_flag(tmp_path: Path) -> None:
+    """Without --replay-user-messages the absorbed frame is recorded but never
+    echoed on stdout (matching the canary's negative assertion)."""
+    steer = f"STEER-{uuid4().hex}"
+    result = _run_fake_claude_stream_json(_held_then_reference_frame() + _user_frame(steer), home=tmp_path)
+    assert result.returncode == 0, result.stderr
+
+    assert _string_user_echoes(_top_level_events(result.stdout), steer) == []
+    assert _queued_command_prompts(_read_transcript_from_home(tmp_path)) == [steer]
+
+
+def test_replay_echoes_both_frames_in_position(tmp_path: Path) -> None:
+    """Scenario 2: with --replay-user-messages both frames are echoed, the
+    discriminator being position — the turn-starting frame just after its init,
+    the absorbed (steered) frame inside the open turn before its result."""
+    steer = f"STEER-{uuid4().hex}"
+    result = _run_fake_claude_stream_json(
+        _held_then_reference_frame() + _user_frame(steer),
+        replay_user_messages=True,
+        home=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+    events = _top_level_events(result.stdout)
+    assert _string_user_echoes(events, steer) == [steer]
+
+    def is_user_echo(event: dict, needle: str) -> bool:
+        content = event.get("message", {}).get("content")
+        return event.get("type") == "user" and isinstance(content, str) and needle in content
+
+    init_index = next(i for i, e in enumerate(events) if e.get("subtype") == "init")
+    turn_starting_index = next(i for i, e in enumerate(events) if is_user_echo(e, "multi_step"))
+    steered_index = next(
+        i for i, e in enumerate(events) if e.get("type") == "user" and e.get("message", {}).get("content") == steer
+    )
+    result_index = next(i for i, e in enumerate(events) if e.get("type") == "result")
+
+    # init -> turn-starting echo -> steered echo (inside the open turn) -> result.
+    assert init_index < turn_starting_index < steered_index < result_index
+
+
+def test_between_turns_frames_recorded_as_plain_user(tmp_path: Path) -> None:
+    """A between-turns frame is turn-starting, not steering: two fast cycles
+    each record a plain user message and zero queued_command attachments."""
+    frames = _user_frame('fake_claude:text `{"text": "TURN1"}`') + _user_frame('fake_claude:text `{"text": "TURN2"}`')
+    result = _run_fake_claude_stream_json(frames, home=tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert len([e for e in _top_level_events(result.stdout) if e.get("type") == "result"]) == 2
+
+    entries = _read_transcript_from_home(tmp_path)
+    assert _queued_command_prompts(entries) == []
+    plain = _plain_user_texts(entries)
+    assert any("TURN1" in text for text in plain)
+    assert any("TURN2" in text for text in plain)
+
+
+def test_mcp_reader_absorbs_user_frame_while_awaiting_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The unified reader routes each frame by type in one pass: a user frame
+    arriving while a handler awaits its MCP control_response is absorbed
+    (recorded as queued_command), while the awaited response is still delivered.
+
+    This is the core of the reader unification — previously the MCP reader
+    discarded any non-matching line, silently losing a mid-wait user frame.
+    """
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    session_id = f"session-{uuid4().hex}"
+    make_init_message(session_id)  # sets get_last_session_id() for the transcript write
+    configure_stdin_router(replay_user_messages=False, persist_session=True)
+
+    steer = f"STEER-{uuid4().hex}"
+    request_id = "mcp_req_absorb"
+    user_frame = json.dumps({"type": "user", "message": {"role": "user", "content": steer}})
+    response = json.dumps(
+        {
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": request_id,
+                "response": {"mcp_response": {"result": {"content": [{"type": "text", "text": "ANSWER"}]}}},
+            },
+        }
+    )
+    read_fd, write_fd = os.pipe()
+    # User frame arrives first, then the awaited response — the reader must serve both.
+    os.write(write_fd, (user_frame + "\n" + response + "\n").encode("utf-8"))
+    os.close(write_fd)
+    fake_stdin = os.fdopen(read_fd, "r")
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+    try:
+        results = _read_mcp_control_responses({request_id}, timeout_seconds=2.0)
+    finally:
+        fake_stdin.close()
+
+    assert results[request_id]["result"]["content"][0]["text"] == "ANSWER"
+    assert _ABSORBED_FRAMES == [steer]
+    assert _queued_command_prompts(_read_transcript_from_home(tmp_path)) == [steer]
+
+
+class _BackgroundLineReader:
+    """Collects a subprocess's stdout JSONL on a daemon thread, so a test can
+    interleave stdin writes with waits on observed events (true mid-cycle
+    timing, unlike ``subprocess.run`` which writes all of stdin up front)."""
+
+    def __init__(self, stream: IO[str]) -> None:
+        self._stream = stream
+        self._events: list[dict] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        for raw_line in self._stream:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            with self._lock:
+                self._events.append(obj)
+
+    def events(self) -> list[dict]:
+        with self._lock:
+            return list(self._events)
+
+    def count(self, predicate: Callable[[dict], bool]) -> int:
+        return sum(1 for e in self.events() if predicate(e))
+
+    def wait_for(self, predicate: Callable[[dict], bool], timeout: float, description: str) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if any(predicate(e) for e in self.events()):
+                return
+            time.sleep(0.02)
+        raise AssertionError(f"Timed out waiting for {description}; events={self.events()}")
+
+
+def test_mid_cycle_absorption_true_timing_via_wait_for_file(tmp_path: Path) -> None:
+    """Scenario 1 with genuine mid-cycle timing: the steer frame is written only
+    AFTER the held cycle is observed in flight (not pre-buffered), then absorbed."""
+    steer = f"STEER-{uuid4().hex}"
+    sentinel = tmp_path / "release.signal"
+    argv = [
+        sys.executable,
+        "-m",
+        "sculptor.agents.testing.fake_claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--input-format",
+        "stream-json",
+        "--replay-user-messages",
+    ]
+    env = {**os.environ, "HOME": str(tmp_path)}
+    process = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(Path(__file__).parents[3]),
+        env=env,
+    )
+    assert process.stdin is not None and process.stdout is not None
+    reader = _BackgroundLineReader(process.stdout)
+    try:
+        # Hold a cycle open on the sentinel, then wait until it is genuinely in flight.
+        process.stdin.write(_user_frame("fake_claude:wait_for_file `" + json.dumps({"path": str(sentinel)}) + "`"))
+        process.stdin.flush()
+        reader.wait_for(lambda e: e.get("subtype") == "init", timeout=15, description="system/init")
+
+        # Inject the steer frame mid-cycle; its echo proves the held cycle absorbed it.
+        process.stdin.write(_user_frame(steer))
+        process.stdin.flush()
+        reader.wait_for(
+            lambda e: e.get("type") == "user" and e.get("message", {}).get("content") == steer,
+            timeout=15,
+            description="steered replay echo",
+        )
+        # Absorption must not have opened a second turn.
+        assert reader.count(lambda e: e.get("type") == "result") == 0
+
+        sentinel.touch()  # release the held cycle so it finishes naturally
+        process.stdin.close()
+        assert process.wait(timeout=15) == 0, process.stderr.read() if process.stderr else ""
+    finally:
+        if process.poll() is None:
+            process.kill()
+        if process.stderr is not None:
+            process.stderr.close()
+        process.stdout.close()
+
+    assert reader.count(lambda e: e.get("type") == "result") == 1
+    assert _queued_command_prompts(_read_transcript_from_home(tmp_path)) == [steer]

--- a/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
+++ b/sculptor/sculptor/agents/testing/tests/test_fake_claude.py
@@ -17,6 +17,7 @@ import pytest
 from sculptor.agents.testing.fake_claude import _parse_prompt
 from sculptor.agents.testing.fake_claude import _read_prompt_from_stream_json_stdin
 from sculptor.agents.testing.fake_claude_commands import _ABSORBED_FRAMES
+from sculptor.agents.testing.fake_claude_commands import _STDIN_EOF
 from sculptor.agents.testing.fake_claude_commands import _STDIN_ROUTER
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_response_text
 from sculptor.agents.testing.fake_claude_commands import _read_mcp_control_responses
@@ -39,6 +40,7 @@ from sculptor.agents.testing.fake_claude_jsonl import generate_id
 from sculptor.agents.testing.fake_claude_jsonl import make_assistant_message
 from sculptor.agents.testing.fake_claude_jsonl import make_end_message
 from sculptor.agents.testing.fake_claude_jsonl import make_init_message
+from sculptor.agents.testing.fake_claude_jsonl import make_queued_command_attachment_entry
 from sculptor.agents.testing.fake_claude_jsonl import make_task_notification_message
 from sculptor.agents.testing.fake_claude_jsonl import make_task_started_message
 from sculptor.agents.testing.fake_claude_jsonl import make_text_block
@@ -1253,6 +1255,42 @@ def test_between_turns_frames_recorded_as_plain_user(tmp_path: Path) -> None:
     plain = _plain_user_texts(entries)
     assert any("TURN1" in text for text in plain)
     assert any("TURN2" in text for text in plain)
+
+
+def test_queued_command_attachment_shape_matches_real_cli() -> None:
+    """The absorbed-frame transcript entry carries the real CLI's attachment
+    shape, including ``commandMode: "prompt"`` (a queued plain prompt)."""
+    entry = make_queued_command_attachment_entry("sess-1", "hello")
+    assert entry["type"] == "attachment"
+    assert entry["sessionId"] == "sess-1"
+    assert entry["attachment"] == {"type": "queued_command", "prompt": "hello", "commandMode": "prompt"}
+
+
+def test_stdin_router_flushes_final_frame_without_trailing_newline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A last frame written without a trailing newline before EOF is still
+    returned (parity with the old ``for line in sys.stdin`` iterator), not
+    dropped — it is flushed once EOF is observed, then EOF is reported.
+
+    Data and EOF arrive in separate pipe reads, so the frame surfaces across
+    the loop iterations every real caller already runs (they retry on
+    ``_STDIN_TIMEOUT``).
+    """
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b'{"type": "user", "message": {"role": "user", "content": "tail"}}')  # no newline
+    os.close(write_fd)
+    fake_stdin = os.fdopen(read_fd, "r")
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+    try:
+        frame: object = None
+        for _ in range(5):
+            frame = _STDIN_ROUTER.next_frame(timeout=1.0)
+            if isinstance(frame, dict):
+                break
+        assert isinstance(frame, dict), frame
+        assert frame["message"]["content"] == "tail"
+        assert _STDIN_ROUTER.next_frame(timeout=1.0) is _STDIN_EOF
+    finally:
+        fake_stdin.close()
 
 
 def test_mcp_reader_absorbs_user_frame_while_awaiting_response(


### PR DESCRIPTION
Part of the **In-turn messages** epic (SCU-1675), Phase 0. Gives the test harness a deterministic way to reproduce the wrapper's write-gate / delivery-bookkeeping / race behavior, matching the real CLI's verified semantics.

## Problem

FakeClaude silently **lost** any user frame that arrived while a cycle was held open. Each stdin-polling handler read stdin its own way and discarded whatever it wasn't looking for — `_wait_until` dropped every non-interrupt line, the MCP reader dropped every non-matching line — on top of a split-buffer flake between `sys.stdin`'s BufferedReader and raw `os.read` (SCU-783). The real CLI instead *absorbs* a mid-turn frame as steering.

So this wasn't additive: the absorption work had to **unify the readers**, not bolt onto the side of them.

## Change

**One stdin router** owns a single raw-fd buffer and classifies each frame exactly once:

- `interrupt` control_request → exit (SIGTERM code);
- `control_response` → the handler waiting on that request id;
- a **user frame mid-cycle** → absorbed as a `queued_command` attachment in the session transcript (the real CLI's on-disk steering shape), distinct from a **between-cycles** frame, which is turn-starting and recorded as a plain user message;
- anything else (`get_context_usage`, injected chrome events) → ignored.

The single buffer also retires the SCU-783 interplay: a non-matching line batched into one read stays buffered for the next reader across the cycle boundary instead of being stranded in an invisible Python buffer.

**Behavior change worth noting:** the router now honors an `interrupt` control_request *during* MCP/AUQ waits and the compact hook-ack wait too. Previously those waiters ignored interrupts and relied on the SIGTERM fallback; now they exit promptly like the other readers. A fidelity improvement, but a change from prior FakeClaude behavior.

**`--replay-user-messages`**: each accepted frame is echoed on stdout with the real CLI's shape/ordering — a turn-starting frame just after its `init`, an absorbed frame inside the open turn before its `result`. Position is the only discriminator, as the control-request spike established.

**`reference_absorbed` directive**: lets a scripted held cycle quote what it absorbed, so a test controls whether/how the fake assistant references the steered content.

## Behavior scenarios

- **Scenario 1 (absorption)** ✅ — a frame that lands while a cycle is held open (sleep / wait_for_file) is recorded as a `queued_command` attachment, no second cycle starts, and `reference_absorbed` proves the held cycle saw it.
- **Scenario 2 (replay echo)** ✅ — with `--replay-user-messages`, both turn-starting and absorbed frames are echoed, discriminated by position; without it, neither is.
- **Scenario 3 (write-gate race into a reaction turn)** ⚠️ — the absorption path is generic and reaction-turn-agnostic (any held-open cycle absorbs a mid-cycle frame), which is exactly what scenario 3 needs, but expressing it end-to-end requires the test-timed reaction-turn machinery from SCU-1680 (in flight on a parallel branch). Deferred to compose with that ticket; called out here so it isn't mistaken for done.

## Tests

New tests drive absorption both from a pre-buffered frame during a held sleep and from a genuinely mid-cycle frame written only after the cycle is observed in flight (`wait_for_file` + a background stdout reader). They assert the transcript with the **same `queued_command` / plain-user detectors the real-CLI delivery-matrix canary (SCU-1676) uses**, so the fake and the canary agree on shape. The between-cycle reader unit tests move from `io.StringIO` to real pipes, since the router reads a real fd.

`just format` / `just check` / `just test-unit` all green.

(Sent by Claude)
