### PR TITLE
Cherry-pick #350 into 0.42.0: fix Review All button collision (SCU-1811)

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.module.scss
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.module.scss
@@ -20,8 +20,8 @@
   padding: var(--space-1) var(--space-2);
 }
 
-.toolbarSpacer {
-  flex: 1;
+.commitFooter {
+  border-top: 1px solid var(--gray-a5);
 }
 
 .splitWrapper {

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.tsx
@@ -335,10 +335,6 @@ export const CombinedDiffView = ({
           {areAllCollapsed ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
         </TooltipIconButton>
         <DiffScopePicker scope={scope} onScopeChange={setScope} hasTargetBranch={hasTargetBranch} />
-        <span className={styles.toolbarSpacer} />
-        {scope === "uncommitted" && (
-          <CommitButton changesCount={isReady ? fileChanges.length : 0} onCommit={onCommit} />
-        )}
       </div>
       {isActive &&
         (fileChanges.length === 0 ? (
@@ -369,6 +365,14 @@ export const CombinedDiffView = ({
             </div>
           </div>
         ))}
+      {/* Commit action pinned as a full-width footer, matching the Changes
+          panel. Keeping it out of the toolbar row avoids colliding with the
+          scope picker (both want the full width) when the panel is narrow. */}
+      {scope === "uncommitted" && (
+        <Flex flexShrink="0" px="3" py="2" className={styles.commitFooter}>
+          <CommitButton changesCount={isReady ? fileChanges.length : 0} onCommit={onCommit} />
+        </Flex>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Cherry-picks #350 (SCU-1811) into the 0.42.0 release branch — a UX fix so the Review All commit button no longer collides with the scope toggle.

## Included
- `42e69b09db9` Fix Review All commit button colliding with the scope toggle

Original commit on `main`. Clean cherry-pick, no conflicts — touches only the diff-panel `CombinedDiffView` (`.tsx` + `.module.scss`), which had zero intervening changes on the 0.42 branch.

After this merges, `just fixup` on the release branch will tag rc5.

(Sent by Claude)