### PR TITLE
Harden ClaudeOutputProcessor against notification-turn accounting hang

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -391,6 +391,33 @@ class ClaudeOutputProcessor:
         # turn.
         self._awaiting_notification_turn_init: bool = False
         self._pending_notification_turn_results: int = 0
+        # SCU-1770: ``_notification_reset_pending_result`` is set when a
+        # task-notification consumes found_final_message (the True→False reset
+        # above) and is cleared by the follow-up turn's ``system/init`` or by a
+        # ``result``. While set, the follow-up turn is ALREADY accounted for by
+        # the reset, so (a) further coalesced notifications in the same cluster
+        # must not add a second accounting via _awaiting_notification_turn_init,
+        # and (b) the init must not promote that flag into
+        # _pending_notification_turn_results. Without this, a cluster of
+        # notifications delivered as one follow-up turn (the CLI coalesces
+        # them) double-counts that turn — the counter then absorbs the
+        # invocation's real final result and the loop waits forever.
+        self._notification_reset_pending_result: bool = False
+        # SCU-1770 idle backstop: timestamp armed whenever found_final_message
+        # is knocked back to False at a turn boundary (the notification reset
+        # above, or the notification-turn result absorption in
+        # _parse_stream_end_response) — i.e. whenever the loop is waiting for a
+        # follow-up turn that cannot be locally guaranteed to arrive. Any
+        # parsed stream frame disarms it (the follow-up is arriving); if the
+        # CLI instead stays silent for the grace period with no pending
+        # background task or wakeup, the loop concludes the invocation is
+        # complete rather than waiting forever. Control-protocol frames
+        # (context-usage responses, permission requests) do NOT disarm it —
+        # the CLI emits those at turn boundaries without implying a follow-up
+        # turn.
+        self._notification_followup_armed_at: float | None = None
+        # Instance attribute (not a module constant) so tests can shrink it.
+        self._notification_followup_grace_seconds: float = 30.0
         # Last time we received any stdout line from the CLI. Used to detect
         # hangs where the CLI stops producing output after an interrupt.
         self._last_output_time: float = time.monotonic()
@@ -505,6 +532,39 @@ class ClaudeOutputProcessor:
                 self._flush_due_workflow_progress()
                 now = time.monotonic()
                 if not self.found_final_message:
+                    # SCU-1770 idle backstop: found_final_message was knocked
+                    # back to False at a turn boundary (a task-notification
+                    # reset or a notification-turn result absorption) and the
+                    # CLI has produced no stream frame since. The predicted
+                    # follow-up turn cannot be locally guaranteed to arrive
+                    # (notification/turn accounting is heuristic — see the
+                    # coalescing double-count this backstops); after the grace
+                    # period of true silence with nothing else pending,
+                    # conclude the invocation is complete so the loop exits
+                    # and the terminal RequestSuccess is emitted instead of
+                    # streaming forever. Long-running quiet tools are safe:
+                    # the backstop is only armed at turn boundaries and any
+                    # stream frame (e.g. the follow-up turn's init) disarms
+                    # it before such a tool can start.
+                    if (
+                        self._notification_followup_armed_at is not None
+                        and not self._pending_background_tasks
+                        and not self._pending_wakeup
+                        and now - self._notification_followup_armed_at >= self._notification_followup_grace_seconds
+                    ):
+                        logger.info(
+                            "Notification follow-up turn never arrived after {:.0f}s of silence; concluding the invocation is complete (pending_notification_turn_results={}, awaiting_notification_turn_init={})",
+                            now - self._notification_followup_armed_at,
+                            self._pending_notification_turn_results,
+                            self._awaiting_notification_turn_init,
+                        )
+                        self.found_final_message = True
+                        self._final_message_time = now
+                        self._pending_notification_turn_results = 0
+                        self._awaiting_notification_turn_init = False
+                        self._notification_reset_pending_result = False
+                        self._notification_followup_armed_at = None
+                        continue
                     # Detect hung CLI after interrupt: if we sent an interrupt
                     # but no stdout line has arrived for _idle_timeout_seconds
                     # and we never got the end-of-turn message, the CLI is
@@ -592,6 +652,16 @@ class ClaudeOutputProcessor:
             # requests and hook callbacks).
             if self._maybe_handle_control_request(line):
                 continue
+
+            # Any parsed stream frame disarms the notification-followup idle
+            # backstop: whatever follow-up activity the arming reset was
+            # waiting on is arriving (handlers re-arm at the next silent reset
+            # point). Deliberately placed AFTER the control-protocol
+            # short-circuits above — the CLI emits context-usage responses at
+            # turn boundaries without implying a follow-up turn, and such a
+            # frame must not defuse the backstop during the very silence it
+            # exists to detect. (SCU-1770)
+            self._notification_followup_armed_at = None
 
             # Detect the start of compaction from the system/status frame. This
             # fires for both auto-compaction and user-triggered `/compact` (sent
@@ -801,8 +871,18 @@ class ClaudeOutputProcessor:
                 #    for the latter.
                 if self.found_final_message:
                     self.found_final_message = False
+                    self._notification_reset_pending_result = True
+                    self._notification_followup_armed_at = time.monotonic()
                 else:
                     self._awaiting_notification_turn_init = True
+                    if self._notification_reset_pending_result:
+                        # Part of a coalesced cluster: an earlier notification
+                        # already reset found_final_message and the single
+                        # follow-up turn will answer the whole cluster. The
+                        # armed flag above will be discarded (not promoted) by
+                        # _parse_init_response; refresh the idle backstop while
+                        # the cluster keeps arriving. (SCU-1770)
+                        self._notification_followup_armed_at = time.monotonic()
                 # final_workflow_entries doubles as the workflow marker on the
                 # persisted notification: an empty tuple (not None) for a
                 # workflow that never reported a tree, so history replay can
@@ -1081,7 +1161,19 @@ class ClaudeOutputProcessor:
         # of the user's prompt (SCU-1660) rather than inline mid-turn. Promote
         # it to a pending notification-turn result so _parse_stream_end_response
         # skips that turn's result and keeps the loop open for the user's turn.
-        if self._awaiting_notification_turn_init:
+        #
+        # Exception (SCU-1770): when found_final_message is False because a
+        # notification RESET it (rather than because the user's turn is still
+        # running), this init IS the follow-up turn that the reset already
+        # accounts for. The CLI coalesces a cluster of notifications into that
+        # one follow-up turn; the cluster's later notifications armed
+        # _awaiting_notification_turn_init, and promoting it here would count
+        # the same turn twice — the counter then absorbs the invocation's real
+        # final result and the loop never exits.
+        if self._notification_reset_pending_result:
+            self._notification_reset_pending_result = False
+            self._awaiting_notification_turn_init = False
+        elif self._awaiting_notification_turn_init:
             self._awaiting_notification_turn_init = False
             self._pending_notification_turn_results += 1
 
@@ -1194,6 +1286,9 @@ class ClaudeOutputProcessor:
 
         self.found_final_message = True
         self._final_message_time = time.monotonic()
+        # A result answers any outstanding notification reset; a notification
+        # arriving after this point flips found_final_message afresh.
+        self._notification_reset_pending_result = False
 
         # SCU-1660: if this result terminates a task-notification turn the CLI
         # delivered ahead of the user's own message turn, it is not the end of
@@ -1202,6 +1297,9 @@ class ClaudeOutputProcessor:
         if self._pending_notification_turn_results > 0:
             self._pending_notification_turn_results -= 1
             self.found_final_message = False
+            # Waiting again for a turn that cannot be locally guaranteed to
+            # arrive — arm the idle backstop (SCU-1770).
+            self._notification_followup_armed_at = time.monotonic()
         # A notification that never started a fresh request cycle before this
         # result was an inline mid-turn notification (SCU-267), not a separate
         # turn — drop the pending classification so it doesn't leak into a later

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -653,16 +653,6 @@ class ClaudeOutputProcessor:
             if self._maybe_handle_control_request(line):
                 continue
 
-            # Any parsed stream frame disarms the notification-followup idle
-            # backstop: whatever follow-up activity the arming reset was
-            # waiting on is arriving (handlers re-arm at the next silent reset
-            # point). Deliberately placed AFTER the control-protocol
-            # short-circuits above — the CLI emits context-usage responses at
-            # turn boundaries without implying a follow-up turn, and such a
-            # frame must not defuse the backstop during the very silence it
-            # exists to detect. (SCU-1770)
-            self._notification_followup_armed_at = None
-
             # Detect the start of compaction from the system/status frame. This
             # fires for both auto-compaction and user-triggered `/compact` (sent
             # as a plain user message). For auto-compaction the PreCompact hook
@@ -746,6 +736,20 @@ class ClaudeOutputProcessor:
                 )
                 self.output_message_queue.put(warning)
                 continue
+
+            # A successfully parsed frame (even one the parser drops to None)
+            # is real CLI activity, so it disarms the notification-followup
+            # idle backstop: the follow-up turn the arming reset was waiting on
+            # is arriving (handlers re-arm at the next silent reset point).
+            # Placed AFTER the parse — a malformed/non-JSON line degrades to a
+            # warning via the except above and must NOT defuse the backstop
+            # during the very silence it exists to detect (recurring CLI debug
+            # output would otherwise keep it from ever firing). Control-protocol
+            # frames (context-usage responses, permission requests) are already
+            # excluded: they short-circuit with their own `continue` above,
+            # since the CLI emits them at turn boundaries without implying a
+            # follow-up turn. (SCU-1770)
+            self._notification_followup_armed_at = None
 
             if result is None:
                 continue

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -2171,6 +2171,35 @@ class TestNotificationCoalescingAndIdleBackstop:
         assert processor._pending_notification_turn_results == 0
 
     @pytest.mark.timeout(30)
+    def test_non_json_line_during_silence_does_not_defuse_backstop(self) -> None:
+        """A non-JSON stdout line (CLI debug output) is NOT a stream frame and
+        must not disarm the idle backstop. The loop tolerates such lines as a
+        warning; if one of them defused the backstop, a CLI that periodically
+        logs non-JSON noise faster than the grace period would keep the
+        backstop from ever firing and reintroduce the wait-forever hang."""
+        session_id = "s-noise"
+        frames = [
+            make_task_started_message(
+                task_id="sub-n", tool_use_id="toolu-n", description="N", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched.")]),
+            make_end_message(session_id=session_id),
+            make_task_notification_message(
+                task_id="sub-n", tool_use_id="toolu-n", status="completed", summary="N done"
+            ),
+        ]
+        processor, input_queue = self._build_idle_processor(frames, grace_seconds=0.3)
+        # A non-JSON debug line arrives after the notification and then the CLI
+        # goes silent. The backstop must still conclude the invocation.
+        input_queue.put(("Claude CLI debug: still working on it", True))
+
+        completed = processor._process_output()
+
+        assert completed is True
+        assert processor.found_final_message is True
+        assert processor._pending_notification_turn_results == 0
+
+    @pytest.mark.timeout(30)
     def test_inline_notification_mid_followup_turn_does_not_trigger_backstop(self) -> None:
         """An inline notification during an already-started follow-up turn must
         not arm the idle backstop: a long silent tool in that turn would

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from queue import Queue
 from threading import Event
+from threading import Thread
 from unittest.mock import MagicMock
 
 import pytest
@@ -1622,8 +1623,10 @@ class TestPartialAndPersistenceShapeEquality:
         assert tuple(current) == persistence
 
 
-def _run_process_output(jsonl_dicts: list[dict]) -> list:
-    """Feed JSONL dicts through the real ``_process_output`` loop and return emitted messages.
+def _run_process_output_returning_processor(jsonl_dicts: list[dict]) -> tuple[list, ClaudeOutputProcessor]:
+    """Feed JSONL dicts through the real ``_process_output`` loop and return
+    (emitted messages, the processor) so tests can also assert on the
+    processor's final accounting state.
 
     Unlike ``_feed_jsonl`` (which mirrors only a subset of the dispatch), this
     pre-populates the process's stdout queue and runs the production
@@ -1652,7 +1655,14 @@ def _run_process_output(jsonl_dicts: list[dict]) -> list:
         streaming_enabled=True,
     )
     processor._process_output()
-    return _drain_queue(processor.output_message_queue)
+    return _drain_queue(processor.output_message_queue), processor
+
+
+def _run_process_output(jsonl_dicts: list[dict]) -> list:
+    """Like ``_run_process_output_returning_processor`` but returns only the
+    emitted messages."""
+    emitted, _ = _run_process_output_returning_processor(jsonl_dicts)
+    return emitted
 
 
 def _collect_tool_ids(messages: Iterable) -> set[str]:
@@ -2026,3 +2036,183 @@ class TestNotificationTurnBeforeUserTurn:
         assert continuation_text in _collect_text(chat_messages), (
             "the user turn's post-tool continuation never reached the chat: the turn was terminated after its first tool result"
         )
+
+
+class TestNotificationCoalescingAndIdleBackstop:
+    """Regression tests for SCU-1770: coalesced task-notifications must not
+    double-count their single follow-up turn, and a follow-up turn that never
+    arrives must not park the output loop forever.
+
+    The CLI can deliver a CLUSTER of task_notifications (one per completed
+    background task) followed by a SINGLE follow-up turn (one init → assistant
+    → result) that responds to all of them. The first notification of the
+    cluster resets ``found_final_message`` (accounting for that follow-up
+    turn); the later notifications used to arm
+    ``_awaiting_notification_turn_init``, which the init then promoted into
+    ``_pending_notification_turn_results`` — counting the SAME follow-up turn a
+    second time. The counter then absorbed the invocation's real final result,
+    and each later notification cycle re-incremented it, so the off-by-one
+    self-perpetuated and the loop waited forever: an orphaned RequestStarted
+    and a UI that streams until the user interrupts.
+    """
+
+    @staticmethod
+    def _incident_frame_sequence() -> list[dict]:
+        """The production frame shape: a user turn launches seven subagents;
+        five completions arrive as one coalesced cluster with a single
+        follow-up turn; a sixth completes with its own follow-up turn; the
+        seventh's notification arrives INLINE mid-follow-up-turn (no init of
+        its own)."""
+        session_id = "session_scu1770"
+        frames: list[dict] = [
+            make_task_started_message(
+                task_id=f"sub-{i}", tool_use_id=f"toolu-{i}", description=f"Explore {i}", task_type="local_agent"
+            )
+            for i in range(7)
+        ]
+        frames.append(make_assistant_message("msg-main", [make_text_block("Dispatched seven subagents.")]))
+        frames.append(make_end_message(session_id=session_id))
+        # Five completions coalesced into ONE follow-up turn.
+        for i in range(5):
+            frames.append(
+                make_task_notification_message(
+                    task_id=f"sub-{i}", tool_use_id=f"toolu-{i}", status="completed", summary=f"done {i}"
+                )
+            )
+        frames.append(make_init_message(session_id=session_id))
+        frames.append(make_assistant_message("msg-cluster", [make_text_block("CLUSTER-SYNTHESIS")]))
+        frames.append(make_end_message(session_id=session_id))
+        # Sixth task: its own notification + follow-up turn, which also
+        # receives the seventh task's notification inline (no init).
+        frames.append(
+            make_task_notification_message(
+                task_id="sub-5", tool_use_id="toolu-5", status="completed", summary="done 5"
+            )
+        )
+        frames.append(make_init_message(session_id=session_id))
+        frames.append(
+            make_task_notification_message(
+                task_id="sub-6", tool_use_id="toolu-6", status="completed", summary="done 6"
+            )
+        )
+        frames.append(make_assistant_message("msg-final", [make_text_block("FINAL-SYNTHESIS")]))
+        frames.append(make_end_message(session_id=session_id))
+        return frames
+
+    # Timeout guard: without the fix these exercise the exact infinite-wait
+    # bug (the output loop never concludes), so bound them so a regression
+    # fails CI fast instead of hanging the whole suite.
+    @pytest.mark.timeout(30)
+    def test_coalesced_notifications_do_not_absorb_the_final_result(self) -> None:
+        """After the full incident sequence the loop must conclude the
+        invocation is complete: found_final_message True with no leftover
+        pending notification-turn results. Before the fix the coalescing
+        double-count left found_final_message False (the real final result was
+        absorbed) and the invocation waited forever."""
+        emitted, processor = _run_process_output_returning_processor(self._incident_frame_sequence())
+
+        assert processor.found_final_message is True
+        assert processor._pending_notification_turn_results == 0
+        text = _collect_text(emitted)
+        assert "CLUSTER-SYNTHESIS" in text
+        assert "FINAL-SYNTHESIS" in text
+
+    @staticmethod
+    def _build_idle_processor(frames: list[dict], grace_seconds: float) -> tuple[ClaudeOutputProcessor, Queue]:
+        """Processor over a live (not finished) process whose queue holds the
+        given frames. ``is_finished`` reports the processor's own
+        found_final_message: False during the silent wait (so the loop keeps
+        idling instead of exiting on queue-drained), True once the turn
+        concludes (so the post-loop context-usage drain returns immediately
+        instead of burning its full timeout)."""
+        input_queue: Queue = Queue()
+        for d in frames:
+            input_queue.put((json.dumps(d), True))
+        mock_process = MagicMock()
+        mock_process.get_queue.return_value = input_queue
+        processor = ClaudeOutputProcessor(
+            process=mock_process,
+            source_command="test",
+            output_message_queue=Queue(),
+            environment=MagicMock(),
+            diff_tracker=None,
+            task_id=TaskID(),
+            session_id_written_event=Event(),
+            harness=CLAUDE_CODE_HARNESS,
+            streaming_enabled=True,
+        )
+        processor._notification_followup_grace_seconds = grace_seconds
+        mock_process.is_finished.side_effect = lambda: processor.found_final_message
+        return processor, input_queue
+
+    @pytest.mark.timeout(30)
+    def test_idle_backstop_concludes_invocation_when_followup_never_arrives(self) -> None:
+        """A notification resets found_final_message and then nothing follows:
+        the idle backstop must conclude the invocation after the grace period
+        instead of waiting forever."""
+        session_id = "s-backstop"
+        frames = [
+            make_task_started_message(
+                task_id="sub-x", tool_use_id="toolu-x", description="X", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched.")]),
+            make_end_message(session_id=session_id),
+            make_task_notification_message(
+                task_id="sub-x", tool_use_id="toolu-x", status="completed", summary="X done"
+            ),
+            # No follow-up init/assistant/result ever arrives.
+        ]
+        processor, _ = self._build_idle_processor(frames, grace_seconds=0.3)
+
+        completed = processor._process_output()
+
+        assert completed is True
+        assert processor.found_final_message is True
+        assert processor._pending_notification_turn_results == 0
+
+    @pytest.mark.timeout(30)
+    def test_inline_notification_mid_followup_turn_does_not_trigger_backstop(self) -> None:
+        """An inline notification during an already-started follow-up turn must
+        not arm the idle backstop: a long silent tool in that turn would
+        otherwise trip it and tear the invocation down mid-turn. The sleep here
+        is 3x the grace period, so an incorrectly armed backstop fires during
+        it and the late content goes missing."""
+        session_id = "s-inline"
+        pre_silence = [
+            make_task_started_message(
+                task_id="sub-a", tool_use_id="toolu-a", description="A", task_type="local_agent"
+            ),
+            make_task_started_message(
+                task_id="sub-b", tool_use_id="toolu-b", description="B", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched two.")]),
+            make_end_message(session_id=session_id),
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_init_message(session_id=session_id),
+            # Inline notification mid-follow-up-turn: no init of its own.
+            make_task_notification_message(
+                task_id="sub-b", tool_use_id="toolu-b", status="completed", summary="B done"
+            ),
+            # ... the turn now runs a long, silent tool ...
+        ]
+        post_silence = [
+            make_assistant_message("msg-late", [make_text_block("LATE-TOOL-SYNTHESIS")]),
+            make_end_message(session_id=session_id),
+        ]
+        grace_seconds = 0.2
+        processor, input_queue = self._build_idle_processor(pre_silence, grace_seconds=grace_seconds)
+
+        def feed_late_frames() -> None:
+            time.sleep(grace_seconds * 3)
+            for d in post_silence:
+                input_queue.put((json.dumps(d), True))
+
+        feeder = Thread(target=feed_late_frames)
+        feeder.start()
+        completed = processor._process_output()
+        feeder.join()
+
+        assert completed is True
+        assert "LATE-TOOL-SYNTHESIS" in _collect_text(_drain_queue(processor.output_message_queue))


### PR DESCRIPTION
## Summary

Fixes the "stuck streaming" bug (SCU-1770, the now-active fix ticket for SCU-1767): a chat turn finishes cleanly — full streamed response, finalized `ResponseBlock`, and `TurnMetrics` all persisted — yet its terminal `RequestSuccess` is never persisted. That leaves an orphaned `RequestStarted` in the persisted message stream, which the frontend reads as "streaming" **forever**. It survives reloads/reconnects (it's in the persisted stream, not a live-connection flag), so the only recovery is a manual interrupt.

Bumping the Claude CLI floor to 2.1.202 (PR #306) removed one *trigger* but left the underlying accounting fragility in place — and it **reproduced in production on 2.1.202** (twice in one day), on ordinary subagent/background-heavy turns with no interrupt involved.

## Root cause

The notification-turn accounting that keeps the output loop open across task-notification turns the CLI delivers ahead of the user's own turn (SCU-1660) double-counts when the CLI **coalesces a cluster of task-notifications into a single follow-up turn**:

- the first notification of the cluster resets `found_final_message` (accounting for that follow-up turn), and
- the follow-up turn's `init` then *also* promotes the awaiting-init flag into `_pending_notification_turn_results` — counting the same turn a second time.

The off-by-one absorbs the invocation's real final `result`, each later notification cycle re-incurs it, and the loop waits forever for a follow-up turn that never comes.

## Fix (defense in depth)

- **Coalescing double-count fix** — a new `_notification_reset_pending_result` flag records that a notification already reset `found_final_message`. While set, the coalesced cluster's follow-up-turn `init` is not promoted a second time into the pending-result counter. Cleared by that `init` and by any `result`.
- **Idle backstop** — whenever `found_final_message` is knocked back to `False` at a turn boundary, arm a timestamp. Any parsed **stream** frame disarms it, so a legit follow-up turn (even one running a long, silent tool) is never cut short. If the CLI instead stays silent for a grace period (30s) with no pending background task or wakeup, conclude the invocation is complete and emit the terminal `RequestSuccess`. Control-protocol frames (context-usage responses, permission requests) deliberately do **not** disarm it, since the CLI emits those at turn boundaries without implying a follow-up turn.

The backstop fires only on true silence, so it adds ~zero latency to the legit SCU-1660 flow.

## Tests

New `TestNotificationCoalescingAndIdleBackstop` class:
- **Incident replay** of the production frame shape (a user turn launching seven subagents; five completions coalesced into one follow-up turn; a sixth with its own turn; the seventh inline). This hangs the output loop *before* the fix — verified.
- **Idle-backstop recovery** — a follow-up turn that never arrives is concluded after the grace period.
- **Inline-notification safety** — an inline notification mid-follow-up-turn must not arm the backstop and tear down a long, silent tool turn.

All three are bounded with `@pytest.mark.timeout` so a future regression fails CI fast instead of hanging the suite.

Local validation: `just format`, `just check`, the full `output_processor_test.py` (67 passed), and the full backend unit suite (2232 passed, 4 skipped) — all green.

Refs SCU-1770, SCU-1767.

(Sent by Claude)