### PR TITLE
Cherry-pick #328 into 0.42.0: Linear board create/assign workspace (SCU-1789)

### DIFF
--- a/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.test.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.test.tsx
@@ -85,6 +85,16 @@ describe("BoardTicketRow", () => {
     expect(placeholder.closest("[role='menuitem']")?.getAttribute("aria-disabled")).toBe("true");
   });
 
+  it("shows a disabled loading placeholder while the workspace list is undefined", async () => {
+    // `undefined` is the SDK's "not loaded yet" state, distinct from an empty list.
+    renderRow({ allWorkspaces: undefined });
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Assign workspace"));
+    const placeholder = await screen.findByText("Loading workspaces…");
+    expect(placeholder.closest("[role='menuitem']")?.getAttribute("aria-disabled")).toBe("true");
+    expect(screen.queryByText("No workspaces")).toBeNull();
+  });
+
   it("labels the open button with the single workspace and navigates to it on click", async () => {
     const onOpen = vi.fn();
     renderRow({ row: row([workspace("w1", "My workspace")]), onOpenWorkspace: onOpen });

--- a/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.test.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.test.tsx
@@ -2,7 +2,7 @@ import { Theme } from "@radix-ui/themes";
 import type { WorkspaceView } from "@sculptor/plugin-sdk";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactElement, ReactNode } from "react";
+import type { ComponentProps, ReactElement, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { LinearIssue } from "../linear/client.ts";
@@ -10,7 +10,7 @@ import type { BoardRow } from "../linear/board.ts";
 import { BoardTicketRow } from "./BoardTicketRow.tsx";
 
 // The row reads only `openExternal` from the SDK (for the issue link); stub it so
-// the import resolves without the host runtime. Navigation is a prop, not a hook.
+// the import resolves without the host runtime. All actions are props, not hooks.
 vi.mock("@sculptor/plugin-sdk", () => ({ openExternal: vi.fn() }));
 
 const Wrapper = ({ children }: { children: ReactNode }): ReactElement => <Theme>{children}</Theme>;
@@ -39,33 +39,61 @@ const issue: LinearIssue = {
 
 const row = (workspaces: ReadonlyArray<WorkspaceView>): BoardRow<WorkspaceView> => ({ issue, workspaces });
 
+const renderRow = (overrides: Partial<ComponentProps<typeof BoardTicketRow>> = {}): void => {
+  render(
+    <Wrapper>
+      <BoardTicketRow
+        row={row([])}
+        allWorkspaces={[]}
+        onOpenWorkspace={vi.fn()}
+        onCreateWorkspace={vi.fn()}
+        onAssignWorkspace={vi.fn()}
+        {...overrides}
+      />
+    </Wrapper>,
+  );
+};
+
 describe("BoardTicketRow", () => {
-  it("shows the muted 'No workspace' slot when nothing is associated", () => {
-    render(
-      <Wrapper>
-        <BoardTicketRow row={row([])} onOpenWorkspace={vi.fn()} />
-      </Wrapper>,
-    );
-    expect(screen.getByText("No workspace")).toBeTruthy();
+  it("shows the quiet 'No workspace' menu trigger when nothing is associated", () => {
+    renderRow();
+    expect(screen.getByRole("button", { name: /No workspace/ })).toBeTruthy();
+  });
+
+  it("invokes the create callback with the row's issue from 'Create workspace…'", async () => {
+    const onCreate = vi.fn();
+    renderRow({ onCreateWorkspace: onCreate });
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Create workspace…"));
+    expect(onCreate).toHaveBeenCalledWith(issue);
+  });
+
+  it("assigns an existing workspace picked from the submenu", async () => {
+    const onAssign = vi.fn();
+    renderRow({ allWorkspaces: [workspace("w1", "My workspace")], onAssignWorkspace: onAssign });
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Assign workspace"));
+    await userEvent.click(await screen.findByText("My workspace"));
+    expect(onAssign).toHaveBeenCalledWith("w1", issue);
+  });
+
+  it("shows a disabled placeholder in the assign submenu when there are no workspaces", async () => {
+    renderRow({ allWorkspaces: [] });
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Assign workspace"));
+    const placeholder = await screen.findByText("No workspaces");
+    expect(placeholder.closest("[role='menuitem']")?.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("labels the open button with the single workspace and navigates to it on click", async () => {
     const onOpen = vi.fn();
-    render(
-      <Wrapper>
-        <BoardTicketRow row={row([workspace("w1", "My workspace")])} onOpenWorkspace={onOpen} />
-      </Wrapper>,
-    );
+    renderRow({ row: row([workspace("w1", "My workspace")]), onOpenWorkspace: onOpen });
     await userEvent.click(screen.getByRole("button", { name: /My workspace/ }));
     expect(onOpen).toHaveBeenCalledWith("w1");
   });
 
   it("collapses several workspaces into a count", () => {
-    render(
-      <Wrapper>
-        <BoardTicketRow row={row([workspace("w1", "A"), workspace("w2", "B")])} onOpenWorkspace={vi.fn()} />
-      </Wrapper>,
-    );
+    renderRow({ row: row([workspace("w1", "A"), workspace("w2", "B")]) });
     expect(screen.getByText(/2 workspaces/)).toBeTruthy();
   });
 });

--- a/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.tsx
@@ -6,6 +6,14 @@ import type { ReactElement } from "react";
 import type { BoardRow } from "../linear/board.ts";
 import type { LinearIssue } from "../linear/client.ts";
 
+// Width of the trailing "No workspace" slot, matching the workspace indicators
+// so the trailing column stays aligned down the board.
+const WORKSPACE_SLOT_MIN_WIDTH_PX = 120;
+
+// Height cap (with scroll) for the assign submenu: it lists every workspace,
+// and long-lived installs can have far more than fit on screen.
+const ASSIGN_SUBMENU_MAX_HEIGHT_PX = 320;
+
 /**
  * One ticket on the board: its identifier and title (opening the issue in Linear
  * on click), with a trailing indicator of whether a Sculptor workspace is
@@ -26,8 +34,12 @@ export const BoardTicketRow = ({
   onAssignWorkspace,
 }: {
   row: BoardRow<WorkspaceView>;
-  /** Every workspace the assign menu can offer (not just this ticket's). */
-  allWorkspaces: ReadonlyArray<WorkspaceView>;
+  /**
+   * Every workspace the assign menu can offer (not just this ticket's);
+   * `undefined` while the workspace list hasn't loaded yet, which the assign
+   * submenu renders as a loading placeholder rather than "No workspaces".
+   */
+  allWorkspaces: ReadonlyArray<WorkspaceView> | undefined;
   onOpenWorkspace: (workspaceId: string) => void;
   onCreateWorkspace: (issue: LinearIssue) => void;
   onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
@@ -100,7 +112,7 @@ const NoWorkspaceMenu = ({
   onAssignWorkspace,
 }: {
   issue: LinearIssue;
-  allWorkspaces: ReadonlyArray<WorkspaceView>;
+  allWorkspaces: ReadonlyArray<WorkspaceView> | undefined;
   onCreateWorkspace: (issue: LinearIssue) => void;
   onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
 }): ReactElement => (
@@ -110,7 +122,7 @@ const NoWorkspaceMenu = ({
         size="1"
         variant="ghost"
         color="gray"
-        style={{ flexShrink: 0, minWidth: 120, justifyContent: "flex-end" }}
+        style={{ flexShrink: 0, minWidth: WORKSPACE_SLOT_MIN_WIDTH_PX, justifyContent: "flex-end" }}
       >
         No workspace
         <ChevronDown size={13} />
@@ -120,23 +132,45 @@ const NoWorkspaceMenu = ({
       <DropdownMenu.Item onSelect={() => onCreateWorkspace(issue)}>Create workspace…</DropdownMenu.Item>
       <DropdownMenu.Sub>
         <DropdownMenu.SubTrigger>Assign workspace</DropdownMenu.SubTrigger>
-        {/* Capped height with scroll: the submenu lists every workspace, and
-            long-lived installs can have far more than fit on screen. */}
-        <DropdownMenu.SubContent style={{ maxHeight: 320, overflowY: "auto" }}>
-          {allWorkspaces.length === 0 ? (
-            <DropdownMenu.Item disabled>No workspaces</DropdownMenu.Item>
-          ) : (
-            allWorkspaces.map((workspace) => (
-              <DropdownMenu.Item key={workspace.id} onSelect={() => onAssignWorkspace(workspace.id, issue)}>
-                {workspace.description}
-              </DropdownMenu.Item>
-            ))
-          )}
+        <DropdownMenu.SubContent style={{ maxHeight: ASSIGN_SUBMENU_MAX_HEIGHT_PX, overflowY: "auto" }}>
+          <AssignSubmenuItems issue={issue} allWorkspaces={allWorkspaces} onAssignWorkspace={onAssignWorkspace} />
         </DropdownMenu.SubContent>
       </DropdownMenu.Sub>
     </DropdownMenu.Content>
   </DropdownMenu.Root>
 );
+
+/**
+ * The assign submenu's body: a loading placeholder while the workspace list is
+ * still `undefined` (the SDK hasn't delivered the first batch), a "No
+ * workspaces" placeholder for a loaded-but-empty list, and otherwise one item
+ * per workspace.
+ */
+const AssignSubmenuItems = ({
+  issue,
+  allWorkspaces,
+  onAssignWorkspace,
+}: {
+  issue: LinearIssue;
+  allWorkspaces: ReadonlyArray<WorkspaceView> | undefined;
+  onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
+}): ReactElement => {
+  if (allWorkspaces === undefined) {
+    return <DropdownMenu.Item disabled>Loading workspaces…</DropdownMenu.Item>;
+  }
+  if (allWorkspaces.length === 0) {
+    return <DropdownMenu.Item disabled>No workspaces</DropdownMenu.Item>;
+  }
+  return (
+    <>
+      {allWorkspaces.map((workspace) => (
+        <DropdownMenu.Item key={workspace.id} onSelect={() => onAssignWorkspace(workspace.id, issue)}>
+          {workspace.description}
+        </DropdownMenu.Item>
+      ))}
+    </>
+  );
+};
 
 const WorkspaceIndicator = ({
   workspaces,

--- a/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/BoardTicketRow.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, FolderGit2 } from "lucide-react";
 import type { ReactElement } from "react";
 
 import type { BoardRow } from "../linear/board.ts";
+import type { LinearIssue } from "../linear/client.ts";
 
 /**
  * One ticket on the board: its identifier and title (opening the issue in Linear
@@ -11,16 +12,25 @@ import type { BoardRow } from "../linear/board.ts";
  * already working it. The indicator is the board's whole point — a glance tells
  * you which assigned tickets have a workspace and which don't.
  *
- * The "no workspace" case is a deliberate, fixed-width muted slot rather than
- * empty space: it's where the "start a workspace for this ticket" control will
- * live, so its presence keeps the column aligned today and reserves the spot.
+ * The "no workspace" case is a quiet "No workspace" menu in the same
+ * fixed-width slot: it creates a new workspace pre-filled from the ticket, or
+ * assigns one of the existing workspaces (`allWorkspaces`) to it. Purely
+ * presentational — creation, assignment, and navigation are all callbacks, so
+ * the row stays free of SDK hooks.
  */
 export const BoardTicketRow = ({
   row,
+  allWorkspaces,
   onOpenWorkspace,
+  onCreateWorkspace,
+  onAssignWorkspace,
 }: {
   row: BoardRow<WorkspaceView>;
+  /** Every workspace the assign menu can offer (not just this ticket's). */
+  allWorkspaces: ReadonlyArray<WorkspaceView>;
   onOpenWorkspace: (workspaceId: string) => void;
+  onCreateWorkspace: (issue: LinearIssue) => void;
+  onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
 }): ReactElement => {
   const { issue, workspaces } = row;
   return (
@@ -63,10 +73,70 @@ export const BoardTicketRow = ({
           {issue.title}
         </Text>
       </Flex>
-      <WorkspaceIndicator workspaces={workspaces} onOpenWorkspace={onOpenWorkspace} />
+      {workspaces.length === 0 ? (
+        <NoWorkspaceMenu
+          issue={issue}
+          allWorkspaces={allWorkspaces}
+          onCreateWorkspace={onCreateWorkspace}
+          onAssignWorkspace={onAssignWorkspace}
+        />
+      ) : (
+        <WorkspaceIndicator workspaces={workspaces} onOpenWorkspace={onOpenWorkspace} />
+      )}
     </Flex>
   );
 };
+
+/**
+ * The no-workspace slot: reads as quiet gray text until hovered, but is the
+ * menu for getting a workspace onto the ticket — create a new one pre-filled
+ * from the issue, or assign an existing one. The fixed min-width matches the
+ * workspace indicators so the trailing column stays aligned down the board.
+ */
+const NoWorkspaceMenu = ({
+  issue,
+  allWorkspaces,
+  onCreateWorkspace,
+  onAssignWorkspace,
+}: {
+  issue: LinearIssue;
+  allWorkspaces: ReadonlyArray<WorkspaceView>;
+  onCreateWorkspace: (issue: LinearIssue) => void;
+  onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
+}): ReactElement => (
+  <DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+      <Button
+        size="1"
+        variant="ghost"
+        color="gray"
+        style={{ flexShrink: 0, minWidth: 120, justifyContent: "flex-end" }}
+      >
+        No workspace
+        <ChevronDown size={13} />
+      </Button>
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content>
+      <DropdownMenu.Item onSelect={() => onCreateWorkspace(issue)}>Create workspace…</DropdownMenu.Item>
+      <DropdownMenu.Sub>
+        <DropdownMenu.SubTrigger>Assign workspace</DropdownMenu.SubTrigger>
+        {/* Capped height with scroll: the submenu lists every workspace, and
+            long-lived installs can have far more than fit on screen. */}
+        <DropdownMenu.SubContent style={{ maxHeight: 320, overflowY: "auto" }}>
+          {allWorkspaces.length === 0 ? (
+            <DropdownMenu.Item disabled>No workspaces</DropdownMenu.Item>
+          ) : (
+            allWorkspaces.map((workspace) => (
+              <DropdownMenu.Item key={workspace.id} onSelect={() => onAssignWorkspace(workspace.id, issue)}>
+                {workspace.description}
+              </DropdownMenu.Item>
+            ))
+          )}
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Sub>
+    </DropdownMenu.Content>
+  </DropdownMenu.Root>
+);
 
 const WorkspaceIndicator = ({
   workspaces,
@@ -75,15 +145,6 @@ const WorkspaceIndicator = ({
   workspaces: ReadonlyArray<WorkspaceView>;
   onOpenWorkspace: (workspaceId: string) => void;
 }): ReactElement => {
-  // No workspace yet: a muted, fixed-min-width slot (see component docstring).
-  if (workspaces.length === 0) {
-    return (
-      <Text size="1" color="gray" style={{ flexShrink: 0, minWidth: 120, textAlign: "right" }}>
-        No workspace
-      </Text>
-    );
-  }
-
   // Exactly one: a direct button into that workspace, labelled with its name.
   if (workspaces.length === 1) {
     const workspace = workspaces[0];

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.test.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.test.tsx
@@ -27,8 +27,13 @@ vi.mock("../linear/useLinearBoard.ts", () => ({ useLinearBoard: vi.fn() }));
 
 const Wrapper = ({ children }: { children: ReactNode }): ReactElement => <Theme>{children}</Theme>;
 
+// The board reads several settings (the API key plus the three new-workspace
+// templates), so the mocked `usePluginSetting` serves values from a per-test
+// key/value map rather than one blanket return value.
+let settings: Record<string, string> = {};
+
 const setApiKey = (key: string): void => {
-  vi.mocked(usePluginSetting).mockReturnValue([key, vi.fn()]);
+  settings["apiKey"] = key;
 };
 const setBoard = (overrides: Partial<LinearBoardData>): void => {
   vi.mocked(useLinearBoard).mockReturnValue({
@@ -84,7 +89,8 @@ const groupWithUnworkedTicket = (): BoardGroup<WorkspaceView> => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setApiKey("");
+  settings = {};
+  vi.mocked(usePluginSetting).mockImplementation((key: string) => [settings[key] ?? "", vi.fn()]);
   setBoard({});
   vi.mocked(useWorkspaces).mockReturnValue([]);
   vi.mocked(useOpenNewWorkspaceModal).mockReturnValue(vi.fn());
@@ -141,10 +147,33 @@ describe("LinearBoard", () => {
     expect(options.initialPrompt).toBe(
       "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42\n\nSome details.",
     );
+    // No branch template is configured, so the host derives the branch from
+    // the title.
+    expect(options.initialBranchName).toBeUndefined();
     // The modal reports the created workspace's id; the board pins the ticket
     // to it via the same assignment key the workspace panel uses.
     options.onCreated?.("w9");
     expect(setSetting).toHaveBeenCalledWith("assignment:w9", "SCU-42");
+  });
+
+  it("seeds the modal from the configured templates, including the branch name", async () => {
+    const openModal = vi.fn();
+    vi.mocked(useOpenNewWorkspaceModal).mockReturnValue(openModal);
+    setApiKey("k");
+    settings["template:title"] = "[{identifier}] {title}";
+    settings["template:branch"] = "linear/{identifierLower}-{titleSlug}";
+    settings["template:prompt"] = "Fix {identifier} ({url})";
+    setBoard({ groups: [groupWithUnworkedTicket()] });
+    renderBoard();
+
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Create workspace…"));
+
+    expect(openModal).toHaveBeenCalledTimes(1);
+    const options = openModal.mock.calls[0][0] as NewWorkspaceModalOptions;
+    expect(options.initialTitle).toBe("[SCU-42] Wire up the thing");
+    expect(options.initialBranchName).toBe("linear/scu-42-wire-up-the-thing");
+    expect(options.initialPrompt).toBe("Fix SCU-42 (https://linear.app/x/SCU-42)");
   });
 
   it("writes the assignment when an existing workspace is picked from the submenu", async () => {

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.test.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.test.tsx
@@ -1,7 +1,8 @@
 import { Theme } from "@radix-ui/themes";
-import type { WorkspaceView } from "@sculptor/plugin-sdk";
-import { usePluginSetting } from "@sculptor/plugin-sdk";
+import type { NewWorkspaceModalOptions, WorkspaceView } from "@sculptor/plugin-sdk";
+import { useOpenNewWorkspaceModal, usePluginSetting, useSetPluginSetting, useWorkspaces } from "@sculptor/plugin-sdk";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,12 +11,16 @@ import type { LinearBoardData } from "../linear/useLinearBoard.ts";
 import { useLinearBoard } from "../linear/useLinearBoard.ts";
 import { LinearBoard } from "./LinearBoard.tsx";
 
-// Mock the SDK seam (api-key setting + navigation) and the data hook, so the
-// test exercises the board's view logic — its empty/error/populated branches —
-// without TanStack, the host atoms, or a live fetch.
+// Mock the SDK seam (settings, navigation, workspace list, new-workspace modal)
+// and the data hook, so the test exercises the board's view logic — its
+// empty/error/populated branches and its row actions — without TanStack, the
+// host atoms, or a live fetch.
 vi.mock("@sculptor/plugin-sdk", () => ({
   usePluginSetting: vi.fn(() => ["", vi.fn()]),
+  useSetPluginSetting: vi.fn(() => vi.fn()),
   useNavigateToWorkspace: () => vi.fn(),
+  useOpenNewWorkspaceModal: vi.fn(() => vi.fn()),
+  useWorkspaces: vi.fn(() => []),
   openExternal: vi.fn(),
 }));
 vi.mock("../linear/useLinearBoard.ts", () => ({ useLinearBoard: vi.fn() }));
@@ -44,9 +49,46 @@ const renderBoard = (): void => {
   );
 };
 
+const workspace = (id: string, description: string): WorkspaceView => ({
+  id,
+  description,
+  branch: null,
+  targetBranch: null,
+  pullRequestUrl: null,
+});
+
+/** One populated group whose single ticket has no associated workspace yet. */
+const groupWithUnworkedTicket = (): BoardGroup<WorkspaceView> => ({
+  key: "started:In Progress",
+  stateName: "In Progress",
+  stateType: "started",
+  color: "#000",
+  rows: [
+    {
+      issue: {
+        identifier: "SCU-42",
+        title: "Wire up the thing",
+        url: "https://linear.app/x/SCU-42",
+        description: "Some details.",
+        priorityLabel: null,
+        state: null,
+        assignee: null,
+        attachments: [],
+        children: [],
+      },
+      workspaces: [],
+    },
+  ],
+  hiddenCount: 0,
+});
+
 beforeEach(() => {
+  vi.clearAllMocks();
   setApiKey("");
   setBoard({});
+  vi.mocked(useWorkspaces).mockReturnValue([]);
+  vi.mocked(useOpenNewWorkspaceModal).mockReturnValue(vi.fn());
+  vi.mocked(useSetPluginSetting).mockReturnValue(vi.fn());
 });
 afterEach(() => cleanup());
 
@@ -73,34 +115,50 @@ describe("LinearBoard", () => {
   });
 
   it("renders a group header and its ticket rows when populated", () => {
-    const group: BoardGroup<WorkspaceView> = {
-      key: "started:In Progress",
-      stateName: "In Progress",
-      stateType: "started",
-      color: "#000",
-      rows: [
-        {
-          issue: {
-            identifier: "SCU-42",
-            title: "Wire up the thing",
-            url: "https://linear.app/x/SCU-42",
-            description: null,
-            priorityLabel: null,
-            state: null,
-            assignee: null,
-            attachments: [],
-            children: [],
-          },
-          workspaces: [],
-        },
-      ],
-      hiddenCount: 0,
-    };
     setApiKey("k");
-    setBoard({ groups: [group] });
+    setBoard({ groups: [groupWithUnworkedTicket()] });
     renderBoard();
     expect(screen.getByText("In Progress")).toBeTruthy();
     expect(screen.getByText("SCU-42")).toBeTruthy();
     expect(screen.getByText("Wire up the thing")).toBeTruthy();
+  });
+
+  it("opens the new-workspace modal pre-filled from the ticket and records the assignment on create", async () => {
+    const openModal = vi.fn();
+    const setSetting = vi.fn();
+    vi.mocked(useOpenNewWorkspaceModal).mockReturnValue(openModal);
+    vi.mocked(useSetPluginSetting).mockReturnValue(setSetting);
+    setApiKey("k");
+    setBoard({ groups: [groupWithUnworkedTicket()] });
+    renderBoard();
+
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Create workspace…"));
+
+    expect(openModal).toHaveBeenCalledTimes(1);
+    const options = openModal.mock.calls[0][0] as NewWorkspaceModalOptions;
+    expect(options.initialTitle).toBe("SCU-42: Wire up the thing");
+    expect(options.initialPrompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42\n\nSome details.",
+    );
+    // The modal reports the created workspace's id; the board pins the ticket
+    // to it via the same assignment key the workspace panel uses.
+    options.onCreated?.("w9");
+    expect(setSetting).toHaveBeenCalledWith("assignment:w9", "SCU-42");
+  });
+
+  it("writes the assignment when an existing workspace is picked from the submenu", async () => {
+    const setSetting = vi.fn();
+    vi.mocked(useSetPluginSetting).mockReturnValue(setSetting);
+    vi.mocked(useWorkspaces).mockReturnValue([workspace("w1", "My workspace")]);
+    setApiKey("k");
+    setBoard({ groups: [groupWithUnworkedTicket()] });
+    renderBoard();
+
+    await userEvent.click(screen.getByRole("button", { name: /No workspace/ }));
+    await userEvent.click(await screen.findByText("Assign workspace"));
+    await userEvent.click(await screen.findByText("My workspace"));
+
+    expect(setSetting).toHaveBeenCalledWith("assignment:w1", "SCU-42");
   });
 });

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.tsx
@@ -10,8 +10,9 @@ import {
 import { RefreshCw } from "lucide-react";
 import { useCallback, type ReactElement } from "react";
 
-import { type BoardGroup, workspaceSeedForIssue } from "../linear/board.ts";
+import type { BoardGroup } from "../linear/board.ts";
 import type { LinearIssue } from "../linear/client.ts";
+import { workspaceSeedForIssue } from "../linear/templates.ts";
 import { useLinearBoard } from "../linear/useLinearBoard.ts";
 import { ticketAssignmentKey } from "../linear/useTicketAssignment.ts";
 import { BoardTicketRow } from "./BoardTicketRow.tsx";
@@ -27,6 +28,12 @@ import { StateIcon } from "./StateIcon.tsx";
  */
 export const LinearBoard = (): ReactElement => {
   const [apiKey] = usePluginSetting("apiKey");
+  // Seed templates for "Create workspace…" (see LinearSettings); blank means
+  // the defaults in linear/templates.ts. Read here, at click time, rather than
+  // baked into any cached query.
+  const [titleTemplate] = usePluginSetting("template:title");
+  const [branchTemplate] = usePluginSetting("template:branch");
+  const [promptTemplate] = usePluginSetting("template:prompt");
   const navigateToWorkspace = useNavigateToWorkspace();
   const openNewWorkspaceModal = useOpenNewWorkspaceModal();
   const setPluginSetting = useSetPluginSetting();
@@ -35,16 +42,23 @@ export const LinearBoard = (): ReactElement => {
 
   const handleCreateWorkspace = useCallback(
     (issue: LinearIssue): void => {
-      const seed = workspaceSeedForIssue(issue);
+      const seed = workspaceSeedForIssue(issue, {
+        title: titleTemplate,
+        branch: branchTemplate,
+        prompt: promptTemplate,
+      });
       openNewWorkspaceModal({
         initialTitle: seed.title,
         initialPrompt: seed.prompt,
+        // `undefined` when there is no branch template: the host derives the
+        // branch from the title as usual.
+        initialBranchName: seed.branchName,
         // Record an explicit assignment so the association holds even if the
         // user edits the title (and thus the derived branch name) in the modal.
         onCreated: (workspaceId) => setPluginSetting(ticketAssignmentKey(workspaceId), issue.identifier),
       });
     },
-    [openNewWorkspaceModal, setPluginSetting],
+    [openNewWorkspaceModal, setPluginSetting, titleTemplate, branchTemplate, promptTemplate],
   );
 
   const handleAssignWorkspace = useCallback(

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.tsx
@@ -1,10 +1,19 @@
 import { Badge, Box, Button, Flex, Heading, IconButton, Spinner, Text } from "@radix-ui/themes";
-import { useNavigateToWorkspace, usePluginSetting, type WorkspaceView } from "@sculptor/plugin-sdk";
+import {
+  useNavigateToWorkspace,
+  useOpenNewWorkspaceModal,
+  usePluginSetting,
+  useSetPluginSetting,
+  useWorkspaces,
+  type WorkspaceView,
+} from "@sculptor/plugin-sdk";
 import { RefreshCw } from "lucide-react";
-import type { ReactElement } from "react";
+import { useCallback, type ReactElement } from "react";
 
-import { type BoardGroup } from "../linear/board.ts";
+import { type BoardGroup, workspaceSeedForIssue } from "../linear/board.ts";
+import type { LinearIssue } from "../linear/client.ts";
 import { useLinearBoard } from "../linear/useLinearBoard.ts";
+import { ticketAssignmentKey } from "../linear/useTicketAssignment.ts";
 import { BoardTicketRow } from "./BoardTicketRow.tsx";
 import { EmptyState } from "./EmptyState.tsx";
 import { StateIcon } from "./StateIcon.tsx";
@@ -19,7 +28,33 @@ import { StateIcon } from "./StateIcon.tsx";
 export const LinearBoard = (): ReactElement => {
   const [apiKey] = usePluginSetting("apiKey");
   const navigateToWorkspace = useNavigateToWorkspace();
+  const openNewWorkspaceModal = useOpenNewWorkspaceModal();
+  const setPluginSetting = useSetPluginSetting();
+  const workspaces = useWorkspaces();
   const { groups, isFetching, isError, error, refetch } = useLinearBoard(apiKey);
+
+  const handleCreateWorkspace = useCallback(
+    (issue: LinearIssue): void => {
+      const seed = workspaceSeedForIssue(issue);
+      openNewWorkspaceModal({
+        initialTitle: seed.title,
+        initialPrompt: seed.prompt,
+        // Record an explicit assignment so the association holds even if the
+        // user edits the title (and thus the derived branch name) in the modal.
+        onCreated: (workspaceId) => setPluginSetting(ticketAssignmentKey(workspaceId), issue.identifier),
+      });
+    },
+    [openNewWorkspaceModal, setPluginSetting],
+  );
+
+  const handleAssignWorkspace = useCallback(
+    (workspaceId: string, issue: LinearIssue): void => {
+      // Same write as the workspace panel's "assign": the board reads these
+      // keys reactively, so the ticket shows the workspace immediately.
+      setPluginSetting(ticketAssignmentKey(workspaceId), issue.identifier);
+    },
+    [setPluginSetting],
+  );
 
   return (
     <Flex direction="column" style={{ flex: 1, minHeight: 0, background: "var(--gray-2)" }}>
@@ -54,7 +89,10 @@ export const LinearBoard = (): ReactElement => {
             isError={isError}
             error={error}
             refetch={refetch}
+            allWorkspaces={workspaces ?? []}
             onOpenWorkspace={navigateToWorkspace}
+            onCreateWorkspace={handleCreateWorkspace}
+            onAssignWorkspace={handleAssignWorkspace}
           />
         </Box>
       </Box>
@@ -69,7 +107,10 @@ const BoardBody = ({
   isError,
   error,
   refetch,
+  allWorkspaces,
   onOpenWorkspace,
+  onCreateWorkspace,
+  onAssignWorkspace,
 }: {
   apiKey: string;
   groups: ReadonlyArray<BoardGroup<WorkspaceView>>;
@@ -77,7 +118,10 @@ const BoardBody = ({
   isError: boolean;
   error: unknown;
   refetch: () => void;
+  allWorkspaces: ReadonlyArray<WorkspaceView>;
   onOpenWorkspace: (workspaceId: string) => void;
+  onCreateWorkspace: (issue: LinearIssue) => void;
+  onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
 }): ReactElement => {
   if (!apiKey) {
     return <EmptyState message="Add your Linear API key in the plugin settings to see your assigned issues." />;
@@ -112,7 +156,14 @@ const BoardBody = ({
   return (
     <Flex direction="column" gap="4">
       {groups.map((group) => (
-        <BoardGroupSection key={group.key} group={group} onOpenWorkspace={onOpenWorkspace} />
+        <BoardGroupSection
+          key={group.key}
+          group={group}
+          allWorkspaces={allWorkspaces}
+          onOpenWorkspace={onOpenWorkspace}
+          onCreateWorkspace={onCreateWorkspace}
+          onAssignWorkspace={onAssignWorkspace}
+        />
       ))}
     </Flex>
   );
@@ -120,10 +171,16 @@ const BoardBody = ({
 
 const BoardGroupSection = ({
   group,
+  allWorkspaces,
   onOpenWorkspace,
+  onCreateWorkspace,
+  onAssignWorkspace,
 }: {
   group: BoardGroup<WorkspaceView>;
+  allWorkspaces: ReadonlyArray<WorkspaceView>;
   onOpenWorkspace: (workspaceId: string) => void;
+  onCreateWorkspace: (issue: LinearIssue) => void;
+  onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
 }): ReactElement => {
   const total = group.rows.length + group.hiddenCount;
   return (
@@ -139,7 +196,14 @@ const BoardGroupSection = ({
       </Flex>
       <Box style={{ borderBottom: "1px solid var(--gray-a3)" }}>
         {group.rows.map((row) => (
-          <BoardTicketRow key={row.issue.identifier} row={row} onOpenWorkspace={onOpenWorkspace} />
+          <BoardTicketRow
+            key={row.issue.identifier}
+            row={row}
+            allWorkspaces={allWorkspaces}
+            onOpenWorkspace={onOpenWorkspace}
+            onCreateWorkspace={onCreateWorkspace}
+            onAssignWorkspace={onAssignWorkspace}
+          />
         ))}
       </Box>
       {group.hiddenCount > 0 ? (

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearBoard.tsx
@@ -89,7 +89,7 @@ export const LinearBoard = (): ReactElement => {
             isError={isError}
             error={error}
             refetch={refetch}
-            allWorkspaces={workspaces ?? []}
+            allWorkspaces={workspaces}
             onOpenWorkspace={navigateToWorkspace}
             onCreateWorkspace={handleCreateWorkspace}
             onAssignWorkspace={handleAssignWorkspace}
@@ -118,7 +118,8 @@ const BoardBody = ({
   isError: boolean;
   error: unknown;
   refetch: () => void;
-  allWorkspaces: ReadonlyArray<WorkspaceView>;
+  /** `undefined` while the SDK's workspace list is still loading. */
+  allWorkspaces: ReadonlyArray<WorkspaceView> | undefined;
   onOpenWorkspace: (workspaceId: string) => void;
   onCreateWorkspace: (issue: LinearIssue) => void;
   onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;
@@ -177,7 +178,7 @@ const BoardGroupSection = ({
   onAssignWorkspace,
 }: {
   group: BoardGroup<WorkspaceView>;
-  allWorkspaces: ReadonlyArray<WorkspaceView>;
+  allWorkspaces: ReadonlyArray<WorkspaceView> | undefined;
   onOpenWorkspace: (workspaceId: string) => void;
   onCreateWorkspace: (issue: LinearIssue) => void;
   onAssignWorkspace: (workspaceId: string, issue: LinearIssue) => void;

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearSettings.test.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearSettings.test.tsx
@@ -1,0 +1,78 @@
+import { Theme } from "@radix-ui/themes";
+import { usePluginSetting } from "@sculptor/plugin-sdk";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import { DEFAULT_PROMPT_TEMPLATE, DEFAULT_TITLE_TEMPLATE } from "../linear/templates.ts";
+import { LinearSettings } from "./LinearSettings.tsx";
+
+// Mock only the SDK settings hook; the query client comes from a real provider
+// so the API-key invalidation path runs for real.
+vi.mock("@sculptor/plugin-sdk", () => ({ usePluginSetting: vi.fn() }));
+
+// One mock setter per settings key, so each field's writes are observable
+// independently of the others.
+const setters = new Map<string, Mock>();
+const setterFor = (key: string): Mock => {
+  let setter = setters.get(key);
+  if (!setter) {
+    setter = vi.fn();
+    setters.set(key, setter);
+  }
+  return setter;
+};
+
+beforeEach(() => {
+  setters.clear();
+  vi.mocked(usePluginSetting).mockImplementation((key: string) => ["", setterFor(key)]);
+});
+afterEach(() => cleanup());
+
+const renderSettings = (): void => {
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <Theme>
+        <LinearSettings />
+      </Theme>
+    </QueryClientProvider>,
+  );
+};
+
+describe("LinearSettings", () => {
+  it("renders the API key field and the three template fields", () => {
+    renderSettings();
+    expect(screen.getByPlaceholderText("lin_api_...")).toBeTruthy();
+    expect(screen.getByLabelText("Title")).toBeTruthy();
+    expect(screen.getByLabelText("Branch")).toBeTruthy();
+    expect(screen.getByLabelText("Prompt")).toBeTruthy();
+  });
+
+  it("shows each field's effective default as its placeholder", () => {
+    renderSettings();
+    expect((screen.getByLabelText("Title") as HTMLInputElement).placeholder).toBe(DEFAULT_TITLE_TEMPLATE);
+    expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).placeholder).toBe(DEFAULT_PROMPT_TEMPLATE);
+    // Branch has no template default — blank defers to the host's title-derived branch.
+    expect((screen.getByLabelText("Branch") as HTMLInputElement).placeholder).toMatch(/derived from the title/i);
+  });
+
+  it("writes each template field to its own setting key", async () => {
+    renderSettings();
+    await userEvent.type(screen.getByLabelText("Title"), "T");
+    await userEvent.type(screen.getByLabelText("Branch"), "B");
+    await userEvent.type(screen.getByLabelText("Prompt"), "P");
+    expect(setterFor("template:title")).toHaveBeenCalledWith("T");
+    expect(setterFor("template:branch")).toHaveBeenCalledWith("B");
+    expect(setterFor("template:prompt")).toHaveBeenCalledWith("P");
+    expect(setterFor("apiKey")).not.toHaveBeenCalled();
+  });
+
+  it("writes the API key to its setting key without touching the templates", async () => {
+    renderSettings();
+    await userEvent.type(screen.getByPlaceholderText("lin_api_..."), "k");
+    expect(setterFor("apiKey")).toHaveBeenCalledWith("k");
+    expect(setterFor("template:title")).not.toHaveBeenCalled();
+  });
+});

--- a/sculptor/frontend/plugins/linear-issue/src/components/LinearSettings.tsx
+++ b/sculptor/frontend/plugins/linear-issue/src/components/LinearSettings.tsx
@@ -1,35 +1,86 @@
-import { Flex, Text, TextField } from "@radix-ui/themes";
+import { Flex, Text, TextArea, TextField } from "@radix-ui/themes";
 import { usePluginSetting } from "@sculptor/plugin-sdk";
 import { useQueryClient } from "@tanstack/react-query";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import { PLUGIN_ID } from "../constants.ts";
+import { DEFAULT_PROMPT_TEMPLATE, DEFAULT_TITLE_TEMPLATE } from "../linear/templates.ts";
 
-/** Plugin settings: the Linear personal API key, stored via the SDK. */
+/**
+ * Plugin settings: the Linear personal API key, plus the templates that seed
+ * the new-workspace dialog when a workspace is created from a board ticket.
+ */
 export const LinearSettings = (): ReactElement => {
   const [apiKey, setApiKey] = usePluginSetting("apiKey");
+  const [titleTemplate, setTitleTemplate] = usePluginSetting("template:title");
+  const [branchTemplate, setBranchTemplate] = usePluginSetting("template:branch");
+  const [promptTemplate, setPromptTemplate] = usePluginSetting("template:prompt");
   const queryClient = useQueryClient();
 
   const handleKeyChange = (value: string): void => {
     setApiKey(value);
     // Cached issues were fetched with the old key (deliberately not part of any
     // query key) — drop this plugin's namespace so panels refetch with the new
-    // credentials.
+    // credentials. Template edits need no such invalidation: they are read at
+    // create-workspace click time, not baked into cached queries.
     void queryClient.invalidateQueries({ queryKey: [PLUGIN_ID] });
   };
 
   return (
-    <Flex direction="column" gap="2" style={{ maxWidth: 460 }}>
-      <Text size="1" color="gray">
-        Personal API key from Linear → Settings → Security &amp; access → Personal API keys. Stored locally in this
-        browser only.
-      </Text>
-      <TextField.Root
-        type="password"
-        placeholder="lin_api_..."
-        value={apiKey}
-        onChange={(e) => handleKeyChange(e.target.value)}
-      />
+    <Flex direction="column" gap="4" style={{ maxWidth: 460 }}>
+      <Flex direction="column" gap="2">
+        <Text size="1" color="gray">
+          Personal API key from Linear → Settings → Security &amp; access → Personal API keys. Stored locally in this
+          browser only.
+        </Text>
+        <TextField.Root
+          type="password"
+          placeholder="lin_api_..."
+          value={apiKey}
+          onChange={(e) => handleKeyChange(e.target.value)}
+        />
+      </Flex>
+      <Flex direction="column" gap="2">
+        <Text size="2" weight="medium">
+          New workspace templates
+        </Text>
+        <Text size="1" color="gray">
+          Seeds for workspaces created from board tickets. Variables: {"{identifier}"}, {"{identifierLower}"},{" "}
+          {"{title}"}, {"{titleSlug}"}, {"{url}"}, {"{description}"}. Leave a field blank to use its default.
+        </Text>
+        <TemplateField label="Title">
+          <TextField.Root
+            placeholder={DEFAULT_TITLE_TEMPLATE}
+            value={titleTemplate}
+            onChange={(e) => setTitleTemplate(e.target.value)}
+          />
+        </TemplateField>
+        <TemplateField label="Branch">
+          <TextField.Root
+            placeholder="Derived from the title"
+            value={branchTemplate}
+            onChange={(e) => setBranchTemplate(e.target.value)}
+          />
+        </TemplateField>
+        <TemplateField label="Prompt">
+          <TextArea
+            rows={4}
+            placeholder={DEFAULT_PROMPT_TEMPLATE}
+            value={promptTemplate}
+            onChange={(e) => setPromptTemplate(e.target.value)}
+          />
+        </TemplateField>
+      </Flex>
     </Flex>
   );
 };
+
+/** A labeled template input; the wrapping <label> gives the field its accessible name. */
+const TemplateField = ({ label, children }: { label: string; children: ReactNode }): ReactElement => (
+  <label>
+    <Text size="1" weight="medium" as="div" mb="1">
+      {label}
+    </Text>
+    {children}
+  </label>
+);

--- a/sculptor/frontend/plugins/linear-issue/src/linear/board.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/board.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBoard } from "./board.ts";
+import { buildBoard, workspaceSeedForIssue } from "./board.ts";
 import type { LinearIssue, LinearState } from "./client.ts";
 
 const state = (name: string, type: string, position = 0): LinearState => ({
@@ -89,5 +89,31 @@ describe("buildBoard", () => {
   it("groups issues with no state under a trailing 'No status' bucket", () => {
     const groups = buildBoard([issue("A", null), issue("B", state("In Progress", "started"))], []);
     expect(groups.map((g) => g.stateName)).toEqual(["In Progress", "No status"]);
+  });
+});
+
+describe("workspaceSeedForIssue", () => {
+  const base = { ...issue("SCU-42", null), title: "Wire up the thing" };
+
+  it("leads the title with the identifier so the derived branch carries it", () => {
+    expect(workspaceSeedForIssue(base).title).toBe("SCU-42: Wire up the thing");
+  });
+
+  it("builds the prompt as assignment line + URL when there is no description", () => {
+    expect(workspaceSeedForIssue(base).prompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42",
+    );
+  });
+
+  it("appends the description after a blank line when present", () => {
+    expect(workspaceSeedForIssue({ ...base, description: "Details\nhere." }).prompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42\n\nDetails\nhere.",
+    );
+  });
+
+  it("treats an empty description like a missing one", () => {
+    expect(workspaceSeedForIssue({ ...base, description: "" }).prompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42",
+    );
   });
 });

--- a/sculptor/frontend/plugins/linear-issue/src/linear/board.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/board.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBoard, workspaceSeedForIssue } from "./board.ts";
+import { buildBoard } from "./board.ts";
 import type { LinearIssue, LinearState } from "./client.ts";
 
 const state = (name: string, type: string, position = 0): LinearState => ({
@@ -89,31 +89,5 @@ describe("buildBoard", () => {
   it("groups issues with no state under a trailing 'No status' bucket", () => {
     const groups = buildBoard([issue("A", null), issue("B", state("In Progress", "started"))], []);
     expect(groups.map((g) => g.stateName)).toEqual(["In Progress", "No status"]);
-  });
-});
-
-describe("workspaceSeedForIssue", () => {
-  const base = { ...issue("SCU-42", null), title: "Wire up the thing" };
-
-  it("leads the title with the identifier so the derived branch carries it", () => {
-    expect(workspaceSeedForIssue(base).title).toBe("SCU-42: Wire up the thing");
-  });
-
-  it("builds the prompt as assignment line + URL when there is no description", () => {
-    expect(workspaceSeedForIssue(base).prompt).toBe(
-      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42",
-    );
-  });
-
-  it("appends the description after a blank line when present", () => {
-    expect(workspaceSeedForIssue({ ...base, description: "Details\nhere." }).prompt).toBe(
-      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42\n\nDetails\nhere.",
-    );
-  });
-
-  it("treats an empty description like a missing one", () => {
-    expect(workspaceSeedForIssue({ ...base, description: "" }).prompt).toBe(
-      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42",
-    );
   });
 });

--- a/sculptor/frontend/plugins/linear-issue/src/linear/board.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/board.ts
@@ -23,30 +23,6 @@ export type BoardGroup<T extends WorkspaceLink> = {
   hiddenCount: number;
 };
 
-/** Pre-fill values for the host's new-workspace modal, derived from a ticket. */
-export type WorkspaceSeed = {
-  title: string;
-  prompt: string;
-};
-
-/**
- * Build the new-workspace title and prompt for a ticket. The title leads with
- * the identifier because the host derives the branch name from the title — so
- * the generated branch carries the ticket id, which is also how the board
- * associates branches back to tickets. The prompt is a short self-contained
- * brief: the assignment, the issue URL, and the description when there is one.
- */
-export const workspaceSeedForIssue = (issue: LinearIssue): WorkspaceSeed => {
-  const promptLines = [`Work on Linear issue ${issue.identifier}: ${issue.title}`, issue.url];
-  if (issue.description) {
-    promptLines.push("", issue.description);
-  }
-  return {
-    title: `${issue.identifier}: ${issue.title}`,
-    prompt: promptLines.join("\n"),
-  };
-};
-
 // Group order: active work first, terminal states last. Anything Linear adds
 // that we don't know sorts after the known types but before nothing.
 const TYPE_ORDER: Record<string, number> = {

--- a/sculptor/frontend/plugins/linear-issue/src/linear/board.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/board.ts
@@ -23,6 +23,30 @@ export type BoardGroup<T extends WorkspaceLink> = {
   hiddenCount: number;
 };
 
+/** Pre-fill values for the host's new-workspace modal, derived from a ticket. */
+export type WorkspaceSeed = {
+  title: string;
+  prompt: string;
+};
+
+/**
+ * Build the new-workspace title and prompt for a ticket. The title leads with
+ * the identifier because the host derives the branch name from the title — so
+ * the generated branch carries the ticket id, which is also how the board
+ * associates branches back to tickets. The prompt is a short self-contained
+ * brief: the assignment, the issue URL, and the description when there is one.
+ */
+export const workspaceSeedForIssue = (issue: LinearIssue): WorkspaceSeed => {
+  const promptLines = [`Work on Linear issue ${issue.identifier}: ${issue.title}`, issue.url];
+  if (issue.description) {
+    promptLines.push("", issue.description);
+  }
+  return {
+    title: `${issue.identifier}: ${issue.title}`,
+    prompt: promptLines.join("\n"),
+  };
+};
+
 // Group order: active work first, terminal states last. Anything Linear adds
 // that we don't know sorts after the known types but before nothing.
 const TYPE_ORDER: Record<string, number> = {

--- a/sculptor/frontend/plugins/linear-issue/src/linear/templates.test.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/templates.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import type { LinearIssue } from "./client.ts";
+import {
+  applyIssueTemplate,
+  DEFAULT_PROMPT_TEMPLATE,
+  DEFAULT_TITLE_TEMPLATE,
+  workspaceSeedForIssue,
+  type WorkspaceSeedTemplates,
+} from "./templates.ts";
+
+const issue = (overrides: Partial<LinearIssue> = {}): LinearIssue => ({
+  identifier: "SCU-42",
+  title: "Wire up the thing",
+  url: "https://linear.app/x/SCU-42",
+  description: null,
+  priorityLabel: null,
+  state: null,
+  assignee: null,
+  attachments: [],
+  children: [],
+  ...overrides,
+});
+
+/** All-blank templates: every field falls back to its default behavior. */
+const BLANK_TEMPLATES: WorkspaceSeedTemplates = { title: "", branch: "", prompt: "" };
+
+describe("applyIssueTemplate", () => {
+  it("substitutes every supported variable", () => {
+    const result = applyIssueTemplate(
+      "{identifier}|{identifierLower}|{title}|{titleSlug}|{url}|{description}",
+      issue({ description: "Some details." }),
+    );
+    expect(result).toBe("SCU-42|scu-42|Wire up the thing|wire-up-the-thing|https://linear.app/x/SCU-42|Some details.");
+  });
+
+  it("substitutes a missing description as an empty string", () => {
+    expect(applyIssueTemplate("[{description}]", issue())).toBe("[]");
+  });
+
+  it("leaves unknown tokens literal so typos stay visible", () => {
+    expect(applyIssueTemplate("{identifer} and {nope}", issue())).toBe("{identifer} and {nope}");
+  });
+
+  it("does not resolve tokens through the object prototype", () => {
+    expect(applyIssueTemplate("{toString}", issue())).toBe("{toString}");
+  });
+
+  it("trims trailing whitespace after substitution", () => {
+    expect(applyIssueTemplate("{identifier}\n\n{description}", issue())).toBe("SCU-42");
+  });
+
+  describe("{titleSlug}", () => {
+    const slugOf = (title: string): string => applyIssueTemplate("{titleSlug}", issue({ title }));
+
+    it("kebab-cases the title", () => {
+      expect(slugOf("Wire up the thing")).toBe("wire-up-the-thing");
+    });
+
+    it("collapses runs of edge characters to single hyphens and trims the ends", () => {
+      expect(slugOf("  Fix: (weird)   chars!! ")).toBe("fix-weird-chars");
+    });
+
+    it("caps long titles at a hyphen boundary without a trailing fragment", () => {
+      // 5 chars per "word-" unit: the 48-char cap lands mid-word, so the slug
+      // backs off to the previous hyphen boundary.
+      const slug = slugOf(Array.from({ length: 20 }, (_, i) => `word${i % 10}`).join(" "));
+      expect(slug.length).toBeLessThanOrEqual(48);
+      expect(slug).toBe("word0-word1-word2-word3-word4-word5-word6-word7");
+      expect(slug.endsWith("-")).toBe(false);
+    });
+
+    it("keeps a whole word that ends exactly at the cap", () => {
+      // "aaaa...(48)" followed by more words: position 48 is a hyphen, so the
+      // full 48-char word survives.
+      expect(slugOf(`${"a".repeat(48)} tail words`)).toBe("a".repeat(48));
+    });
+
+    it("hard-cuts a single word longer than the cap", () => {
+      expect(slugOf("b".repeat(60))).toBe("b".repeat(48));
+    });
+  });
+});
+
+describe("workspaceSeedForIssue", () => {
+  it("leads the default title with the identifier so the derived branch carries it", () => {
+    expect(workspaceSeedForIssue(issue(), BLANK_TEMPLATES).title).toBe("SCU-42: Wire up the thing");
+  });
+
+  it("builds the default prompt as assignment line + URL when there is no description", () => {
+    expect(workspaceSeedForIssue(issue(), BLANK_TEMPLATES).prompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42",
+    );
+  });
+
+  it("appends the description after a blank line when present", () => {
+    expect(workspaceSeedForIssue(issue({ description: "Details\nhere." }), BLANK_TEMPLATES).prompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42\n\nDetails\nhere.",
+    );
+  });
+
+  it("treats an empty description like a missing one", () => {
+    expect(workspaceSeedForIssue(issue({ description: "" }), BLANK_TEMPLATES).prompt).toBe(
+      "Work on Linear issue SCU-42: Wire up the thing\nhttps://linear.app/x/SCU-42",
+    );
+  });
+
+  it("matches the explicit default templates when they are passed verbatim", () => {
+    const explicit = { title: DEFAULT_TITLE_TEMPLATE, branch: "", prompt: DEFAULT_PROMPT_TEMPLATE };
+    for (const ticket of [issue(), issue({ description: "Some details." })]) {
+      expect(workspaceSeedForIssue(ticket, explicit)).toEqual(workspaceSeedForIssue(ticket, BLANK_TEMPLATES));
+    }
+  });
+
+  it("applies custom title and prompt templates", () => {
+    const seed = workspaceSeedForIssue(issue(), {
+      title: "[{identifier}] {title}",
+      branch: "",
+      prompt: "Fix {identifier} ({url})",
+    });
+    expect(seed.title).toBe("[SCU-42] Wire up the thing");
+    expect(seed.prompt).toBe("Fix SCU-42 (https://linear.app/x/SCU-42)");
+  });
+
+  it("treats whitespace-only templates as blank and falls back to the defaults", () => {
+    expect(workspaceSeedForIssue(issue(), { title: "  ", branch: " \n", prompt: "\t" })).toEqual(
+      workspaceSeedForIssue(issue(), BLANK_TEMPLATES),
+    );
+  });
+
+  it("leaves branchName undefined when the branch template is blank", () => {
+    expect(workspaceSeedForIssue(issue(), BLANK_TEMPLATES).branchName).toBeUndefined();
+  });
+
+  it("applies the branch template when set", () => {
+    const seed = workspaceSeedForIssue(issue(), { ...BLANK_TEMPLATES, branch: "linear/{identifierLower}-{titleSlug}" });
+    expect(seed.branchName).toBe("linear/scu-42-wire-up-the-thing");
+  });
+});

--- a/sculptor/frontend/plugins/linear-issue/src/linear/templates.ts
+++ b/sculptor/frontend/plugins/linear-issue/src/linear/templates.ts
@@ -1,0 +1,92 @@
+import type { LinearIssue } from "./client.ts";
+
+/**
+ * User-templatable seeds for the new-workspace dialog. Templates use `{name}`
+ * tokens (see `applyIssueTemplate`); the plugin settings UI stores one template
+ * per field and blank means "use the default".
+ *
+ * The default title leads with the identifier because the host derives the
+ * branch name from the title — so the generated branch carries the ticket id,
+ * which is also how the board associates branches back to tickets.
+ */
+export const DEFAULT_TITLE_TEMPLATE = "{identifier}: {title}";
+
+/**
+ * The default prompt is a short self-contained brief: the assignment, the
+ * issue URL, and the description. For a ticket without a description the
+ * `{description}` block substitutes to nothing and the trailing trim in
+ * `applyIssueTemplate` drops the blank line before it.
+ */
+export const DEFAULT_PROMPT_TEMPLATE = "Work on Linear issue {identifier}: {title}\n{url}\n\n{description}";
+
+// Branch names get unwieldy past this; the cut happens at a hyphen boundary so
+// the slug never ends mid-word.
+const SLUG_MAX_LENGTH = 48;
+
+/**
+ * Kebab-case a ticket title for use in branch names: lowercase, runs of
+ * non-alphanumerics collapsed to single hyphens, hyphens trimmed from both
+ * ends, capped at `SLUG_MAX_LENGTH` characters.
+ */
+const slugForTitle = (title: string): string => {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  if (slug.length <= SLUG_MAX_LENGTH) return slug;
+  const head = slug.slice(0, SLUG_MAX_LENGTH);
+  // A hyphen right after the cut means the head already ends on a whole word.
+  if (slug[SLUG_MAX_LENGTH] === "-") return head;
+  const lastHyphen = head.lastIndexOf("-");
+  return lastHyphen > 0 ? head.slice(0, lastHyphen) : head;
+};
+
+/**
+ * Substitute a template's `{name}` tokens with values from the ticket, then
+ * trim trailing whitespace (so templates whose tail substitutes to nothing —
+ * like the default prompt on a description-less ticket — end cleanly).
+ * Unknown tokens are left literal so a typo shows up in the seeded text
+ * instead of vanishing silently.
+ */
+export const applyIssueTemplate = (template: string, issue: LinearIssue): string => {
+  const variables = new Map<string, string>([
+    ["identifier", issue.identifier],
+    ["identifierLower", issue.identifier.toLowerCase()],
+    ["title", issue.title],
+    ["titleSlug", slugForTitle(issue.title)],
+    ["url", issue.url],
+    ["description", issue.description ?? ""],
+  ]);
+  return template.replace(/\{(\w+)\}/g, (token, name: string) => variables.get(name) ?? token).trimEnd();
+};
+
+/** Pre-fill values for the host's new-workspace modal, derived from a ticket. */
+export type WorkspaceSeed = {
+  title: string;
+  prompt: string;
+  /** `undefined` when no branch template is set: the host derives the branch from the title. */
+  branchName: string | undefined;
+};
+
+/** The user-configured templates, one per seeded field; blank means default. */
+export type WorkspaceSeedTemplates = {
+  title: string;
+  branch: string;
+  prompt: string;
+};
+
+/**
+ * Build the new-workspace seeds for a ticket from the configured templates.
+ * A blank (empty or whitespace-only) title or prompt template falls back to
+ * its default; branch has no default template — blank yields an `undefined`
+ * branch name, deferring to the host's title-derived branch.
+ */
+export const workspaceSeedForIssue = (issue: LinearIssue, templates: WorkspaceSeedTemplates): WorkspaceSeed => {
+  const titleTemplate = templates.title.trim() ? templates.title : DEFAULT_TITLE_TEMPLATE;
+  const promptTemplate = templates.prompt.trim() ? templates.prompt : DEFAULT_PROMPT_TEMPLATE;
+  return {
+    title: applyIssueTemplate(titleTemplate, issue),
+    prompt: applyIssueTemplate(promptTemplate, issue),
+    branchName: templates.branch.trim() ? applyIssueTemplate(templates.branch, issue) : undefined,
+  };
+};

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
@@ -51,7 +51,7 @@ export type CreateWorkspaceError = {
   cause: unknown;
 };
 
-type CreateWorkspaceResult = { ok: true } | { ok: false; error: CreateWorkspaceError };
+type CreateWorkspaceResult = { ok: true; workspaceId: string } | { ok: false; error: CreateWorkspaceError };
 
 type UseCreateWorkspaceReturn = {
   /** True while a create is in flight. */
@@ -171,7 +171,7 @@ export const useCreateWorkspace = (): UseCreateWorkspaceReturn => {
         });
 
         navigateToAgent(workspaceId, agentResponse.data.id);
-        return { ok: true };
+        return { ok: true, workspaceId };
       } catch (error) {
         console.error("Failed to create workspace:", error);
         const kind: CreateWorkspaceErrorKind =

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { createStore } from "jotai";
+import type { ComponentProps } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ElementIds } from "~/api";
+import { renderWithProviders } from "~/common/testUtils.tsx";
+
+import { keepNewWorkspaceModalOpenAtom } from "./newWorkspaceAtoms.ts";
+import { NewWorkspaceForm } from "./NewWorkspaceForm.tsx";
+
+// What is under test is the form's own behavior — seeding, submit, and the
+// post-create callbacks — so everything that reaches the backend is stubbed at
+// its module seam: the project fetches, the create flow, the per-repo branch
+// info, the terminal-agent registrations, and the debounced branch-name
+// preview/validation queries.
+const { mockCreateWorkspace } = vi.hoisted(() => ({ mockCreateWorkspace: vi.fn() }));
+
+vi.mock("~/api", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...(original as object),
+    getActiveProjects: vi.fn(async () => ({ data: [{ objectId: "p1", name: "Repo One" }] })),
+    getMostRecentlyUsedProject: vi.fn(async () => ({ data: "p1" })),
+    // The agent-type select re-checks pi availability on mount.
+    getDependenciesStatus: vi.fn(async () => ({ data: undefined })),
+  };
+});
+
+vi.mock("~/common/state/hooks/useCreateWorkspace.ts", () => ({
+  useCreateWorkspace: (): { isCreating: boolean; createWorkspace: typeof mockCreateWorkspace } => ({
+    isCreating: false,
+    createWorkspace: mockCreateWorkspace,
+  }),
+}));
+
+vi.mock("~/common/state/hooks/useRepoInfo.ts", () => ({
+  useRepoInfo: (): unknown => ({
+    repoInfo: { currentBranch: "main", recentBranches: ["main"] },
+    fetchRepoInfo: vi.fn(),
+    fetchCurrentBranch: vi.fn(),
+  }),
+}));
+
+vi.mock("~/common/state/hooks/useTerminalAgentRegistrations.ts", () => ({
+  useTerminalAgentRegistrations: (): unknown => ({ registrations: [], refetch: vi.fn() }),
+}));
+
+vi.mock("~/components/newWorkspace/hooks/useBranchNamePreview.ts", () => ({
+  useBranchNamePreview: (): unknown => ({
+    preview: "sculptor/test-branch",
+    displayedValue: "sculptor/test-branch",
+    isLoading: false,
+    status: "available",
+  }),
+}));
+
+type FormProps = ComponentProps<typeof NewWorkspaceForm>;
+
+const renderForm = (
+  props: Partial<FormProps> = {},
+  options: { keepOpen?: boolean } = {},
+): ReturnType<typeof renderWithProviders> => {
+  const store = createStore();
+  if (options.keepOpen) {
+    store.set(keepNewWorkspaceModalOpenAtom, true);
+  }
+  return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} {...props} />, { store });
+};
+
+// The Create button stays disabled until the (mocked) project fetch resolves a
+// selection, so wait for it to enable before clicking.
+const clickCreate = async (): Promise<void> => {
+  const button = screen.getByTestId(ElementIds.NEW_WORKSPACE_CREATE_BUTTON);
+  await waitFor(() => expect(button).toBeEnabled());
+  fireEvent.click(button);
+};
+
+describe("NewWorkspaceForm", () => {
+  beforeEach(() => {
+    mockCreateWorkspace.mockResolvedValue({ ok: true, workspaceId: "w1" });
+  });
+
+  // vitest runs with `globals: false`, so RTL's automatic post-test cleanup
+  // isn't registered — do it explicitly. keepNewWorkspaceModalOpenAtom persists
+  // to localStorage, so wipe that too.
+  afterEach(() => {
+    cleanup();
+    mockCreateWorkspace.mockReset();
+    window.localStorage.clear();
+  });
+
+  it("seeds the title and prompt fields from the open request", () => {
+    renderForm({ initialTitle: "Fix the bug", initialPrompt: "Please fix it" });
+
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("Fix the bug");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("Please fix it");
+  });
+
+  it("reports a successful create to onWorkspaceCreated, then closes via onCreated", async () => {
+    const onWorkspaceCreated = vi.fn();
+    const onCreated = vi.fn();
+    renderForm({ onWorkspaceCreated, onCreated });
+
+    await clickCreate();
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+    expect(onWorkspaceCreated).toHaveBeenCalledExactlyOnceWith("w1");
+    // The open request's own callback observes the create before the form
+    // reports completion to its host.
+    expect(onWorkspaceCreated.mock.invocationCallOrder[0]).toBeLessThan(onCreated.mock.invocationCallOrder[0]);
+  });
+
+  it("contains a throwing onWorkspaceCreated so the post-create flow still runs", async () => {
+    const onWorkspaceCreated = vi.fn(() => {
+      throw new Error("plugin exploded");
+    });
+    const onCreated = vi.fn();
+    // The form logs the contained throw; keep the test output clean.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      renderForm({ onWorkspaceCreated, onCreated });
+
+      await clickCreate();
+
+      await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+      expect(onWorkspaceCreated).toHaveBeenCalledExactlyOnceWith("w1");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("re-seeds the title and prompt after a keep-open create", async () => {
+    const onWorkspaceCreated = vi.fn();
+    const onCreated = vi.fn();
+    renderForm(
+      { initialTitle: "Fix the bug", initialPrompt: "Please fix it", onWorkspaceCreated, onCreated },
+      { keepOpen: true },
+    );
+
+    // The user repurposes the seeded dialog for this one create...
+    const titleInput = screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT);
+    const promptTextarea = screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA);
+    fireEvent.change(titleInput, { target: { value: "Edited title" } });
+    fireEvent.change(promptTextarea, { target: { value: "Edited prompt" } });
+
+    await clickCreate();
+
+    // ...the create still reports to the open request's callback, and the
+    // fields return to the request's seeds (not blank) so the still-open
+    // dialog keeps saying what the request is.
+    await waitFor(() => expect(onWorkspaceCreated).toHaveBeenCalledExactlyOnceWith("w1"));
+    expect(onCreated).not.toHaveBeenCalled();
+    await waitFor(() => expect(titleInput).toHaveValue("Fix the bug"));
+    expect(promptTextarea).toHaveValue("Please fix it");
+  });
+});

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -3,7 +3,9 @@ import { createStore } from "jotai";
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Project } from "~/api";
 import { ElementIds } from "~/api";
+import { updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { renderWithProviders } from "~/common/testUtils.tsx";
 
 import { keepNewWorkspaceModalOpenAtom } from "./newWorkspaceAtoms.ts";
@@ -46,10 +48,13 @@ vi.mock("~/common/state/hooks/useTerminalAgentRegistrations.ts", () => ({
   useTerminalAgentRegistrations: (): unknown => ({ registrations: [], refetch: vi.fn() }),
 }));
 
+// Honors the override argument the same way the real hook does (override wins
+// over the auto preview), so a seeded or user-edited branch name is observable
+// in the rendered field and in the create call's `branchName`.
 vi.mock("~/components/newWorkspace/hooks/useBranchNamePreview.ts", () => ({
-  useBranchNamePreview: (): unknown => ({
+  useBranchNamePreview: ({ override }: { override: string | null }): unknown => ({
     preview: "sculptor/test-branch",
-    displayedValue: "sculptor/test-branch",
+    displayedValue: override ?? "sculptor/test-branch",
     isLoading: false,
     status: "available",
   }),
@@ -62,6 +67,12 @@ const renderForm = (
   options: { keepOpen?: boolean } = {},
 ): ReturnType<typeof renderWithProviders> => {
   const store = createStore();
+  // The app keeps the projects atom populated before the modal can open. With
+  // an empty store, the form's initial project load would look like a repo
+  // just added through the Add Repository dialog, which the form answers by
+  // auto-selecting it and resetting branch choices — clobbering mount-time
+  // seeds. Pre-populate the store so the tests see the app's real conditions.
+  store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
   if (options.keepOpen) {
     store.set(keepNewWorkspaceModalOpenAtom, true);
   }
@@ -95,6 +106,20 @@ describe("NewWorkspaceForm", () => {
 
     expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("Fix the bug");
     expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("Please fix it");
+  });
+
+  it("seeds the branch-name field into override mode and creates with the seeded name", async () => {
+    renderForm({ initialBranchName: "linear/scu-1-fix" });
+
+    // The seed lands as a manual override, so the field shows it in place of
+    // the auto preview.
+    expect(screen.getByTestId(ElementIds.BRANCH_NAME_INPUT)).toHaveValue("linear/scu-1-fix");
+
+    await clickCreate();
+
+    await waitFor(() =>
+      expect(mockCreateWorkspace).toHaveBeenCalledWith(expect.objectContaining({ branchName: "linear/scu-1-fix" })),
+    );
   });
 
   it("reports a successful create to onWorkspaceCreated, then closes via onCreated", async () => {
@@ -153,5 +178,22 @@ describe("NewWorkspaceForm", () => {
     expect(onCreated).not.toHaveBeenCalled();
     await waitFor(() => expect(titleInput).toHaveValue("Fix the bug"));
     expect(promptTextarea).toHaveValue("Please fix it");
+  });
+
+  it("re-seeds the branch name after a keep-open create", async () => {
+    renderForm({ initialBranchName: "linear/scu-1-fix" }, { keepOpen: true });
+
+    // The user hand-edits the branch for this one create...
+    const branchInput = screen.getByTestId(ElementIds.BRANCH_NAME_INPUT);
+    fireEvent.change(branchInput, { target: { value: "custom/branch" } });
+
+    await clickCreate();
+
+    await waitFor(() =>
+      expect(mockCreateWorkspace).toHaveBeenCalledWith(expect.objectContaining({ branchName: "custom/branch" })),
+    );
+    // ...and the still-open dialog returns to the request's seeded branch name
+    // (not the auto preview).
+    await waitFor(() => expect(branchInput).toHaveValue("linear/scu-1-fix"));
   });
 });

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -59,8 +59,11 @@ type NewWorkspaceFormProps = {
   initialPrompt?: string;
   /**
    * Called with the new workspace's id after every successful create —
-   * including each repeat create in keep-open mode. May come from a plugin,
-   * so a throw is contained and never breaks the form's own post-create flow.
+   * including each repeat create in keep-open mode, where the title/prompt
+   * re-seed from `initialTitle`/`initialPrompt` between creates so the open
+   * dialog stays visibly about the request this callback belongs to. May come
+   * from a plugin, so a throw is contained and never breaks the form's own
+   * post-create flow.
    */
   onWorkspaceCreated?: (workspaceId: string) => void;
   /** Called after a successful create when "keep open" is off. */
@@ -318,11 +321,15 @@ export const NewWorkspaceForm = ({
     if (isKeepOpen) {
       // Keep the dialog open for rapid multi-create — reset the
       // per-workspace fields but retain the repo + agent type (+ mode/source)
-      // and the per-prompt agent settings. Plan mode is the exception: it is
-      // a per-task choice, so it resets to off rather than silently carrying
-      // into the next workspace.
-      setWorkspaceName("");
-      setPrompt("");
+      // and the per-prompt agent settings. Title and prompt reset back to
+      // their seeds, not to blank: every create from a seeded open request
+      // reports to the same `onWorkspaceCreated`, so the fields must keep
+      // saying what that request is (an unseeded open falls back to blank
+      // either way). Plan mode is the exception: it is a per-task choice, so
+      // it resets to off rather than silently carrying into the next
+      // workspace.
+      setWorkspaceName(initialTitle ?? "");
+      setPrompt(initialPrompt ?? "");
       setIsAgentPlanMode(false);
       setBranchNameOverride(null);
       setShuffleNonce((prev) => prev + 1);
@@ -346,6 +353,8 @@ export const NewWorkspaceForm = ({
     isAgentFastMode,
     isAgentPlanMode,
     isKeepOpen,
+    initialTitle,
+    initialPrompt,
     onWorkspaceCreated,
     onCreated,
   ]);

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -47,11 +47,22 @@ type NewWorkspaceFormProps = {
   /** Repo to pre-select (from a repo group's "+"); overrides the MRU seed. */
   presetProjectId?: string;
   /**
+   * Text to seed the title input with on mount (e.g. a plugin pre-filling a
+   * ticket title). A mount-time snapshot the user can freely edit.
+   */
+  initialTitle?: string;
+  /**
    * Text to seed the prompt textarea with on mount. Used by the empty
    * first-run page to default the very first prompt to `/sculptor:help`.
    * A mount-time snapshot the user can freely edit.
    */
   initialPrompt?: string;
+  /**
+   * Called with the new workspace's id after every successful create —
+   * including each repeat create in keep-open mode. May come from a plugin,
+   * so a throw is contained and never breaks the form's own post-create flow.
+   */
+  onWorkspaceCreated?: (workspaceId: string) => void;
   /** Called after a successful create when "keep open" is off. */
   onCreated: () => void;
 };
@@ -66,7 +77,9 @@ type NewWorkspaceFormProps = {
  */
 export const NewWorkspaceForm = ({
   presetProjectId,
+  initialTitle,
   initialPrompt,
+  onWorkspaceCreated,
   onCreated,
 }: NewWorkspaceFormProps): ReactElement => {
   // State and hooks — atoms
@@ -97,7 +110,7 @@ export const NewWorkspaceForm = ({
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     () => presetProjectId ?? lastSettings?.projectId ?? null,
   );
-  const [workspaceName, setWorkspaceName] = useState<string>("");
+  const [workspaceName, setWorkspaceName] = useState<string>(() => initialTitle ?? "");
   const [prompt, setPrompt] = useState<string>(() => initialPrompt ?? "");
   const [mode, setMode] = useState<WorkspaceInitializationStrategy>(
     () => lastSettings?.initStrategy ?? WorkspaceInitializationStrategy.WORKTREE,
@@ -293,6 +306,15 @@ export const NewWorkspaceForm = ({
       return;
     }
 
+    // Fires on every success, keep-open or not. The callback may come from a
+    // plugin, so contain a throw rather than letting it break the form's own
+    // post-create flow (field reset / dialog close).
+    try {
+      onWorkspaceCreated?.(result.workspaceId);
+    } catch (error) {
+      console.error("onWorkspaceCreated callback failed:", error);
+    }
+
     if (isKeepOpen) {
       // Keep the dialog open for rapid multi-create — reset the
       // per-workspace fields but retain the repo + agent type (+ mode/source)
@@ -324,6 +346,7 @@ export const NewWorkspaceForm = ({
     isAgentFastMode,
     isAgentPlanMode,
     isKeepOpen,
+    onWorkspaceCreated,
     onCreated,
   ]);
 

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -58,6 +58,12 @@ type NewWorkspaceFormProps = {
    */
   initialPrompt?: string;
   /**
+   * Name to seed the branch-name field with on mount, putting it in
+   * manually-edited mode — the user can still shuffle back to the auto
+   * preview. The form's existing exists/invalid validation applies unchanged.
+   */
+  initialBranchName?: string;
+  /**
    * Called with the new workspace's id after every successful create —
    * including each repeat create in keep-open mode, where the title/prompt
    * re-seed from `initialTitle`/`initialPrompt` between creates so the open
@@ -82,6 +88,7 @@ export const NewWorkspaceForm = ({
   presetProjectId,
   initialTitle,
   initialPrompt,
+  initialBranchName,
   onWorkspaceCreated,
   onCreated,
 }: NewWorkspaceFormProps): ReactElement => {
@@ -130,7 +137,7 @@ export const NewWorkspaceForm = ({
   // `null` means "use the auto-filled preview"; any string means the user has
   // taken over. Both the value and the manual flag collapse into one piece of
   // state so they can never disagree.
-  const [branchNameOverride, setBranchNameOverride] = useState<string | null>(null);
+  const [branchNameOverride, setBranchNameOverride] = useState<string | null>(() => initialBranchName ?? null);
   const [shuffleNonce, setShuffleNonce] = useState<number>(0);
   const [isLoadingProjects, setIsLoadingProjects] = useState<boolean>(true);
   const [toast, setToast] = useState<ToastContent | null>(null);
@@ -321,17 +328,17 @@ export const NewWorkspaceForm = ({
     if (isKeepOpen) {
       // Keep the dialog open for rapid multi-create — reset the
       // per-workspace fields but retain the repo + agent type (+ mode/source)
-      // and the per-prompt agent settings. Title and prompt reset back to
-      // their seeds, not to blank: every create from a seeded open request
-      // reports to the same `onWorkspaceCreated`, so the fields must keep
-      // saying what that request is (an unseeded open falls back to blank
-      // either way). Plan mode is the exception: it is a per-task choice, so
-      // it resets to off rather than silently carrying into the next
-      // workspace.
+      // and the per-prompt agent settings. Title, prompt, and branch name
+      // reset back to their seeds, not to blank/auto: every create from a
+      // seeded open request reports to the same `onWorkspaceCreated`, so the
+      // fields must keep saying what that request is (an unseeded open falls
+      // back to blank fields and the auto branch preview either way). Plan
+      // mode is the exception: it is a per-task choice, so it resets to off
+      // rather than silently carrying into the next workspace.
       setWorkspaceName(initialTitle ?? "");
       setPrompt(initialPrompt ?? "");
       setIsAgentPlanMode(false);
-      setBranchNameOverride(null);
+      setBranchNameOverride(initialBranchName ?? null);
       setShuffleNonce((prev) => prev + 1);
       nameInputRef.current?.focus();
     } else {
@@ -355,6 +362,7 @@ export const NewWorkspaceForm = ({
     isKeepOpen,
     initialTitle,
     initialPrompt,
+    initialBranchName,
     onWorkspaceCreated,
     onCreated,
   ]);

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.test.tsx
@@ -49,6 +49,7 @@ describe("NewWorkspaceModal", () => {
       open: true,
       initialTitle: "Fix the bug",
       initialPrompt: "Please fix it",
+      initialBranchName: "fix/the-bug",
       onWorkspaceCreated,
     });
     renderWithProviders(<NewWorkspaceModal />, { store });
@@ -57,6 +58,7 @@ describe("NewWorkspaceModal", () => {
       expect.objectContaining({
         initialTitle: "Fix the bug",
         initialPrompt: "Please fix it",
+        initialBranchName: "fix/the-bug",
         onWorkspaceCreated,
       }),
     );

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.test.tsx
@@ -9,9 +9,14 @@ import { newWorkspaceModalAtom } from "./newWorkspaceAtoms.ts";
 import { NewWorkspaceModal } from "./NewWorkspaceModal.tsx";
 
 // The real form pulls in project queries and creation hooks; the modal's
-// open/close contract is what is under test, so stub the form out.
+// open/close contract and its prop pass-through are what is under test, so
+// stub the form out but record the props it receives.
+const { formProps } = vi.hoisted(() => ({ formProps: vi.fn() }));
 vi.mock("~/components/newWorkspace/NewWorkspaceForm.tsx", () => ({
-  NewWorkspaceForm: (): null => null,
+  NewWorkspaceForm: (props: Record<string, unknown>): null => {
+    formProps(props);
+    return null;
+  },
 }));
 
 describe("NewWorkspaceModal", () => {
@@ -19,6 +24,7 @@ describe("NewWorkspaceModal", () => {
   // isn't registered — do it explicitly so each render starts from a fresh DOM.
   afterEach(() => {
     cleanup();
+    formProps.mockClear();
   });
 
   it("renders nothing while the atom holds no open request", () => {
@@ -32,6 +38,28 @@ describe("NewWorkspaceModal", () => {
     store.set(newWorkspaceModalAtom, { open: true });
     renderWithProviders(<NewWorkspaceModal />, { store });
     expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_DIALOG)).toBeTruthy();
+  });
+
+  it("passes the open request's seeds and create callback through to the form", () => {
+    // A plugin's open request (via the SDK's useOpenNewWorkspaceModal) rides
+    // this atom; the form only sees what the modal forwards.
+    const store = createStore();
+    const onWorkspaceCreated = vi.fn();
+    store.set(newWorkspaceModalAtom, {
+      open: true,
+      initialTitle: "Fix the bug",
+      initialPrompt: "Please fix it",
+      onWorkspaceCreated,
+    });
+    renderWithProviders(<NewWorkspaceModal />, { store });
+
+    expect(formProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialTitle: "Fix the bug",
+        initialPrompt: "Please fix it",
+        onWorkspaceCreated,
+      }),
+    );
   });
 
   it("closes a stale open request when the host unmounts", () => {

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
@@ -48,6 +48,10 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
     setModalState({ open: false });
   }, [setModalState]);
 
+  // The open request's own per-create callback (e.g. from a plugin's
+  // useOpenNewWorkspaceModal), handed to the form as-is.
+  const handleWorkspaceCreated = modalState.onWorkspaceCreated;
+
   // JSX and rendering logic
   if (!modalState.open) {
     return undefined;
@@ -63,6 +67,9 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
       <NewWorkspaceForm
         key={modalState.presetProjectId ?? "default"}
         presetProjectId={modalState.presetProjectId}
+        initialTitle={modalState.initialTitle}
+        initialPrompt={modalState.initialPrompt}
+        onWorkspaceCreated={handleWorkspaceCreated}
         onCreated={handleCreated}
       />
     </PaletteDialog>

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
@@ -48,14 +48,14 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
     setModalState({ open: false });
   }, [setModalState]);
 
-  // The open request's own per-create callback (e.g. from a plugin's
-  // useOpenNewWorkspaceModal), handed to the form as-is.
-  const handleWorkspaceCreated = modalState.onWorkspaceCreated;
-
   // JSX and rendering logic
   if (!modalState.open) {
     return undefined;
   }
+
+  // Destructured because react/jsx-handler-names rejects a member expression
+  // on an `on*` prop (it accepts a plain identifier).
+  const { onWorkspaceCreated } = modalState;
 
   return (
     <PaletteDialog
@@ -69,7 +69,7 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
         presetProjectId={modalState.presetProjectId}
         initialTitle={modalState.initialTitle}
         initialPrompt={modalState.initialPrompt}
-        onWorkspaceCreated={handleWorkspaceCreated}
+        onWorkspaceCreated={onWorkspaceCreated}
         onCreated={handleCreated}
       />
     </PaletteDialog>

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
@@ -69,6 +69,7 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
         presetProjectId={modalState.presetProjectId}
         initialTitle={modalState.initialTitle}
         initialPrompt={modalState.initialPrompt}
+        initialBranchName={modalState.initialBranchName}
         onWorkspaceCreated={onWorkspaceCreated}
         onCreated={handleCreated}
       />

--- a/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
+++ b/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
@@ -7,14 +7,22 @@ import type { StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
 import { workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
 
 /**
- * Open/close state of the new-workspace modal plus the optional repo it should
- * pre-select. `presetProjectId` is set when the dialog is opened from a repo
- * group's "+" so the form lands on that repo. Transient — the modal is
- * ephemeral, so this resets on reload.
+ * Open/close state of the new-workspace modal plus optional seeds for the form
+ * it hosts. `presetProjectId` is set when the dialog is opened from a repo
+ * group's "+" so the form lands on that repo. This atom is also the seam
+ * plugins use (via the SDK's `useOpenNewWorkspaceModal`) to open the dialog
+ * pre-filled: `initialTitle` / `initialPrompt` seed the form's title and
+ * prompt fields, and `onWorkspaceCreated` fires after each successful create
+ * while the dialog stays associated with this open request (including repeat
+ * creates in keep-open mode). Transient — the modal is ephemeral, so this
+ * resets on reload.
  */
 export type NewWorkspaceModalState = {
   open: boolean;
   presetProjectId?: string;
+  initialTitle?: string;
+  initialPrompt?: string;
+  onWorkspaceCreated?: (workspaceId: string) => void;
 };
 
 export const newWorkspaceModalAtom: PrimitiveAtom<NewWorkspaceModalState> = atom<NewWorkspaceModalState>({

--- a/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
+++ b/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
@@ -11,8 +11,9 @@ import { workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
  * it hosts. `presetProjectId` is set when the dialog is opened from a repo
  * group's "+" so the form lands on that repo. This atom is also the seam
  * plugins use (via the SDK's `useOpenNewWorkspaceModal`) to open the dialog
- * pre-filled: `initialTitle` / `initialPrompt` seed the form's title and
- * prompt fields, and `onWorkspaceCreated` fires after each successful create
+ * pre-filled: `initialTitle` / `initialPrompt` / `initialBranchName` seed the
+ * form's title, prompt, and new-branch-name fields, and `onWorkspaceCreated`
+ * fires after each successful create
  * while the dialog stays associated with this open request (including repeat
  * creates in keep-open mode). Transient — the modal is ephemeral, so this
  * resets on reload.
@@ -22,6 +23,7 @@ export type NewWorkspaceModalState = {
   presetProjectId?: string;
   initialTitle?: string;
   initialPrompt?: string;
+  initialBranchName?: string;
   onWorkspaceCreated?: (workspaceId: string) => void;
 };
 
@@ -31,9 +33,10 @@ export const newWorkspaceModalAtom: PrimitiveAtom<NewWorkspaceModalState> = atom
 
 /**
  * The "keep open" switch: when on, Create keeps the dialog open for rapid
- * multi-create — the form resets its title/prompt back to their seeds (blank
- * when the dialog was opened unseeded) and re-rolls the branch, but retains
- * the repo + agent type. Persisted so the preference survives reloads.
+ * multi-create — the form resets its title/prompt/branch name back to their
+ * seeds (blank fields and a re-rolled branch when the dialog was opened
+ * unseeded), but retains the repo + agent type. Persisted so the preference
+ * survives reloads.
  */
 export const keepNewWorkspaceModalOpenAtom: WritableAtom<boolean, [boolean], void> = atomWithStorage<boolean>(
   "sculptor-keep-new-workspace-modal-open",

--- a/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
+++ b/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
@@ -30,8 +30,9 @@ export const newWorkspaceModalAtom: PrimitiveAtom<NewWorkspaceModalState> = atom
 });
 
 /**
- * The "keep open" switch: when on, Create keeps the dialog open
- * for rapid multi-create — the form resets its title/prompt/branch but retains
+ * The "keep open" switch: when on, Create keeps the dialog open for rapid
+ * multi-create — the form resets its title/prompt back to their seeds (blank
+ * when the dialog was opened unseeded) and re-rolls the branch, but retains
  * the repo + agent type. Persisted so the preference survives reloads.
  */
 export const keepNewWorkspaceModalOpenAtom: WritableAtom<boolean, [boolean], void> = atomWithStorage<boolean>(

--- a/sculptor/frontend/src/plugins/sdk/hooks.test.tsx
+++ b/sculptor/frontend/src/plugins/sdk/hooks.test.tsx
@@ -40,13 +40,19 @@ describe("useOpenNewWorkspaceModal", () => {
     });
 
     act(() => {
-      result.current({ initialTitle: "Fix the bug", initialPrompt: "Please fix it", onCreated });
+      result.current({
+        initialTitle: "Fix the bug",
+        initialPrompt: "Please fix it",
+        initialBranchName: "fix/the-bug",
+        onCreated,
+      });
     });
 
     expect(store.get(newWorkspaceModalAtom)).toEqual({
       open: true,
       initialTitle: "Fix the bug",
       initialPrompt: "Please fix it",
+      initialBranchName: "fix/the-bug",
       onWorkspaceCreated: onCreated,
     });
   });
@@ -65,6 +71,7 @@ describe("useOpenNewWorkspaceModal", () => {
     expect(state.open).toBe(true);
     expect(state.initialTitle).toBeUndefined();
     expect(state.initialPrompt).toBeUndefined();
+    expect(state.initialBranchName).toBeUndefined();
     expect(state.onWorkspaceCreated).toBeUndefined();
   });
 });

--- a/sculptor/frontend/src/plugins/sdk/hooks.test.tsx
+++ b/sculptor/frontend/src/plugins/sdk/hooks.test.tsx
@@ -23,8 +23,11 @@ const createWrapper = (store: Store, pluginId: string) => {
 
 afterEach(() => {
   cleanup();
-  // The per-key setting atoms persist to localStorage (and the atomFamily cache
-  // outlives each test's store), so wipe it to keep tests independent.
+  // The per-key setting atoms persist to localStorage, so wipe it between
+  // tests. This alone does not isolate the atoms themselves: the module-level
+  // atomFamily cache outlives each test's store, and a cached atom reads
+  // storage only once, at creation — so test independence also relies on no
+  // two tests reusing the same (pluginId, key) pair.
   window.localStorage.clear();
 });
 

--- a/sculptor/frontend/src/plugins/sdk/hooks.test.tsx
+++ b/sculptor/frontend/src/plugins/sdk/hooks.test.tsx
@@ -1,0 +1,109 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { newWorkspaceModalAtom } from "~/components/newWorkspace/newWorkspaceAtoms.ts";
+
+import { PluginContext } from "../PluginContext.tsx";
+import { useOpenNewWorkspaceModal, usePluginSetting, usePluginSettings, useSetPluginSetting } from "./hooks.ts";
+
+type Store = ReturnType<typeof createStore>;
+
+// Wrap in the jotai store plus the host's plugin identity, mirroring how the
+// host mounts plugin components — the settings hooks derive their storage
+// namespace from PluginContext.
+const createWrapper = (store: Store, pluginId: string) => {
+  return ({ children }: { children: ReactNode }): ReactElement => (
+    <Provider store={store}>
+      <PluginContext.Provider value={{ pluginId }}>{children}</PluginContext.Provider>
+    </Provider>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  // The per-key setting atoms persist to localStorage (and the atomFamily cache
+  // outlives each test's store), so wipe it to keep tests independent.
+  window.localStorage.clear();
+});
+
+describe("useOpenNewWorkspaceModal", () => {
+  it("opens the modal with the given seeds and create callback", () => {
+    const store = createStore();
+    const onCreated = vi.fn();
+    const { result } = renderHook(() => useOpenNewWorkspaceModal(), {
+      wrapper: createWrapper(store, "test-plugin"),
+    });
+
+    act(() => {
+      result.current({ initialTitle: "Fix the bug", initialPrompt: "Please fix it", onCreated });
+    });
+
+    expect(store.get(newWorkspaceModalAtom)).toEqual({
+      open: true,
+      initialTitle: "Fix the bug",
+      initialPrompt: "Please fix it",
+      onWorkspaceCreated: onCreated,
+    });
+  });
+
+  it("opens the modal unseeded when called with no options", () => {
+    const store = createStore();
+    const { result } = renderHook(() => useOpenNewWorkspaceModal(), {
+      wrapper: createWrapper(store, "test-plugin"),
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    const state = store.get(newWorkspaceModalAtom);
+    expect(state.open).toBe(true);
+    expect(state.initialTitle).toBeUndefined();
+    expect(state.initialPrompt).toBeUndefined();
+    expect(state.onWorkspaceCreated).toBeUndefined();
+  });
+});
+
+describe("useSetPluginSetting", () => {
+  it("writes are seen reactively by usePluginSettings and usePluginSetting", () => {
+    const store = createStore();
+    const { result } = renderHook(
+      () => ({
+        set: useSetPluginSetting(),
+        settings: usePluginSettings(["ws:1", "ws:2"]),
+        single: usePluginSetting("ws:1")[0],
+      }),
+      { wrapper: createWrapper(store, "test-plugin") },
+    );
+
+    expect(result.current.settings.get("ws:1")).toBe("");
+
+    act(() => {
+      result.current.set("ws:1", "linked");
+    });
+
+    expect(result.current.settings.get("ws:1")).toBe("linked");
+    expect(result.current.settings.get("ws:2")).toBe("");
+    expect(result.current.single).toBe("linked");
+  });
+
+  it("namespaces writes by the calling plugin's id", () => {
+    const store = createStore();
+    const { result } = renderHook(() => useSetPluginSetting(), {
+      wrapper: createWrapper(store, "plugin-a"),
+    });
+
+    act(() => {
+      result.current("shared-key", "a-value");
+    });
+
+    // A different plugin reading the same key must not see plugin-a's value.
+    const other = renderHook(() => usePluginSettings(["shared-key"]), {
+      wrapper: createWrapper(store, "plugin-b"),
+    });
+    expect(other.result.current.get("shared-key")).toBe("");
+    expect(window.localStorage.getItem("sculptor-plugin:plugin-a:shared-key")).toBe(JSON.stringify("a-value"));
+  });
+});

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -159,7 +159,9 @@ export type NewWorkspaceModalOptions = {
   /**
    * Called with the new workspace's id per successful create — keep-open mode
    * lets the user create several workspaces from one open dialog, so this can
-   * fire more than once.
+   * fire more than once. Between such creates the form re-seeds its title and
+   * prompt from `initialTitle`/`initialPrompt`, so the dialog stays visibly
+   * about this open request and every report belongs to it.
    */
   onCreated?: (workspaceId: string) => void;
 };

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -157,19 +157,25 @@ export type NewWorkspaceModalOptions = {
   /** Pre-fills the first-agent prompt textarea. */
   initialPrompt?: string;
   /**
+   * Pre-fills the new-branch-name field; when omitted the host derives the
+   * branch from the title as usual. The host validates the name, and the user
+   * can edit it or re-roll back to the derived one.
+   */
+  initialBranchName?: string;
+  /**
    * Called with the new workspace's id per successful create — keep-open mode
    * lets the user create several workspaces from one open dialog, so this can
-   * fire more than once. Between such creates the form re-seeds its title and
-   * prompt from `initialTitle`/`initialPrompt`, so the dialog stays visibly
-   * about this open request and every report belongs to it.
+   * fire more than once. Between such creates the form re-seeds its fields
+   * from the `initial*` options, so the dialog stays visibly about this open
+   * request and every report belongs to it.
    */
   onCreated?: (workspaceId: string) => void;
 };
 
 /**
  * Returns a stable function that opens the host's own new-workspace dialog —
- * the same one behind Cmd/Meta+T — optionally pre-filled with a title and
- * prompt. The user remains in control: they can edit every field or cancel
+ * the same one behind Cmd/Meta+T — optionally pre-filled with a title, prompt,
+ * and branch name. The user remains in control: they can edit every field or cancel
  * without creating anything. `onCreated` reports the created workspace's id
  * (e.g. to record a plugin-side association, or to follow up with
  * `useNavigateToWorkspace`).
@@ -182,6 +188,7 @@ export const useOpenNewWorkspaceModal = (): ((options?: NewWorkspaceModalOptions
         open: true,
         initialTitle: options?.initialTitle,
         initialPrompt: options?.initialPrompt,
+        initialBranchName: options?.initialBranchName,
         onWorkspaceCreated: options?.onCreated,
       });
     },

--- a/sculptor/frontend/src/plugins/sdk/hooks.ts
+++ b/sculptor/frontend/src/plugins/sdk/hooks.ts
@@ -1,6 +1,6 @@
-import { atom, useAtom, useAtomValue } from "jotai";
+import { atom, useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { atomFamily, atomWithStorage, selectAtom } from "jotai/utils";
-import { useContext, useEffect, useMemo, useRef } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
 
 import type { CodingAgentTaskView } from "~/api";
@@ -9,6 +9,7 @@ import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { workspaceBranchAtomFamily } from "~/common/state/atoms/workspaceBranch.ts";
 import { workspaceAtomFamily, workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
 import { useWorkspaceNavigation } from "~/common/state/hooks/useWorkspaceNavigation.ts";
+import { newWorkspaceModalAtom } from "~/components/newWorkspace/newWorkspaceAtoms.ts";
 
 import { usePluginContext } from "../PluginContext.tsx";
 import { useWorkspacePluginContext, WorkspacePluginContext } from "../WorkspaceContext.tsx";
@@ -149,6 +150,43 @@ export const useNavigateToWorkspace = (): ((workspaceId: string) => void) =>
   // navigateToWorkspaceById is already a stable callback, so hand it back as-is.
   useWorkspaceNavigation().navigateToWorkspaceById;
 
+/** Seeds and callback for {@link useOpenNewWorkspaceModal}. */
+export type NewWorkspaceModalOptions = {
+  /** Pre-fills the workspace title field. */
+  initialTitle?: string;
+  /** Pre-fills the first-agent prompt textarea. */
+  initialPrompt?: string;
+  /**
+   * Called with the new workspace's id per successful create — keep-open mode
+   * lets the user create several workspaces from one open dialog, so this can
+   * fire more than once.
+   */
+  onCreated?: (workspaceId: string) => void;
+};
+
+/**
+ * Returns a stable function that opens the host's own new-workspace dialog —
+ * the same one behind Cmd/Meta+T — optionally pre-filled with a title and
+ * prompt. The user remains in control: they can edit every field or cancel
+ * without creating anything. `onCreated` reports the created workspace's id
+ * (e.g. to record a plugin-side association, or to follow up with
+ * `useNavigateToWorkspace`).
+ */
+export const useOpenNewWorkspaceModal = (): ((options?: NewWorkspaceModalOptions) => void) => {
+  const setModalState = useSetAtom(newWorkspaceModalAtom);
+  return useCallback(
+    (options?: NewWorkspaceModalOptions): void => {
+      setModalState({
+        open: true,
+        initialTitle: options?.initialTitle,
+        initialPrompt: options?.initialPrompt,
+        onWorkspaceCreated: options?.onCreated,
+      });
+    },
+    [setModalState],
+  );
+};
+
 // One persisted atom per (plugin, key). atomFamily caches by the full storage
 // key; getOnInit reads localStorage synchronously so the value is present on
 // first render instead of flashing the default.
@@ -198,6 +236,25 @@ export const usePluginSettings = (keys: ReadonlyArray<string>): ReadonlyMap<stri
     [pluginId, encodedKeys],
   );
   return useAtomValue(mapAtom);
+};
+
+/**
+ * Returns a stable function that writes one of the calling plugin's persisted
+ * settings — the imperative companion to {@link usePluginSetting} for keys only
+ * known at event time (e.g. a per-workspace key for a workspace picked in a
+ * menu), where the hook-per-key form can't be called. Writes land in the same
+ * per-key atoms as the reading hooks, so `usePluginSetting` and
+ * `usePluginSettings` see them reactively.
+ */
+export const useSetPluginSetting = (): ((key: string, value: string) => void) => {
+  const { pluginId } = usePluginContext();
+  const store = useStore();
+  return useCallback(
+    (key: string, value: string): void => {
+      store.set(pluginSettingAtomFamily(settingStorageKey(pluginId, key)), value);
+    },
+    [pluginId, store],
+  );
 };
 
 /**

--- a/sculptor/frontend/src/plugins/sdk/index.ts
+++ b/sculptor/frontend/src/plugins/sdk/index.ts
@@ -7,12 +7,14 @@ import type { PluginPanelDefinition } from "../types.ts";
 
 export { openExternal } from "./actions.ts";
 export { Markdown, PanelHeader } from "./components.ts";
-export type { CurrentWorkspace, WorkspaceView } from "./hooks.ts";
+export type { CurrentWorkspace, NewWorkspaceModalOptions, WorkspaceView } from "./hooks.ts";
 export {
   useCurrentWorkspace,
   useNavigateToWorkspace,
+  useOpenNewWorkspaceModal,
   usePluginSetting,
   usePluginSettings,
+  useSetPluginSetting,
   useWorkspaces,
   useWorkspaceTasks,
 } from "./hooks.ts";

--- a/sculptor/sculptor-plugin/skills/build-sculptor-plugin/SKILL.md
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-plugin/SKILL.md
@@ -153,8 +153,8 @@ summary. What it contains, in one breath:
   contribution; every component renders inside a per-plugin error boundary and
   receives **no props**.
 - Hooks: `useCurrentWorkspace` (selector form available), `useWorkspaces`,
-  `useWorkspaceTasks`, `useNavigateToWorkspace`, `usePluginSetting`,
-  `usePluginSettings`.
+  `useWorkspaceTasks`, `useNavigateToWorkspace`, `useOpenNewWorkspaceModal`,
+  `usePluginSetting`, `usePluginSettings`, `useSetPluginSetting`.
 - Components and actions: `Markdown`, `PanelHeader`, `openExternal`.
 
 Semantics that matter beyond the types:

--- a/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
@@ -597,18 +597,24 @@ export type NewWorkspaceModalOptions = {
 	/** Pre-fills the first-agent prompt textarea. */
 	initialPrompt?: string;
 	/**
+	 * Pre-fills the new-branch-name field; when omitted the host derives the
+	 * branch from the title as usual. The host validates the name, and the user
+	 * can edit it or re-roll back to the derived one.
+	 */
+	initialBranchName?: string;
+	/**
 	 * Called with the new workspace's id per successful create — keep-open mode
 	 * lets the user create several workspaces from one open dialog, so this can
-	 * fire more than once. Between such creates the form re-seeds its title and
-	 * prompt from `initialTitle`/`initialPrompt`, so the dialog stays visibly
-	 * about this open request and every report belongs to it.
+	 * fire more than once. Between such creates the form re-seeds its fields
+	 * from the `initial*` options, so the dialog stays visibly about this open
+	 * request and every report belongs to it.
 	 */
 	onCreated?: (workspaceId: string) => void;
 };
 /**
  * Returns a stable function that opens the host's own new-workspace dialog —
- * the same one behind Cmd/Meta+T — optionally pre-filled with a title and
- * prompt. The user remains in control: they can edit every field or cancel
+ * the same one behind Cmd/Meta+T — optionally pre-filled with a title, prompt,
+ * and branch name. The user remains in control: they can edit every field or cancel
  * without creating anything. `onCreated` reports the created workspace's id
  * (e.g. to record a plugin-side association, or to follow up with
  * `useNavigateToWorkspace`).

--- a/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
@@ -590,6 +590,28 @@ export declare function useCurrentWorkspace<T = WorkspaceView | null>(selector?:
  * with clicking a workspace in the host's own lists.
  */
 export declare const useNavigateToWorkspace: () => ((workspaceId: string) => void);
+/** Seeds and callback for {@link useOpenNewWorkspaceModal}. */
+export type NewWorkspaceModalOptions = {
+	/** Pre-fills the workspace title field. */
+	initialTitle?: string;
+	/** Pre-fills the first-agent prompt textarea. */
+	initialPrompt?: string;
+	/**
+	 * Called with the new workspace's id per successful create — keep-open mode
+	 * lets the user create several workspaces from one open dialog, so this can
+	 * fire more than once.
+	 */
+	onCreated?: (workspaceId: string) => void;
+};
+/**
+ * Returns a stable function that opens the host's own new-workspace dialog —
+ * the same one behind Cmd/Meta+T — optionally pre-filled with a title and
+ * prompt. The user remains in control: they can edit every field or cancel
+ * without creating anything. `onCreated` reports the created workspace's id
+ * (e.g. to record a plugin-side association, or to follow up with
+ * `useNavigateToWorkspace`).
+ */
+export declare const useOpenNewWorkspaceModal: () => ((options?: NewWorkspaceModalOptions) => void);
 /**
  * A persisted string setting scoped to the calling plugin. Backed by
  * localStorage under a `sculptor-plugin:<id>:<key>` namespace and shared
@@ -610,6 +632,15 @@ export declare const usePluginSetting: (key: string) => [
  * atoms.
  */
 export declare const usePluginSettings: (keys: ReadonlyArray<string>) => ReadonlyMap<string, string>;
+/**
+ * Returns a stable function that writes one of the calling plugin's persisted
+ * settings — the imperative companion to {@link usePluginSetting} for keys only
+ * known at event time (e.g. a per-workspace key for a workspace picked in a
+ * menu), where the hook-per-key form can't be called. Writes land in the same
+ * per-key atoms as the reading hooks, so `usePluginSetting` and
+ * `usePluginSettings` see them reactively.
+ */
+export declare const useSetPluginSetting: () => ((key: string, value: string) => void);
 /**
  * All non-deleted tasks for the workspace the plugin is mounted in. Returns
  * `undefined` until the host's task stream has produced its first batch.

--- a/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-plugin/sdk.d.ts
@@ -599,7 +599,9 @@ export type NewWorkspaceModalOptions = {
 	/**
 	 * Called with the new workspace's id per successful create — keep-open mode
 	 * lets the user create several workspaces from one open dialog, so this can
-	 * fire more than once.
+	 * fire more than once. Between such creates the form re-seeds its title and
+	 * prompt from `initialTitle`/`initialPrompt`, so the dialog stays visibly
+	 * about this open request and every report belongs to it.
 	 */
 	onCreated?: (workspaceId: string) => void;
 };

--- a/sculptor/sculptor/testing/elements/settings_plugins.py
+++ b/sculptor/sculptor/testing/elements/settings_plugins.py
@@ -129,16 +129,20 @@ class PlaywrightPluginsSettingsElement(PlaywrightIntegrationTestElement):
         """
         self.get_source_row(source).get_by_test_id(ElementIDs.SETTINGS_PLUGINS_SOURCE_SETTINGS).click()
 
-    def set_source_text_setting(self, source: str, value: str) -> None:
-        """Open a source's plugin-rendered settings and fill its text input.
+    def set_source_text_setting(self, source: str, value: str, *, placeholder: str | None = None) -> None:
+        """Open a source's plugin-rendered settings and fill a text input.
 
-        The settings component is plugin-authored, so its field carries no host
-        testid; scope to the (single) ``<input>`` inside the source's row. Used
-        e.g. to enter the Linear plugin's API key, which the plugin persists via
-        the settings SDK and applies reactively (no reload needed).
+        The settings component is plugin-authored, so its fields carry no host
+        testids. A plugin whose settings render a single ``<input>`` needs no
+        disambiguation; when they render several (e.g. the Linear plugin's API
+        key beside its template fields), pass the target field's ``placeholder``
+        — Playwright's canonical locator for a label-less input. Used e.g. to
+        enter the Linear plugin's API key, which the plugin persists via the
+        settings SDK and applies reactively (no reload needed).
         """
         self.open_source_settings(source)
-        field = self.get_source_row(source).locator("input")
+        row = self.get_source_row(source)
+        field = row.get_by_placeholder(placeholder) if placeholder is not None else row.locator("input")
         expect(field).to_be_visible()
         field.fill(value)
 

--- a/sculptor/tests/integration/frontend/test_linear_plugin_runtime.py
+++ b/sculptor/tests/integration/frontend/test_linear_plugin_runtime.py
@@ -30,6 +30,9 @@ from sculptor.testing.sculptor_instance import SculptorInstanceFactory
 LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
 LINEAR_SOURCE = "/plugins/linear-issue"
 API_KEY = "lin_api_test_key_1234"
+# The API key field's placeholder, used to pick it out of the plugin's
+# settings (which also render the workspace-seed template fields).
+API_KEY_FIELD_PLACEHOLDER = "lin_api_..."
 
 
 def _make_linear_route(captured_auth: list[str]):
@@ -95,7 +98,7 @@ def test_linear_panel_follows_workspace_branch_and_sends_key(
         settings_page = navigate_to_settings_page(page=page)
         plugins = settings_page.click_on_plugins()
         plugins.expect_loaded(LINEAR_SOURCE, name="Linear", version="0.1.0")
-        plugins.set_source_text_setting(LINEAR_SOURCE, API_KEY)
+        plugins.set_source_text_setting(LINEAR_SOURCE, API_KEY, placeholder=API_KEY_FIELD_PLACEHOLDER)
 
         right_section = PlaywrightWorkspaceSection(page, "right")
 


### PR DESCRIPTION
Cherry-picks #328 (SCU-1789) into the 0.42.0 release branch — Linear board can create or assign a workspace for tickets that don't have one, plus user-editable new-workspace seed templates and the plugin-SDK hook to open the new-workspace dialog pre-filled.

## Included (the 5 change commits from #328)
- `6c689935a67` Plugin SDK: open the new-workspace dialog pre-filled + imperative setting writes
- `0eb55485b7e` Linear board: create or assign a workspace for tickets without one
- `6fb4fcd8b57` Address review: keep-open re-seed, submenu loading state, form tests
- `0ded8ff9324` Linear board: user-editable templates for the new-workspace seeds
- `c31c323f780` Fix Linear plugin settings fill for multi-field settings

## Cherry-pick notes
- #328's branch contained an internal `Merge origin/main (first-run dialog rework)` commit (`21f616f80ff`). That merge is **omitted** here (you cannot cherry-pick a merge commit into a linear branch); its five *change* commits are picked directly, in order.
- Textual cherry-pick is **clean, no conflicts**. Because the omitted merge brought a new-workspace "first-run dialog rework" that isn't on the 0.42 branch, the real validation is this PR's **typecheck + frontend unit tests** — if they fail on a missing/reworked new-workspace API, that rework needs cherry-picking too. (The first commit adds the SDK function #328 relies on, so it's largely self-contained.)

After this merges, `just fixup` on the release branch will tag rc4.

(Sent by Claude)