### PR TITLE
[SCU-1811] Fix Review All commit button colliding with the scope toggle

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.module.scss
@@ -20,8 +20,8 @@
   padding: var(--space-1) var(--space-2);
 }
 
-.toolbarSpacer {
-  flex: 1;
+.commitFooter {
+  border-top: 1px solid var(--gray-a5);
 }
 
 .splitWrapper {

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.tsx
@@ -335,10 +335,6 @@ export const CombinedDiffView = ({
           {areAllCollapsed ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
         </TooltipIconButton>
         <DiffScopePicker scope={scope} onScopeChange={setScope} hasTargetBranch={hasTargetBranch} />
-        <span className={styles.toolbarSpacer} />
-        {scope === "uncommitted" && (
-          <CommitButton changesCount={isReady ? fileChanges.length : 0} onCommit={onCommit} />
-        )}
       </div>
       {isActive &&
         (fileChanges.length === 0 ? (
@@ -369,6 +365,14 @@ export const CombinedDiffView = ({
             </div>
           </div>
         ))}
+      {/* Commit action pinned as a full-width footer, matching the Changes
+          panel. Keeping it out of the toolbar row avoids colliding with the
+          scope picker (both want the full width) when the panel is narrow. */}
+      {scope === "uncommitted" && (
+        <Flex flexShrink="0" px="3" py="2" className={styles.commitFooter}>
+          <CommitButton changesCount={isReady ? fileChanges.length : 0} onCommit={onCommit} />
+        </Flex>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What & why

In the **Review All** panel, switching the scope toggle to **Uncommitted** made a full-width "Commit N changes" button appear in the *same* toolbar row as the **All | Uncommitted** scope toggle. Both controls are styled `width: 100%` — which is correct in the **Changes** panel, where each owns its own row — so sharing a single flex row they overflowed, the spacer between them collapsed, and the toggle was squeezed to **zero width**. In Uncommitted scope the "All" segment became unclickable, leaving no way to switch back to "All".

## Fix

Move the commit button into a **full-width footer pinned at the bottom** of the panel, mirroring how the **Changes** panel lays out the very same switcher + commit button. The toolbar now holds only the navigation icons and the scope toggle, so the two controls never compete for width — at any panel size.

- `CombinedDiffView.tsx`: commit button removed from the toolbar; rendered in a `<Flex flexShrink="0" px="3" py="2" className={styles.commitFooter}>` after the content, gated on `scope === "uncommitted"`.
- `CombinedDiffView.module.scss`: dropped the now-unused `.toolbarSpacer`; added `.commitFooter { border-top: 1px solid var(--gray-a5) }` (the same border token the Changes footer uses).

## Layout, before → after (Uncommitted scope)

Before (single toolbar row — toggle crushed):

```
[ ◀ ▶ ⊟ ]  [All|Uncommitted → 0px]  [===== Commit N changes =====]
```

After (toggle in toolbar, button as bottom footer):

```
[ ◀ ▶ ⊟ ]  [  All  |  Uncommitted  ]
…panel content…
[============ Commit N changes ============]   (full-width footer)
```

## Testing

This is a purely visual/layout bug, so per the repo's testing policy it carries no automated test (layout-only assertions are disallowed). Verified manually with the headless-browser QA harness, in Uncommitted scope, at both a narrow (~230px docked side column) and a wide panel width: the scope toggle renders full-size and clickable at the top, and the commit button is a full-width footer at the bottom — visually matching the Changes tab. Before/after screenshots were captured during QA. `just format`, `just check`, and `just test-unit` all pass.

(Sent by Claude)
