### PR TITLE
[SCU-1795] Attribute workspace creation and reorder the sidebar around it

### DIFF
--- a/sculptor/frontend/src/components/nav/sidebarWorkspaceOrder.test.ts
+++ b/sculptor/frontend/src/components/nav/sidebarWorkspaceOrder.test.ts
@@ -18,6 +18,23 @@ import {
 const makeWorkspace = (id: string, projectId: string, description: string): Workspace =>
   ({ objectId: id, projectId, description }) as unknown as Workspace;
 
+// A workspace carrying the creation fields the default order keys on: createdAt
+// (newest-first) and createdBy.createdByWorkspaceId (the creator it nests beneath).
+const makeAttributedWorkspace = (
+  id: string,
+  projectId: string,
+  description: string,
+  options: { createdAt?: string; createdByWorkspaceId?: string },
+): Workspace =>
+  ({
+    objectId: id,
+    projectId,
+    description,
+    createdAt: options.createdAt,
+    createdBy:
+      options.createdByWorkspaceId !== undefined ? { createdByWorkspaceId: options.createdByWorkspaceId } : undefined,
+  }) as unknown as Workspace;
+
 const makeProject = (id: string, name: string): Project => ({ objectId: id, name }) as unknown as Project;
 
 const PROJECTS = [makeProject("p-alpha", "alpha"), makeProject("p-beta", "beta")];
@@ -32,13 +49,13 @@ const workspaceIdsOf = (groups: ReturnType<typeof groupWorkspacesByRepo>, projec
   groups.find((group) => group.projectId === projectId)?.workspaces.map((ws) => ws.objectId) ?? [];
 
 describe("groupWorkspacesByRepo", () => {
-  it("defaults to alphabetical groups and workspaces without a stored order", () => {
+  it("defaults to alphabetical groups; workspaces without createdAt tie-break by description", () => {
     const groups = groupWorkspacesByRepo(WORKSPACES, PROJECTS);
     expect(groups.map((group) => group.projectId)).toEqual(["p-alpha", "p-beta"]);
     expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-apple", "w-banana", "w-cherry"]);
   });
 
-  it("renders stored workspace positions first, then unstored ones alphabetically", () => {
+  it("renders stored workspace positions first, then unstored ones in default order", () => {
     const groups = groupWorkspacesByRepo(WORKSPACES, PROJECTS, {
       repos: [],
       // banana was dragged above cherry; apple has no stored position.
@@ -71,6 +88,107 @@ describe("groupWorkspacesByRepo", () => {
       workspaces: {},
     });
     expect(groups.map((group) => group.projectId)).toEqual(["p-gamma", "p-alpha", "p-beta"]);
+  });
+});
+
+describe("groupWorkspacesByRepo creation ordering and nesting", () => {
+  it("orders top-level workspaces newest-first by createdAt", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-old", "p-alpha", "old", { createdAt: "2026-01-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-new", "p-alpha", "new", { createdAt: "2026-03-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-mid", "p-alpha", "mid", { createdAt: "2026-02-01T00:00:00Z" }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-new", "w-mid", "w-old"]);
+  });
+
+  it("nests an agent-spawned workspace directly beneath its creator", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-parent", "p-alpha", "parent", { createdAt: "2026-01-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-top", "p-alpha", "top", { createdAt: "2026-03-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-child", "p-alpha", "child", {
+        createdAt: "2026-02-01T00:00:00Z",
+        createdByWorkspaceId: "w-parent",
+      }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    // w-top is newest so it leads; w-parent follows with its child directly beneath,
+    // even though the child was created more recently than the parent.
+    expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-top", "w-parent", "w-child"]);
+  });
+
+  it("orders sibling children newest-first under their creator", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-parent", "p-alpha", "parent", { createdAt: "2026-01-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-child-old", "p-alpha", "child-old", {
+        createdAt: "2026-01-02T00:00:00Z",
+        createdByWorkspaceId: "w-parent",
+      }),
+      makeAttributedWorkspace("w-child-new", "p-alpha", "child-new", {
+        createdAt: "2026-01-03T00:00:00Z",
+        createdByWorkspaceId: "w-parent",
+      }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-parent", "w-child-new", "w-child-old"]);
+  });
+
+  it("nests grandchildren recursively down the creation chain", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-a", "p-alpha", "a", { createdAt: "2026-01-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-b", "p-alpha", "b", {
+        createdAt: "2026-01-02T00:00:00Z",
+        createdByWorkspaceId: "w-a",
+      }),
+      makeAttributedWorkspace("w-c", "p-alpha", "c", {
+        createdAt: "2026-01-03T00:00:00Z",
+        createdByWorkspaceId: "w-b",
+      }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-a", "w-b", "w-c"]);
+  });
+
+  it("treats a workspace whose creator lives in another repo as top-level", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-parent", "p-beta", "parent", { createdAt: "2026-01-01T00:00:00Z" }),
+      makeAttributedWorkspace("w-orphan", "p-alpha", "orphan", {
+        createdAt: "2026-01-02T00:00:00Z",
+        createdByWorkspaceId: "w-parent",
+      }),
+      makeAttributedWorkspace("w-plain", "p-alpha", "plain", { createdAt: "2026-01-03T00:00:00Z" }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    // w-parent isn't in p-alpha, so w-orphan roots at the top level and sorts by its
+    // own createdAt rather than nesting.
+    expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-plain", "w-orphan"]);
+  });
+
+  it("treats a self-referential creator as top-level", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-self", "p-alpha", "self", {
+        createdAt: "2026-01-01T00:00:00Z",
+        createdByWorkspaceId: "w-self",
+      }),
+      makeAttributedWorkspace("w-other", "p-alpha", "other", { createdAt: "2026-01-02T00:00:00Z" }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    expect(workspaceIdsOf(groups, "p-alpha")).toEqual(["w-other", "w-self"]);
+  });
+
+  it("still renders every workspace when creators form a cycle", () => {
+    const workspaces = [
+      makeAttributedWorkspace("w-x", "p-alpha", "x", {
+        createdAt: "2026-01-01T00:00:00Z",
+        createdByWorkspaceId: "w-y",
+      }),
+      makeAttributedWorkspace("w-y", "p-alpha", "y", {
+        createdAt: "2026-01-02T00:00:00Z",
+        createdByWorkspaceId: "w-x",
+      }),
+    ];
+    const groups = groupWorkspacesByRepo(workspaces, PROJECTS);
+    expect([...workspaceIdsOf(groups, "p-alpha")].sort()).toEqual(["w-x", "w-y"]);
   });
 });
 

--- a/sculptor/frontend/src/components/nav/sidebarWorkspaceOrder.ts
+++ b/sculptor/frontend/src/components/nav/sidebarWorkspaceOrder.ts
@@ -2,8 +2,21 @@
 // keyboard workspace cycling (Meta+] / Meta+[) can never disagree: workspaces are
 // grouped by repo (project), and both the groups and the workspaces within them
 // render in the user's stored drag order first (sidebarOrder in the global layout
-// snapshot), with anything not yet reordered following alphabetically — the
-// default order a user reads top-to-bottom before ever dragging.
+// snapshot), with anything not yet reordered following in the default order below.
+//
+// The default within-group order is newest-first (by createdAt), so a freshly created
+// workspace lands at the top — EXCEPT that a workspace spawned by an agent via
+// `sculpt` (which stamps createdBy.createdByWorkspaceId) is nested directly beneath
+// the workspace that created it rather than jumping to the top. User-created and
+// unattributed workspaces have no creator and stay at the top level. Repo groups
+// themselves are still ordered alphabetically by name (below the stored order).
+//
+// Drag order wins where it exists, and it takes precedence over "newest at the top":
+// dragging any workspace stores the group's whole materialized order, so every existing
+// workspace becomes pinned. A workspace created afterward is unpinned and therefore
+// renders BELOW the pinned block (and detached from its creator), not at the top — an
+// accepted edge of layering this default order under an explicit user drag order.
+// Groups the user has never dragged keep the pure newest-first-with-nesting order.
 
 import { arrayMove } from "@dnd-kit/sortable";
 import { atom } from "jotai";
@@ -26,7 +39,7 @@ export type RepoGroup = {
 const EMPTY_SIDEBAR_ORDER: SidebarOrderState = { repos: [], workspaces: {} };
 
 // Stored-first ordering: items whose keys appear in `storedKeys` come first, in
-// that stored order; the rest keep their incoming (alphabetical) order after them.
+// that stored order; the rest keep their incoming (default) order after them.
 // Stored keys that no longer resolve to an item are skipped, so deletions never
 // require cleaning the stored list; a key stored twice (a hand-edited or corrupt
 // snapshot) takes its first slot only, so an item is never rendered twice.
@@ -51,6 +64,73 @@ function applyStoredOrder<T>(
   }
   const unstored = items.filter((item) => remainingByKey.has(keyOf(item)));
   return [...stored, ...unstored];
+}
+
+// Compare workspaces newest-first by creation time, falling back to description then
+// id so the order stays stable when createdAt is missing or two match. ISO-8601
+// timestamps sort lexicographically, so a plain reversed string compare = newest-first.
+function byCreatedAtDesc(a: Workspace, b: Workspace): number {
+  const aCreated = a.createdAt ?? "";
+  const bCreated = b.createdAt ?? "";
+  if (aCreated !== bCreated) {
+    return bCreated.localeCompare(aCreated);
+  }
+  const aDescription = a.description ?? "";
+  const bDescription = b.description ?? "";
+  if (aDescription !== bDescription) {
+    return aDescription.localeCompare(bDescription);
+  }
+  return a.objectId.localeCompare(b.objectId);
+}
+
+// The default within-group order (before the stored drag order is layered on):
+// newest-first at the top level, with each workspace's agent-spawned children
+// (created via `sculpt`, carrying createdBy.createdByWorkspaceId) flattened directly
+// beneath it — recursively, and newest-first among themselves. A workspace whose
+// creator isn't present in this group (user-created, unattributed, or created by a
+// workspace living in another repo) is treated as top-level. A self-parent or a
+// parent cycle can't strand a workspace: any not reached by walking down from a root
+// is appended at the end.
+function orderWorkspacesByCreation(workspaces: ReadonlyArray<Workspace>): Array<Workspace> {
+  const byId = new Map(workspaces.map((ws) => [ws.objectId, ws]));
+  const childrenByParent = new Map<string, Array<Workspace>>();
+  const roots: Array<Workspace> = [];
+  for (const ws of workspaces) {
+    const parentId = ws.createdBy?.createdByWorkspaceId ?? null;
+    if (parentId !== null && parentId !== ws.objectId && byId.has(parentId)) {
+      const siblings = childrenByParent.get(parentId) ?? [];
+      siblings.push(ws);
+      childrenByParent.set(parentId, siblings);
+    } else {
+      roots.push(ws);
+    }
+  }
+
+  const ordered: Array<Workspace> = [];
+  const visited = new Set<string>();
+  const emit = (ws: Workspace): void => {
+    if (visited.has(ws.objectId)) {
+      return;
+    }
+    visited.add(ws.objectId);
+    ordered.push(ws);
+    const children = childrenByParent.get(ws.objectId);
+    if (children !== undefined) {
+      for (const child of [...children].sort(byCreatedAtDesc)) {
+        emit(child);
+      }
+    }
+  };
+
+  for (const root of [...roots].sort(byCreatedAtDesc)) {
+    emit(root);
+  }
+
+  // Defensive: a workspace trapped in a parent cycle is never reached from a root.
+  for (const ws of [...workspaces].sort(byCreatedAtDesc)) {
+    emit(ws);
+  }
+  return ordered;
 }
 
 // Build the sidebar's repo groups and apply the stored drag order. Seeds a group
@@ -79,11 +159,7 @@ export function groupWorkspacesByRepo(
     .map(([projectId, wsList]) => ({
       projectId,
       name: projectsById.get(projectId)?.name ?? "Other",
-      workspaces: applyStoredOrder(
-        wsList.sort((a, b) => (a.description ?? "").localeCompare(b.description ?? "")),
-        order.workspaces[projectId],
-        (ws) => ws.objectId,
-      ),
+      workspaces: applyStoredOrder(orderWorkspacesByCreation(wsList), order.workspaces[projectId], (ws) => ws.objectId),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
   return applyStoredOrder(groups, order.repos, (group) => group.projectId);

--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -3147,5 +3147,41 @@
         "type": "object"
       }
     }
+  },
+  "Workspace": {
+    "created_by": {
+      "CreationAttribution": {
+        "additionalProperties": true,
+        "description": "Records what created a workspace, so the UI can group agent-spawned workspaces\nunder the workspace that created them (and place user-initiated ones on top).\n\nPopulated by `sculpt workspace create` from the creating agent's own identity\n(SCULPT_WORKSPACE_ID / SCULPT_AGENT_ID). Left null for user-initiated creation\nthrough the UI, which is why a null attribution is treated the same as \"created\nby the user\" everywhere it's consumed.\n\nThis is intentionally an embedded object stored inline as a JSON column, NOT a\nforeign-key relation: SQLite foreign keys fight the two-table\n(`<name>` / `<name>_latest`) trigger design, so parentage lives here as plain\nembedded ids rather than a cross-table constraint.",
+        "properties": {
+          "createdByAgentId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Createdbyagentid"
+          },
+          "createdByWorkspaceId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Createdbyworkspaceid"
+          }
+        },
+        "title": "CreationAttribution",
+        "type": "object"
+      }
+    }
   }
 }

--- a/sculptor/sculptor/database/alembic/version_tests/test_70ec89dbef5d.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_70ec89dbef5d.py
@@ -8,7 +8,7 @@ class TestMigration70ec89dbef5d(MigrationTestFixture):
 
     Adds the nullable created_by (JSON) column to the workspace tables. Schema-only
     and additive — existing rows simply gain a NULL created_by — so there is no data
-    to preserve or verify.
+    to preserve; verify() just asserts the column landed on both tables.
     """
 
     @property
@@ -23,4 +23,9 @@ class TestMigration70ec89dbef5d(MigrationTestFixture):
         pass
 
     def verify(self, connection: sa.engine.Connection) -> None:
-        pass
+        # The two-table (`<name>` / `<name>_latest`) design means both tables must
+        # gain the column; assert it rather than trusting the migration blindly.
+        inspector = sa.inspect(connection)
+        for table in ("workspace", "workspace_latest"):
+            columns = {column["name"] for column in inspector.get_columns(table)}
+            assert "created_by" in columns, f"created_by column missing from {table} after migration"

--- a/sculptor/sculptor/database/alembic/version_tests/test_70ec89dbef5d.py
+++ b/sculptor/sculptor/database/alembic/version_tests/test_70ec89dbef5d.py
@@ -1,0 +1,26 @@
+import sqlalchemy as sa
+
+from sculptor.database.alembic.migration_test_utils import MigrationTestFixture
+
+
+class TestMigration70ec89dbef5d(MigrationTestFixture):
+    """Test fixture for migration 70ec89dbef5d.
+
+    Adds the nullable created_by (JSON) column to the workspace tables. Schema-only
+    and additive — existing rows simply gain a NULL created_by — so there is no data
+    to preserve or verify.
+    """
+
+    @property
+    def revision(self) -> str:
+        return "70ec89dbef5d"
+
+    @property
+    def down_revision(self) -> str:
+        return "6026c03dc852"
+
+    def seed(self, connection: sa.engine.Connection) -> None:
+        pass
+
+    def verify(self, connection: sa.engine.Connection) -> None:
+        pass

--- a/sculptor/sculptor/database/alembic/versions/70ec89dbef5d_add_workspace_created_by_column.py
+++ b/sculptor/sculptor/database/alembic/versions/70ec89dbef5d_add_workspace_created_by_column.py
@@ -1,0 +1,33 @@
+"""add workspace created_by attribution column
+
+Revision ID: 70ec89dbef5d
+Revises: 6026c03dc852
+Create Date: 2026-07-08 00:00:00.000000
+
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "70ec89dbef5d"
+down_revision: str | None = "6026c03dc852"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # created_by stores an embedded CreationAttribution object (JSON), not an FK.
+    # Added to both the `workspace` and `workspace_latest` tables per the
+    # two-table trigger design.
+    op.add_column("workspace", sa.Column("created_by", sa.JSON(), nullable=True))
+    op.add_column("workspace_latest", sa.Column("created_by", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("workspace_latest", "created_by")
+    op.drop_column("workspace", "created_by")

--- a/sculptor/sculptor/database/models.py
+++ b/sculptor/sculptor/database/models.py
@@ -80,6 +80,31 @@ class Project(DatabaseModel):
         return Path(self.user_git_repo_url.replace("file://", ""))
 
 
+class CreationAttribution(SerializableModel):
+    """
+    Records what created a workspace, so the UI can group agent-spawned workspaces
+    under the workspace that created them (and place user-initiated ones on top).
+
+    Populated by `sculpt workspace create` from the creating agent's own identity
+    (SCULPT_WORKSPACE_ID / SCULPT_AGENT_ID). Left null for user-initiated creation
+    through the UI, which is why a null attribution is treated the same as "created
+    by the user" everywhere it's consumed.
+
+    This is intentionally an embedded object stored inline as a JSON column, NOT a
+    foreign-key relation: SQLite foreign keys fight the two-table
+    (`<name>` / `<name>_latest`) trigger design, so parentage lives here as plain
+    embedded ids rather than a cross-table constraint.
+    """
+
+    # The workspace whose agent spawned this one. Drives the sidebar nesting; a
+    # workspace whose creator isn't currently visible in the same repo group falls
+    # back to top-level.
+    created_by_workspace_id: WorkspaceID | None = None
+    # The specific agent (task) that spawned this workspace, when known. Not used
+    # for sidebar ordering today; kept as the "task-level" detail for future use.
+    created_by_agent_id: TaskID | None = None
+
+
 class Workspace(DatabaseModel):
     """
     A workspace represents an isolated working environment for one or more tasks.
@@ -120,6 +145,10 @@ class Workspace(DatabaseModel):
     # here so it survives a backend restart (the coordinator's in-memory state is
     # rebuilt lazily and would otherwise revert to the default).
     ci_babysitter_paused: bool = False
+    # What created this workspace. Null for user-initiated creation via the UI;
+    # populated by `sculpt workspace create` when an agent spawns a workspace.
+    # Consumed by the sidebar to nest agent-spawned workspaces under their creator.
+    created_by: CreationAttribution | None = None
 
 
 # Runtime tables

--- a/sculptor/sculptor/services/data_model_service/data_types.py
+++ b/sculptor/sculptor/services/data_model_service/data_types.py
@@ -92,6 +92,8 @@ WORKSPACE_CREATION_ONLY_FIELDS: frozenset[str] = frozenset(
         "source_git_hash",
         "requested_branch_name",
         "harness",
+        # Attribution stamped once when the workspace is created; never updated.
+        "created_by",
     }
 )
 

--- a/sculptor/sculptor/services/workspace_service/api.py
+++ b/sculptor/sculptor/services/workspace_service/api.py
@@ -6,6 +6,7 @@ from typing import Generator
 from typing import Literal
 from typing import TYPE_CHECKING
 
+from sculptor.database.models import CreationAttribution
 from sculptor.database.models import Project
 from sculptor.database.models import Workspace
 from sculptor.database.workspace_enums import WorkspaceInitializationStrategy
@@ -161,6 +162,7 @@ class WorkspaceService(Service, ABC):
         description: str | None,
         transaction: DataModelTransaction,
         target_branch: str | None = None,
+        created_by: CreationAttribution | None = None,
     ) -> Workspace:
         """
         Create a new workspace for a project.
@@ -175,6 +177,8 @@ class WorkspaceService(Service, ABC):
             transaction: Database transaction for atomicity.
             target_branch: Diff/merge target branch. When None, a default is resolved
                 from the repo (origin's default branch, else local main/master).
+            created_by: Attribution for an agent-spawned workspace. None for
+                user-initiated creation.
 
         Returns:
             The created Workspace.

--- a/sculptor/sculptor/services/workspace_service/default_implementation.py
+++ b/sculptor/sculptor/services/workspace_service/default_implementation.py
@@ -15,6 +15,7 @@ from loguru import logger
 from pydantic import PrivateAttr
 
 from sculptor.config.settings import SculptorSettings
+from sculptor.database.models import CreationAttribution
 from sculptor.database.models import Project
 from sculptor.database.models import Workspace
 from sculptor.database.workspace_enums import DiffStatus
@@ -410,6 +411,7 @@ class DefaultWorkspaceService(WorkspaceService):
         description: str | None,
         transaction: DataModelTransaction,
         target_branch: str | None = None,
+        created_by: CreationAttribution | None = None,
     ) -> Workspace:
         """Create a new workspace for a project."""
         # Generate workspace description if not provided
@@ -451,6 +453,7 @@ class DefaultWorkspaceService(WorkspaceService):
             source_git_hash=source_git_hash,
             target_branch=target_branch,
             setup_status=initial_setup_status,
+            created_by=created_by,
         )
 
         logger.debug(

--- a/sculptor/sculptor/services/workspace_service/workspace_service_test.py
+++ b/sculptor/sculptor/services/workspace_service/workspace_service_test.py
@@ -14,6 +14,7 @@ from pydantic import PrivateAttr
 
 from sculptor.config.settings import SculptorSettings
 from sculptor.config.settings import TEST_LOG_PATH
+from sculptor.database.models import CreationAttribution
 from sculptor.database.models import Project
 from sculptor.database.workspace_enums import DiffStatus
 from sculptor.database.workspace_enums import WorkspaceInitializationStrategy
@@ -178,6 +179,56 @@ def test_create_workspace_clone(
     assert workspace is not None
     assert workspace.initialization_strategy == WorkspaceInitializationStrategy.CLONE
     assert workspace.source_branch == "feature-branch"
+
+
+def test_create_workspace_persists_creation_attribution(
+    test_service_collection: CompleteServiceCollection,
+    test_project: Project,
+) -> None:
+    """created_by round-trips through the JSON column so the sidebar can nest workspaces."""
+    creator_workspace_id = WorkspaceID()
+    creator_agent_id = TaskID()
+    with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
+        workspace = test_service_collection.workspace_service.create_workspace(
+            project=test_project,
+            initialization_strategy=WorkspaceInitializationStrategy.IN_PLACE,
+            source_branch=None,
+            requested_branch_name=None,
+            description="Attributed workspace",
+            transaction=transaction,
+            created_by=CreationAttribution(
+                created_by_workspace_id=creator_workspace_id,
+                created_by_agent_id=creator_agent_id,
+            ),
+        )
+        workspace_id = workspace.object_id
+
+    # Re-fetch in a fresh transaction to prove the attribution survives serialization.
+    with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
+        found_workspace = transaction.get_workspace(workspace_id)
+
+    assert found_workspace is not None
+    assert found_workspace.created_by is not None
+    assert found_workspace.created_by.created_by_workspace_id == creator_workspace_id
+    assert found_workspace.created_by.created_by_agent_id == creator_agent_id
+
+
+def test_create_workspace_defaults_creation_attribution_to_none(
+    test_service_collection: CompleteServiceCollection,
+    test_project: Project,
+) -> None:
+    """A user-initiated workspace has no attribution, so it sorts to the top of the sidebar."""
+    with test_service_collection.data_model_service.open_transaction(request_id=RequestID()) as transaction:
+        workspace = test_service_collection.workspace_service.create_workspace(
+            project=test_project,
+            initialization_strategy=WorkspaceInitializationStrategy.IN_PLACE,
+            source_branch=None,
+            requested_branch_name=None,
+            description="Unattributed workspace",
+            transaction=transaction,
+        )
+
+    assert workspace.created_by is None
 
 
 def test_create_workspace_generates_description_without_prefix(

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -755,6 +755,7 @@ def create_workspace_v2(
             description=workspace_request.description,
             transaction=transaction,
             target_branch=workspace_request.target_branch,
+            created_by=workspace_request.created_by,
         )
         update_most_recently_used_project(project_id=validated_project_id)
         logger.info("Created workspace {} for project {}", workspace.object_id, workspace_request.project_id)

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -13,6 +13,7 @@ from pydantic import Tag
 
 from sculptor.agents.pi_agent.provider_catalog import ProviderGroup
 from sculptor.config.settings import SculptorSettings
+from sculptor.database.models import CreationAttribution
 from sculptor.database.workspace_enums import WorkspaceInitializationStrategy
 from sculptor.foundation.pydantic_serialization import SerializableModel
 from sculptor.foundation.pydantic_serialization import build_discriminator
@@ -156,6 +157,11 @@ class CreateWorkspaceRequestV2(RequestModel):
     # Diff/merge target branch. When None, the backend resolves a sensible default
     # from the repo (origin's default branch, else local main/master).
     target_branch: str | None = None
+    # Attribution for agent-spawned workspaces: `sculpt workspace create` fills this
+    # from the calling agent's own SCULPT_WORKSPACE_ID / SCULPT_AGENT_ID. Left None
+    # for user-initiated creation via the UI, so the sidebar can nest agent-spawned
+    # workspaces under their creator and keep user-created ones on top.
+    created_by: CreationAttribution | None = None
 
 
 class UpdateWorkspaceRequest(RequestModel):

--- a/tools/sculpt/sculpt/commands/workspace.py
+++ b/tools/sculpt/sculpt/commands/workspace.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import httpx
 import typer
@@ -11,10 +12,13 @@ from sculpt.client.api.default import delete_workspace
 from sculpt.client.api.default import list_recent_workspaces
 from sculpt.client.api.default import list_workspaces
 from sculpt.client.api.default import update_workspace
+from sculpt.client.models.creation_attribution import CreationAttribution
 from sculpt.client.models.create_workspace_request_v2 import CreateWorkspaceRequestV2
 from sculpt.client.models.http_validation_error import HTTPValidationError
 from sculpt.client.models.recent_workspace_response import RecentWorkspaceResponse
 from sculpt.client.models.update_workspace_request import UpdateWorkspaceRequest
+from sculpt.client.types import UNSET
+from sculpt.client.types import Unset
 from sculpt.commands._workspace_helpers import STRATEGY_MAPPING
 from sculpt.commands._workspace_helpers import resolve_requested_branch_name
 from sculpt.commands._workspace_helpers import resolve_strategy
@@ -43,6 +47,26 @@ workspace_app = typer.Typer(
 _RECENT_REPO_DISPLAY_MAX_LENGTH = 30
 _RECENT_DESCRIPTION_DISPLAY_MAX_LENGTH = 30
 _PROJECT_DESCRIPTION_DISPLAY_MAX_LENGTH = 40
+
+
+def _resolve_creation_attribution() -> CreationAttribution | Unset:
+    """Record which workspace/agent spawned a new workspace, for sidebar nesting.
+
+    Sculptor injects SCULPT_WORKSPACE_ID (and, inside an agent, SCULPT_AGENT_ID) into
+    every workspace shell. When present, this command is running on behalf of an
+    existing workspace, so the new workspace is attributed to it and the UI nests it
+    beneath its creator. When absent — e.g. a user running `sculpt` from a plain
+    terminal — attribution is left unset and the workspace is treated as user-created
+    (it goes to the top of the sidebar).
+    """
+    workspace_id = os.environ.get("SCULPT_WORKSPACE_ID")
+    agent_id = os.environ.get("SCULPT_AGENT_ID")
+    if not workspace_id and not agent_id:
+        return UNSET
+    return CreationAttribution(
+        created_by_workspace_id=workspace_id if workspace_id else UNSET,
+        created_by_agent_id=agent_id if agent_id else UNSET,
+    )
 
 
 @workspace_app.command("create")
@@ -99,6 +123,7 @@ def create(
         description=name,
         requested_branch_name=resolved_branch_name,
         target_branch=target_branch,
+        created_by=_resolve_creation_attribution(),
     )
 
     try:

--- a/tools/sculpt/sculpt/commands/workspace.py
+++ b/tools/sculpt/sculpt/commands/workspace.py
@@ -61,10 +61,14 @@ def _resolve_creation_attribution() -> CreationAttribution | Unset:
     """
     workspace_id = os.environ.get("SCULPT_WORKSPACE_ID")
     agent_id = os.environ.get("SCULPT_AGENT_ID")
-    if not workspace_id and not agent_id:
+    # Attribution keys off the creating workspace — that's what drives the sidebar
+    # nesting — so without a workspace id there's nothing useful to record, even if
+    # an agent id is somehow present on its own (Sculptor always injects the two
+    # together, but guard against a stray SCULPT_AGENT_ID producing an orphan record).
+    if not workspace_id:
         return UNSET
     return CreationAttribution(
-        created_by_workspace_id=workspace_id if workspace_id else UNSET,
+        created_by_workspace_id=workspace_id,
         created_by_agent_id=agent_id if agent_id else UNSET,
     )
 

--- a/tools/sculpt/tests/unit/test_workspace.py
+++ b/tools/sculpt/tests/unit/test_workspace.py
@@ -258,6 +258,70 @@ class TestWorkspaceCreate:
         assert request_body["targetBranch"] == "feature"
 
     @respx.mock
+    def test_create_attributes_to_creating_workspace_and_agent(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When run from an agent shell, the new workspace records its creator."""
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_creator")
+        monkeypatch.setenv("SCULPT_AGENT_ID", "tsk_creator")
+        _mock_session()
+        _mock_initialize_project()
+        _mock_preview_branch_name()
+        create_route = respx.post("http://localhost:5050/api/v1/workspaces").mock(
+            return_value=Response(200, json=_workspace_response_dict())
+        )
+
+        result = runner.invoke(app, ["workspace", "create", "--repo", "/tmp/test"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        request_body = json.loads(create_route.calls[0].request.content)
+        assert request_body["createdBy"] == {
+            "createdByWorkspaceId": "ws_creator",
+            "createdByAgentId": "tsk_creator",
+        }
+
+    @respx.mock
+    def test_create_attributes_workspace_only_outside_an_agent(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """From a workspace terminal (not an agent), only the workspace id is attributed."""
+        monkeypatch.setenv("SCULPT_WORKSPACE_ID", "ws_creator")
+        monkeypatch.delenv("SCULPT_AGENT_ID", raising=False)
+        _mock_session()
+        _mock_initialize_project()
+        _mock_preview_branch_name()
+        create_route = respx.post("http://localhost:5050/api/v1/workspaces").mock(
+            return_value=Response(200, json=_workspace_response_dict())
+        )
+
+        result = runner.invoke(app, ["workspace", "create", "--repo", "/tmp/test"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        request_body = json.loads(create_route.calls[0].request.content)
+        assert request_body["createdBy"] == {"createdByWorkspaceId": "ws_creator"}
+        assert "createdByAgentId" not in request_body["createdBy"]
+
+    @respx.mock
+    def test_create_omits_attribution_without_env(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A plain-terminal create sends no attribution, so the workspace stays user-created."""
+        monkeypatch.delenv("SCULPT_WORKSPACE_ID", raising=False)
+        monkeypatch.delenv("SCULPT_AGENT_ID", raising=False)
+        _mock_session()
+        _mock_initialize_project()
+        _mock_preview_branch_name()
+        create_route = respx.post("http://localhost:5050/api/v1/workspaces").mock(
+            return_value=Response(200, json=_workspace_response_dict())
+        )
+
+        result = runner.invoke(app, ["workspace", "create", "--repo", "/tmp/test"])
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        request_body = json.loads(create_route.calls[0].request.content)
+        assert "createdBy" not in request_body
+
+    @respx.mock
     def test_create_invalid_strategy(self, runner: CliRunner) -> None:
         _mock_session()
         _mock_initialize_project()


### PR DESCRIPTION
## What & why

Makes newly-created workspaces easy to find in the sidebar, and gives agent-spawned workspaces a sensible home:

- **New workspaces sort to the top** of their repo group (newest-first by `createdAt`), so a freshly created workspace is immediately visible.
- **Workspaces spawned by an agent via `sculpt workspace create` nest directly under the workspace that created them**, instead of jumping to the top. User-created and unattributed workspaces have no creator and stay at the top level.

Doing the nesting required something that didn't exist before: **persisted creation attribution**. Until now a workspace made in the UI and one made by `sculpt` were byte-for-byte identical rows, and `sculpt workspace create` didn't even read its own workspace identity.

## How

- New embedded `CreationAttribution` model (`created_by_workspace_id`, `created_by_agent_id`) stored inline as a **nullable JSON column** `created_by` on `Workspace` — **not a foreign key**. SQLite FKs fight the two-table (`<name>` / `<name>_latest`) trigger design, so parentage lives inline as plain ids.
- Threaded through `CreateWorkspaceRequestV2` → `create_workspace_v2` → `WorkspaceService.create_workspace`.
- `sculpt workspace create` fills the attribution from the calling agent's own `SCULPT_WORKSPACE_ID` / `SCULPT_AGENT_ID`; the UI leaves it null.
- Frontend `sidebarWorkspaceOrder.ts`: the default within-group order is computed newest-first, with each workspace's children flattened directly beneath it (recursive, cycle-safe). Creator-in-another-repo, self-parent, and cycles all fall back to top-level. The existing persisted drag order is still layered on top.
- Alembic migration adds the JSON column to `workspace` and `workspace_latest`; frozen JSON-schema baseline regenerated; `created_by` added to `WORKSPACE_CREATION_ONLY_FIELDS` (set once at creation, never updated).

## Tests

- Frontend: newest-first ordering, nesting under creator, sibling ordering, recursive grandchildren, creator-in-other-repo → top-level, self-parent → top-level, cycle-safety.
- Backend: attribution round-trips through the JSON column; user-created workspace has null attribution.
- `sculpt` CLI: attribution from both env vars, from workspace-only (outside an agent), and omitted with no env.
- Migration data-preservation fixture.

`just format`, `just check`, `just test-unit` all green.

## Scope notes

- **Nesting is positional only** (no visual indent) — a deliberate product decision for this PR.
- **`created_by_agent_id` is stored but not yet consumed** — forward-looking; the symmetric agent-side attribution is **SCU-1796**.
- **Known edge:** the "new workspace at the top" default is layered *under* the persisted drag order, so in a repo group the user has already drag-reordered, a newly created workspace lands below the pinned block rather than at the very top. Documented in the source and tracked as **SCU-1812**.

Follow-ups: **SCU-1796** (agent/Task creation attribution), **SCU-1812** (new-at-top inside drag-ordered groups).

(Sent by Claude)
