### PR TITLE
Fix: pi task should not stay RUNNING with idle process after no-op resume

### DIFF
--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -820,6 +820,7 @@ class PiAgent(DefaultAgentWrapper):
                     request_id=message.for_user_message_id,
                     error=None,
                     interrupted=True,
+                    turn_abandoned=True,
                 )
             )
             return True

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -2092,6 +2092,7 @@ class TestPushMessageDispatch:
         assert isinstance(emitted, RequestSuccessAgentMessage)
         assert emitted.request_id == stuck_id
         assert emitted.interrupted is True
+        assert emitted.turn_abandoned is True
 
     def test_push_message_enqueues_clear_context_returns_true(self) -> None:
         """A ClearContextUserMessage goes on the same FIFO as chat turns — handled, not dead-lettered."""

--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -1420,6 +1420,11 @@
           "source": {
             "$ref": "#/$defs/AgentMessageSource",
             "default": "AGENT"
+          },
+          "turnAbandoned": {
+            "default": false,
+            "title": "Turnabandoned",
+            "type": "boolean"
           }
         },
         "required": [

--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -2792,18 +2792,6 @@
             ],
             "default": null
           },
-          "lastProcessedMessageId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Lastprocessedmessageid"
-          },
           "objectType": {
             "default": "AgentTaskStateV2",
             "title": "Objecttype",

--- a/sculptor/sculptor/database/alembic/version_tests/test_1da4cc57bb93.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_1da4cc57bb93.py
@@ -1,0 +1,26 @@
+import sqlalchemy as sa
+
+from sculptor.database.alembic.migration_test_utils import MigrationTestFixture
+
+
+class TestMigration1da4cc57bb93(MigrationTestFixture):
+    """Test fixture for migration 1da4cc57bb93.
+
+    No-op migration: adds the turn_abandoned field to RequestSuccessAgentMessage
+    JSON blobs. A backwards-compatible addition with a False default, so no SQL
+    changes are needed.
+    """
+
+    @property
+    def revision(self) -> str:
+        return "1da4cc57bb93"
+
+    @property
+    def down_revision(self) -> str:
+        return "5cb094ae1d22"
+
+    def seed(self, connection: sa.engine.Connection) -> None:
+        pass
+
+    def verify(self, connection: sa.engine.Connection) -> None:
+        pass

--- a/sculptor/sculptor/database/alembic/version_tests/test_6026c03dc852.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_6026c03dc852.py
@@ -1,0 +1,26 @@
+import sqlalchemy as sa
+
+from sculptor.database.alembic.migration_test_utils import MigrationTestFixture
+
+
+class TestMigration6026c03dc852(MigrationTestFixture):
+    """Test fixture for migration 6026c03dc852.
+
+    No-op migration: removes the last_processed_message_id field from
+    AgentTaskStateV2 JSON blobs. Old rows keep the key; it is an extra key
+    that is ignored on validate, so no SQL changes are needed.
+    """
+
+    @property
+    def revision(self) -> str:
+        return "6026c03dc852"
+
+    @property
+    def down_revision(self) -> str:
+        return "1da4cc57bb93"
+
+    def seed(self, connection: sa.engine.Connection) -> None:
+        pass
+
+    def verify(self, connection: sa.engine.Connection) -> None:
+        pass

--- a/sculptor/sculptor/database/alembic/versions/1da4cc57bb93_add_turn_abandoned_field_to_request_.py
+++ b/sculptor/sculptor/database/alembic/versions/1da4cc57bb93_add_turn_abandoned_field_to_request_.py
@@ -1,0 +1,28 @@
+"""add turn_abandoned field to request success messages
+
+No SQL changes are needed — the new field lives inside the saved-message
+JSON blob and defaults to False, so existing data is unaffected.
+
+Revision ID: 1da4cc57bb93
+Revises: 5cb094ae1d22
+Create Date: 2026-07-09 20:14:08.657965
+
+"""
+
+from typing import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "1da4cc57bb93"
+down_revision: str | None = "5cb094ae1d22"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """No schema changes: the new field lives inside JSON blobs and defaults to False."""
+    pass
+
+
+def downgrade() -> None:
+    """No schema changes to reverse."""
+    pass

--- a/sculptor/sculptor/database/alembic/versions/6026c03dc852_remove_stored_last_processed_message_id_.py
+++ b/sculptor/sculptor/database/alembic/versions/6026c03dc852_remove_stored_last_processed_message_id_.py
@@ -1,0 +1,29 @@
+"""remove stored last_processed_message_id from agent task state
+
+No SQL changes are needed — the field lived inside the task-state JSON blob
+and is now derived from the persisted message log at runtime. Old rows that
+still carry the key validate fine: the extra key is ignored on validate.
+
+Revision ID: 6026c03dc852
+Revises: 1da4cc57bb93
+Create Date: 2026-07-09 21:34:57.331510
+
+"""
+
+from typing import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "6026c03dc852"
+down_revision: str | None = "1da4cc57bb93"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """No schema changes: the removed field lived inside JSON blobs and is ignored on validate."""
+    pass
+
+
+def downgrade() -> None:
+    """No schema changes to reverse."""
+    pass

--- a/sculptor/sculptor/database/models.py
+++ b/sculptor/sculptor/database/models.py
@@ -192,7 +192,6 @@ class AgentTaskStateV2(BaseTaskState):
     """
 
     object_type: str = "AgentTaskStateV2"
-    last_processed_message_id: AgentMessageID | None = None
     title: str | None = None
     workspace_id: WorkspaceID
     # Terminal agents only: the session id the registered program last

--- a/sculptor/sculptor/interfaces/agents/agent.py
+++ b/sculptor/sculptor/interfaces/agents/agent.py
@@ -366,6 +366,14 @@ class RequestSuccessAgentMessage(PersistentRequestCompleteAgentMessage):
     # pyrefly: ignore [bad-override]
     error: None = None
     interrupted: bool = False
+    # Only meaningful when interrupted=True. An interrupted success normally
+    # means "the turn may still be resumed after a restart", so replay keeps the
+    # request orphaned and startup reconciliation refuses to count it as
+    # processed. turn_abandoned=True declares the opposite contract: this
+    # completion terminally settles the request and the turn will not be
+    # continued (harness orphan-finalization on a no-op resume, pi's
+    # resume-settle). Replay and dedup treat such requests as fully processed.
+    turn_abandoned: bool = False
 
 
 class RequestFailureAgentMessage(PersistentRequestCompleteAgentMessage, ErrorMessage):

--- a/sculptor/sculptor/services/task_service/base_implementation.py
+++ b/sculptor/sculptor/services/task_service/base_implementation.py
@@ -271,6 +271,8 @@ class BaseTaskService(TaskService, ABC):
             raise InvalidTaskOperation("Task is not in a failed state - cannot restore")
         self._check_workspace_not_deleted(task, transaction)
         updated_task = task.evolve(task.ref().outcome, TaskState.QUEUED)
+        # Clear the stale error so outcome and error stay consistent.
+        updated_task = updated_task.evolve(updated_task.ref().error, None)
         updated_task = transaction.upsert_task(updated_task)
         message = TaskStatusRunnerMessage(outcome=TaskState.QUEUED, message_id=AgentMessageID())
         self.create_message(message=message, task_id=updated_task.object_id, transaction=transaction)

--- a/sculptor/sculptor/services/task_service/threaded_implementation_test.py
+++ b/sculptor/sculptor/services/task_service/threaded_implementation_test.py
@@ -14,6 +14,7 @@ from sculptor.database.models import Task
 from sculptor.database.models import TaskID
 from sculptor.foundation.git import get_repo_base_path
 from sculptor.foundation.itertools import only
+from sculptor.foundation.serialization import SerializedException
 from sculptor.interfaces.agents.agent import MessageTypes
 from sculptor.interfaces.agents.tasks import TaskState
 from sculptor.primitives.ids import RequestID
@@ -207,3 +208,55 @@ def test_task_service_proper_shutdown(
 
     for runner in service._runner_by_id.values():
         assert not runner.is_alive(), f"Runner {runner.get_name()} is still alive!"
+
+
+def test_restore_task_clears_stale_error(
+    test_service_collection: CompleteServiceCollection, specimen_project: Project
+) -> None:
+    """restore_task must clear the stale error field so outcome and error stay
+    consistent. A FAILED task with error set should come back as QUEUED with
+    error=None after restore.
+    """
+    user_session = authenticate_anonymous(test_service_collection, RequestID())
+    service = test_service_collection.task_service
+    assert isinstance(service, LocalThreadTaskService)
+
+    task = get_simple_task(user_session, specimen_project)
+    with user_session.open_transaction(test_service_collection) as transaction:
+        service.create_task(task, transaction)
+
+    # Wait for the task to complete (no-op task finishes quickly).
+    for _ in range(50):
+        with user_session.open_transaction(test_service_collection) as transaction:
+            current_task = service.get_task(task.object_id, transaction)
+            if current_task is not None and current_task.outcome not in (TaskState.QUEUED, TaskState.RUNNING):
+                break
+        time.sleep(0.1)
+
+    # Simulate a crash: manually set outcome to FAILED with a stored error.
+    try:
+        raise RuntimeError("simulated crash")
+    except RuntimeError as e:
+        fake_error = SerializedException.build(e)
+    with service.data_model_service.open_task_transaction() as transaction:
+        current_task = service.get_task(task.object_id, transaction)
+        assert current_task is not None
+        failed_task = current_task.evolve(current_task.ref().outcome, TaskState.FAILED)
+        failed_task = failed_task.evolve(failed_task.ref().error, fake_error)
+        transaction.upsert_task(failed_task)
+
+    # Precondition: error is set
+    with service.data_model_service.open_task_transaction() as transaction:
+        pre = service.get_task(task.object_id, transaction)
+        assert pre is not None
+        assert pre.outcome == TaskState.FAILED
+        assert pre.error is not None
+
+    # Restore the task.
+    with service.data_model_service.open_task_transaction() as transaction:
+        restored = service.restore_task(task.object_id, transaction)
+
+    assert restored.outcome == TaskState.QUEUED
+    assert restored.error is None, "restore_task must clear the stale error field"
+
+    service.stop()

--- a/sculptor/sculptor/services/task_service/threaded_implementation_test.py
+++ b/sculptor/sculptor/services/task_service/threaded_implementation_test.py
@@ -245,14 +245,12 @@ def test_restore_task_clears_stale_error(
         failed_task = failed_task.evolve(failed_task.ref().error, fake_error)
         transaction.upsert_task(failed_task)
 
-    # Precondition: error is set
     with service.data_model_service.open_task_transaction() as transaction:
         pre = service.get_task(task.object_id, transaction)
         assert pre is not None
         assert pre.outcome == TaskState.FAILED
         assert pre.error is not None
 
-    # Restore the task.
     with service.data_model_service.open_task_transaction() as transaction:
         restored = service.restore_task(task.object_id, transaction)
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/setup.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/setup.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from queue import Queue
 from threading import Thread
 from typing import Generator
+from typing import Sequence
 from typing import cast
 
 from loguru import logger
@@ -21,13 +22,19 @@ from sculptor.foundation.nested_evolver import chill
 from sculptor.foundation.nested_evolver import evolver
 from sculptor.foundation.progress_tracking.progress_tracking import RootProgressHandle
 from sculptor.foundation.progress_tracking.progress_tracking import start_finish_context
+from sculptor.foundation.pydantic_serialization import FrozenModel
 from sculptor.interfaces.agents.agent import PersistentRequestCompleteAgentMessage
 from sculptor.interfaces.agents.agent import PersistentUserMessageUnion
+from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestStoppedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
 from sculptor.interfaces.agents.agent import StopAgentUserMessage
 from sculptor.interfaces.agents.agent import UserMessageUnion
+from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
+from sculptor.interfaces.agents.constants import SIGINT_EXIT_CODES
+from sculptor.interfaces.agents.constants import SIGTERM_EXIT_CODES
+from sculptor.interfaces.agents.errors import AgentClientError
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import TaskID
 from sculptor.server.llm_content_generation import TaskTitle
@@ -36,7 +43,9 @@ from sculptor.services.task_service.data_types import ServiceCollectionForTask
 from sculptor.services.task_service.errors import UserPausedTaskError
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import Message
+from sculptor.state.messages import PersistentAgentMessage
 from sculptor.state.messages import PersistentUserMessage
+from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.utils.type_utils import extract_leaf_types
 
 # it will take at most this much time to notice when the process has finished
@@ -67,10 +76,13 @@ def message_queue_subscription_context(
 
 def wait_for_initial_message_and_process_queue(
     input_message_queue: Queue[UserMessageUnion | ResumeAgentResponseRunnerMessage],
-    task_state: AgentTaskStateV2,
+    last_processed_message_id: AgentMessageID | None,
     shutdown_event: ReadOnlyEvent,
 ) -> tuple[tuple[PersistentUserMessageUnion, ...], ChatInputUserMessage]:
     """Wait for the initial user message and process already-queued messages.
+
+    ``last_processed_message_id`` is the dedup cursor derived by
+    ``scan_message_history``; the replayed queue is consumed up to and including it.
 
     Returns (re_queued_messages, initial_message).
     """
@@ -81,7 +93,7 @@ def wait_for_initial_message_and_process_queue(
 
     # Discard already processed messages
     _, re_queued_messages = _drop_already_processed_messages(
-        task_state.last_processed_message_id, cast(Queue[Message], input_message_queue)
+        last_processed_message_id, cast(Queue[Message], input_message_queue)
     )
 
     leaf_persistent_user_message_types = extract_leaf_types(PersistentUserMessageUnion)
@@ -240,95 +252,160 @@ def load_initial_task_state(services: ServiceCollectionForTask, task: Task) -> t
         # load the project so that we can figure out the repo path as well
         project = transaction.get_project(task.project_id)
         assert project is not None, "Project must exist in the database"
-
-        # Reconcile last_processed_message_id with persisted message history.
-        # The v1 loop's success path commits _save_messages (the agent's completion
-        # message) and _update_task_state (the last_processed cursor) in separate
-        # transactions. A SIGKILL / OOM / power loss between those two writes leaves
-        # the DB with a persisted completion but a stale last_processed cursor, which
-        # makes _drop_already_processed_messages leave the message in the queue and
-        # the loop re-deliver it to Claude on the next agent run.
-        #
-        # The reconciliation is to scan all persisted messages, find the latest user
-        # message whose message_id matches a request_id on any
-        # PersistentRequestCompleteAgentMessage, and treat that as the effective
-        # last_processed. Then persist the correction in this same transaction so
-        # downstream dedup sees it.
-        reconciled_state = _reconcile_last_processed_from_history(task_state, task.object_id, services)
-        if reconciled_state.last_processed_message_id != task_state.last_processed_message_id:
-            task_state = reconciled_state
-            task_row = task_row.evolve(task_row.ref().current_state, task_state.model_dump())
-            transaction.upsert_task(task_row)
     return task_state, project
 
 
-def _is_truly_processed_completion(message: PersistentRequestCompleteAgentMessage) -> bool:
-    """True iff this completion represents the agent actually finishing the user message.
+class HistoryScan(FrozenModel):
+    """Startup state replayed from a task's persisted message log.
 
-    Interrupted / killed completions (``RequestSuccessAgentMessage(interrupted=True)``,
-    ``RequestStoppedAgentMessage`` — always emitted on SIGTERM/SIGINT) do NOT count,
-    because the agent didn't really finish processing the message. If we counted them
-    here, dedup would treat the message as processed and silently drop it on the next
-    run — which loses the user's typed input in the post-answer-shutdown scenario.
-
-    The exception is an interrupted success marked ``turn_abandoned``: the request
-    was terminally settled (harness orphan-finalization, pi resume-settle) and the
-    turn will never be continued, so re-delivering the message could only duplicate
-    it. Those count.
-
-    ``RequestFailureAgentMessage`` and ``RequestSkippedAgentMessage`` do count: the
-    agent received the message and reached a terminal state for it (failed or
-    intentionally skipped). Re-delivering would just hit the same outcome.
+    Computed once per run by ``scan_message_history`` before the agent starts;
+    ``_run_agent_in_environment`` consumes it instead of re-reading the log.
     """
-    if isinstance(message, RequestStoppedAgentMessage):
-        return False
-    if isinstance(message, RequestSuccessAgentMessage) and message.interrupted and not message.turn_abandoned:
-        return False
-    return True
+
+    # The chat message a previous run started processing but never finished, which
+    # the loop resumes instead of re-sending (None when there is nothing to resume).
+    in_flight_chat_message_id: AgentMessageID | None
+    # An orphaned answer: a UserQuestionAnswerMessage that was delivered to a
+    # now-dead agent process (its RequestStarted is in history) but whose turn
+    # never completed cleanly. On resume the agent has already recorded the
+    # answer (e.g. pi persists it as a toolResult) and has no open dialog, so
+    # re-delivering it raw is a stale dialog the harness skips — dropping the
+    # answer and leaving the request perpetually in-flight. Resuming it instead
+    # settles that dangling request (see _send_user_input_message).
+    in_flight_answer_message_id: AgentMessageID | None
+    # Whether the agent emitted any visible response for the in-flight chat message.
+    is_partial_agent_response: bool
+    # The last started chat message with no terminal completion the replay accepts,
+    # regardless of partial output. Distinct from in_flight_chat_message_id, which
+    # additionally requires partial output (there must be something to resume from):
+    # a crash before any output leaves the request dangling but not resumable, and
+    # the orphan synthesis must still terminalize it or the frontend stays
+    # "thinking" forever.
+    dangling_chat_message_id: AgentMessageID | None
+    # The last user chat message the agent started processing.
+    last_user_chat_message_id: AgentMessageID | None
+    # Every persistent message replayed in log order: user messages the agent
+    # started processing plus the agent's own non-killed messages. The loop keeps
+    # appending to (a copy of) this as the run produces more messages.
+    persistent_message_history: list[PersistentUserMessage | PersistentAgentMessage]
+    # The dedup cursor: the latest settled user message in log order (None when
+    # nothing is settled). _drop_already_processed_messages consumes the replayed
+    # queue up to and including this id on restart.
+    last_processed_message_id: AgentMessageID | None
 
 
-def _reconcile_last_processed_from_history(
-    task_state: AgentTaskStateV2,
-    task_id: TaskID,
-    services: ServiceCollectionForTask,
-) -> AgentTaskStateV2:
-    """Return task_state with last_processed_message_id derived from message history.
+def scan_message_history(all_messages: Sequence[Message]) -> HistoryScan:
+    """Replay a task's persisted message log to reconstruct the loop's startup state.
 
-    Walks the persisted messages for this task, finds the latest user message whose
-    ``message_id`` matches some ``PersistentRequestCompleteAgentMessage.request_id``
-    where the completion represents truly-finished processing (see
-    ``_is_truly_processed_completion``), and uses that as the effective
-    ``last_processed_message_id``. Only upgrades the cursor (never downgrades), so a
-    stale persisted value heals to the truth from the message log without ever
-    moving backward.
+    The scan is the single authority on which persisted user messages are settled
+    versus still in flight after a restart: a user message is settled iff some
+    ``RequestStartedAgentMessage`` references it and the scan does not leave it in
+    flight. ``last_processed_message_id`` is derived from the same pass state as
+    the in-flight ids, so the dedup cursor and the resume tracking cannot diverge.
     """
-    with services.data_model_service.open_task_transaction() as transaction:
-        all_messages = services.task_service.get_saved_messages_for_task(task_id, transaction)
-
-    completed_request_ids: set[AgentMessageID] = set()
+    persistent_user_message_by_id: dict[AgentMessageID, PersistentUserMessage] = {}
+    # ids of user messages some RequestStartedAgentMessage references — i.e. user
+    # messages the agent started processing at some point
+    started_user_message_ids: set[AgentMessageID] = set()
+    # the last user chat message that we *started* processing — tracked in case we
+    # never *finished* processing it, so that the agent can resume where it left off
+    last_user_chat_message_id: AgentMessageID | None = None
+    in_flight_chat_message_id: AgentMessageID | None = None
+    in_flight_answer_message_id: AgentMessageID | None = None
+    # Track whether the agent emitted any visible response for the in-flight chat
+    # message. If it didn't, there's nothing for Claude to "resume" from — we'd
+    # rather just resend the original prompt than send a "continue where you left
+    # off" instruction with no prior content. Reset on each new RequestStarted.
+    is_partial_agent_response = False
+    persistent_message_history: list[PersistentUserMessage | PersistentAgentMessage] = []
     for message in all_messages:
-        if isinstance(message, PersistentRequestCompleteAgentMessage) and _is_truly_processed_completion(message):
-            completed_request_ids.add(message.request_id)
+        # just remember the last chat message from the user (that the agent started processing)
+        if isinstance(message, RequestStartedAgentMessage):
+            persistent_message = persistent_user_message_by_id.get(message.request_id)
+            if persistent_message is not None:
+                started_user_message_ids.add(message.request_id)
+                if isinstance(persistent_message, ChatInputUserMessage):
+                    last_user_chat_message_id = message.request_id
+                    in_flight_chat_message_id = message.request_id
+                    is_partial_agent_response = False
+                elif isinstance(persistent_message, UserQuestionAnswerMessage):
+                    in_flight_answer_message_id = message.request_id
+                # add the user message to the history as well
+                persistent_message_history.append(persistent_message)
+        if isinstance(message, PersistentRequestCompleteAgentMessage):
+            if message.request_id == in_flight_chat_message_id:
+                # it doesn't count if this was from a sigterm
+                was_killed = get_killed_exit_code(message)
+                if not was_killed:
+                    in_flight_chat_message_id = None
+            # A clean (non-interrupted) success means the answer's turn
+            # actually finished, and a turn_abandoned success means it was
+            # terminally settled (harness finalization or pi resume-settle)
+            # — clear it either way so it isn't resumed again. A plain
+            # interrupted success, a failure, or a kill all leave the answer
+            # orphaned (its toolResult is recorded but nothing drove the
+            # follow-up turn), so keep it for resume.
+            if message.request_id == in_flight_answer_message_id and (
+                isinstance(message, RequestSuccessAgentMessage) and (not message.interrupted or message.turn_abandoned)
+            ):
+                in_flight_answer_message_id = None
+        # used above so that we can figure out which user messages started being processed so far
+        if isinstance(message, PersistentUserMessage):
+            persistent_user_message_by_id[message.message_id] = message
+        # remember all messages that have been emitted so far by the agent
+        if isinstance(message, PersistentAgentMessage):
+            was_killed = get_killed_exit_code(message)
+            if not was_killed:
+                persistent_message_history.append(message)
+            # A ResponseBlockAgentMessage from the in-flight turn means Claude
+            # produced visible content that we'd want to continue from on resume.
+            if isinstance(message, ResponseBlockAgentMessage):
+                is_partial_agent_response = True
+    # The pre-gate value: dangling means "no accepted terminal completion", even
+    # when there is no partial output to resume from.
+    dangling_chat_message_id = in_flight_chat_message_id
+    # If we didn't observe any partial response from the agent, there's nothing
+    # to "continue from" — clear the in-flight ID so the message gets pushed as
+    # a fresh ChatInputUserMessage rather than a ResumeAgentResponseRunnerMessage.
+    # When there IS a partial response, keep the ID so _send_user_input_message
+    # converts the push into a resume and Claude continues its --resume session.
+    if not is_partial_agent_response:
+        in_flight_chat_message_id = None
 
-    latest_completed_user_message_id: AgentMessageID | None = None
-    for message in all_messages:
-        if isinstance(message, PersistentUserMessage) and message.message_id in completed_request_ids:
-            latest_completed_user_message_id = message.message_id
+    # Derive the dedup cursor: the latest user message (in log order) that was
+    # started and did not end the scan in flight. In-flight messages stay ahead of
+    # the cursor so the restart queue re-delivers them for resume; messages that
+    # were never started are not settled either.
+    last_processed_message_id: AgentMessageID | None = None
+    for user_message_id in persistent_user_message_by_id:
+        if user_message_id not in started_user_message_ids:
+            continue
+        if user_message_id in (in_flight_chat_message_id, in_flight_answer_message_id):
+            continue
+        last_processed_message_id = user_message_id
 
-    if latest_completed_user_message_id is None:
-        return task_state
-    current = task_state.last_processed_message_id
-    if current is not None and str(latest_completed_user_message_id) <= str(current):
-        # Don't downgrade — current cursor is already at or ahead of what history shows.
-        return task_state
-    logger.debug(
-        "Reconciled last_processed_message_id from {} to {} based on persisted completions",
-        current,
-        latest_completed_user_message_id,
+    return HistoryScan(
+        in_flight_chat_message_id=in_flight_chat_message_id,
+        in_flight_answer_message_id=in_flight_answer_message_id,
+        is_partial_agent_response=is_partial_agent_response,
+        dangling_chat_message_id=dangling_chat_message_id,
+        last_user_chat_message_id=last_user_chat_message_id,
+        persistent_message_history=persistent_message_history,
+        last_processed_message_id=last_processed_message_id,
     )
-    mutable = evolver(task_state)
-    assign(mutable.last_processed_message_id, lambda: latest_completed_user_message_id)
-    return chill(mutable)
+
+
+def get_killed_exit_code(message: Message) -> int:
+    if isinstance(message, RequestStoppedAgentMessage):
+        causal_error = message.error.construct_instance()
+        # sigterm and signint
+        if isinstance(causal_error, AgentClientError) and causal_error.exit_code in (
+            SIGTERM_EXIT_CODES | SIGINT_EXIT_CODES
+        ):
+            # exit_code is a member of a set of ints here, so it cannot be None
+            # pyrefly: ignore [bad-return]
+            return causal_error.exit_code
+    return 0
 
 
 def _drop_already_processed_messages(

--- a/sculptor/sculptor/tasks/handlers/run_agent/setup.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/setup.py
@@ -271,13 +271,18 @@ def _is_truly_processed_completion(message: PersistentRequestCompleteAgentMessag
     here, dedup would treat the message as processed and silently drop it on the next
     run — which loses the user's typed input in the post-answer-shutdown scenario.
 
+    The exception is an interrupted success marked ``turn_abandoned``: the request
+    was terminally settled (harness orphan-finalization, pi resume-settle) and the
+    turn will never be continued, so re-delivering the message could only duplicate
+    it. Those count.
+
     ``RequestFailureAgentMessage`` and ``RequestSkippedAgentMessage`` do count: the
     agent received the message and reached a terminal state for it (failed or
     intentionally skipped). Re-delivering would just hit the same outcome.
     """
     if isinstance(message, RequestStoppedAgentMessage):
         return False
-    if isinstance(message, RequestSuccessAgentMessage) and message.interrupted:
+    if isinstance(message, RequestSuccessAgentMessage) and message.interrupted and not message.turn_abandoned:
         return False
     return True
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -53,7 +53,6 @@ from sculptor.interfaces.agents.agent import PersistentRequestCompleteAgentMessa
 from sculptor.interfaces.agents.agent import PersistentRunnerMessageUnion
 from sculptor.interfaces.agents.agent import PersistentUserMessageUnion
 from sculptor.interfaces.agents.agent import RequestFailureAgentMessage
-from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
 from sculptor.interfaces.agents.agent import RequestStoppedAgentMessage
 from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
 from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
@@ -66,7 +65,6 @@ from sculptor.interfaces.agents.artifacts import FileAgentArtifact
 from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_CLEAN_SHUTDOWN_ON_INTERRUPT
 from sculptor.interfaces.agents.constants import SIGINT_EXIT_CODES
 from sculptor.interfaces.agents.constants import SIGTERM_EXIT_CODES
-from sculptor.interfaces.agents.errors import AgentClientError
 from sculptor.interfaces.agents.errors import AgentCrashed
 from sculptor.interfaces.agents.errors import UncleanTerminationAgentError
 from sculptor.interfaces.agents.errors import WaitTimeoutAgentError
@@ -92,10 +90,12 @@ from sculptor.state.messages import Message
 from sculptor.state.messages import ModelOption
 from sculptor.state.messages import PersistentAgentMessage
 from sculptor.state.messages import PersistentUserMessage
-from sculptor.state.messages import ResponseBlockAgentMessage
+from sculptor.tasks.handlers.run_agent.setup import HistoryScan
 from sculptor.tasks.handlers.run_agent.setup import finalize_task_setup
+from sculptor.tasks.handlers.run_agent.setup import get_killed_exit_code
 from sculptor.tasks.handlers.run_agent.setup import load_initial_task_state
 from sculptor.tasks.handlers.run_agent.setup import message_queue_subscription_context
+from sculptor.tasks.handlers.run_agent.setup import scan_message_history
 from sculptor.tasks.handlers.run_agent.setup import title_prediction_context
 from sculptor.tasks.handlers.run_agent.setup import wait_for_initial_message_and_process_queue
 from sculptor.utils.build import build_sculpt_backend_env
@@ -176,6 +176,17 @@ def run_agent_task_v1(
         # Load task state and project
         task_state, project = load_initial_task_state(services, task)
 
+        # Replay the persisted message log once to derive the loop's startup state:
+        # the in-flight (resumable) messages and the dedup cursor. Fetching this
+        # early is safe because no agent runs between this fetch and the loop start
+        # in _run_agent_in_environment, so no RequestStarted or completion messages
+        # can be persisted in the gap; user messages that arrive during the initial
+        # wait below cannot be in flight and reach the loop via the live
+        # input_message_queue.
+        with services.data_model_service.open_task_transaction() as transaction:
+            all_messages = services.task_service.get_saved_messages_for_task(task.object_id, transaction)
+        history_scan = scan_message_history(all_messages)
+
         # Subscribe to the message queue, set up the environment, then wait for the initial message.
         # Environment setup happens before the initial message wait so that prompt-less agents
         # (created via the "Add agent" button) reach READY state while waiting for user input.
@@ -233,7 +244,7 @@ def run_agent_task_v1(
 
                     # Now wait for the initial user message (may block for prompt-less agents)
                     re_queued_messages, initial_message = wait_for_initial_message_and_process_queue(
-                        input_message_queue, task_state, shutdown_event
+                        input_message_queue, history_scan.last_processed_message_id, shutdown_event
                     )
 
                     # A pre-first-message model switch is written to task state out of band
@@ -269,6 +280,7 @@ def run_agent_task_v1(
                         task=task,
                         task_data=task_data,
                         task_state=task_state,
+                        history_scan=history_scan,
                         re_queued_messages=re_queued_messages,
                         input_message_queue=input_message_queue,
                         environment=environment,
@@ -322,6 +334,7 @@ def _run_agent_in_environment(
     task: Task,
     task_data: AgentTaskInputsV2,
     task_state: AgentTaskStateV2,
+    history_scan: HistoryScan,
     re_queued_messages: tuple[PersistentUserMessageUnion, ...],
     input_message_queue: Queue[UserMessageUnion | ResumeAgentResponseRunnerMessage],
     environment: AgentExecutionEnvironment,
@@ -339,6 +352,10 @@ def _run_agent_in_environment(
     - it handles the agent's output (eg, by sending it to the database)
     - it handles the user messages (eg, by sending them to the agent)
     - it syncs artifacts from the agent's output to the task_service
+
+    ``history_scan`` is the replay of the task's persisted message log (see
+    ``scan_message_history``), which seeds the loop's view of what a previous run
+    left in flight.
     """
     # state: these variables are changed as the agent runs
     shutdown_started_at: float | None = None
@@ -347,10 +364,13 @@ def _run_agent_in_environment(
     # and have nothing to do with snapshotting
     user_input_message_being_processed: PersistentUserMessage | None = None
     queued_user_input_messages: list[PersistentUserMessageUnion] = list(re_queued_messages)
-    # is set below from old messages
-    last_user_chat_message_id: AgentMessageID | None = None
+    last_user_chat_message_id: AgentMessageID | None = history_scan.last_user_chat_message_id
     # track the full history of persistent messages we've seen
-    persistent_message_history: list[PersistentUserMessage | PersistentAgentMessage] = []
+    persistent_message_history: list[PersistentUserMessage | PersistentAgentMessage] = list(
+        history_scan.persistent_message_history
+    )
+    initial_in_flight_user_chat_message_id = history_scan.in_flight_chat_message_id
+    initial_in_flight_user_question_answer_message_id = history_scan.in_flight_answer_message_id
     # tool_use_ids of questions the agent asked that haven't been answered yet;
     # while non-empty, queued messages must not be dequeued — only answers should
     # be sent. A set (not a flag) because multiple questions can pend at once:
@@ -379,112 +399,43 @@ def _run_agent_in_environment(
         if on_agent_started is not None:
             on_agent_started()
 
-        # make sure that we've synced anything that happened previously
-        # this ensures that we reach a consistent state once the task has been resumed
-        with services.data_model_service.open_task_transaction() as transaction:
-            all_messages = services.task_service.get_saved_messages_for_task(task.object_id, transaction)
-
-        # we need to replay the messages to do a variety of things
-        persistent_user_message_by_id: dict[AgentMessageID, PersistentUserMessageUnion] = {}
-        # one of those things is to figure out what the last user chat message was that we *started* processing
-        # this is in case we never *finished* processing it, so that the agent can resume from where it left off
-        initial_in_flight_user_chat_message_id: AgentMessageID | None = None
-        # An orphaned answer: a UserQuestionAnswerMessage that was delivered to a
-        # now-dead agent process (its RequestStarted is in history) but whose turn
-        # never completed cleanly. On resume the agent has already recorded the
-        # answer (e.g. pi persists it as a toolResult) and has no open dialog, so
-        # re-delivering it raw is a stale dialog the harness skips — dropping the
-        # answer and leaving the request perpetually in-flight. Resuming it instead
-        # settles that dangling request (see _send_user_input_message).
-        initial_in_flight_user_question_answer_message_id: AgentMessageID | None = None
-        # Track whether the agent emitted any visible response for the in-flight chat
-        # message. If it didn't, there's nothing for Claude to "resume" from — we'd
-        # rather just resend the original prompt than send a "continue where you left
-        # off" instruction with no prior content. Reset on each new RequestStarted.
-        is_partial_agent_response = False
-        for message in all_messages:
-            # just remember the last chat message from the user (that the agent started processing)
-            if isinstance(message, RequestStartedAgentMessage):
-                persistent_message = persistent_user_message_by_id.get(message.request_id)
-                if persistent_message is not None:
-                    if isinstance(persistent_message, ChatInputUserMessage):
-                        last_user_chat_message_id = message.request_id
-                        initial_in_flight_user_chat_message_id = message.request_id
-                        is_partial_agent_response = False
-                    elif isinstance(persistent_message, UserQuestionAnswerMessage):
-                        initial_in_flight_user_question_answer_message_id = message.request_id
-                    # add the user message to the history as well
-                    persistent_message_history.append(persistent_user_message_by_id[message.request_id])
-            if isinstance(message, PersistentRequestCompleteAgentMessage):
-                if message.request_id == initial_in_flight_user_chat_message_id:
-                    # it doesn't count if this was from a sigterm
-                    was_killed = _get_killed_exit_code(message)
-                    if not was_killed:
-                        initial_in_flight_user_chat_message_id = None
-                # A clean (non-interrupted) success means the answer's turn
-                # actually finished, and a turn_abandoned success means it was
-                # terminally settled (harness finalization or pi resume-settle)
-                # — clear it either way so it isn't resumed again. A plain
-                # interrupted success, a failure, or a kill all leave the answer
-                # orphaned (its toolResult is recorded but nothing drove the
-                # follow-up turn), so keep it for resume.
-                if message.request_id == initial_in_flight_user_question_answer_message_id and (
-                    isinstance(message, RequestSuccessAgentMessage)
-                    and (not message.interrupted or message.turn_abandoned)
-                ):
-                    initial_in_flight_user_question_answer_message_id = None
-            # used above so that we can figure out which user messages started being processed so far
-            if isinstance(message, PersistentUserMessage):
-                persistent_user_message_by_id[message.message_id] = message
-            # remember all messages that have been emitted so far by the agent
-            if isinstance(message, PersistentAgentMessage):
-                was_killed = _get_killed_exit_code(message)
-                if not was_killed:
-                    persistent_message_history.append(message)
-                # A ResponseBlockAgentMessage from the in-flight turn means Claude
-                # produced visible content that we'd want to continue from on resume.
-                if isinstance(message, ResponseBlockAgentMessage):
-                    is_partial_agent_response = True
-        # If we didn't observe any partial response from the agent, there's nothing
-        # to "continue from" — clear the in-flight ID so the message gets pushed as
-        # a fresh ChatInputUserMessage rather than a ResumeAgentResponseRunnerMessage.
-        # When there IS a partial response, keep the ID so _send_user_input_message
-        # converts the push into a resume and Claude continues its --resume session.
-        if not is_partial_agent_response:
-            initial_in_flight_user_chat_message_id = None
-
         logger.debug("Initial in-flight user chat message ID: {}", initial_in_flight_user_chat_message_id)
-        logger.debug("Last processed message id:              {}", task_state.last_processed_message_id)
+        logger.debug("Derived last processed message id:      {}", history_scan.last_processed_message_id)
 
         # When a crash left orphaned requests (RequestStarted with no terminal
-        # completion) but no queued user messages remain to drive their resume,
+        # completion) and no pending user input will drive their resume,
         # synthesize an interrupted completion so the frontend settles to READY
         # instead of staying stuck "thinking" forever.
-        if not queued_user_input_messages:
-            orphan_request_ids = [
-                rid
-                for rid in (
-                    initial_in_flight_user_chat_message_id,
-                    initial_in_flight_user_question_answer_message_id,
-                )
-                if rid is not None
-            ]
-            orphaned_completion_msgs = [
-                RequestSuccessAgentMessage(
-                    message_id=AgentMessageID(),
-                    request_id=rid,
-                    interrupted=True,
-                    turn_abandoned=True,
-                )
-                for rid in orphan_request_ids
-            ]
-            if orphaned_completion_msgs:
-                _save_messages(task.object_id, services, orphaned_completion_msgs, {})
-                # Advance the dedup cursor so a future restart doesn't re-queue
-                # a user message whose completion we just synthesized.
-                task_state = _record_latest_completion_in_state(
-                    orphaned_completion_msgs, task.object_id, task_state, services
-                )
+        #
+        # The chat candidate is the scan's DANGLING id (no accepted terminal
+        # completion), not the post-partial-gate in-flight id: a crash before any
+        # output leaves a dangling request with nothing to resume from, and it must
+        # still be terminalized here — settling it as an empty interrupted turn
+        # rather than silently re-executing a possibly-side-effectful prompt.
+        pending_input_message_ids = {message.message_id for message in queued_user_input_messages} | {
+            message.message_id for message in input_message_queue.queue
+        }
+        orphan_request_ids = [
+            rid
+            for rid in (
+                history_scan.dangling_chat_message_id,
+                initial_in_flight_user_question_answer_message_id,
+            )
+            if rid is not None and rid not in pending_input_message_ids
+        ]
+        orphaned_completion_msgs = [
+            RequestSuccessAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=rid,
+                interrupted=True,
+                turn_abandoned=True,
+            )
+            for rid in orphan_request_ids
+        ]
+        if orphaned_completion_msgs:
+            _save_messages(task.object_id, services, orphaned_completion_msgs, {})
+            # No cursor write is needed: the next run's scan_message_history sees
+            # the turn_abandoned completion and derives the message as settled.
 
     # this is the core event loop for the agent.
     exit_code: int | None
@@ -517,7 +468,6 @@ def _run_agent_in_environment(
                     agent_wrapper,
                     exit_code,
                     task,
-                    task_state,
                     project,
                     environment,
                     services,
@@ -530,7 +480,6 @@ def _run_agent_in_environment(
                 agent_wrapper,
                 exit_code,
                 task,
-                task_state,
                 project,
                 environment,
                 services,
@@ -562,14 +511,13 @@ def _run_agent_in_environment(
         # add any persistent messages to our history
         for message in new_messages:
             if isinstance(message, PersistentAgentMessage):
-                killed_exit_code = _get_killed_exit_code(message)
+                killed_exit_code = get_killed_exit_code(message)
                 if killed_exit_code:
                     logger.debug("Agent seems like it exited, returning")
                     return _handle_completed_agent(
                         agent_wrapper,
                         killed_exit_code,
                         task,
-                        task_state,
                         project,
                         environment,
                         services,
@@ -577,20 +525,12 @@ def _run_agent_in_environment(
                 else:
                     persistent_message_history.append(message)
 
-        # Advance the dedup cursor for any completion in this batch. Catches
-        # in-flight chat completions, queued-answer completions, and the AUQ-pending
-        # case where the in-flight chat ID isn't reflected in
-        # user_input_message_being_processed (cleared at v1.py:600 by design).
-        task_state = _record_latest_completion_in_state(new_messages, task.object_id, task_state, services)
-
         # Persist any model catalog the agent surfaced this batch (pi emits one at
         # start) onto task state so the harness's get_available_models reads it.
         task_state = _record_available_models_in_state(new_messages, task.object_id, task_state, services)
 
         # Did the currently-pending in-flight message complete? Drives the dispatch
-        # decision below — distinct from the cursor advance above, which fires for
-        # any completion in this batch (including ones for messages other than the
-        # one tracked by user_input_message_being_processed).
+        # decision below.
         is_agent_turn_finished = user_input_message_being_processed is not None and any(
             isinstance(m, PersistentRequestCompleteAgentMessage)
             and m.request_id == user_input_message_being_processed.message_id
@@ -683,19 +623,6 @@ def _run_agent_in_environment(
             # otherwise, simply forward the message to the agent and let it figure it out
             else:
                 agent_wrapper.push_message(message)
-
-
-def _get_killed_exit_code(message: Message) -> int:
-    if isinstance(message, RequestStoppedAgentMessage):
-        causal_error = message.error.construct_instance()
-        # sigterm and signint
-        if isinstance(causal_error, AgentClientError) and causal_error.exit_code in (
-            SIGTERM_EXIT_CODES | SIGINT_EXIT_CODES
-        ):
-            # exit_code is a member of a set of ints here, so it cannot be None
-            # pyrefly: ignore [bad-return]
-            return causal_error.exit_code
-    return 0
 
 
 InputMessageT = TypeVar("InputMessageT", bound=UserMessageUnion | ResumeAgentResponseRunnerMessage)
@@ -970,7 +897,6 @@ def _handle_completed_agent(
     agent_wrapper: Agent,
     exit_code: int,
     task: Task,
-    task_state: AgentTaskStateV2,
     project: Project,
     environment: AgentExecutionEnvironment,
     services: ServiceCollectionForTask,
@@ -990,10 +916,6 @@ def _handle_completed_agent(
     )
 
     _save_messages(task.object_id, services, new_messages, callbacks)
-
-    # Same per-iteration cursor advance the main loop does after its own _save_messages
-    # call — applied here for the final batch of messages popped after the loop exits.
-    _record_latest_completion_in_state(new_messages, task.object_id, task_state, services)
 
     agent_wrapper.wait(
         _COMPLETED_AGENT_FINAL_WAIT_SECONDS
@@ -1096,67 +1018,6 @@ def sync_artifacts(
     return callbacks_by_name
 
 
-def _record_latest_completion_in_state(
-    new_messages: Sequence[Message],
-    task_id: TaskID,
-    task_state: AgentTaskStateV2,
-    services: ServiceCollectionForTask,
-) -> AgentTaskStateV2:
-    """Bump last_processed_message_id to the latest completion's request_id in new_messages.
-
-    Single source of truth for advancing the dedup cursor when the agent reaches a
-    terminal state for a user message. Called from both the main loop (after
-    _save_messages) and _handle_completed_agent (for its post-pop save). The wrapper
-    constructs every PersistentRequestCompleteAgentMessage with request_id = the
-    user message ID it was wrapping, so request_id alone identifies which user
-    message was processed — we don't need to cross-reference the loop's mutable
-    user_input_message_being_processed local, which the AUQ-pending state
-    intentionally clears to None at v1.py:600 while the chat message is still in
-    flight.
-
-    BUT — the wrapper's ``_handle_user_message`` is also invoked for the
-    ephemeral ``StopAgentUserMessage`` (and ``InterruptProcessUserMessage`` via
-    the same code path), and it emits a completion for those too. Their
-    message_ids are never persisted, so blindly setting
-    last_processed_message_id to such a request_id would make the NEXT run's
-    ``_drop_already_processed_messages`` walk the replay queue looking for an
-    ID that isn't there and raise. Filter to request_ids that resolve to a
-    persisted user message in the DB.
-
-    Does NOT filter interrupted/killed completions here — the runtime cursor must
-    advance for those too (otherwise dedup re-delivers them on the next agent run).
-    The startup reconciliation in setup.py applies a different policy (skip
-    interrupted) because its semantics differ: it's healing past state, and
-    treating an interrupted completion as "done" would lose still-pending input
-    (see post-answer-shutdown — hypothesis #12).
-    """
-    completion_request_ids: list[AgentMessageID] = []
-    for message in new_messages:
-        if isinstance(message, PersistentRequestCompleteAgentMessage):
-            completion_request_ids.append(message.request_id)
-    if not completion_request_ids:
-        return task_state
-
-    # Resolve which request_ids actually correspond to persisted user messages.
-    with services.data_model_service.open_task_transaction() as transaction:
-        all_messages = services.task_service.get_saved_messages_for_task(task_id, transaction)
-    persistent_user_message_ids = {m.message_id for m in all_messages if isinstance(m, PersistentUserMessage)}
-
-    latest_persisted_request_id: AgentMessageID | None = None
-    for request_id in completion_request_ids:
-        if request_id in persistent_user_message_ids:
-            latest_persisted_request_id = request_id
-    if latest_persisted_request_id is None:
-        return task_state
-
-    return _update_task_state(
-        last_processed_input_message_id=latest_persisted_request_id,
-        task_id=task_id,
-        task_state=task_state,
-        services=services,
-    )
-
-
 def _record_available_models_in_state(
     new_messages: Sequence[Message],
     task_id: TaskID,
@@ -1169,8 +1030,8 @@ def _record_available_models_in_state(
     at agent start; this writes its `available_models` / `current_model` onto
     `AgentTaskStateV2` (which the harness's `get_available_models` /
     `get_selected_model_id` read). The last message in the batch wins. No-op when
-    the batch carries none. Preserves the DB title like `_update_task_state`, so a
-    concurrent rename is not clobbered.
+    the batch carries none. Preserves the DB title, so a concurrent rename is not
+    clobbered.
     """
     latest: ModelsAvailableAgentMessage | None = None
     for message in new_messages:
@@ -1242,34 +1103,6 @@ def _persist_available_models(
     if updated_task is None or not isinstance(updated_task.current_state, AgentTaskStateV2):
         return task_state
     return updated_task.current_state
-
-
-def _update_task_state(
-    last_processed_input_message_id: AgentMessageID,
-    task_id: TaskID,
-    task_state: AgentTaskStateV2,
-    services: ServiceCollectionForTask,
-) -> AgentTaskStateV2:
-    """Update the task state with the message ID that was processed successfully."""
-    if task_state.last_processed_message_id == last_processed_input_message_id:
-        return task_state
-
-    logger.debug(
-        f"Updating last processed message ID from {task_state.last_processed_message_id} to {last_processed_input_message_id}"
-    )
-    with services.data_model_service.open_task_transaction() as transaction:
-        task_row = transaction.get_task(task_id)
-        assert task_row is not None
-        # Read the current DB title so we don't clobber a concurrent rename.
-        db_state = AgentTaskStateV2.model_validate(task_row.current_state)
-        mutable_task_state = evolver(task_state)
-        assign(mutable_task_state.last_processed_message_id, lambda: last_processed_input_message_id)
-        assign(mutable_task_state.title, lambda: db_state.title)
-        updated_task_state = chill(mutable_task_state)
-        task_row = task_row.evolve(task_row.ref().current_state, updated_task_state.model_dump())
-        _task_row = transaction.upsert_task(task_row)
-
-    return updated_task_state
 
 
 def _save_messages(

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -421,13 +421,16 @@ def _run_agent_in_environment(
                     was_killed = _get_killed_exit_code(message)
                     if not was_killed:
                         initial_in_flight_user_chat_message_id = None
-                # Only a clean (non-interrupted) success means the answer's turn
-                # actually finished — clear it so it isn't resumed. An interrupted
-                # success, a failure, or a kill all leave the answer orphaned (its
-                # toolResult is recorded but nothing drove the follow-up turn), so
-                # keep it for resume.
+                # A clean (non-interrupted) success means the answer's turn
+                # actually finished, and a turn_abandoned success means it was
+                # terminally settled (harness finalization or pi resume-settle)
+                # — clear it either way so it isn't resumed again. A plain
+                # interrupted success, a failure, or a kill all leave the answer
+                # orphaned (its toolResult is recorded but nothing drove the
+                # follow-up turn), so keep it for resume.
                 if message.request_id == initial_in_flight_user_question_answer_message_id and (
-                    isinstance(message, RequestSuccessAgentMessage) and not message.interrupted
+                    isinstance(message, RequestSuccessAgentMessage)
+                    and (not message.interrupted or message.turn_abandoned)
                 ):
                     initial_in_flight_user_question_answer_message_id = None
             # used above so that we can figure out which user messages started being processed so far
@@ -471,6 +474,7 @@ def _run_agent_in_environment(
                     message_id=AgentMessageID(),
                     request_id=rid,
                     interrupted=True,
+                    turn_abandoned=True,
                 )
                 for rid in orphan_request_ids
             ]

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -476,6 +476,11 @@ def _run_agent_in_environment(
             ]
             if orphaned_completion_msgs:
                 _save_messages(task.object_id, services, orphaned_completion_msgs, {})
+                # Advance the dedup cursor so a future restart doesn't re-queue
+                # a user message whose completion we just synthesized.
+                task_state = _record_latest_completion_in_state(
+                    orphaned_completion_msgs, task.object_id, task_state, services
+                )
 
     # this is the core event loop for the agent.
     exit_code: int | None

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -453,6 +453,30 @@ def _run_agent_in_environment(
         logger.debug("Initial in-flight user chat message ID: {}", initial_in_flight_user_chat_message_id)
         logger.debug("Last processed message id:              {}", task_state.last_processed_message_id)
 
+        # When a crash left orphaned requests (RequestStarted with no terminal
+        # completion) but no queued user messages remain to drive their resume,
+        # synthesize an interrupted completion so the frontend settles to READY
+        # instead of staying stuck "thinking" forever.
+        if not queued_user_input_messages:
+            orphan_request_ids = [
+                rid
+                for rid in (
+                    initial_in_flight_user_chat_message_id,
+                    initial_in_flight_user_question_answer_message_id,
+                )
+                if rid is not None
+            ]
+            orphaned_completion_msgs = [
+                RequestSuccessAgentMessage(
+                    message_id=AgentMessageID(),
+                    request_id=rid,
+                    interrupted=True,
+                )
+                for rid in orphan_request_ids
+            ]
+            if orphaned_completion_msgs:
+                _save_messages(task.object_id, services, orphaned_completion_msgs, {})
+
     # this is the core event loop for the agent.
     exit_code: int | None
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_restart_characterization_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_restart_characterization_test.py
@@ -1,0 +1,978 @@
+"""Characterization tests for the run_agent v1 handler's restart/restore behavior.
+
+These tests pin the CURRENT behavior of the replay scan and dispatch logic in
+``_run_agent_in_environment`` (``v1.py``) and the cursor reconciliation and dedup
+logic in ``setup.py``, so that a planned refactor -- deriving
+``last_processed_message_id`` from the persisted message log instead of storing it
+as mutable task state ("phase 3") -- makes every behavior change explicit and
+deliberate rather than accidental. A scenario failing after that refactor means
+"this behavior changed"; the refactor must then either accept the change on
+purpose or treat it as a regression to fix. Docstrings marked PHASE-3 SENSITIVE
+flag the scenarios most likely to move.
+
+Fixture vocabulary shared across these tests:
+- "chat": a persisted ``ChatInputUserMessage`` plus its
+  ``RequestStartedAgentMessage(request_id=chat.message_id)``.
+- "partial": a ``ResponseBlockAgentMessage`` persisted after the chat's
+  ``RequestStarted`` (Claude produced visible output before the run ended).
+- "answer": a persisted ``UserQuestionAnswerMessage`` plus its own
+  ``RequestStartedAgentMessage``.
+- "cursor": ``AgentTaskStateV2.last_processed_message_id``, seeded directly via
+  ``_set_task_state`` rather than derived -- ``_run_agent_in_environment`` only
+  logs this value, it does not branch on it. The replay scan branches on the
+  persisted message history instead.
+"""
+
+import threading
+from queue import Queue
+from unittest.mock import patch
+
+import pytest
+from pydantic import PrivateAttr
+
+from sculptor.agents.default.agent_wrapper import DefaultAgentWrapper
+from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
+from sculptor.config.settings import SculptorSettings
+from sculptor.database.models import AgentTaskInputsV2
+from sculptor.database.models import AgentTaskStateV2
+from sculptor.database.models import Project
+from sculptor.database.models import Task
+from sculptor.foundation.common import generate_id
+from sculptor.foundation.serialization import SerializedException
+from sculptor.interfaces.agents.agent import MessageTypes
+from sculptor.interfaces.agents.agent import RequestStartedAgentMessage
+from sculptor.interfaces.agents.agent import RequestStoppedAgentMessage
+from sculptor.interfaces.agents.agent import RequestSuccessAgentMessage
+from sculptor.interfaces.agents.agent import ResumeAgentResponseRunnerMessage
+from sculptor.interfaces.agents.agent import StopAgentUserMessage
+from sculptor.interfaces.agents.agent import UserQuestionAnswerMessage
+from sculptor.interfaces.agents.constants import AGENT_EXIT_CODE_FROM_SIGTERM
+from sculptor.interfaces.agents.errors import AgentClientError
+from sculptor.primitives.ids import AgentMessageID
+from sculptor.primitives.ids import AssistantMessageID
+from sculptor.primitives.ids import WorkspaceID
+from sculptor.services.task_service.data_types import ServiceCollectionForTask
+from sculptor.services.workspace_service.environment_manager.environments.local_agent_execution_environment import (
+    LocalAgentExecutionEnvironment,
+)
+from sculptor.services.workspace_service.environment_manager.environments.local_environment import LocalEnvironment
+from sculptor.state.chat_state import AskUserQuestionData
+from sculptor.state.chat_state import TextBlock
+from sculptor.state.messages import ChatInputUserMessage
+from sculptor.state.messages import LLMModel
+from sculptor.state.messages import Message
+from sculptor.state.messages import ResponseBlockAgentMessage
+from sculptor.tasks.handlers.run_agent.setup import _drop_already_processed_messages
+from sculptor.tasks.handlers.run_agent.setup import load_initial_task_state
+from sculptor.tasks.handlers.run_agent.v1 import AgentPaused
+from sculptor.tasks.handlers.run_agent.v1 import _run_agent_in_environment
+
+
+def _set_task_state(task: Task, state: AgentTaskStateV2, services: ServiceCollectionForTask) -> None:
+    """Store current_state on a task in the database."""
+    with services.data_model_service.open_task_transaction() as transaction:
+        task_row = transaction.get_task(task.object_id)
+        assert task_row is not None
+        updated = task_row.evolve(task_row.ref().current_state, state.model_dump())
+        transaction.upsert_task(updated)
+
+
+def _make_in_flight_chat_message() -> ChatInputUserMessage:
+    return ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Long prompt",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+
+
+def _make_partial_response_block() -> ResponseBlockAgentMessage:
+    return ResponseBlockAgentMessage(
+        message_id=AgentMessageID(),
+        role="assistant",
+        assistant_message_id=AssistantMessageID(generate_id()),
+        content=(TextBlock(text="I'll start by..."),),
+    )
+
+
+def _persist_messages(local_task: Task, services: ServiceCollectionForTask, messages: list[MessageTypes]) -> None:
+    """Persist ``messages`` in order, one transaction per message.
+
+    Per-message transactions mirror how the real flows write (API save, then the
+    loop's _save_messages batches).
+    """
+    for message in messages:
+        with services.data_model_service.open_task_transaction() as transaction:
+            services.task_service.create_message(message, local_task.object_id, transaction)
+
+
+def _make_sigterm_error() -> SerializedException:
+    """Build a serialized AgentClientError with a SIGTERM exit code -- a "killed" completion."""
+    try:
+        raise AgentClientError("Killed by SIGTERM", exit_code=AGENT_EXIT_CODE_FROM_SIGTERM)
+    except AgentClientError as exc:
+        return SerializedException.build(exc, exc.__traceback__)
+
+
+def _make_non_killed_error(exit_code: int) -> SerializedException:
+    """Build a serialized AgentClientError whose exit code is not a SIGTERM/SIGINT code."""
+    try:
+        raise AgentClientError("Agent exited with an error", exit_code=exit_code)
+    except AgentClientError as exc:
+        return SerializedException.build(exc, exc.__traceback__)
+
+
+def _assert_no_synthesized_settlement(
+    local_task: Task, services: ServiceCollectionForTask, request_id: AgentMessageID
+) -> None:
+    """No RequestSuccess(turn_abandoned=True) was persisted for ``request_id``.
+
+    ``turn_abandoned=True`` is the marker the orphan-synthesis code in v1.py always
+    sets, so its absence means the loop did not treat this request as a settled
+    orphan.
+    """
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+    synthesized = [
+        m
+        for m in saved_messages
+        if isinstance(m, RequestSuccessAgentMessage) and m.request_id == request_id and m.turn_abandoned
+    ]
+    assert synthesized == [], f"expected no synthesized settlement for {request_id}, got {synthesized}"
+
+
+class _RecordOnlyAgent(DefaultAgentWrapper):
+    """Fake agent that records pushed chat/resume messages without doing real work.
+
+    On ``StopAgentUserMessage`` (which the v1 loop pushes when it observes
+    ``shutdown_event``), the agent emits ``RequestStoppedAgentMessage`` for the most
+    recent chat/resume message and sets ``_exit_code = SIGTERM`` so the next loop
+    iteration early-returns into ``_handle_completed_agent`` via the poll() check.
+    Requires a chat/resume message to have been pushed before Stop arrives.
+    """
+
+    _pushed_chat_or_resume: list[ChatInputUserMessage | ResumeAgentResponseRunnerMessage] = PrivateAttr(
+        default_factory=list
+    )
+    _last_chat_message_id: AgentMessageID | None = PrivateAttr(default=None)
+
+    def _start(self) -> None: ...
+
+    def _terminate(self, force_kill_seconds: float) -> None: ...
+
+    def wait(self, timeout: float) -> int:
+        return self._exit_code if self._exit_code is not None else 0
+
+    @property
+    def pushed_chat_or_resume(self) -> list[ChatInputUserMessage | ResumeAgentResponseRunnerMessage]:
+        return self._pushed_chat_or_resume
+
+    def _push_message(self, message: Message) -> bool:
+        if isinstance(message, ChatInputUserMessage):
+            self._pushed_chat_or_resume.append(message)
+            self._last_chat_message_id = message.message_id
+            return True
+        if isinstance(message, ResumeAgentResponseRunnerMessage):
+            self._pushed_chat_or_resume.append(message)
+            self._last_chat_message_id = message.for_user_message_id
+            return True
+        if isinstance(message, StopAgentUserMessage):
+            chat_id = self._last_chat_message_id
+            assert chat_id is not None, "Stop arrived before any chat/resume message"
+            self._output_messages.put(
+                RequestStoppedAgentMessage(
+                    message_id=AgentMessageID(),
+                    request_id=chat_id,
+                    error=_make_sigterm_error(),
+                )
+            )
+            self._exit_code = AGENT_EXIT_CODE_FROM_SIGTERM
+            return True
+        return False
+
+
+class _RecordingIdleStopAgent(DefaultAgentWrapper):
+    """Fake agent that records every message pushed to it and treats
+    ``StopAgentUserMessage`` as an immediate SIGTERM exit, without requiring any
+    chat/resume/answer push to precede it.
+
+    Used for empty-queue (no-op resume) scenarios, where Stop may be the only
+    message ever pushed -- or may even arrive before a message already sitting in
+    ``input_message_queue``, since the loop's shutdown check runs before it
+    dispatches messages drained from that queue in the same iteration.
+    """
+
+    _pushed: list[Message] = PrivateAttr(default_factory=list)
+
+    def _start(self) -> None: ...
+
+    def _terminate(self, force_kill_seconds: float) -> None: ...
+
+    def wait(self, timeout: float) -> int:
+        return self._exit_code if self._exit_code is not None else 0
+
+    @property
+    def pushed(self) -> list[Message]:
+        return self._pushed
+
+    def _push_message(self, message: Message) -> bool:
+        self._pushed.append(message)
+        if isinstance(message, StopAgentUserMessage):
+            self._exit_code = AGENT_EXIT_CODE_FROM_SIGTERM
+        return True
+
+
+def test_queued_inflight_chat_with_partial_is_resumed_not_synthesized(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A queued in-flight chat message with a partial response and no completion
+    is resumed, not synthesized as a settled orphan.
+
+    Orphan synthesis (see the killed-stop-with-empty-queue scenario) only fires
+    when there is nothing left in the queue to drive a resume. Here the chat
+    message is still in ``re_queued_messages``, so the replay scan's in-flight
+    tracking survives to the pre-loop send and converts the push into a
+    ``ResumeAgentResponseRunnerMessage`` instead.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordOnlyAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(chat_message,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert len(fake_agent.pushed_chat_or_resume) == 1, (
+        f"expected exactly one chat/resume push, got {fake_agent.pushed_chat_or_resume}"
+    )
+    first_push = fake_agent.pushed_chat_or_resume[0]
+    assert isinstance(first_push, ResumeAgentResponseRunnerMessage), (
+        f"expected a resume, got {type(first_push).__name__}"
+    )
+    assert first_push.for_user_message_id == chat_message.message_id
+
+    _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
+
+
+def test_queued_inflight_chat_without_partial_is_resent_raw(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A queued in-flight chat message with NO partial response and no completion
+    is resent as a fresh raw chat message, not a resume.
+
+    With no visible output to continue from, the replay scan's end-of-loop
+    ``is_partial_agent_response`` check clears the in-flight id, so
+    ``_send_user_input_message`` falls through to pushing the original message
+    as-is instead of converting it to a resume.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordOnlyAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(chat_message,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert len(fake_agent.pushed_chat_or_resume) == 1, (
+        f"expected exactly one chat/resume push, got {fake_agent.pushed_chat_or_resume}"
+    )
+    first_push = fake_agent.pushed_chat_or_resume[0]
+    assert isinstance(first_push, ChatInputUserMessage), f"expected a raw resend, got {type(first_push).__name__}"
+    assert first_push.message_id == chat_message.message_id
+
+    _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
+
+
+def test_user_stopped_turn_is_settled_no_redelivery_no_synthesis(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A user-initiated stop (a plain interrupted, non-abandoned RequestSuccess)
+    with the cursor already at the chat message and an empty queue is a dead
+    end: no redelivery, no synthesis. This is the everyday "user clicked stop"
+    shape, and it is the dominant path phase 3 must preserve exactly.
+
+    The persisted completion here is a RequestSuccess, not a
+    RequestStoppedAgentMessage, so the replay scan's ``_get_killed_exit_code``
+    check (which only special-cases RequestStoppedAgentMessage) never applies to
+    it -- the completion unconditionally clears the in-flight tracking on sight,
+    settling the turn without needing ``turn_abandoned=True``.
+    """
+    workspace_id = WorkspaceID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=chat_message.message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            RequestSuccessAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                interrupted=True,
+                turn_abandoned=False,
+            ),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordingIdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert len(fake_agent.pushed) == 1, f"expected only the Stop to be pushed, got {fake_agent.pushed}"
+    assert isinstance(fake_agent.pushed[0], StopAgentUserMessage)
+
+    _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
+
+
+def test_killed_stop_with_partial_and_empty_queue_synthesizes_settlement(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """The original SCU-1559 stuck shape: a killed (SIGTERM) stop leaves the chat
+    message's in-flight tracking alive across replay, and with no queued message
+    to drive a resume, the no-op-resume path synthesizes exactly one
+    interrupted+turn_abandoned RequestSuccess so the frontend settles instead of
+    sticking on "thinking" forever.
+
+    ``_get_killed_exit_code`` recognizes the SIGTERM exit code on the persisted
+    ``RequestStoppedAgentMessage``, so the replay scan's completion-clearing branch
+    treats it as "not really done" and keeps ``initial_in_flight_user_chat_message_id``
+    set -- unlike a plain RequestSuccess (see the user-stopped-turn scenario), which
+    always clears it.
+    """
+    workspace_id = WorkspaceID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=chat_message.message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            RequestStoppedAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                error=_make_sigterm_error(),
+            ),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordingIdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+        task_row = transaction.get_task(local_task.object_id)
+        assert task_row is not None
+        final_state = AgentTaskStateV2.model_validate(task_row.current_state)
+
+    synthesized = [
+        m
+        for m in saved_messages
+        if isinstance(m, RequestSuccessAgentMessage) and m.request_id == chat_message.message_id and m.turn_abandoned
+    ]
+    assert len(synthesized) == 1, f"expected exactly one synthesized settlement, got {synthesized}"
+    assert synthesized[0].interrupted is True
+
+    assert final_state.last_processed_message_id == chat_message.message_id
+
+
+def test_killed_stop_with_partial_and_queued_chat_is_resumed_not_synthesized(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """Same killed-stop history as the empty-queue scenario, but the chat message
+    is still in the re-queued messages (a stale cursor hasn't caught up to it
+    yet). Being queued takes priority over the empty-queue synthesis path: the
+    loop resumes the message instead of settling it with a synthesized
+    completion.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            RequestStoppedAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                error=_make_sigterm_error(),
+            ),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordOnlyAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(chat_message,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert len(fake_agent.pushed_chat_or_resume) == 1, (
+        f"expected exactly one chat/resume push, got {fake_agent.pushed_chat_or_resume}"
+    )
+    first_push = fake_agent.pushed_chat_or_resume[0]
+    assert isinstance(first_push, ResumeAgentResponseRunnerMessage), (
+        f"expected a resume, got {type(first_push).__name__}"
+    )
+    assert first_push.for_user_message_id == chat_message.message_id
+
+    _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
+
+
+def test_crash_window_marked_completion_heals_cursor_and_drops_message(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+) -> None:
+    """A turn_abandoned completion heals a stale cursor, and the healed cursor
+    correctly drops the now-settled chat message from a replayed queue.
+
+    Simulates the crash window between ``_save_messages`` (persisting the
+    synthesized turn_abandoned completion) and ``_update_task_state`` (persisting
+    the cursor advance): ``task_state.last_processed_message_id`` is stale, but
+    ``load_initial_task_state``'s reconciliation heals it from message history
+    (``_is_truly_processed_completion`` counts a turn_abandoned completion as truly
+    processed), and the healed cursor is then usable by
+    ``_drop_already_processed_messages`` without raising or re-queuing the
+    already-settled message.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            RequestSuccessAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                interrupted=True,
+                turn_abandoned=True,
+            ),
+        ],
+    )
+
+    loaded_state, _project = load_initial_task_state(services, local_task)
+
+    assert loaded_state.last_processed_message_id == chat_message.message_id, (
+        "reconciliation must heal the stale cursor to the turn_abandoned completion's request id"
+    )
+
+    replay_queue: Queue = Queue()
+    replay_queue.put(chat_message)
+    dropped, re_queued = _drop_already_processed_messages(loaded_state.last_processed_message_id, replay_queue)
+
+    assert dropped == (chat_message,)
+    assert re_queued == ()
+    assert replay_queue.empty()
+
+
+def test_crash_window_unmarked_interrupted_redelivers_raw(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """PHASE-3 SENSITIVE: a plain interrupted (non-abandoned) RequestSuccess for
+    the in-flight chat message clears the replay scan's in-flight tracking the
+    same as a clean completion would -- so when the message is still queued
+    (cursor stale from the crash window between saving that completion and
+    advancing the cursor), it is re-delivered as a fresh raw chat message, not
+    resumed, even though a partial response exists to resume from.
+
+    ``_get_killed_exit_code`` only special-cases ``RequestStoppedAgentMessage``, so
+    any ``RequestSuccessAgentMessage`` -- even ``interrupted=True,
+    turn_abandoned=False``, which ``RequestSuccessAgentMessage``'s own docstring
+    says means "the turn may still be resumed" -- clears
+    ``initial_in_flight_user_chat_message_id``. This is the opposite of how an
+    orphaned ANSWER's interrupted, non-abandoned completion is treated (see
+    ``test_orphaned_answer_with_interrupted_completion_is_still_resumed`` in
+    v1_test.py, which keeps the answer orphaned and resumable): the chat and
+    answer completion-clearing conditions in the replay scan are not symmetric
+    today. A cursor derived from message history (phase 3) must decide this
+    branch on purpose, one way or the other.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            RequestSuccessAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                interrupted=True,
+                turn_abandoned=False,
+            ),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordOnlyAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(chat_message,),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert len(fake_agent.pushed_chat_or_resume) == 1, (
+        f"expected exactly one chat/resume push, got {fake_agent.pushed_chat_or_resume}"
+    )
+    first_push = fake_agent.pushed_chat_or_resume[0]
+    assert isinstance(first_push, ChatInputUserMessage), (
+        f"pin: an interrupted-but-not-abandoned completion still clears in-flight tracking, forcing raw redelivery instead of resume; got {type(first_push).__name__}"
+    )
+    assert first_push.message_id == chat_message.message_id
+
+    _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
+
+
+def test_nonkilled_stop_is_terminal_no_synthesis(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A RequestStoppedAgentMessage whose error is NOT a SIGTERM/SIGINT exit code
+    is treated as a genuine terminal stop, not a kill: ``_get_killed_exit_code``
+    returns 0 for it, so the replay scan clears the in-flight chat tracking the
+    same as any other completion. With no queued message, there is nothing left
+    to synthesize -- unlike the killed-stop shape, which keeps the in-flight id
+    alive and does synthesize.
+    """
+    workspace_id = WorkspaceID()
+    chat_message = _make_in_flight_chat_message()
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=chat_message.message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            _make_partial_response_block(),
+            RequestStoppedAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                error=_make_non_killed_error(exit_code=1),
+            ),
+        ],
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordingIdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    assert len(fake_agent.pushed) == 1, f"expected only the Stop to be pushed, got {fake_agent.pushed}"
+    assert isinstance(fake_agent.pushed[0], StopAgentUserMessage)
+
+    _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
+
+
+def test_completed_answer_after_cursor_is_redelivered_raw(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """PHASE-3 SENSITIVE: a cleanly-completed answer trailing the cursor is
+    dropped from ``_drop_already_processed_messages``' dedup walk (which stops as
+    soon as it finds the cursor id), left LIVE in the actual input queue rather
+    than re-queued, and then re-delivered RAW to the agent -- even though it
+    already has a clean completion on disk.
+
+    ``_record_latest_completion_in_state`` sets the cursor to whichever
+    completion the main loop's most recently-processed batch contained, not by
+    comparing message ids -- so it can trail persisted queue order. Here the
+    cursor sits at the chat message even though the answer's own clean
+    completion was persisted afterward. ``_drop_already_processed_messages``
+    walks the queue only until it finds the cursor id and stops, so it never
+    inspects the answer sitting behind the chat message: the answer survives in
+    the live queue, relying entirely on the harness to skip it as a stale
+    dialog turn. Nothing in the replay path performs that skip today -- the
+    loop delivers the answer raw. A cursor derived from message history (phase
+    3) must decide, on purpose, whether an already-completed message like this
+    is redelivered, dropped, or handled some other way.
+    """
+    workspace_id = WorkspaceID()
+    chat_message = _make_in_flight_chat_message()
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Continue?": "Yes, proceed"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
+        tool_use_id="t1",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=chat_message.message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    _persist_messages(
+        local_task,
+        services,
+        [
+            chat_message,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            answer,
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+            RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+        ],
+    )
+
+    # Part (a): replaying the queue against the cursor drops the chat message and
+    # leaves the answer sitting live in the queue -- not captured as "re-queued".
+    replay_queue: Queue = Queue()
+    replay_queue.put(chat_message)
+    replay_queue.put(answer)
+    dropped, re_queued = _drop_already_processed_messages(chat_message.message_id, replay_queue)
+
+    assert dropped == (chat_message,)
+    assert re_queued == ()
+    assert replay_queue.qsize() == 1
+    assert replay_queue.get() == answer
+
+    # Part (b): running the loop with the answer live in input_message_queue (as
+    # part (a) leaves it) shows what actually happens to it.
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _RecordingIdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    input_message_queue.put(answer)
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    delivered_for_answer = [
+        m for m in fake_agent.pushed if isinstance(m, (UserQuestionAnswerMessage, ResumeAgentResponseRunnerMessage))
+    ]
+    assert len(delivered_for_answer) == 1, f"expected exactly one dispatch for the answer, got {delivered_for_answer}"
+    assert isinstance(delivered_for_answer[0], UserQuestionAnswerMessage), (
+        f"pin: a cleanly-completed answer still live in the queue is re-delivered RAW, not resumed; got {type(delivered_for_answer[0]).__name__}"
+    )

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_restart_characterization_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_restart_characterization_test.py
@@ -1,14 +1,16 @@
 """Characterization tests for the run_agent v1 handler's restart/restore behavior.
 
-These tests pin the CURRENT behavior of the replay scan and dispatch logic in
-``_run_agent_in_environment`` (``v1.py``) and the cursor reconciliation and dedup
-logic in ``setup.py``, so that a planned refactor -- deriving
-``last_processed_message_id`` from the persisted message log instead of storing it
-as mutable task state ("phase 3") -- makes every behavior change explicit and
-deliberate rather than accidental. A scenario failing after that refactor means
-"this behavior changed"; the refactor must then either accept the change on
-purpose or treat it as a regression to fix. Docstrings marked PHASE-3 SENSITIVE
-flag the scenarios most likely to move.
+These tests pin the behavior of the replay scan (``scan_message_history`` in
+``setup.py``), the dedup walk (``_drop_already_processed_messages``), and the
+dispatch/orphan-synthesis logic in ``_run_agent_in_environment`` (``v1.py``), so
+that changes to restart/restore semantics are explicit and deliberate rather
+than accidental. A failing scenario means "this behavior changed"; a change must
+then either be accepted on purpose or treated as a regression to fix.
+
+Most scenarios drive the loop with explicit queue contents (``re_queued_messages``
+/ ``input_message_queue``), pinning loop behavior independently of what the
+production dedup path would put in the queue. Where the production path matters,
+the scenario asserts on the scan's derived cursor directly.
 
 Fixture vocabulary shared across these tests:
 - "chat": a persisted ``ChatInputUserMessage`` plus its
@@ -17,10 +19,10 @@ Fixture vocabulary shared across these tests:
   ``RequestStarted`` (Claude produced visible output before the run ended).
 - "answer": a persisted ``UserQuestionAnswerMessage`` plus its own
   ``RequestStartedAgentMessage``.
-- "cursor": ``AgentTaskStateV2.last_processed_message_id``, seeded directly via
-  ``_set_task_state`` rather than derived -- ``_run_agent_in_environment`` only
-  logs this value, it does not branch on it. The replay scan branches on the
-  persisted message history instead.
+- "cursor": ``HistoryScan.last_processed_message_id``, derived from the persisted
+  message log by ``scan_message_history`` -- there is no stored cursor. The loop
+  does not branch on it; it feeds ``_drop_already_processed_messages`` on the
+  production path.
 """
 
 import threading
@@ -62,8 +64,9 @@ from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import LLMModel
 from sculptor.state.messages import Message
 from sculptor.state.messages import ResponseBlockAgentMessage
+from sculptor.tasks.handlers.run_agent.setup import HistoryScan
 from sculptor.tasks.handlers.run_agent.setup import _drop_already_processed_messages
-from sculptor.tasks.handlers.run_agent.setup import load_initial_task_state
+from sculptor.tasks.handlers.run_agent.setup import scan_message_history
 from sculptor.tasks.handlers.run_agent.v1 import AgentPaused
 from sculptor.tasks.handlers.run_agent.v1 import _run_agent_in_environment
 
@@ -75,6 +78,13 @@ def _set_task_state(task: Task, state: AgentTaskStateV2, services: ServiceCollec
         assert task_row is not None
         updated = task_row.evolve(task_row.ref().current_state, state.model_dump())
         transaction.upsert_task(updated)
+
+
+def _scan_history(local_task: Task, services: ServiceCollectionForTask) -> HistoryScan:
+    """Fetch the task's saved messages and scan them, as run_agent_task_v1 does."""
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+    return scan_message_history(saved_messages)
 
 
 def _make_in_flight_chat_message() -> ChatInputUserMessage:
@@ -238,12 +248,8 @@ def test_queued_inflight_chat_with_partial_is_resumed_not_synthesized(
     ``ResumeAgentResponseRunnerMessage`` instead.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -281,6 +287,7 @@ def test_queued_inflight_chat_with_partial_is_resumed_not_synthesized(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -316,14 +323,17 @@ def test_queued_inflight_chat_without_partial_is_resent_raw(
     ``is_partial_agent_response`` check clears the in-flight id, so
     ``_send_user_input_message`` falls through to pushing the original message
     as-is instead of converting it to a resume.
+
+    This pins the loop's behavior GIVEN a queued message. On the production
+    path the derivation settles this shape (it is dropped, not queued) and the
+    dangling request is terminalized by the orphan synthesis instead — see
+    ``test_crash_before_any_output_with_empty_queue_synthesizes_settlement``
+    in v1_test.py. The raw-resend path remains reachable when the message is
+    explicitly re-queued (e.g. a Stop-triggered re-queue).
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -360,6 +370,7 @@ def test_queued_inflight_chat_without_partial_is_resent_raw(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -387,22 +398,19 @@ def test_user_stopped_turn_is_settled_no_redelivery_no_synthesis(
     test_settings: SculptorSettings,
 ) -> None:
     """A user-initiated stop (a plain interrupted, non-abandoned RequestSuccess)
-    with the cursor already at the chat message and an empty queue is a dead
-    end: no redelivery, no synthesis. This is the everyday "user clicked stop"
-    shape, and it is the dominant path phase 3 must preserve exactly.
+    settles the chat message: the derived cursor lands on it, and with an empty
+    queue the loop performs no redelivery and no synthesis. This is the everyday
+    "user clicked stop" shape, the dominant restart path.
 
     The persisted completion here is a RequestSuccess, not a
-    RequestStoppedAgentMessage, so the replay scan's ``_get_killed_exit_code``
+    RequestStoppedAgentMessage, so the replay scan's ``get_killed_exit_code``
     check (which only special-cases RequestStoppedAgentMessage) never applies to
     it -- the completion unconditionally clears the in-flight tracking on sight,
     settling the turn without needing ``turn_abandoned=True``.
     """
     workspace_id = WorkspaceID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=chat_message.message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -420,6 +428,10 @@ def test_user_stopped_turn_is_settled_no_redelivery_no_synthesis(
             ),
         ],
     )
+
+    # The production path settles the chat message via the derived cursor, so it
+    # is dropped from the replayed queue before the loop ever sees it.
+    assert _scan_history(local_task, services).last_processed_message_id == chat_message.message_id
 
     agent_env = LocalAgentExecutionEnvironment(
         environment=environment,
@@ -446,6 +458,7 @@ def test_user_stopped_turn_is_settled_no_redelivery_no_synthesis(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -469,23 +482,20 @@ def test_killed_stop_with_partial_and_empty_queue_synthesizes_settlement(
     test_settings: SculptorSettings,
 ) -> None:
     """The original SCU-1559 stuck shape: a killed (SIGTERM) stop leaves the chat
-    message's in-flight tracking alive across replay, and with no queued message
+    message's in-flight tracking alive across replay, and with no pending message
     to drive a resume, the no-op-resume path synthesizes exactly one
     interrupted+turn_abandoned RequestSuccess so the frontend settles instead of
     sticking on "thinking" forever.
 
-    ``_get_killed_exit_code`` recognizes the SIGTERM exit code on the persisted
+    ``get_killed_exit_code`` recognizes the SIGTERM exit code on the persisted
     ``RequestStoppedAgentMessage``, so the replay scan's completion-clearing branch
-    treats it as "not really done" and keeps ``initial_in_flight_user_chat_message_id``
-    set -- unlike a plain RequestSuccess (see the user-stopped-turn scenario), which
+    treats it as "not really done" and keeps ``in_flight_chat_message_id`` set --
+    unlike a plain RequestSuccess (see the user-stopped-turn scenario), which
     always clears it.
     """
     workspace_id = WorkspaceID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=chat_message.message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -528,6 +538,7 @@ def test_killed_stop_with_partial_and_empty_queue_synthesizes_settlement(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -539,9 +550,6 @@ def test_killed_stop_with_partial_and_empty_queue_synthesizes_settlement(
 
     with services.data_model_service.open_task_transaction() as transaction:
         saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
-        task_row = transaction.get_task(local_task.object_id)
-        assert task_row is not None
-        final_state = AgentTaskStateV2.model_validate(task_row.current_state)
 
     synthesized = [
         m
@@ -551,7 +559,9 @@ def test_killed_stop_with_partial_and_empty_queue_synthesizes_settlement(
     assert len(synthesized) == 1, f"expected exactly one synthesized settlement, got {synthesized}"
     assert synthesized[0].interrupted is True
 
-    assert final_state.last_processed_message_id == chat_message.message_id
+    # The synthesized completion settles the chat message for the next restart's
+    # derived cursor, so it will be dropped rather than re-queued.
+    assert scan_message_history(saved_messages).last_processed_message_id == chat_message.message_id
 
 
 def test_killed_stop_with_partial_and_queued_chat_is_resumed_not_synthesized(
@@ -562,18 +572,14 @@ def test_killed_stop_with_partial_and_queued_chat_is_resumed_not_synthesized(
     test_settings: SculptorSettings,
 ) -> None:
     """Same killed-stop history as the empty-queue scenario, but the chat message
-    is still in the re-queued messages (a stale cursor hasn't caught up to it
-    yet). Being queued takes priority over the empty-queue synthesis path: the
-    loop resumes the message instead of settling it with a synthesized
-    completion.
+    is still queued -- which is what the production path produces here, since a
+    killed stop keeps the message in flight and the derived cursor never settles
+    an in-flight message. Being queued takes priority over synthesis: the loop
+    resumes the message instead of settling it with a synthesized completion.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -616,6 +622,7 @@ def test_killed_stop_with_partial_and_queued_chat_is_resumed_not_synthesized(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -637,30 +644,21 @@ def test_killed_stop_with_partial_and_queued_chat_is_resumed_not_synthesized(
     _assert_no_synthesized_settlement(local_task, services, chat_message.message_id)
 
 
-def test_crash_window_marked_completion_heals_cursor_and_drops_message(
+def test_marked_completion_derives_cursor_and_drops_message(
     local_task: Task,
     services: ServiceCollectionForTask,
 ) -> None:
-    """A turn_abandoned completion heals a stale cursor, and the healed cursor
-    correctly drops the now-settled chat message from a replayed queue.
+    """A turn_abandoned completion settles the chat message in the derived
+    cursor, and that cursor drops the now-settled message from a replayed queue.
 
-    Simulates the crash window between ``_save_messages`` (persisting the
-    synthesized turn_abandoned completion) and ``_update_task_state`` (persisting
-    the cursor advance): ``task_state.last_processed_message_id`` is stale, but
-    ``load_initial_task_state``'s reconciliation heals it from message history
-    (``_is_truly_processed_completion`` counts a turn_abandoned completion as truly
-    processed), and the healed cursor is then usable by
+    This is the persisted shape the orphan-synthesis path leaves behind: the
+    synthesized turn_abandoned completion is the only record that the request was
+    terminally settled. The derivation must count it (in-flight tracking clears
+    on the completion), and the derived cursor must be usable by
     ``_drop_already_processed_messages`` without raising or re-queuing the
     already-settled message.
     """
-    workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
-    _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
         local_task,
@@ -678,54 +676,50 @@ def test_crash_window_marked_completion_heals_cursor_and_drops_message(
         ],
     )
 
-    loaded_state, _project = load_initial_task_state(services, local_task)
+    scan = _scan_history(local_task, services)
 
-    assert loaded_state.last_processed_message_id == chat_message.message_id, (
-        "reconciliation must heal the stale cursor to the turn_abandoned completion's request id"
+    assert scan.last_processed_message_id == chat_message.message_id, (
+        "the derived cursor must settle on the turn_abandoned completion's request id"
     )
 
     replay_queue: Queue = Queue()
     replay_queue.put(chat_message)
-    dropped, re_queued = _drop_already_processed_messages(loaded_state.last_processed_message_id, replay_queue)
+    dropped, re_queued = _drop_already_processed_messages(scan.last_processed_message_id, replay_queue)
 
     assert dropped == (chat_message,)
     assert re_queued == ()
     assert replay_queue.empty()
 
 
-def test_crash_window_unmarked_interrupted_redelivers_raw(
+def test_unmarked_interrupted_completion_settles_derivation_but_redelivers_raw_if_queued(
     local_task: Task,
     services: ServiceCollectionForTask,
     project: Project,
     environment: LocalEnvironment,
     test_settings: SculptorSettings,
 ) -> None:
-    """PHASE-3 SENSITIVE: a plain interrupted (non-abandoned) RequestSuccess for
-    the in-flight chat message clears the replay scan's in-flight tracking the
-    same as a clean completion would -- so when the message is still queued
-    (cursor stale from the crash window between saving that completion and
-    advancing the cursor), it is re-delivered as a fresh raw chat message, not
-    resumed, even though a partial response exists to resume from.
+    """A plain interrupted (non-abandoned) RequestSuccess for the in-flight chat
+    message clears the replay scan's in-flight tracking the same as a clean
+    completion would. On the production path that settles the message in the
+    derived cursor, so dedup drops it before it ever reaches the queue -- it is
+    neither resumed nor re-delivered. At the loop level, if such a message IS
+    handed to the loop as queued input, it is re-delivered as a fresh raw chat
+    message, not resumed, even though a partial response exists to resume from
+    (the cleared in-flight tracking is what would have converted it to a resume).
 
-    ``_get_killed_exit_code`` only special-cases ``RequestStoppedAgentMessage``, so
+    ``get_killed_exit_code`` only special-cases ``RequestStoppedAgentMessage``, so
     any ``RequestSuccessAgentMessage`` -- even ``interrupted=True,
     turn_abandoned=False``, which ``RequestSuccessAgentMessage``'s own docstring
     says means "the turn may still be resumed" -- clears
-    ``initial_in_flight_user_chat_message_id``. This is the opposite of how an
-    orphaned ANSWER's interrupted, non-abandoned completion is treated (see
+    ``in_flight_chat_message_id``. This is the opposite of how an orphaned
+    ANSWER's interrupted, non-abandoned completion is treated (see
     ``test_orphaned_answer_with_interrupted_completion_is_still_resumed`` in
     v1_test.py, which keeps the answer orphaned and resumable): the chat and
-    answer completion-clearing conditions in the replay scan are not symmetric
-    today. A cursor derived from message history (phase 3) must decide this
-    branch on purpose, one way or the other.
+    answer completion-clearing conditions in the replay scan are not symmetric.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -743,6 +737,10 @@ def test_crash_window_unmarked_interrupted_redelivers_raw(
             ),
         ],
     )
+
+    # Production path: the interrupted completion settles the chat message, so
+    # the derived cursor drops it from the replayed queue.
+    assert _scan_history(local_task, services).last_processed_message_id == chat_message.message_id
 
     agent_env = LocalAgentExecutionEnvironment(
         environment=environment,
@@ -769,6 +767,7 @@ def test_crash_window_unmarked_interrupted_redelivers_raw(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -798,18 +797,15 @@ def test_nonkilled_stop_is_terminal_no_synthesis(
     test_settings: SculptorSettings,
 ) -> None:
     """A RequestStoppedAgentMessage whose error is NOT a SIGTERM/SIGINT exit code
-    is treated as a genuine terminal stop, not a kill: ``_get_killed_exit_code``
+    is treated as a genuine terminal stop, not a kill: ``get_killed_exit_code``
     returns 0 for it, so the replay scan clears the in-flight chat tracking the
-    same as any other completion. With no queued message, there is nothing left
-    to synthesize -- unlike the killed-stop shape, which keeps the in-flight id
-    alive and does synthesize.
+    same as any other completion -- the derived cursor settles the message. With
+    no pending message, there is nothing left to synthesize -- unlike the
+    killed-stop shape, which keeps the in-flight id alive and does synthesize.
     """
     workspace_id = WorkspaceID()
     chat_message = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=chat_message.message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -826,6 +822,10 @@ def test_nonkilled_stop_is_terminal_no_synthesis(
             ),
         ],
     )
+
+    # The non-killed stop settles the chat message in the derived cursor, which
+    # is why the production path arrives here with nothing queued.
+    assert _scan_history(local_task, services).last_processed_message_id == chat_message.message_id
 
     agent_env = LocalAgentExecutionEnvironment(
         environment=environment,
@@ -852,6 +852,7 @@ def test_nonkilled_stop_is_terminal_no_synthesis(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -874,24 +875,19 @@ def test_completed_answer_after_cursor_is_redelivered_raw(
     environment: LocalEnvironment,
     test_settings: SculptorSettings,
 ) -> None:
-    """PHASE-3 SENSITIVE: a cleanly-completed answer trailing the cursor is
-    dropped from ``_drop_already_processed_messages``' dedup walk (which stops as
-    soon as it finds the cursor id), left LIVE in the actual input queue rather
-    than re-queued, and then re-delivered RAW to the agent -- even though it
-    already has a clean completion on disk.
+    """On the production path a cleanly-completed answer is settled by the
+    derived cursor (both the chat and the answer derive as settled, and the
+    cursor lands on the answer -- the latest in log order), so dedup drops it
+    before the loop ever sees it. Two lower-level pins remain:
 
-    ``_record_latest_completion_in_state`` sets the cursor to whichever
-    completion the main loop's most recently-processed batch contained, not by
-    comparing message ids -- so it can trail persisted queue order. Here the
-    cursor sits at the chat message even though the answer's own clean
-    completion was persisted afterward. ``_drop_already_processed_messages``
-    walks the queue only until it finds the cursor id and stops, so it never
-    inspects the answer sitting behind the chat message: the answer survives in
-    the live queue, relying entirely on the harness to skip it as a stale
-    dialog turn. Nothing in the replay path performs that skip today -- the
-    loop delivers the answer raw. A cursor derived from message history (phase
-    3) must decide, on purpose, whether an already-completed message like this
-    is redelivered, dropped, or handled some other way.
+    Part (a): ``_drop_already_processed_messages`` stops walking as soon as it
+    finds the cursor id, so given a cursor at the chat message it leaves the
+    trailing answer LIVE in the queue rather than re-queued -- the walk never
+    inspects messages behind the cursor.
+
+    Part (b): an answer that does reach the loop via the live input queue is
+    re-delivered RAW to the agent, never converted to a resume, relying on the
+    harness to skip it as a stale dialog turn.
     """
     workspace_id = WorkspaceID()
     chat_message = _make_in_flight_chat_message()
@@ -901,10 +897,7 @@ def test_completed_answer_after_cursor_is_redelivered_raw(
         question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
         tool_use_id="t1",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=chat_message.message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -920,8 +913,12 @@ def test_completed_answer_after_cursor_is_redelivered_raw(
         ],
     )
 
-    # Part (a): replaying the queue against the cursor drops the chat message and
-    # leaves the answer sitting live in the queue -- not captured as "re-queued".
+    # Production path: the derived cursor settles both messages and lands on the
+    # answer, so dedup would drop both from the replayed queue.
+    assert _scan_history(local_task, services).last_processed_message_id == answer.message_id
+
+    # Part (a): a cursor sitting at the chat message drops it and leaves the
+    # trailing answer live in the queue -- not captured as "re-queued".
     replay_queue: Queue = Queue()
     replay_queue.put(chat_message)
     replay_queue.put(answer)
@@ -960,6 +957,7 @@ def test_completed_answer_after_cursor_is_redelivered_raw(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -51,6 +51,7 @@ from sculptor.state.messages import Message
 from sculptor.state.messages import ModelCatalogState
 from sculptor.state.messages import ModelOption
 from sculptor.state.messages import NOT_FETCHED_YET
+from sculptor.state.messages import PersistentUserMessage
 from sculptor.state.messages import ResponseBlockAgentMessage
 from sculptor.tasks.handlers.run_agent.setup import _drop_already_processed_messages
 from sculptor.tasks.handlers.run_agent.setup import _resolve_title_prediction_thread
@@ -2044,3 +2045,129 @@ def test_orphaned_answer_is_finalized_on_noop_resume(
     assert len(orphan_completions) == 1, (
         f"Expected exactly one interrupted RequestSuccess for the orphaned answer, got {len(orphan_completions)}"
     )
+
+
+def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """Synthesizing orphan completions must also advance last_processed_message_id.
+
+    The synthetic completions are written outside the main loop, so they bypass
+    the loop's cursor advance at v1.py:580. If the cursor is left stale, the next
+    restart's _drop_already_processed_messages re-queues the very user messages
+    whose completions we just synthesized, re-delivering them to the agent.
+
+    Uses the both-orphans crash shape (chat mid-response AND a delivered-but-
+    unfinished answer) so it also pins the ordering rule: the cursor must land on
+    the answer — the later message in queue order — not the chat message.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Prompt that crashed mid-response",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Continue?": "Yes, proceed"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="toolu_cursor"),
+        tool_use_id="toolu_cursor",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        # Chat turn started, produced partial output, never completed.
+        services.task_service.create_message(chat_message, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            local_task.object_id,
+            transaction,
+        )
+        services.task_service.create_message(
+            ResponseBlockAgentMessage(
+                message_id=AgentMessageID(),
+                role="assistant",
+                assistant_message_id=AssistantMessageID(generate_id()),
+                content=(TextBlock(text="Partial work before crash..."),),
+            ),
+            local_task.object_id,
+            transaction,
+        )
+        # The answer was delivered but its turn never completed either.
+        services.task_service.create_message(answer, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+            local_task.object_id,
+            transaction,
+        )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _IdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        task_row = transaction.get_task(local_task.object_id)
+        assert task_row is not None
+        final_state = AgentTaskStateV2.model_validate(task_row.current_state)
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+
+    # Both orphans got a synthetic interrupted completion.
+    synthesized_request_ids = [
+        m.request_id for m in saved_messages if isinstance(m, RequestSuccessAgentMessage) and m.interrupted
+    ]
+    assert synthesized_request_ids == [chat_message.message_id, answer.message_id]
+
+    # The persisted cursor advanced to the LAST synthesized completion (the answer,
+    # which follows the chat message in queue order).
+    assert final_state.last_processed_message_id == answer.message_id
+
+    # Simulate the next restart's dedup over the replayed user-message queue: both
+    # finalized messages must be dropped (not re-queued, no
+    # LastProcessedMessageNotInQueueError).
+    replay_queue: Queue = Queue()
+    for m in saved_messages:
+        if isinstance(m, PersistentUserMessage):
+            replay_queue.put(m)
+    dropped, re_queued = _drop_already_processed_messages(final_state.last_processed_message_id, replay_queue)
+    assert {m.message_id for m in dropped} == {chat_message.message_id, answer.message_id}
+    assert re_queued == ()
+    assert replay_queue.empty()

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -1815,3 +1815,234 @@ def test_save_messages_writes_artifact_before_publishing_its_message() -> None:
     assert chat_publish_idx < sync_idx, (
         f"non-artifact publishes should run before any artifact sync (surgical interleave — chat tokens shouldn't wait for artifact writes); got {registered}"
     )
+
+
+class _IdleStopAgent(DefaultAgentWrapper):
+    """Fake agent that handles Stop without requiring a prior chat/resume push.
+
+    Used in no-op-resume tests where the loop has nothing to dispatch (no
+    queued messages, orphaned requests were finalized pre-loop) and only
+    needs to drain the Stop → exit.
+    """
+
+    def _start(self) -> None: ...
+
+    def _terminate(self, force_kill_seconds: float) -> None: ...
+
+    def wait(self, timeout: float) -> int:
+        return self._exit_code if self._exit_code is not None else 0
+
+    def _push_message(self, message: Message) -> bool:
+        if isinstance(message, StopAgentUserMessage):
+            self._exit_code = AGENT_EXIT_CODE_FROM_SIGTERM
+            return True
+        return False
+
+
+def test_orphaned_chat_request_is_finalized_on_noop_resume(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A crash-mid-response orphan (RequestStarted with no terminal completion)
+    must be finalized with an interrupted RequestSuccess when the restored task
+    has no queued messages to drive a resume.
+
+    Without this synthetic completion the frontend stays stuck ``thinking``
+    forever because message_conversion never sees a terminal event for the
+    dangling request_id.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Prompt that crashed mid-response",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    # Persist the crash state: chat message + RequestStarted + partial response,
+    # but no terminal completion.
+    with services.data_model_service.open_task_transaction() as transaction:
+        services.task_service.create_message(chat_message, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+            ),
+            local_task.object_id,
+            transaction,
+        )
+        services.task_service.create_message(
+            ResponseBlockAgentMessage(
+                message_id=AgentMessageID(),
+                role="assistant",
+                assistant_message_id=AssistantMessageID(generate_id()),
+                content=(TextBlock(text="Partial work before crash..."),),
+            ),
+            local_task.object_id,
+            transaction,
+        )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _IdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),  # no queued messages — the no-op resume case
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    # The fix must have saved a RequestSuccessAgentMessage(interrupted=True)
+    # for the orphaned chat request so the frontend can settle to READY.
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+
+    orphan_completions = [
+        m
+        for m in saved_messages
+        if isinstance(m, RequestSuccessAgentMessage) and m.request_id == chat_message.message_id and m.interrupted
+    ]
+    assert len(orphan_completions) == 1, (
+        f"Expected exactly one interrupted RequestSuccess for the orphaned request, got {len(orphan_completions)}"
+    )
+
+
+def test_orphaned_answer_is_finalized_on_noop_resume(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A crash-mid-answer orphan (UserQuestionAnswerMessage with RequestStarted but
+    no terminal completion) must be finalized with an interrupted RequestSuccess
+    when the restored task has no queued messages.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+
+    # Original chat message + completed turn
+    chat_message = ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Do something",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Continue?": "Yes, proceed"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="toolu_orphan"),
+        tool_use_id="toolu_orphan",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        # Chat turn completed normally
+        services.task_service.create_message(chat_message, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+            ),
+            local_task.object_id,
+            transaction,
+        )
+        services.task_service.create_message(
+            RequestSuccessAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+            ),
+            local_task.object_id,
+            transaction,
+        )
+        # Answer was delivered but the process crashed before its turn completed
+        services.task_service.create_message(answer, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=answer.message_id,
+            ),
+            local_task.object_id,
+            transaction,
+        )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    fake_agent = _IdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    task_data = local_task.input_data
+
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=task_data,
+                task_state=stale_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+
+    orphan_completions = [
+        m
+        for m in saved_messages
+        if isinstance(m, RequestSuccessAgentMessage) and m.request_id == answer.message_id and m.interrupted
+    ]
+    assert len(orphan_completions) == 1, (
+        f"Expected exactly one interrupted RequestSuccess for the orphaned answer, got {len(orphan_completions)}"
+    )

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -2171,3 +2171,167 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
     assert {m.message_id for m in dropped} == {chat_message.message_id, answer.message_id}
     assert re_queued == ()
     assert replay_queue.empty()
+
+
+def _run_noop_resume(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    agent_env: LocalAgentExecutionEnvironment,
+    test_settings: SculptorSettings,
+    task_state: AgentTaskStateV2,
+) -> None:
+    """Run one no-op resume cycle (no queued messages, shutdown pre-set) to AgentPaused."""
+    fake_agent = _IdleStopAgent(
+        harness=CLAUDE_CODE_HARNESS,
+        environment=agent_env,
+        task_id=local_task.object_id,
+        system_prompt="",
+    )
+    input_message_queue: Queue = Queue()
+    shutdown_event = threading.Event()
+    shutdown_event.set()
+    assert isinstance(local_task.input_data, AgentTaskInputsV2)
+    with patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=fake_agent):
+        with pytest.raises(AgentPaused):
+            _run_agent_in_environment(
+                task=local_task,
+                task_data=local_task.input_data,
+                task_state=task_state,
+                re_queued_messages=(),
+                input_message_queue=input_message_queue,
+                environment=agent_env,
+                services=services,
+                project=project,
+                settings=test_settings,
+                shutdown_event=shutdown_event,
+            )
+
+
+def test_second_noop_resume_does_not_duplicate_answer_finalization(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A finalized answer orphan must stay finalized across further restarts.
+
+    The synthesized completion is interrupted, and replay used to treat any
+    interrupted success as "keep the answer orphaned for resume" — so every
+    subsequent no-op resume re-detected the same orphan and appended another
+    synthetic completion, one per restart cycle. The turn_abandoned marker
+    tells replay the request was terminally settled, so the second cycle must
+    synthesize nothing.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Do something",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"Continue?": "Yes, proceed"},
+        question_data=AskUserQuestionData(questions=[], tool_use_id="toolu_repeat"),
+        tool_use_id="toolu_repeat",
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        services.task_service.create_message(chat_message, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            local_task.object_id,
+            transaction,
+        )
+        services.task_service.create_message(
+            RequestSuccessAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            local_task.object_id,
+            transaction,
+        )
+        services.task_service.create_message(answer, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=answer.message_id),
+            local_task.object_id,
+            transaction,
+        )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+
+    _run_noop_resume(local_task, services, project, agent_env, test_settings, stale_state)
+    # Second cycle loads state the way a real restart does (also exercising the
+    # reconciler against the marked completion persisted by the first cycle).
+    reloaded_state, _project = load_initial_task_state(services, local_task)
+    _run_noop_resume(local_task, services, project, agent_env, test_settings, reloaded_state)
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+
+    answer_completions = [
+        m for m in saved_messages if isinstance(m, RequestSuccessAgentMessage) and m.request_id == answer.message_id
+    ]
+    assert len(answer_completions) == 1, (
+        f"The second no-op resume must not re-finalize the settled answer, got {len(answer_completions)} completions"
+    )
+    assert answer_completions[0].interrupted and answer_completions[0].turn_abandoned
+
+
+def test_load_initial_task_state_counts_turn_abandoned_completions(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+) -> None:
+    """Reconciliation counts interrupted completions marked turn_abandoned.
+
+    Mirror of test_load_initial_task_state_does_not_count_interrupted_completions:
+    a plain interrupted success means "may still be resumed" and must not advance
+    the cursor, but a turn_abandoned one means "terminally settled, never
+    re-drive" — if the cursor write was lost to a crash between _save_messages
+    and _update_task_state, reconciliation must heal it so the settled message
+    isn't re-delivered.
+    """
+    workspace_id = WorkspaceID()
+    previous_message_id = AgentMessageID()
+    chat_message = ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Prompt that crashed mid-response",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    stale_state = AgentTaskStateV2(
+        workspace_id=workspace_id,
+        last_processed_message_id=previous_message_id,
+    )
+    _set_task_state(local_task, stale_state, services)
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        services.task_service.create_message(chat_message, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            local_task.object_id,
+            transaction,
+        )
+        services.task_service.create_message(
+            RequestSuccessAgentMessage(
+                message_id=AgentMessageID(),
+                request_id=chat_message.message_id,
+                interrupted=True,
+                turn_abandoned=True,
+            ),
+            local_task.object_id,
+            transaction,
+        )
+
+    loaded_state, _project = load_initial_task_state(services, local_task)
+
+    assert loaded_state.last_processed_message_id == chat_message.message_id, (
+        "Reconciliation must advance the cursor over a turn_abandoned completion"
+    )

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -1924,8 +1924,6 @@ def test_orphaned_chat_request_is_finalized_on_noop_resume(
                 shutdown_event=shutdown_event,
             )
 
-    # The fix must have saved a RequestSuccessAgentMessage(interrupted=True)
-    # for the orphaned chat request so the frontend can settle to READY.
     with services.data_model_service.open_task_transaction() as transaction:
         saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -53,16 +53,17 @@ from sculptor.state.messages import ModelOption
 from sculptor.state.messages import NOT_FETCHED_YET
 from sculptor.state.messages import PersistentUserMessage
 from sculptor.state.messages import ResponseBlockAgentMessage
+from sculptor.tasks.handlers.run_agent.setup import HistoryScan
 from sculptor.tasks.handlers.run_agent.setup import _drop_already_processed_messages
 from sculptor.tasks.handlers.run_agent.setup import _resolve_title_prediction_thread
 from sculptor.tasks.handlers.run_agent.setup import load_initial_task_state
+from sculptor.tasks.handlers.run_agent.setup import scan_message_history
 from sculptor.tasks.handlers.run_agent.v1 import AgentPaused
 from sculptor.tasks.handlers.run_agent.v1 import _build_agent_path
 from sculptor.tasks.handlers.run_agent.v1 import _eager_fetch_pi_models_into_state
 from sculptor.tasks.handlers.run_agent.v1 import _run_agent_in_environment
 from sculptor.tasks.handlers.run_agent.v1 import _save_messages
 from sculptor.tasks.handlers.run_agent.v1 import _send_user_input_message
-from sculptor.tasks.handlers.run_agent.v1 import _update_task_state
 
 
 def test_drop_already_processed_messages_with_processed_id() -> None:
@@ -249,49 +250,11 @@ def _get_task_title(task: Task, services: ServiceCollectionForTask) -> str | Non
         return AgentTaskStateV2.model_validate(task_row.current_state).title
 
 
-def test_update_task_state_overwrites_renamed_title(
-    local_task: Task,
-    services: ServiceCollectionForTask,
-) -> None:
-    """_update_task_state clobbers a title that was renamed via the API.
-
-    Simulates the race condition:
-    1. Agent loads task state with title "Original Title"
-    2. User renames the agent to "Renamed Title" (updates DB)
-    3. Agent processes a message and calls _update_task_state with stale state
-    4. DB title is overwritten back to "Original Title"
-    """
-    workspace_id = WorkspaceID()
-    initial_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        title="Original Title",
-        last_processed_message_id=None,
-    )
-    _set_task_state(local_task, initial_state, services)
-
-    # Step 1: Agent loads state into memory (capturing "Original Title").
-    in_memory_state = initial_state
-
-    # Step 2: User renames agent via API (directly updating DB).
-    renamed_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        title="Renamed Title",
-        last_processed_message_id=None,
-    )
-    _set_task_state(local_task, renamed_state, services)
-    assert _get_task_title(local_task, services) == "Renamed Title"
-
-    # Step 3: Agent finishes processing and calls _update_task_state with stale state.
-    new_message_id = AgentMessageID()
-    _update_task_state(
-        last_processed_input_message_id=new_message_id,
-        task_id=local_task.object_id,
-        task_state=in_memory_state,
-        services=services,
-    )
-
-    # Step 4: The renamed title should be preserved, not overwritten.
-    assert _get_task_title(local_task, services) == "Renamed Title"
+def _scan_history(local_task: Task, services: ServiceCollectionForTask) -> HistoryScan:
+    """Fetch the task's saved messages and scan them, as run_agent_task_v1 does."""
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+    return scan_message_history(saved_messages)
 
 
 def test_resolve_title_prediction_overwrites_renamed_title(
@@ -309,7 +272,6 @@ def test_resolve_title_prediction_overwrites_renamed_title(
     initial_state = AgentTaskStateV2(
         workspace_id=workspace_id,
         title=None,
-        last_processed_message_id=None,
     )
     _set_task_state(local_task, initial_state, services)
 
@@ -320,7 +282,6 @@ def test_resolve_title_prediction_overwrites_renamed_title(
     renamed_state = AgentTaskStateV2(
         workspace_id=workspace_id,
         title="Renamed Title",
-        last_processed_message_id=None,
     )
     _set_task_state(local_task, renamed_state, services)
     assert _get_task_title(local_task, services) == "Renamed Title"
@@ -397,32 +358,30 @@ def test_sigtermed_in_flight_message_is_recorded_as_processed(
     environment: LocalEnvironment,
     test_settings: SculptorSettings,
 ) -> None:
-    """When the agent is SIGTERM'd mid-turn, the in-flight user message must be recorded
-    as ``last_processed_message_id`` so the next agent run does not re-deliver it to Claude.
+    """When the agent is SIGTERM'd mid-turn, the in-flight user message must derive
+    as settled from the persisted log so the next agent run does not re-deliver it.
 
-    Reproduces the user-visible bug: on the next run, ``_drop_already_processed_messages``
-    keys off ``last_processed_message_id`` to decide which queued messages to drop. If the
-    interrupted message wasn't recorded as processed, it survives in the queue and the
-    main loop pushes it to Claude again — making the agent appear to auto-start with the
-    user's previously-interrupted prompt.
+    The user-visible pin: on the next run, ``_drop_already_processed_messages``
+    keys off the derived ``last_processed_message_id`` to decide which queued
+    messages to drop. If the interrupted message doesn't derive as settled, it
+    survives in the queue and the main loop pushes it to Claude again — making the
+    agent appear to auto-start with the user's previously-interrupted prompt. Here
+    the killed turn produced no partial response, so nothing is resumable and the
+    scan settles the message on its persisted RequestStopped.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     in_flight_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Long-running prompt",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Persist the chat message — in production it would have been written via
     # the HTTP send endpoint before the agent picked it up via subscription.
-    # _record_latest_completion_in_state needs the user message in the DB to
-    # distinguish it from ephemeral request_ids (e.g. StopAgentUserMessage's).
+    # The scan can only resolve a RequestStarted (and hence derive the cursor)
+    # for a user message that exists in the DB.
     with services.data_model_service.open_task_transaction() as transaction:
         services.task_service.create_message(in_flight_message, local_task.object_id, transaction)
 
@@ -450,6 +409,7 @@ def test_sigtermed_in_flight_message_is_recorded_as_processed(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(in_flight_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -459,11 +419,7 @@ def test_sigtermed_in_flight_message_is_recorded_as_processed(
                 shutdown_event=shutdown_event,
             )
 
-    with services.data_model_service.open_task_transaction() as transaction:
-        task_row = transaction.get_task(local_task.object_id)
-        assert task_row is not None
-        final_state = AgentTaskStateV2.model_validate(task_row.current_state)
-        assert final_state.last_processed_message_id == in_flight_message.message_id
+    assert _scan_history(local_task, services).last_processed_message_id == in_flight_message.message_id
 
 
 class _AukThenSigtermOnStopAgent(DefaultAgentWrapper):
@@ -471,8 +427,8 @@ class _AukThenSigtermOnStopAgent(DefaultAgentWrapper):
 
     On the first ``ChatInputUserMessage``: emits ``RequestStartedAgentMessage`` and an
     ``AskUserQuestionAgentMessage`` (ephemeral) so the v1 loop sees the AUQ and
-    sets ``is_waiting_for_question_answer = True``. The loop then clears
-    ``user_input_message_being_processed = None`` at v1.py:600.
+    tracks its pending tool_use_id. The loop then clears
+    ``user_input_message_being_processed = None`` while waiting for the answer.
 
     To trigger the shutdown leg cleanly without orchestrating the
     ``shutdown_event`` from outside the loop, the agent fires the supplied event
@@ -550,26 +506,22 @@ def test_sigtermed_during_auq_wait_records_chat_message_as_processed(
     test_settings: SculptorSettings,
 ) -> None:
     """When the agent is SIGTERM'd while waiting for an AskUserQuestion answer,
-    the in-flight chat message must still be recorded as ``last_processed_message_id``.
+    the in-flight chat message must still derive as settled from the persisted log.
 
     In the AUQ-pending state the v1 loop sets ``user_input_message_being_processed = None``
-    (v1.py:600) by design — the original chat message is still in flight as far as
-    Claude is concerned, but the local variable doesn't reflect that. A fix that
-    keys off ``user_input_message_being_processed`` (hypothesis #1's fix) won't
-    update state in this scenario, leaving the chat prompt ahead of the dedup
-    cursor and re-delivered to Claude on the next agent run.
+    (by design) — the original chat message is still in flight as far as Claude is
+    concerned, but the local variable doesn't reflect that. The derivation must not
+    depend on that local: the wrapper's persisted RequestStopped(chat) is what
+    settles the message (no partial response exists, so nothing is resumable), and
+    dedup drops it instead of re-delivering it to Claude on the next agent run.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Make a plan and ask me to approve it",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Persist the chat message — in production it would have been written via
@@ -602,6 +554,7 @@ def test_sigtermed_during_auq_wait_records_chat_message_as_processed(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -611,40 +564,24 @@ def test_sigtermed_during_auq_wait_records_chat_message_as_processed(
                 shutdown_event=shutdown_event,
             )
 
-    with services.data_model_service.open_task_transaction() as transaction:
-        task_row = transaction.get_task(local_task.object_id)
-        assert task_row is not None
-        final_state = AgentTaskStateV2.model_validate(task_row.current_state)
-        assert final_state.last_processed_message_id == chat_message.message_id
+    assert _scan_history(local_task, services).last_processed_message_id == chat_message.message_id
 
 
-def test_load_initial_task_state_derives_last_processed_from_history(
+def test_scan_message_history_derives_last_processed_from_history(
     local_task: Task,
     services: ServiceCollectionForTask,
 ) -> None:
-    """If the DB shows a completion for a user message that isn't reflected in
-    task_state.last_processed_message_id, load_initial_task_state should derive
-    the corrected value from history.
+    """A started user message with a clean completion derives as the dedup cursor.
 
-    Reproduces hypothesis #3: the v1 loop's success path commits _save_messages
-    (v1.py:510) and _update_task_state (v1.py:557-562) in separate transactions.
-    If the backend is SIGKILL'd or loses power between them, the completion
-    message is persisted but last_processed_message_id is stale. Without
-    reconciliation, the next agent run leaves the user message ahead of the
-    dedup cursor and re-delivers it to Claude.
+    The cursor is never stored: scan_message_history derives it from the
+    persisted log at startup and feeds it straight to
+    wait_for_initial_message_and_process_queue -> _drop_already_processed_messages,
+    so a crash at any point cannot leave the cursor out of sync with the
+    completions on disk (the failure mode a stored cursor had).
     """
-    workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message_id = AgentMessageID()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
-    _set_task_state(local_task, stale_state, services)
 
-    # Persist a user chat message + its completion to the DB. This is the state
-    # left behind by a crash between _save_messages and _update_task_state in
-    # the v1 loop's success path.
+    # Persist a user chat message + its RequestStarted + clean completion.
     chat_message = ChatInputUserMessage(
         message_id=chat_message_id,
         text="Processed but not recorded",
@@ -669,18 +606,9 @@ def test_load_initial_task_state_derives_last_processed_from_history(
             transaction,
         )
 
-    loaded_state, _project = load_initial_task_state(services, local_task)
+    scan = _scan_history(local_task, services)
 
-    assert loaded_state.last_processed_message_id == chat_message_id
-
-    # The correction must also be persisted so downstream dedup
-    # (wait_for_initial_message_and_process_queue -> _drop_already_processed_messages)
-    # sees the corrected value when it re-reads task_state from the DB.
-    with services.data_model_service.open_task_transaction() as transaction:
-        task_row = transaction.get_task(local_task.object_id)
-        assert task_row is not None
-        persisted_state = AgentTaskStateV2.model_validate(task_row.current_state)
-        assert persisted_state.last_processed_message_id == chat_message_id
+    assert scan.last_processed_message_id == chat_message_id
 
 
 class _RecordOnlyAgent(DefaultAgentWrapper):
@@ -749,25 +677,18 @@ def test_in_flight_message_with_partial_response_is_sent_as_resume_not_chat(
     on the next run so Claude continues its existing ``--resume`` session rather than
     restarting the prompt from scratch.
 
-    Reproduces hypothesis #2: ``v1.py:445`` unconditionally sets
-    ``initial_in_flight_user_chat_message_id = None`` (FIXME from commit
-    ``bc3922e4e2c4``, "Disable the new message resumption behavior"), throwing away
-    the value the history walk just computed. ``_send_user_input_message`` then
-    sees the loop's effective in-flight ID as ``None``, fails the equality check
-    at v1.py:681, and pushes the chat message as-is instead of converting to a
-    resume.
+    The scan's in-flight chat id survives the partial-response gate (a partial
+    exists), and ``_send_user_input_message`` keys on it to convert the queued
+    push into a resume; if the id were cleared, the chat message would be pushed
+    as-is and the prompt would restart from scratch.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Long prompt",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Persist the in-flight state: the chat message, its RequestStartedAgentMessage,
@@ -819,6 +740,7 @@ def test_in_flight_message_with_partial_response_is_sent_as_resume_not_chat(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -860,16 +782,12 @@ def test_resuming_in_flight_message_does_not_persist_a_duplicate(
     on-disk row count for the in-flight message stays at exactly one.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Long prompt",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Persist the in-flight state exactly once: the chat message, its
@@ -930,6 +848,7 @@ def test_resuming_in_flight_message_does_not_persist_a_duplicate(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(chat_message,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1022,8 +941,9 @@ def test_orphaned_question_answer_is_resumed_not_stale_skipped(
 
     A crash mid-question-answer leaves the ``UserQuestionAnswerMessage`` with a
     ``RequestStarted`` but no completion -- the per-turn ``RequestSuccess`` is
-    deferred to the turn boundary, which the crash never reaches. Reconciliation
-    keeps the orphaned answer in the queue, so the resume loop re-dispatches it.
+    deferred to the turn boundary, which the crash never reaches. The derived
+    cursor keeps the orphaned answer in the queue, so the resume loop
+    re-dispatches it.
 
     On restart the pi process has already recorded the answer as a ``toolResult``
     and has no open dialog, so re-delivering the answer raw is reported as a stale
@@ -1035,7 +955,6 @@ def test_orphaned_question_answer_is_resumed_not_stale_skipped(
     an orphaned chat message -- so the dangling request settles.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
     answer = UserQuestionAnswerMessage(
         message_id=AgentMessageID(),
@@ -1043,10 +962,7 @@ def test_orphaned_question_answer_is_resumed_not_stale_skipped(
         question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
         tool_use_id="t1",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Persist the crash-mid-answer history: the chat turn started and produced a
@@ -1089,6 +1005,7 @@ def test_orphaned_question_answer_is_resumed_not_stale_skipped(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(answer,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1168,7 +1085,6 @@ def test_orphaned_answer_with_interrupted_completion_is_still_resumed(
     — re-introducing the bug on the next restart.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
     answer = UserQuestionAnswerMessage(
         message_id=AgentMessageID(),
@@ -1176,10 +1092,7 @@ def test_orphaned_answer_with_interrupted_completion_is_still_resumed(
         question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
         tool_use_id="t1",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Crash-mid-answer history where the answer's deferred success fired interrupted
@@ -1223,6 +1136,7 @@ def test_orphaned_answer_with_interrupted_completion_is_still_resumed(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(answer,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1255,7 +1169,6 @@ def test_answer_with_clean_completion_is_not_resumed(
     converted to a resume — the negative side of the clearing condition.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = _make_in_flight_chat_message()
     answer = UserQuestionAnswerMessage(
         message_id=AgentMessageID(),
@@ -1263,10 +1176,7 @@ def test_answer_with_clean_completion_is_not_resumed(
         question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
         tool_use_id="t1",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # The answer's turn finished cleanly: RequestStarted + RequestSuccess(interrupted=False).
@@ -1308,6 +1218,7 @@ def test_answer_with_clean_completion_is_not_resumed(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(answer,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1476,8 +1387,8 @@ def test_queued_followup_is_dispatched_after_resumed_turn_completes(
     response, no completion) and follow-up B queued behind it. On restart the
     loop must resume A, and -- because the resumed turn's completion is keyed on
     ``for_user_message_id`` -- ``is_agent_turn_finished`` must fire when it
-    completes so that B is dispatched. The dedup cursor must advance to A so A
-    is not re-delivered on the run after this one.
+    completes so that B is dispatched. The completion must settle A in the
+    derived cursor so A is not re-delivered on the run after this one.
 
     This binds the two halves of the contract that the wrapper-level test
     (``agent_wrapper_test.test_resume_turn_uses_for_user_message_id_as_request_id``)
@@ -1485,17 +1396,13 @@ def test_queued_followup_is_dispatched_after_resumed_turn_completes(
     keyed on the original turn id, and the loop acts on them.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     message_a = _make_in_flight_chat_message()
     message_b = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Queued follow-up",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # What a SIGKILL mid-turn leaves on disk: A saved + started + partial
@@ -1535,6 +1442,7 @@ def test_queued_followup_is_dispatched_after_resumed_turn_completes(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(message_a, message_b),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1553,10 +1461,12 @@ def test_queued_followup_is_dispatched_after_resumed_turn_completes(
     assert isinstance(second, ChatInputUserMessage)
     assert second.message_id == message_b.message_id
 
-    # The dedup cursor advanced to A, so A is not re-delivered on the next run.
-    persisted_state = _read_persisted_task_state(local_task, services)
-    assert persisted_state.last_processed_message_id == message_a.message_id, (
-        f"cursor must advance to A on resumed-turn completion; got {persisted_state.last_processed_message_id}"
+    # The derived dedup cursor advanced to A, so A is not re-delivered on the
+    # next run. (B was dispatched but never started by the fake, so it stays
+    # unsettled ahead of the cursor.)
+    derived_cursor = _scan_history(local_task, services).last_processed_message_id
+    assert derived_cursor == message_a.message_id, (
+        f"cursor must derive as A on resumed-turn completion; got {derived_cursor}"
     )
 
 
@@ -1569,20 +1479,16 @@ def test_double_hard_kill_without_resumed_turn_output_resends_fresh(
 ) -> None:
     """A second hard kill BEFORE the resumed turn produced output -> fresh re-send.
 
-    The history walk resets ``is_partial_agent_response`` on each
-    RequestStarted for the chat message (v1.py), so a resumed turn that died
-    without emitting any ResponseBlock leaves "nothing to continue from" and the
-    next run pushes the original prompt as a fresh ChatInputUserMessage instead
-    of a resume. This pins that semantic choice -- and that the fresh re-send
-    path does not re-persist the message either.
+    The scan resets ``is_partial_agent_response`` on each RequestStarted for the
+    chat message, so a resumed turn that died without emitting any ResponseBlock
+    leaves "nothing to continue from" and the next run pushes the original prompt
+    as a fresh ChatInputUserMessage instead of a resume. This pins that semantic
+    choice -- and that the fresh re-send path does not re-persist the message
+    either.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     message_a = _make_in_flight_chat_message()
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     _persist_messages(
@@ -1623,6 +1529,7 @@ def test_double_hard_kill_without_resumed_turn_output_resends_fresh(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(message_a,),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1645,31 +1552,24 @@ def test_double_hard_kill_without_resumed_turn_output_resends_fresh(
     assert len(chat_copies) == 1, f"fresh re-send must not re-persist; found {len(chat_copies)} copies"
 
 
-def test_load_initial_task_state_does_not_count_interrupted_completions(
+def test_scan_message_history_does_not_settle_answer_with_interrupted_completion(
     local_task: Task,
     services: ServiceCollectionForTask,
 ) -> None:
-    """Reconciliation must not treat interrupted completions as truly processed.
+    """A plain interrupted answer completion must not settle the answer.
 
-    Reproduces hypothesis #12 (post-answer shutdown): when the user answered an
-    AUQ and Sculptor was killed before Claude finished processing the answer, the
-    wrapper emits ``RequestSuccessAgentMessage(answer, interrupted=True)`` and
-    ``RequestStoppedAgentMessage(X)``. Both are
-    ``PersistentRequestCompleteAgentMessage``s — but neither represents a
-    fully-processed message: the chat X was SIGTERM'd mid-response, and the
-    answer was SIGTERM'd mid-MCP-delivery.
+    The post-answer-shutdown shape: the user answered an AUQ and Sculptor was
+    killed before Claude finished processing the answer. The wrapper emits
+    ``RequestSuccessAgentMessage(answer, interrupted=True)`` (no turn_abandoned
+    marker — the turn may still be resumed) and ``RequestStoppedAgentMessage(X)``
+    for the chat.
 
-    If reconciliation counts these as "processed", it sets
-    ``last_processed_message_id = answer.message_id`` and dedup drops the answer
-    from the queue on the next run. The user's typed answer is silently lost.
-
-    With the fix, reconciliation skips completions flagged as ``interrupted`` or
-    detected as killed (SIGTERM/SIGINT). For the post-answer-shutdown scenario,
-    neither X nor answer is counted, so ``last_processed_message_id`` stays at
-    its prior value and the answer survives in the queue to be re-delivered.
+    If the derivation settled the answer, dedup would drop it from the queue on
+    the next run and the user's typed answer would be silently lost. Instead the
+    scan keeps the answer in flight: the derived cursor stops at the chat message
+    (settled by its killed stop — no partial response is resumable), and the
+    dedup walk leaves the answer in the queue to be re-driven.
     """
-    workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Pick an option",
@@ -1681,11 +1581,6 @@ def test_load_initial_task_state_does_not_count_interrupted_completions(
         question_data=AskUserQuestionData(questions=[], tool_use_id="t1"),
         tool_use_id="t1",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
-    _set_task_state(local_task, stale_state, services)
 
     try:
         raise AgentClientError("Killed by SIGTERM", exit_code=AGENT_EXIT_CODE_FROM_SIGTERM)
@@ -1732,16 +1627,23 @@ def test_load_initial_task_state_does_not_count_interrupted_completions(
             transaction,
         )
 
-    loaded_state, _project = load_initial_task_state(services, local_task)
+    scan = _scan_history(local_task, services)
 
-    # Today: reconciliation counts both completions and sets last_processed
-    # to answer.message_id (the latest). The answer would then be dropped by dedup.
-    # After fix: neither counts (both are interrupted/killed), so last_processed
-    # stays at previous_message_id and the answer survives for re-delivery.
-    assert loaded_state.last_processed_message_id != answer.message_id, (
-        "Reconciliation must not advance last_processed past the answer's interrupted completion"
+    assert scan.last_processed_message_id != answer.message_id, (
+        "The derivation must not settle the answer on its plain interrupted completion"
     )
-    assert loaded_state.last_processed_message_id == previous_message_id
+    assert scan.last_processed_message_id == chat_message.message_id
+
+    # The dedup walk driven by the derived cursor drops the settled chat message
+    # and leaves the answer in the queue to be re-driven.
+    replay_queue: Queue = Queue()
+    replay_queue.put(chat_message)
+    replay_queue.put(answer)
+    dropped, re_queued = _drop_already_processed_messages(scan.last_processed_message_id, replay_queue)
+    assert dropped == (chat_message,)
+    assert re_queued == ()
+    assert replay_queue.qsize() == 1
+    assert replay_queue.get() == answer
 
 
 def test_save_messages_writes_artifact_before_publishing_its_message() -> None:
@@ -1856,16 +1758,12 @@ def test_orphaned_chat_request_is_finalized_on_noop_resume(
     dangling request_id.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Prompt that crashed mid-response",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     # Persist the crash state: chat message + RequestStarted + partial response,
@@ -1916,6 +1814,7 @@ def test_orphaned_chat_request_is_finalized_on_noop_resume(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),  # no queued messages — the no-op resume case
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -1950,7 +1849,6 @@ def test_orphaned_answer_is_finalized_on_noop_resume(
     when the restored task has no queued messages.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
 
     # Original chat message + completed turn
     chat_message = ChatInputUserMessage(
@@ -1964,10 +1862,7 @@ def test_orphaned_answer_is_finalized_on_noop_resume(
         question_data=AskUserQuestionData(questions=[], tool_use_id="toolu_orphan"),
         tool_use_id="toolu_orphan",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     with services.data_model_service.open_task_transaction() as transaction:
@@ -2025,6 +1920,7 @@ def test_orphaned_answer_is_finalized_on_noop_resume(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -2054,19 +1950,18 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
     environment: LocalEnvironment,
     test_settings: SculptorSettings,
 ) -> None:
-    """Synthesizing orphan completions must also advance last_processed_message_id.
+    """Synthesized orphan completions must settle their messages for the next run.
 
-    The synthetic completions are written outside the main loop, so they bypass
-    the loop's cursor advance at v1.py:580. If the cursor is left stale, the next
-    restart's _drop_already_processed_messages re-queues the very user messages
-    whose completions we just synthesized, re-delivering them to the agent.
+    The synthetic turn_abandoned completions are what the next restart's
+    scan_message_history keys on: if they didn't settle the orphans, the next
+    run's _drop_already_processed_messages would re-queue the very user messages
+    whose completions were just synthesized, re-delivering them to the agent.
 
     Uses the both-orphans crash shape (chat mid-response AND a delivered-but-
-    unfinished answer) so it also pins the ordering rule: the cursor must land on
-    the answer — the later message in queue order — not the chat message.
+    unfinished answer) so it also pins the ordering rule: the derived cursor must
+    land on the answer — the later message in queue order — not the chat message.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Prompt that crashed mid-response",
@@ -2078,10 +1973,7 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
         question_data=AskUserQuestionData(questions=[], tool_use_id="toolu_cursor"),
         tool_use_id="toolu_cursor",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     with services.data_model_service.open_task_transaction() as transaction:
@@ -2135,6 +2027,7 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
                 task=local_task,
                 task_data=task_data,
                 task_state=stale_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -2145,9 +2038,6 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
             )
 
     with services.data_model_service.open_task_transaction() as transaction:
-        task_row = transaction.get_task(local_task.object_id)
-        assert task_row is not None
-        final_state = AgentTaskStateV2.model_validate(task_row.current_state)
         saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
 
     # Both orphans got a synthetic interrupted completion.
@@ -2156,9 +2046,10 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
     ]
     assert synthesized_request_ids == [chat_message.message_id, answer.message_id]
 
-    # The persisted cursor advanced to the LAST synthesized completion (the answer,
-    # which follows the chat message in queue order).
-    assert final_state.last_processed_message_id == answer.message_id
+    # The next restart's derived cursor lands on the LAST synthesized completion
+    # (the answer, which follows the chat message in queue order).
+    derived_cursor = scan_message_history(saved_messages).last_processed_message_id
+    assert derived_cursor == answer.message_id
 
     # Simulate the next restart's dedup over the replayed user-message queue: both
     # finalized messages must be dropped (not re-queued, no
@@ -2167,7 +2058,7 @@ def test_noop_resume_advances_dedup_cursor_for_synthesized_completions(
     for m in saved_messages:
         if isinstance(m, PersistentUserMessage):
             replay_queue.put(m)
-    dropped, re_queued = _drop_already_processed_messages(final_state.last_processed_message_id, replay_queue)
+    dropped, re_queued = _drop_already_processed_messages(derived_cursor, replay_queue)
     assert {m.message_id for m in dropped} == {chat_message.message_id, answer.message_id}
     assert re_queued == ()
     assert replay_queue.empty()
@@ -2198,6 +2089,7 @@ def _run_noop_resume(
                 task=local_task,
                 task_data=local_task.input_data,
                 task_state=task_state,
+                history_scan=_scan_history(local_task, services),
                 re_queued_messages=(),
                 input_message_queue=input_message_queue,
                 environment=agent_env,
@@ -2225,7 +2117,6 @@ def test_second_noop_resume_does_not_duplicate_answer_finalization(
     synthesize nothing.
     """
     workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Do something",
@@ -2237,10 +2128,7 @@ def test_second_noop_resume_does_not_duplicate_answer_finalization(
         question_data=AskUserQuestionData(questions=[], tool_use_id="toolu_repeat"),
         tool_use_id="toolu_repeat",
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
+    stale_state = AgentTaskStateV2(workspace_id=workspace_id)
     _set_task_state(local_task, stale_state, services)
 
     with services.data_model_service.open_task_transaction() as transaction:
@@ -2269,8 +2157,8 @@ def test_second_noop_resume_does_not_duplicate_answer_finalization(
     )
 
     _run_noop_resume(local_task, services, project, agent_env, test_settings, stale_state)
-    # Second cycle loads state the way a real restart does (also exercising the
-    # reconciler against the marked completion persisted by the first cycle).
+    # Second cycle loads state the way a real restart does (its scan then sees
+    # the marked completion persisted by the first cycle).
     reloaded_state, _project = load_initial_task_state(services, local_task)
     _run_noop_resume(local_task, services, project, agent_env, test_settings, reloaded_state)
 
@@ -2286,31 +2174,22 @@ def test_second_noop_resume_does_not_duplicate_answer_finalization(
     assert answer_completions[0].interrupted and answer_completions[0].turn_abandoned
 
 
-def test_load_initial_task_state_counts_turn_abandoned_completions(
+def test_scan_message_history_counts_turn_abandoned_completions(
     local_task: Task,
     services: ServiceCollectionForTask,
 ) -> None:
-    """Reconciliation counts interrupted completions marked turn_abandoned.
+    """The derivation settles a message on its turn_abandoned completion.
 
-    Mirror of test_load_initial_task_state_does_not_count_interrupted_completions:
-    a plain interrupted success means "may still be resumed" and must not advance
-    the cursor, but a turn_abandoned one means "terminally settled, never
-    re-drive" — if the cursor write was lost to a crash between _save_messages
-    and _update_task_state, reconciliation must heal it so the settled message
-    isn't re-delivered.
+    Mirror of test_scan_message_history_does_not_settle_answer_with_interrupted_completion:
+    a turn_abandoned success means "terminally settled, never re-drive" (it is the
+    marker the orphan-synthesis path writes), so the derived cursor must advance
+    over it and dedup must drop the message instead of re-delivering it.
     """
-    workspace_id = WorkspaceID()
-    previous_message_id = AgentMessageID()
     chat_message = ChatInputUserMessage(
         message_id=AgentMessageID(),
         text="Prompt that crashed mid-response",
         model_name=LLMModel.CLAUDE_4_SONNET,
     )
-    stale_state = AgentTaskStateV2(
-        workspace_id=workspace_id,
-        last_processed_message_id=previous_message_id,
-    )
-    _set_task_state(local_task, stale_state, services)
 
     with services.data_model_service.open_task_transaction() as transaction:
         services.task_service.create_message(chat_message, local_task.object_id, transaction)
@@ -2330,8 +2209,74 @@ def test_load_initial_task_state_counts_turn_abandoned_completions(
             transaction,
         )
 
-    loaded_state, _project = load_initial_task_state(services, local_task)
+    scan = _scan_history(local_task, services)
 
-    assert loaded_state.last_processed_message_id == chat_message.message_id, (
-        "Reconciliation must advance the cursor over a turn_abandoned completion"
+    assert scan.last_processed_message_id == chat_message.message_id, (
+        "The derived cursor must advance over a turn_abandoned completion"
     )
+
+
+def test_crash_before_any_output_with_empty_queue_synthesizes_settlement(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: LocalEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A chat whose request started but produced NO output and NO completion must
+    still be terminalized on a no-op resume.
+
+    The scan's partial gate clears the resumable in-flight id (nothing to resume
+    from) and the derivation settles the message (it will not be re-driven), so
+    without the dangling-id path the request would keep its RequestStarted with no
+    terminal completion forever — the frontend's stuck-"thinking" shape. The
+    synthesis keys on HistoryScan.dangling_chat_message_id (pre-gate) so this
+    shape settles as an empty interrupted turn. Deliberate delta from the stored-
+    cursor era, which re-executed the prompt raw on restart: a crash between
+    RequestStarted and the first persisted block may still have run side-effectful
+    tools, so silent re-execution was the riskier behavior.
+    """
+    workspace_id = WorkspaceID()
+    chat_message = ChatInputUserMessage(
+        message_id=AgentMessageID(),
+        text="Prompt that crashed before any output",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    _set_task_state(local_task, AgentTaskStateV2(workspace_id=workspace_id), services)
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        services.task_service.create_message(chat_message, local_task.object_id, transaction)
+        services.task_service.create_message(
+            RequestStartedAgentMessage(message_id=AgentMessageID(), request_id=chat_message.message_id),
+            local_task.object_id,
+            transaction,
+        )
+
+    pre_scan = _scan_history(local_task, services)
+    assert pre_scan.in_flight_chat_message_id is None, "no partial output, so nothing is resumable"
+    assert pre_scan.dangling_chat_message_id == chat_message.message_id
+    assert pre_scan.last_processed_message_id == chat_message.message_id, (
+        "the derivation settles the message (it will not be re-driven), which is why synthesis must terminalize it"
+    )
+
+    agent_env = LocalAgentExecutionEnvironment(
+        environment=environment,
+        task_id=local_task.object_id,
+        dependency_management_service=services.dependency_management_service,
+    )
+    _run_noop_resume(
+        local_task, services, project, agent_env, test_settings, AgentTaskStateV2(workspace_id=workspace_id)
+    )
+
+    with services.data_model_service.open_task_transaction() as transaction:
+        saved_messages = services.task_service.get_saved_messages_for_task(local_task.object_id, transaction)
+    settlements = [
+        m
+        for m in saved_messages
+        if isinstance(m, RequestSuccessAgentMessage) and m.request_id == chat_message.message_id and m.turn_abandoned
+    ]
+    assert len(settlements) == 1, f"expected exactly one synthesized settlement, got {settlements}"
+    assert settlements[0].interrupted is True
+
+    post_scan = _scan_history(local_task, services)
+    assert post_scan.dangling_chat_message_id is None, "the settlement terminalizes the dangling request"

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -756,7 +756,12 @@ def navigate_to_settings_page(page: Page, **_kwargs: object) -> PlaywrightSettin
         # route change is in flight survives it and lands ON TOP of Settings,
         # where it would swallow the caller's first click. Require a clear
         # surface too — a failure retries the body, whose Escape dismisses it.
-        expect(page.get_by_test_id(ElementIDs.PALETTE_DIALOG_OVERLAY)).to_have_count(0)
+        # Keep this timeout well under the outer 30s retry budget: the default
+        # expect timeout is also 30s, so an unbounded gate would let the first
+        # stuck-offer attempt exhaust the budget waiting passively, and the
+        # retry that re-presses Escape (the only thing that dismisses the offer)
+        # would never run.
+        expect(page.get_by_test_id(ElementIDs.PALETTE_DIALOG_OVERLAY)).to_have_count(0, timeout=5_000)
 
     retry(
         stop=stop_after_delay(30),

--- a/sculptor/tests/integration/regression/test_regression_replay_on_restart.py
+++ b/sculptor/tests/integration/regression/test_regression_replay_on_restart.py
@@ -16,29 +16,27 @@ The replay scenarios covered here:
   ``user_input_message_being_processed`` is ``None`` in that state, so
   the mid-turn fix originally missed this path).
 
-Other replay paths (disabled-resume FIXME; save/state-update race;
-post-answer interrupted-completion reconciliation) require triggers
-that ``SculptorInstanceFactory`` cannot reproduce — SIGKILL between two
-specific transactions, or shutdown timed inside a millisecond-scale window.
-Those bugs are covered by backend unit tests in
+Other replay paths (orphaned answers, interrupted completions, derived-cursor
+edge shapes) require triggers that ``SculptorInstanceFactory`` cannot
+reproduce — SIGKILL at a precise point, or shutdown timed inside a
+millisecond-scale window. Those are covered by backend unit tests in
 ``sculptor/sculptor/tasks/handlers/run_agent/v1_test.py``.
 
 Both tests use ``fake_claude:sleep`` (or the AUQ-emitting equivalent) for a
 deterministic long-running turn so that any replay would keep the agent in
 ``RUNNING`` for at least 120 seconds. Each test asserts the post-restart
-status reaches ``READY`` within a generous timeout — only true if the dedup
-cursor correctly recorded the prompt as already-processed and the loop
-therefore had nothing to dispatch.
+status reaches ``READY`` within a generous timeout — only true if the restart
+scan (``scan_message_history``) settles or quickly resolves the prompt instead
+of re-running it: a killed turn with no partial output derives as settled and
+is dropped by dedup; a killed turn with partial output is converted to a
+short resume of the original turn, never a fresh re-run of the prompt.
 
 Note on user-clicked Stop: the Stop button does NOT trigger this bug
 class, because Claude's clean exit on a stdin interrupt control_request
 flows through the wrapper's success branch (``RequestSuccessAgentMessage``
-with ``interrupted=True``), which the v1 loop's existing
-``is_agent_turn_finished`` check already correctly translates into a
-``_update_task_state`` call. The bugs above only fire on the SIGTERM
-path, where the wrapper's exception handler emits
-``RequestStoppedAgentMessage`` and the loop's killed-request branch
-short-circuits past the state-update site.
+with ``interrupted=True``), which the restart scan treats as a settled
+turn. The bugs above only fire on the SIGTERM path, where the wrapper's
+exception handler emits ``RequestStoppedAgentMessage``.
 """
 
 import re
@@ -101,13 +99,13 @@ def test_chat_does_not_replay_after_shutdown_mid_turn(
 ) -> None:
     """SIGTERM'ing Sculptor mid-turn must not cause the prompt to be re-delivered.
 
-    Reproduces hypothesis #1: when Claude is killed by SIGTERM mid-turn the
-    wrapper emits ``RequestStoppedAgentMessage`` for the in-flight chat, and
-    the v1 loop's killed-request branch short-circuits into
-    ``_handle_completed_agent`` without bumping ``last_processed_message_id``.
-    On the next agent run ``_drop_already_processed_messages`` leaves the
-    prompt in the queue and the loop re-pushes it to Claude, restarting the
-    sleep.
+    When Claude is killed by SIGTERM mid-turn the wrapper emits
+    ``RequestStoppedAgentMessage`` for the in-flight chat. The sleeping turn
+    produced no visible output, so on the next agent run the restart scan
+    derives the prompt as settled (nothing is resumable) and
+    ``_drop_already_processed_messages`` drops it from the queue. If the
+    derivation instead left the prompt queued, the loop would re-push it to
+    Claude, restarting the sleep.
     """
     with sculptor_instance_factory_.spawn_instance() as instance:
         task_page = start_task_and_wait_for_ready(
@@ -126,8 +124,8 @@ def test_chat_does_not_replay_after_shutdown_mid_turn(
 
     # Exiting the context group SIGTERMs the backend, which propagates SIGTERM to
     # the fake-claude child process. The wrapper emits RequestStoppedAgentMessage
-    # for the in-flight chat; the loop's killed-request branch returns into
-    # _handle_completed_agent without updating last_processed (the bug).
+    # for the in-flight chat; that persisted stop (with no partial response) is
+    # what the next run's scan settles the prompt on.
 
     with sculptor_instance_factory_.spawn_instance() as instance:
         _open_workspace_after_restart(instance.page)
@@ -145,17 +143,15 @@ def test_chat_does_not_replay_after_shutdown_during_auq_wait(
 ) -> None:
     """Sculptor SIGTERM while waiting on an unanswered AUQ must not re-deliver the chat.
 
-    Reproduces hypothesis #4: the v1 loop's AUQ branch deliberately clears
+    In the AUQ-pending state the v1 loop deliberately clears
     ``user_input_message_being_processed = None`` while waiting for the
-    answer. Hypothesis #1's original fix keyed off
-    that local, so it missed this case — the chat that triggered the AUQ
-    never got recorded as processed, and on the next run it was re-delivered
-    to Claude (which re-emitted the AUQ tool block, duplicating the panel
-    and producing observable activity from a "user did nothing" restart).
-
-    With the fix, the cursor advances on the wrapper's RequestStopped(chat)
-    via ``_handle_completed_agent``'s scan, dedup drops the chat, and the
-    agent stays idle post-restart.
+    answer, so restart handling must not key off that local. The AUQ turn
+    emitted a visible tool_use block before blocking, so the restart scan
+    keeps the killed chat in flight (resumable) rather than settling it: the
+    next run converts it into a resume of the original turn — a short
+    "continue" that completes immediately — never a raw re-delivery of the
+    prompt, which would re-emit the AUQ tool block (duplicating the panel and
+    producing observable activity from a "user did nothing" restart).
     """
     with sculptor_instance_factory_.spawn_instance() as instance:
         start_task_and_wait_for_ready(
@@ -168,19 +164,19 @@ def test_chat_does_not_replay_after_shutdown_during_auq_wait(
         auq_panel = get_ask_user_question_panel(instance.page)
         expect(auq_panel).to_be_visible(timeout=_INFLIGHT_OBSERVATION_TIMEOUT_MS)
 
-    # SIGTERM during AUQ wait. The wrapper emits RequestStopped(chat); on the
-    # next agent run (before the fix) the chat is re-delivered to Claude, which
-    # re-emits the AUQ tool block — observable as the agent transitioning
-    # through RUNNING into WAITING again post-restart.
+    # SIGTERM during AUQ wait. The wrapper emits RequestStopped(chat); a raw
+    # re-delivery of the chat would make Claude re-emit the AUQ tool block —
+    # observable as the agent transitioning through RUNNING into WAITING again
+    # post-restart.
 
     with sculptor_instance_factory_.spawn_instance() as instance:
         _open_workspace_after_restart(instance.page)
-        # With the fix: BUILDING → READY (no replay; the historical AUQ
-        # block doesn't pin to WAITING because the derived-status walk
-        # breaks on the persisted RequestStopped) — a read/unread dot. With the
-        # bug: BUILDING → RUNNING → WAITING (Claude re-emits AUQ on the replayed
-        # chat), so the dot would be "running"/"waiting" and the idle dot is
-        # never reached, timing this expect out.
+        # Expected: BUILDING → (brief resume turn) → READY — a read/unread dot;
+        # the historical AUQ block doesn't pin to WAITING because the
+        # derived-status walk breaks on the turn's terminal completion. A raw
+        # replay instead goes BUILDING → RUNNING → WAITING (Claude re-emits AUQ
+        # on the replayed chat), so the dot would stick at "running"/"waiting"
+        # and the idle dot would never be reached, timing this expect out.
         expect(_agent_tab(instance.page)).to_have_attribute(
             "data-dot-status", _IDLE_DOT_STATUS, timeout=_SETTLE_TIMEOUT_MS
         )


### PR DESCRIPTION
## Summary

If Sculptor crashed at the wrong moment and you restored the task, you could get an agent that looked like it was thinking, forever. The process was alive, idle, and perfectly content; the UI just had no way to know the turn was over, because the record that would have said so was never written.

The boring root cause: we stored a little bookkeeping value, `last_processed_message_id`, that remembered which of your messages the agent had finished. It was a copy of something the message log already knew — and like most copies, it drifted. Three different pieces of code each kept their own opinion of "finished": the main loop wrote the value after each turn, a startup reconciler healed it with deliberately different rules, and the restore path re-derived it a third way. Crash between any two of those writes and the opinions disagreed. Depending on where you crashed, that meant a prompt silently ran twice, a settled turn got re-finalized on every restart, or — the bug that started all this — a turn that nobody would ever finish.

This PR fixes the symptom, then removes the reason the whole class of bug exists, in four reviewable steps:

1. **Fix the immediate bug** (55bf8ee0): when a restore finds a turn that died mid-flight with nothing left to nudge it, write the missing "this turn was interrupted" record so the UI settles.
2. **Let the log say what it means** (5a0ea59b): an "interrupted" completion used to carry two opposite meanings — "resume me after restart" or "this turn is over for good" — and readers had to guess from context. There is now an explicit `turn_abandoned` marker, set by the two writers that mean the second thing.
3. **Pin current behavior** (9784e1bd): nine characterization tests covering the restart matrix (crashes with and without output, user stops, kill signals, stale bookkeeping), so the last step couldn't change behavior silently.
4. **Delete the copy** (9e84c743): `last_processed_message_id` is no longer stored anywhere. One function replays the message log at startup and answers both questions — "what should resume?" and "what was already handled?" — from the same pass, so they cannot disagree. The stored field, both of its writers, and the reconciler are gone (about 750 lines of production code and bookkeeping), and the crash-window bugs are now unrepresentable rather than merely unlikely.

A few behavior changes are deliberate, each pinned by a test: crash-window shapes that used to silently re-run your prompt now settle as an interrupted turn (re-executing a prompt that may already have run side-effectful tools was the scarier default), and a killed turn whose message is still queued gets genuinely resumed instead of being stamped "interrupted".

No frontend changes, and no real database migration — two no-op revisions keep the JSON schema tracker honest, and old rows load fine in both directions.

## Changes

- **Restore consistency** (`base_implementation.py`): `restore_task` flips FAILED → QUEUED and now also clears the stale `error` field, keeping the documented invariant ("if `error` is set, outcome is FAILED").
- **Orphan finalization** (`v1.py`): started-but-never-terminalized requests that no pending input will drive get a synthesized `RequestSuccessAgentMessage(interrupted=True, turn_abandoned=True)` before the loop starts. The gate checks actual pending input (re-queued plus the live queue) and keys on the scan's dangling-request id, so a crash before any output still gets terminalized.
- **`turn_abandoned` marker** (`agent.py`, pi wrapper): distinguishes "terminally settled" from "resume me"; honored by the replay scan's answer handling and the settledness derivation.
- **Derived cursor** (`setup.py`, `v1.py`, `models.py`): `scan_message_history` replays the persisted log once per run and returns resume state and the dedup cursor from one pass. Deleted: the stored `last_processed_message_id` field, `_record_latest_completion_in_state`, `_update_task_state`, and the startup reconciler.
- **Migrations**: two no-op alembic revisions (`1da4cc57bb93`, `6026c03dc852`) for the JSON-blob field addition/removal, with version-test fixtures, per repo convention.

## Acceptance criteria

- [x] A restored pi task with an idle process presents as READY/idle (not "thinking"), and the chat input is available.
- [x] `outcome` and `error` are consistent after restore.
- [x] Every started request reaches a terminal record after a restore — either resumed and completed by the agent, or explicitly settled as interrupted.
- [x] Dedup and resume tracking cannot disagree: both derive from the same scan of the message log.

## Tests

- `test_restore_task_clears_stale_error` — `error` is cleared after restore
- `test_orphaned_chat_request_is_finalized_on_noop_resume` / `test_orphaned_answer_is_finalized_on_noop_resume` — synthetic completions for orphaned turns
- `test_second_noop_resume_does_not_duplicate_answer_finalization` — settling is idempotent across repeated restores
- `test_crash_before_any_output_with_empty_queue_synthesizes_settlement` — a turn that died before producing anything still gets terminalized
- `scan_message_history` derivation tests (migrated from the old reconciler tests, preserving their intent — e.g. an interrupted answer still survives to be re-driven)
- `v1_restart_characterization_test.py` — nine-scenario restart matrix pinning resume/redeliver/settle behavior
- Both `test_regression_replay_on_restart` integration tests pass end-to-end

Fixes SCU-1559

(Sent by Claude)
