### PR TITLE
[SCU-1793] Sort workspace switcher by attention and tag cross-project rows

### DIFF
--- a/sculptor/frontend/src/components/CommandPalette/CommandPalette.module.scss
+++ b/sculptor/frontend/src/components/CommandPalette/CommandPalette.module.scss
@@ -286,27 +286,15 @@
   color: var(--gray-11);
 }
 
-// Quiet right-aligned annotation pill (e.g. the switcher's cross-project
-// tag). Muted so it reads as context, not a focal point; the rounded chip
-// with a faint fill distinguishes it from the plain-text kind/shortcut
-// labels that share the trailing slot.
+// Right-aligned annotation pill (the switcher's cross-project tag). A Radix
+// soft-gray Badge provides the quiet chip styling; this only bounds and
+// truncates a long project name so it can't crowd the row.
 .itemBadge {
-  background: var(--gray-a3);
-  border-radius: var(--radius-2);
-  color: var(--gray-10);
   flex-shrink: 0;
-  font-size: var(--font-size-1);
-  font-weight: var(--font-weight-regular);
-  line-height: 1;
   max-width: 12rem;
   overflow: hidden;
-  padding: var(--space-1) var(--space-2);
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.item[data-selected="true"] .itemBadge {
-  color: var(--gray-11);
 }
 
 // Per-row shortcut hint, shown at the right edge of the row. Mirrors

--- a/sculptor/frontend/src/components/CommandPalette/CommandPalette.module.scss
+++ b/sculptor/frontend/src/components/CommandPalette/CommandPalette.module.scss
@@ -286,6 +286,29 @@
   color: var(--gray-11);
 }
 
+// Quiet right-aligned annotation pill (e.g. the switcher's cross-project
+// tag). Muted so it reads as context, not a focal point; the rounded chip
+// with a faint fill distinguishes it from the plain-text kind/shortcut
+// labels that share the trailing slot.
+.itemBadge {
+  background: var(--gray-a3);
+  border-radius: var(--radius-2);
+  color: var(--gray-10);
+  flex-shrink: 0;
+  font-size: var(--font-size-1);
+  font-weight: var(--font-weight-regular);
+  line-height: 1;
+  max-width: 12rem;
+  overflow: hidden;
+  padding: var(--space-1) var(--space-2);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item[data-selected="true"] .itemBadge {
+  color: var(--gray-11);
+}
+
 // Per-row shortcut hint, shown at the right edge of the row. Mirrors
 // the chat input's `<KeyboardHint>` styling: inherited system font (no
 // monospace, no bold) so the platform's modifier-glyph rendering kicks

--- a/sculptor/frontend/src/components/CommandPalette/CommandPalette.tsx
+++ b/sculptor/frontend/src/components/CommandPalette/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { IconButton, Spinner, Tooltip, VisuallyHidden } from "@radix-ui/themes";
+import { Badge, IconButton, Spinner, Tooltip, VisuallyHidden } from "@radix-ui/themes";
 import { Command } from "cmdk";
 import { useAtom, useAtomValue, useStore } from "jotai";
 import { ChevronRightIcon, SearchIcon, XIcon } from "lucide-react";
@@ -108,6 +108,10 @@ const PaletteRow = ({
       <div className={styles.itemBody}>
         <span className={styles.itemTitle}>{displayTitle}</span>
         {displaySubtitle ? <span className={styles.itemSubtitle}>{displaySubtitle}</span> : null}
+        {/* The visible trailing badge lives in an aria-hidden slot, so surface
+            the same project context to assistive tech here — otherwise two
+            same-named workspaces in different projects are indistinguishable. */}
+        {command.trailingBadge ? <VisuallyHidden>{`Project: ${command.trailingBadge}`}</VisuallyHidden> : null}
       </div>
       {/* Trailing slot is fixed-min-width so swapping spinner <-> shortcut
           / kind label doesn't cause a layout shift. Shortcut hint takes
@@ -118,7 +122,11 @@ const PaletteRow = ({
           <Spinner size="1" />
         ) : (
           <>
-            {command.trailingBadge ? <span className={styles.itemBadge}>{command.trailingBadge}</span> : null}
+            {command.trailingBadge ? (
+              <Badge variant="soft" color="gray" size="1" className={styles.itemBadge}>
+                {command.trailingBadge}
+              </Badge>
+            ) : null}
             {binding ? (
               <ShortcutHint binding={binding} />
             ) : kind ? (

--- a/sculptor/frontend/src/components/CommandPalette/CommandPalette.tsx
+++ b/sculptor/frontend/src/components/CommandPalette/CommandPalette.tsx
@@ -118,6 +118,7 @@ const PaletteRow = ({
           <Spinner size="1" />
         ) : (
           <>
+            {command.trailingBadge ? <span className={styles.itemBadge}>{command.trailingBadge}</span> : null}
             {binding ? (
               <ShortcutHint binding={binding} />
             ) : kind ? (

--- a/sculptor/frontend/src/components/CommandPalette/__tests__/dynamicProviders.test.ts
+++ b/sculptor/frontend/src/components/CommandPalette/__tests__/dynamicProviders.test.ts
@@ -1,8 +1,10 @@
 import { getDefaultStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { CodingAgentTaskView, UserConfig, Workspace } from "../../../api";
+import type { CodingAgentTaskView, Project, UserConfig, Workspace } from "../../../api";
+import { TaskStatus } from "../../../api";
 import { encodeRegisteredAgentType } from "../../../common/state/atoms/agentTabs.ts";
+import { projectAtomFamily, projectIdsAtom } from "../../../common/state/atoms/projects.ts";
 import { taskAtomFamily, taskIdsAtom } from "../../../common/state/atoms/tasks.ts";
 import { userConfigAtom } from "../../../common/state/atoms/userConfig.ts";
 import { workspaceAtomFamily, workspaceIdsAtom } from "../../../common/state/atoms/workspaces.ts";
@@ -74,8 +76,55 @@ const seedWorkspace = (id: string, description: string): void => {
   store.set(workspaceAtomFamily(id), { objectId: id, description, isOpen: true } as unknown as Workspace);
 };
 
+// Variant of seedWorkspace that also stamps projectId + createdAt, for the
+// cross-project / recency ordering tests.
+const seedWorkspaceIn = (id: string, description: string, projectId: string, createdAt?: string): void => {
+  getDefaultStore().set(workspaceAtomFamily(id), {
+    objectId: id,
+    description,
+    isOpen: true,
+    projectId,
+    createdAt,
+  } as unknown as Workspace);
+};
+
 const setWorkspaceIds = (ids: Array<string>): void => {
   getDefaultStore().set(workspaceIdsAtom, ids);
+};
+
+const seedProjects = (projects: Array<{ id: string; name: string }>): void => {
+  const store = getDefaultStore();
+  for (const p of projects) {
+    // The provider only reads objectId/name; projectsArrayAtom's URL-dedupe
+    // keeps entries with no userGitRepoUrl, so a bare partial is enough.
+    store.set(projectAtomFamily(p.id), { objectId: p.id, name: p.name } as unknown as Project);
+  }
+  store.set(
+    projectIdsAtom,
+    projects.map((p) => p.id),
+  );
+};
+
+// Seed tasks carrying the status/read fields the attention ranking reads
+// (setTasks above only carries the title/prompt fields the agent tests need).
+const seedAttentionTasks = (
+  tasks: Array<{ id: string; workspaceId: string; status: TaskStatus; updatedAt: string; lastReadAt: string | null }>,
+): void => {
+  const store = getDefaultStore();
+  for (const t of tasks) {
+    store.set(taskAtomFamily(t.id), {
+      id: t.id,
+      workspaceId: t.workspaceId,
+      status: t.status,
+      updatedAt: t.updatedAt,
+      lastReadAt: t.lastReadAt,
+      isDeleted: false,
+    } as unknown as CodingAgentTaskView);
+  }
+  store.set(
+    taskIdsAtom,
+    tasks.map((t) => t.id),
+  );
 };
 
 const setTasks = (
@@ -107,6 +156,7 @@ const setTasks = (
 beforeEach(() => {
   setWorkspaceIds([]);
   setTasks([]);
+  seedProjects([]);
 });
 
 afterEach(() => {
@@ -188,6 +238,86 @@ describe("buildWorkspaceProvider", () => {
     setWorkspaceIds(["ws1", "ws2"]);
     const cmds = buildWorkspaceProvider(makeRuntime()).produce(ROOT_CTX);
     expect(cmds.find((c) => c.id.startsWith("workspaces.go."))).toBeUndefined();
+  });
+
+  const OLDER = "2024-01-01T00:00:00.000Z";
+  const NEWER = "2024-01-02T00:00:00.000Z";
+  const orderOf = (cmds: ReturnType<ReturnType<typeof buildWorkspaceProvider>["produce"]>, id: string): number =>
+    cmds.find((c) => c.id === `workspaces.page.${id}`)?.order ?? Number.POSITIVE_INFINITY;
+
+  it("sorts attention-needing workspaces above idle ones via `order`", () => {
+    seedWorkspaceIn("idle", "Idle", "pA");
+    seedWorkspaceIn("waiting", "Waiting", "pA");
+    setWorkspaceIds(["idle", "waiting"]);
+    seedAttentionTasks([
+      { id: "t-idle", workspaceId: "idle", status: TaskStatus.READY, updatedAt: OLDER, lastReadAt: NEWER },
+      { id: "t-wait", workspaceId: "waiting", status: TaskStatus.WAITING, updatedAt: OLDER, lastReadAt: OLDER },
+    ]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce(PAGE_WS_CTX);
+    expect(orderOf(cmds, "waiting")).toBeLessThan(orderOf(cmds, "idle"));
+  });
+
+  it("breaks ties within a tier by recency (newest activity first)", () => {
+    seedWorkspaceIn("stale", "Stale", "pA");
+    seedWorkspaceIn("fresh", "Fresh", "pA");
+    setWorkspaceIds(["stale", "fresh"]);
+    seedAttentionTasks([
+      { id: "t-stale", workspaceId: "stale", status: TaskStatus.READY, updatedAt: OLDER, lastReadAt: NEWER },
+      { id: "t-fresh", workspaceId: "fresh", status: TaskStatus.READY, updatedAt: NEWER, lastReadAt: NEWER },
+    ]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce(PAGE_WS_CTX);
+    expect(orderOf(cmds, "fresh")).toBeLessThan(orderOf(cmds, "stale"));
+  });
+
+  it("keeps an already-viewed error out of the top tier (acked error → idle)", () => {
+    seedWorkspaceIn("ackedError", "Seen error", "pA");
+    seedWorkspaceIn("unread", "Fresh reply", "pA");
+    setWorkspaceIds(["ackedError", "unread"]);
+    seedAttentionTasks([
+      // Errored but viewed after it broke → drops below the unread reply.
+      { id: "t-err", workspaceId: "ackedError", status: TaskStatus.ERROR, updatedAt: OLDER, lastReadAt: NEWER },
+      { id: "t-unread", workspaceId: "unread", status: TaskStatus.READY, updatedAt: NEWER, lastReadAt: OLDER },
+    ]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce(PAGE_WS_CTX);
+    expect(orderOf(cmds, "unread")).toBeLessThan(orderOf(cmds, "ackedError"));
+  });
+
+  it("tags every row with its project when the list spans projects and there is no current one", () => {
+    seedWorkspaceIn("ws1", "One", "pA");
+    seedWorkspaceIn("ws2", "Two", "pB");
+    setWorkspaceIds(["ws1", "ws2"]);
+    seedProjects([
+      { id: "pA", name: "Alpha" },
+      { id: "pB", name: "Beta" },
+    ]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce(ROOT_CTX);
+    expect(cmds.find((c) => c.id === "workspaces.page.ws1")?.trailingBadge).toBe("Alpha");
+    expect(cmds.find((c) => c.id === "workspaces.page.ws2")?.trailingBadge).toBe("Beta");
+  });
+
+  it("only tags rows from a different project than the current one", () => {
+    seedWorkspaceIn("cur", "Current", "pA");
+    seedWorkspaceIn("same", "Same project", "pA");
+    seedWorkspaceIn("other", "Other project", "pB");
+    setWorkspaceIds(["cur", "same", "other"]);
+    seedProjects([
+      { id: "pA", name: "Alpha" },
+      { id: "pB", name: "Beta" },
+    ]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce({ ...ROOT_CTX, activeWorkspaceId: "cur" });
+    expect(cmds.find((c) => c.id === "workspaces.page.cur")?.trailingBadge).toBeUndefined();
+    expect(cmds.find((c) => c.id === "workspaces.page.same")?.trailingBadge).toBeUndefined();
+    expect(cmds.find((c) => c.id === "workspaces.page.other")?.trailingBadge).toBe("Beta");
+  });
+
+  it("shows no project badges when every workspace shares one project", () => {
+    seedWorkspaceIn("ws1", "One", "pA");
+    seedWorkspaceIn("ws2", "Two", "pA");
+    setWorkspaceIds(["ws1", "ws2"]);
+    seedProjects([{ id: "pA", name: "Alpha" }]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce(ROOT_CTX);
+    expect(cmds.find((c) => c.id === "workspaces.page.ws1")?.trailingBadge).toBeUndefined();
+    expect(cmds.find((c) => c.id === "workspaces.page.ws2")?.trailingBadge).toBeUndefined();
   });
 });
 

--- a/sculptor/frontend/src/components/CommandPalette/__tests__/dynamicProviders.test.ts
+++ b/sculptor/frontend/src/components/CommandPalette/__tests__/dynamicProviders.test.ts
@@ -319,6 +319,18 @@ describe("buildWorkspaceProvider", () => {
     expect(cmds.find((c) => c.id === "workspaces.page.ws1")?.trailingBadge).toBeUndefined();
     expect(cmds.find((c) => c.id === "workspaces.page.ws2")?.trailingBadge).toBeUndefined();
   });
+
+  it("omits the badge for a row whose project record hasn't loaded", () => {
+    // Two distinct projects (so badges are in play), but only pA's record is
+    // loaded — the pB row has no resolvable name, so it must not be tagged.
+    seedWorkspaceIn("ws1", "One", "pA");
+    seedWorkspaceIn("ws2", "Two", "pB");
+    setWorkspaceIds(["ws1", "ws2"]);
+    seedProjects([{ id: "pA", name: "Alpha" }]);
+    const cmds = buildWorkspaceProvider(makeRuntime()).produce(ROOT_CTX);
+    expect(cmds.find((c) => c.id === "workspaces.page.ws1")?.trailingBadge).toBe("Alpha");
+    expect(cmds.find((c) => c.id === "workspaces.page.ws2")?.trailingBadge).toBeUndefined();
+  });
 });
 
 describe("buildAgentProvider", () => {

--- a/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceCommands.tsx
+++ b/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceCommands.tsx
@@ -24,6 +24,9 @@ const latestActivityMs = (tasks: ReadonlyArray<CodingAgentTaskView>, ws: Workspa
   let best = ws.createdAt ? Date.parse(ws.createdAt) : 0;
   if (Number.isNaN(best)) best = 0;
   for (const task of tasks) {
+    // Skip deleted tasks so the recency tiebreak counts the same tasks the
+    // attention rank does (getWorkspaceAttentionRank filters them out too).
+    if (task.isDeleted) continue;
     const ts = Date.parse(task.updatedAt);
     if (!Number.isNaN(ts) && ts > best) best = ts;
   }

--- a/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceCommands.tsx
+++ b/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceCommands.tsx
@@ -21,12 +21,11 @@ const workspaceName = (description: string | undefined): string => (description 
  * missing timestamps collapse to 0 (sorts last within the tier).
  */
 const latestActivityMs = (tasks: ReadonlyArray<CodingAgentTaskView>, ws: Workspace): number => {
+  // Callers pass the workspace's already-active tasks (see the per-workspace
+  // bucket in produce()), so this just takes the newest of them.
   let best = ws.createdAt ? Date.parse(ws.createdAt) : 0;
   if (Number.isNaN(best)) best = 0;
   for (const task of tasks) {
-    // Skip deleted tasks so the recency tiebreak counts the same tasks the
-    // attention rank does (getWorkspaceAttentionRank filters them out too).
-    if (task.isDeleted) continue;
     const ts = Date.parse(task.updatedAt);
     if (!Number.isNaN(ts) && ts > best) best = ts;
   }
@@ -88,13 +87,26 @@ export const buildWorkspaceProvider = (runtime: CommandRuntime): DynamicProvider
       // more than one project — otherwise every row carries a redundant tag.
       const hasMultipleProjects = new Set(workspaces.map((ws) => ws.projectId)).size > 1;
 
+      // Bucket tasks by workspace in a single pass rather than re-scanning the
+      // whole task list once per workspace (O(workspaces × tasks) every time
+      // produce() re-runs — i.e. on every palette keystroke). Deleted tasks are
+      // dropped here so the attention rank and the recency tiebreak below count
+      // the exact same tasks.
+      const tasksByWorkspace = new Map<string, Array<CodingAgentTaskView>>();
+      for (const task of tasks) {
+        if (task.isDeleted || task.workspaceId === null) continue;
+        const bucket = tasksByWorkspace.get(task.workspaceId);
+        if (bucket) bucket.push(task);
+        else tasksByWorkspace.set(task.workspaceId, [task]);
+      }
+
       // Attention-first ordering, most-recent activity as the in-tier
       // tiebreak. We sort here and emit the result through each row's `order`
       // field so groupCommands honours it on the empty-query switcher page;
       // once the user types, cmdk re-ranks by fuzzy score as usual.
       const ordered = workspaces
         .map((ws) => {
-          const wsTasks = tasks.filter((task) => task.workspaceId === ws.objectId);
+          const wsTasks = tasksByWorkspace.get(ws.objectId) ?? [];
           return { ws, rank: getWorkspaceAttentionRank(wsTasks), recencyMs: latestActivityMs(wsTasks, ws) };
         })
         .sort((a, b) => {

--- a/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceCommands.tsx
+++ b/sculptor/frontend/src/components/CommandPalette/dynamic/workspaceCommands.tsx
@@ -2,14 +2,33 @@ import { useAtomValue } from "jotai";
 import { ArrowUpRight } from "lucide-react";
 import { type ReactElement, useMemo } from "react";
 
+import type { CodingAgentTaskView, Workspace } from "../../../api";
+import { projectsArrayAtom } from "../../../common/state/atoms/projects.ts";
 import { tasksArrayAtom } from "../../../common/state/atoms/tasks.ts";
 import { workspacesArrayAtom } from "../../../common/state/atoms/workspaces.ts";
 import { WorkspaceStatusDots } from "../../statusDot";
-import { computeWorkspaceDotStatus } from "../../statusDot/statusUtils.ts";
+import { computeWorkspaceDotStatus, getWorkspaceAttentionRank } from "../../statusDot/statusUtils.ts";
 import type { CommandRuntime } from "../runtime.ts";
 import type { Command, CommandIcon, DynamicProvider } from "../types.ts";
 
 const workspaceName = (description: string | undefined): string => (description ?? "").trim() || "Untitled";
+
+/**
+ * Millisecond timestamp of a workspace's most recent activity, used as the
+ * recency tiebreak within an attention tier. There is no workspace-level
+ * "last activity" field, so we take the newest task `updatedAt` and fall back
+ * to the workspace's own `createdAt` for task-less workspaces. Unparseable /
+ * missing timestamps collapse to 0 (sorts last within the tier).
+ */
+const latestActivityMs = (tasks: ReadonlyArray<CodingAgentTaskView>, ws: Workspace): number => {
+  let best = ws.createdAt ? Date.parse(ws.createdAt) : 0;
+  if (Number.isNaN(best)) best = 0;
+  for (const task of tasks) {
+    const ts = Date.parse(task.updatedAt);
+    if (!Number.isNaN(ts) && ts > best) best = ts;
+  }
+  return best;
+};
 
 /**
  * Surfaces every open workspace in the palette so the user can jump to any
@@ -52,6 +71,35 @@ export const buildWorkspaceProvider = (runtime: CommandRuntime): DynamicProvider
       const workspaces = runtime.store.get(workspacesArrayAtom) ?? [];
       if (workspaces.length === 0) return [];
 
+      const tasks = runtime.store.get(tasksArrayAtom) ?? [];
+      const projects = runtime.store.get(projectsArrayAtom) ?? [];
+      const projectNameById = new Map<string, string>();
+      for (const project of projects) projectNameById.set(project.objectId, project.name);
+
+      // The project the user is currently in, or null. Cmd+K can be opened from
+      // settings / home where there is no active workspace, so this is often
+      // null — every downstream use guards against that.
+      const currentProjectId = workspaces.find((ws) => ws.objectId === ctx.activeWorkspaceId)?.projectId ?? null;
+
+      // Cross-project badges only earn their keep when the list actually spans
+      // more than one project — otherwise every row carries a redundant tag.
+      const hasMultipleProjects = new Set(workspaces.map((ws) => ws.projectId)).size > 1;
+
+      // Attention-first ordering, most-recent activity as the in-tier
+      // tiebreak. We sort here and emit the result through each row's `order`
+      // field so groupCommands honours it on the empty-query switcher page;
+      // once the user types, cmdk re-ranks by fuzzy score as usual.
+      const ordered = workspaces
+        .map((ws) => {
+          const wsTasks = tasks.filter((task) => task.workspaceId === ws.objectId);
+          return { ws, rank: getWorkspaceAttentionRank(wsTasks), recencyMs: latestActivityMs(wsTasks, ws) };
+        })
+        .sort((a, b) => {
+          if (a.rank !== b.rank) return a.rank - b.rank;
+          if (a.recencyMs !== b.recencyMs) return b.recencyMs - a.recencyMs; // newer first
+          return workspaceName(a.ws.description).localeCompare(workspaceName(b.ws.description));
+        });
+
       const out: Array<Command> = [];
 
       // Page-opener stays visible regardless of workspace count so the
@@ -93,22 +141,45 @@ export const buildWorkspaceProvider = (runtime: CommandRuntime): DynamicProvider
       // without firing an unintended self-navigation (which previously
       // showed a spinner while the router tried to navigate to the page
       // it was already on).
-      for (const ws of workspaces) {
+      ordered.forEach(({ ws }, index) => {
         const name = workspaceName(ws.description);
         const isCurrent = ctx.activeWorkspaceId === ws.objectId;
+        const projectName = projectNameById.get(ws.projectId);
+        // Tag rows that belong to a different project so a mixed list is
+        // legible. Gated on the list spanning multiple projects; when anchored
+        // to a current project, only the rows that differ are tagged (the
+        // current project is the implicit "home", so tagging it would be
+        // noise). With no current project (settings / home), every row is
+        // tagged since there is nothing to contrast against.
+        const shouldShowBadge =
+          hasMultipleProjects &&
+          projectName !== undefined &&
+          (currentProjectId === null || ws.projectId !== currentProjectId);
         out.push({
           id: `workspaces.page.${ws.objectId}`,
           title: name,
           subtitle: isCurrent ? "Current workspace" : undefined,
-          keywords: ["workspace", "switch", "go to", "open", name.toLowerCase()],
+          keywords: [
+            "workspace",
+            "switch",
+            "go to",
+            "open",
+            name.toLowerCase(),
+            // Let the user filter the switcher by project name too.
+            ...(projectName ? [projectName.toLowerCase()] : []),
+          ],
           group: "workspaces",
           icon: getStatusIcon(ws.objectId),
+          trailingBadge: shouldShowBadge ? projectName : undefined,
+          // Sequential rank from the attention/recency sort above; keeps the
+          // empty-query switcher list in the computed order.
+          order: index,
           onPage: "workspaces.switch",
           disabled: isCurrent,
           disabledReason: isCurrent ? "Already on this workspace" : undefined,
           perform: () => runtime.navigate.toWorkspace(ws.objectId),
         });
-      }
+      });
 
       return out;
     },

--- a/sculptor/frontend/src/components/CommandPalette/hooks.ts
+++ b/sculptor/frontend/src/components/CommandPalette/hooks.ts
@@ -3,6 +3,7 @@ import { posthog } from "posthog-js";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
 import { useImbueLocation } from "~/common/NavigateUtils.ts";
+import { projectsArrayAtom } from "~/common/state/atoms/projects.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { effectiveOpenTabIdsAtom, workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
 import { recentAgentTypeAtom } from "~/components/sections/addPanelCore.ts";
@@ -238,6 +239,10 @@ const dynamicProviderInputsAtom = atom((get) => {
   return {
     workspaces: get(workspacesArrayAtom),
     tasks: get(tasksArrayAtom),
+    // The workspace switcher provider reads project names to tag cross-project
+    // rows; without this the badges wouldn't refresh when a project snapshot
+    // lands while the palette is open.
+    projects: get(projectsArrayAtom),
     openTabIds: get(effectiveOpenTabIdsAtom),
     panelRegistry: get(panelRegistryAtom),
     // The panel-toggle provider reads the layout's placement to list only

--- a/sculptor/frontend/src/components/CommandPalette/types.ts
+++ b/sculptor/frontend/src/components/CommandPalette/types.ts
@@ -173,6 +173,15 @@ export type Command = {
    */
   disabledReason?: string;
   /**
+   * Short right-aligned label shown at the trailing edge of the row (before
+   * the shortcut / kind slot). Used to annotate a row with a bit of
+   * disambiguating context — e.g. the workspace switcher tags rows that
+   * belong to a different project than the one you're in. Keep it a single
+   * short token; it renders as a quiet pill, not a focal point. Suppressed
+   * while the row is pending (the spinner takes the slot).
+   */
+  trailingBadge?: string;
+  /**
    * Multiplicative score multiplier. Default 1 (no adjustment).
    *   - Values > 1 boost — e.g. dynamic panel toggles outrank same-tier
    *     Settings sub-page rows that share their name.

--- a/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vitest";
 import { TaskStatus } from "~/api";
 
 import type { AgentDotStatus } from "./statusUtils";
-import { computeWorkspaceDotStatus, getAgentDotStatus } from "./statusUtils";
+import {
+  computeWorkspaceDotStatus,
+  getAgentDotStatus,
+  getWorkspaceAttentionRank,
+  WORKSPACE_ATTENTION_TIER,
+} from "./statusUtils";
 
 // An agent whose content changed after the last recorded read — the raw
 // timestamp comparison classifies it as "unread".
@@ -76,5 +81,80 @@ describe("computeWorkspaceDotStatus", () => {
     expect(
       computeWorkspaceDotStatus([unreadTask("agent-1")], resolveWithViewedAgent("agent-in-other-workspace")).hasUnread,
     ).toBe(true);
+  });
+});
+
+const taskWith = (status: TaskStatus, lastReadAt: string | null, updatedAt: string): WorkspaceTask => ({
+  id: `task-${status}-${String(lastReadAt)}`,
+  status,
+  lastReadAt,
+  updatedAt,
+});
+
+describe("getWorkspaceAttentionRank", () => {
+  it("ranks an empty / task-less workspace as IDLE", () => {
+    expect(getWorkspaceAttentionRank([])).toBe(WORKSPACE_ATTENTION_TIER.IDLE);
+  });
+
+  it("ranks a waiting workspace at the top (WAITING)", () => {
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.WAITING, READ_AT, READ_AT)])).toBe(
+      WORKSPACE_ATTENTION_TIER.WAITING,
+    );
+  });
+
+  it("prefers WAITING over an un-acked error in the same workspace", () => {
+    expect(
+      getWorkspaceAttentionRank([
+        taskWith(TaskStatus.ERROR, READ_AT, UPDATED_AT_LATER),
+        taskWith(TaskStatus.WAITING, READ_AT, READ_AT),
+      ]),
+    ).toBe(WORKSPACE_ATTENTION_TIER.WAITING);
+  });
+
+  it("ranks an un-acked error (errored, not viewed since) as UNACKED_ERROR", () => {
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.ERROR, READ_AT, UPDATED_AT_LATER)])).toBe(
+      WORKSPACE_ATTENTION_TIER.UNACKED_ERROR,
+    );
+    // Never read at all also counts as un-acked.
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.ERROR, null, UPDATED_AT_LATER)])).toBe(
+      WORKSPACE_ATTENTION_TIER.UNACKED_ERROR,
+    );
+  });
+
+  it("drops an acked (already-viewed) error to IDLE", () => {
+    // Full ERROR stays red but was viewed after it broke (lastReadAt >= updatedAt).
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.ERROR, UPDATED_AT_LATER, READ_AT)])).toBe(
+      WORKSPACE_ATTENTION_TIER.IDLE,
+    );
+  });
+
+  it("treats a read REQUEST_ERROR as acked (IDLE), an unread one as un-acked", () => {
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.REQUEST_ERROR, UPDATED_AT_LATER, READ_AT)])).toBe(
+      WORKSPACE_ATTENTION_TIER.IDLE,
+    );
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.REQUEST_ERROR, READ_AT, UPDATED_AT_LATER)])).toBe(
+      WORKSPACE_ATTENTION_TIER.UNACKED_ERROR,
+    );
+  });
+
+  it("ranks an unread (non-error) reply as UNREAD", () => {
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.READY, READ_AT, UPDATED_AT_LATER)])).toBe(
+      WORKSPACE_ATTENTION_TIER.UNREAD,
+    );
+  });
+
+  it("ranks a running / building workspace as RUNNING", () => {
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.RUNNING, READ_AT, READ_AT)])).toBe(
+      WORKSPACE_ATTENTION_TIER.RUNNING,
+    );
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.BUILDING, READ_AT, READ_AT)])).toBe(
+      WORKSPACE_ATTENTION_TIER.RUNNING,
+    );
+  });
+
+  it("ranks a fully-read idle workspace as IDLE", () => {
+    expect(getWorkspaceAttentionRank([taskWith(TaskStatus.READY, UPDATED_AT_LATER, READ_AT)])).toBe(
+      WORKSPACE_ATTENTION_TIER.IDLE,
+    );
   });
 });

--- a/sculptor/frontend/src/components/statusDot/statusUtils.ts
+++ b/sculptor/frontend/src/components/statusDot/statusUtils.ts
@@ -103,3 +103,63 @@ export function computeWorkspaceDotStatus<T extends AgentTaskLike>(
 
   return { hasError, hasWaiting, hasRunning, isAllError, hasUnread };
 }
+
+/**
+ * Sort priority for a workspace in attention-first ordering (LOWER = higher
+ * up the list). Derived from the same per-task status semantics as the status
+ * dot, so the ordering and the dot never disagree about what "needs
+ * attention" means.
+ *
+ * Tiers (a workspace takes the highest-priority tier any of its tasks earns):
+ *   0  WAITING       — a task is waiting for the user's input
+ *   1  UNACKED_ERROR — a task errored and the user hasn't viewed it since
+ *   2  UNREAD        — a task has an unread reply
+ *   3  RUNNING       — a task is running / building
+ *   4  IDLE          — everything else, INCLUDING an already-viewed error
+ *
+ * An acked (already-viewed) error deliberately drops to IDLE: once you've
+ * looked at a broken workspace it stops jumping the queue. Recency ordering
+ * within the tier keeps it reachable.
+ */
+export const WORKSPACE_ATTENTION_TIER = {
+  WAITING: 0,
+  UNACKED_ERROR: 1,
+  UNREAD: 2,
+  RUNNING: 3,
+  IDLE: 4,
+} as const;
+
+export type WorkspaceAttentionTier = (typeof WORKSPACE_ATTENTION_TIER)[keyof typeof WORKSPACE_ATTENTION_TIER];
+
+const isErrorStatus = (status: TaskStatus): boolean =>
+  status === TaskStatus.ERROR || status === TaskStatus.REQUEST_ERROR;
+
+export function getWorkspaceAttentionRank<T extends AgentTaskLike>(tasks: ReadonlyArray<T>): WorkspaceAttentionTier {
+  const activeTasks = tasks.filter((task) => !task.isDeleted && !task.isArchived);
+  if (activeTasks.length === 0) {
+    return WORKSPACE_ATTENTION_TIER.IDLE;
+  }
+
+  // Checked in priority order — the first match wins, so a workspace with both
+  // a waiting task and an errored one sorts as WAITING.
+  if (activeTasks.some((task) => task.status === TaskStatus.WAITING)) {
+    return WORKSPACE_ATTENTION_TIER.WAITING;
+  }
+
+  // Un-acked error: errored AND not yet viewed since the failing update. A
+  // read REQUEST_ERROR has already resolved away from "error" (see
+  // getAgentDotStatus); a read full ERROR stays red but is no longer urgent,
+  // so it falls through to IDLE below.
+  if (activeTasks.some((task) => isErrorStatus(task.status) && hasUnreadUpdate(task.lastReadAt, task.updatedAt))) {
+    return WORKSPACE_ATTENTION_TIER.UNACKED_ERROR;
+  }
+
+  if (activeTasks.some((task) => getAgentDotStatus(task.status, task.lastReadAt, task.updatedAt) === "unread")) {
+    return WORKSPACE_ATTENTION_TIER.UNREAD;
+  }
+
+  if (activeTasks.some((task) => task.status === TaskStatus.RUNNING || task.status === TaskStatus.BUILDING)) {
+    return WORKSPACE_ATTENTION_TIER.RUNNING;
+  }
+  return WORKSPACE_ATTENTION_TIER.IDLE;
+}

--- a/sculptor/sculptor/agents/testing/fake_claude_commands.py
+++ b/sculptor/sculptor/agents/testing/fake_claude_commands.py
@@ -2615,13 +2615,22 @@ def handle_crash(args: dict, emit_streaming: bool) -> list[dict]:
     warning, so a bad message alone no longer crashes the turn.)
 
     Args:
-        delay_seconds: Optional delay before emitting the crash.  Useful in
-            integration tests that need to navigate away from the workspace
-            before the crash fires.
+        pause_path: Optional sentinel path (see ``FakeClaudePause``).  When set,
+            the crash blocks until the test touches the file, so the test can
+            navigate away first and then release it — the crash fires while the
+            workspace is unfocused, with no wall-clock race.  Preferred over
+            ``delay_seconds`` for that "crash while backgrounded" pattern.
+        delay_seconds: Optional wall-clock delay before emitting the crash.
     """
-    delay_seconds: float = args.get("delay_seconds", 0)
-    if delay_seconds > 0:
-        time.sleep(delay_seconds)
+    pause_path: str | None = args.get("pause_path")
+    if pause_path is not None:
+        sentinel = Path(pause_path)
+        if not _wait_until(timeout_seconds=120, poll_interval=0.05, done=sentinel.exists):
+            raise RuntimeError(f"fake_claude:crash timed out after 120s waiting for {sentinel}")
+    else:
+        delay_seconds: float = args.get("delay_seconds", 0)
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
 
     session_id = generate_id("session")
 

--- a/sculptor/tests/integration/frontend/test_command_palette_workspace_switch.py
+++ b/sculptor/tests/integration/frontend/test_command_palette_workspace_switch.py
@@ -32,6 +32,7 @@ from playwright.sync_api import expect
 
 from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
 from sculptor.testing.elements.workspace_sidebar import get_workspace_sidebar
+from sculptor.testing.fake_claude_pause import FakeClaudePause
 from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
 from sculptor.testing.playwright_utils import create_zero_agent_workspace
 from sculptor.testing.playwright_utils import navigate_to_home_page
@@ -39,14 +40,6 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.playwright_utils import wait_for_workspace_list_loaded
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
-
-# FakeClaude fires the crash this many seconds after the turn starts. The test
-# navigates home immediately after creating an error workspace, so the crash
-# lands while that workspace is unfocused and therefore stays UN-ACKED (tier
-# UNACKED_ERROR rather than the acked-error IDLE tier; viewing an error
-# acknowledges it). It also settles the crash (via the peek popover) before
-# continuing, so a pending crash never disrupts the next creation.
-_ERROR_DELAY_SECONDS = 4
 
 # An AskUserQuestion leaves the agent in WAITING (it never completes the turn),
 # which is the top attention tier.
@@ -101,21 +94,25 @@ def _make_waiting_workspace(page: Page, name: str) -> str:
 def _make_error_workspace(page: Page, layout: PlaywrightProjectLayoutPage, name: str) -> str:
     """A workspace whose agent crashes while unfocused → the UNACKED_ERROR tier.
 
-    Starts a delayed crash, then immediately navigates home so the crash lands
-    while the workspace is unfocused (un-acked). Settles the crash here — via
-    the peek popover, which hovering does NOT acknowledge — so the switcher
-    order is already stable when we assert it, and no pending crash disrupts a
-    later creation.
+    Uses a sentinel-gated crash (``FakeClaudePause``, no wall-clock): start the
+    crash paused, navigate home, then release it so the crash fires while the
+    workspace is unfocused — keeping it un-acked (viewing an error acknowledges
+    it, dropping it to the IDLE tier). Settles the crash here via the peek
+    popover, which hovering does NOT acknowledge, so the switcher order is
+    already stable when we assert it and no pending crash disrupts a later
+    creation.
     """
+    pause = FakeClaudePause()
     start_task_and_wait_for_ready(
         sculptor_page=page,
-        prompt=f'fake_claude:crash `{{"delay_seconds": {_ERROR_DELAY_SECONDS}}}`',
+        prompt=f'fake_claude:crash `{{"pause_path": "{pause.release_path}"}}`',
         workspace_name=name,
         wait_for_agent_to_finish=False,
     )
     workspace_id = _current_workspace_id(page)
 
     navigate_to_home_page(page)
+    pause.release()  # Now let the crash fire — while the workspace is unfocused.
     # Hover (not click) the sidebar row so the crash is observed without
     # navigating into — and thereby acknowledging — the workspace.
     get_workspace_sidebar(page).get_workspace_row_by_name(name).hover()
@@ -157,14 +154,11 @@ def test_workspace_switcher_orders_by_attention_then_recency(sculptor_instance_:
     rows = palette.get_items_in_group("workspaces")
     expect(rows).to_have_count(len(expected_ids))
 
-    labels = {waiting: "waiting", error_b: "error_b", error_a: "error_a", idle_b: "idle_b", idle_a: "idle_a"}
-    expected_labels = [labels[ws_id] for ws_id in expected_ids]
-    actual_ids = [
-        (rows.nth(i).get_attribute("data-command-id") or "").removeprefix("workspaces.page.")
-        for i in range(rows.count())
-    ]
-    actual_labels = [labels.get(ws_id, ws_id) for ws_id in actual_ids]
-    assert actual_labels == expected_labels, f"switcher order {actual_labels} != expected {expected_labels}"
+    # Assert each row position in order with auto-retrying expects — positional
+    # locators re-resolve on every retry, so this reads the settled order even
+    # if the list is still settling when the count first reaches five.
+    for index, workspace_id in enumerate(expected_ids):
+        expect(rows.nth(index)).to_have_attribute("data-command-id", f"workspaces.page.{workspace_id}")
 
     # The current workspace (last created) is the leading waiting row, marked
     # "Current workspace" and disabled so selecting it can't self-navigate.

--- a/sculptor/tests/integration/frontend/test_command_palette_workspace_switch.py
+++ b/sculptor/tests/integration/frontend/test_command_palette_workspace_switch.py
@@ -1,0 +1,173 @@
+"""Integration test for the workspace switcher's attention + recency ordering.
+
+The command-palette workspace switcher (`workspaces.switch` sub-page) sorts
+workspaces attention-first, then by recency within each attention tier:
+
+    WAITING  ->  UNACKED_ERROR  ->  IDLE
+
+This drives five real workspaces so the expected order is neither creation order
+nor pure recency — it can only be produced by sorting on tier first and recency
+second:
+
+  - one WAITING workspace (an agent asking a question) — the current, focused
+    workspace; see the note below on why waiting is exercised focused-only;
+  - two UNACKED_ERROR workspaces (agents that crashed while unfocused), to
+    check recency ordering within the error tier;
+  - two IDLE workspaces (empty, no agent), to check recency within the idle
+    tier.
+
+Note on the single waiting workspace: the FakeClaude harness only holds a
+pending AskUserQuestion (TaskStatus.WAITING) while its workspace is focused —
+backgrounding it tears the fake agent down and the task settles to READY. So a
+second, unfocused waiting workspace can't be reproduced here. The tier ranking
+itself (including multiple waiting workspaces) is covered by the
+``getWorkspaceAttentionRank`` unit tests; this test verifies the end-to-end DOM
+ordering with the states the harness reliably produces.
+"""
+
+import re
+
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.elements.workspace_sidebar import get_workspace_sidebar
+from sculptor.testing.pages.project_layout import PlaywrightProjectLayoutPage
+from sculptor.testing.playwright_utils import create_zero_agent_workspace
+from sculptor.testing.playwright_utils import navigate_to_home_page
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.playwright_utils import wait_for_workspace_list_loaded
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# FakeClaude fires the crash this many seconds after the turn starts. The test
+# navigates home immediately after creating an error workspace, so the crash
+# lands while that workspace is unfocused and therefore stays UN-ACKED (tier
+# UNACKED_ERROR rather than the acked-error IDLE tier; viewing an error
+# acknowledges it). It also settles the crash (via the peek popover) before
+# continuing, so a pending crash never disrupts the next creation.
+_ERROR_DELAY_SECONDS = 4
+
+# An AskUserQuestion leaves the agent in WAITING (it never completes the turn),
+# which is the top attention tier.
+_WAITING_PROMPT = """\
+fake_claude:ask_user_question `{
+  "questions": [
+    {
+      "question": "Proceed?",
+      "header": "Confirm",
+      "options": [
+        {"label": "Yes", "description": "Go ahead"},
+        {"label": "No", "description": "Stop"}
+      ],
+      "multiSelect": false
+    }
+  ]
+}`"""
+
+
+def _current_workspace_id(page: Page) -> str:
+    """The workspace id in the current URL (``/ws/<id>/agent/<id>``)."""
+    match = re.search(r"/ws/([^/?#]+)", page.url)
+    assert match is not None, f"no workspace id in url: {page.url}"
+    return match.group(1)
+
+
+def _make_idle_workspace(page: Page, name: str) -> str:
+    """An empty (no-agent) workspace → the IDLE tier.
+
+    A workspace with no tasks ranks as idle, so an empty workspace is the
+    lightest way to populate that tier — and it sidesteps the modal
+    create-flow entirely (the backend API path dedupes branch names on its
+    own). Recency within the tier still comes from the workspace's createdAt.
+    """
+    return create_zero_agent_workspace(page, description=name)
+
+
+def _make_waiting_workspace(page: Page, name: str) -> str:
+    """A workspace whose agent is asking a question → the WAITING tier."""
+    start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=_WAITING_PROMPT,
+        workspace_name=name,
+        # AUQ never finishes the turn, so wait for the panel itself as the
+        # WAITING signal rather than for completion.
+        wait_for_agent_to_finish=False,
+    )
+    expect(get_ask_user_question_panel(page)).to_be_visible(timeout=30_000)
+    return _current_workspace_id(page)
+
+
+def _make_error_workspace(page: Page, layout: PlaywrightProjectLayoutPage, name: str) -> str:
+    """A workspace whose agent crashes while unfocused → the UNACKED_ERROR tier.
+
+    Starts a delayed crash, then immediately navigates home so the crash lands
+    while the workspace is unfocused (un-acked). Settles the crash here — via
+    the peek popover, which hovering does NOT acknowledge — so the switcher
+    order is already stable when we assert it, and no pending crash disrupts a
+    later creation.
+    """
+    start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f'fake_claude:crash `{{"delay_seconds": {_ERROR_DELAY_SECONDS}}}`',
+        workspace_name=name,
+        wait_for_agent_to_finish=False,
+    )
+    workspace_id = _current_workspace_id(page)
+
+    navigate_to_home_page(page)
+    # Hover (not click) the sidebar row so the crash is observed without
+    # navigating into — and thereby acknowledging — the workspace.
+    get_workspace_sidebar(page).get_workspace_row_by_name(name).hover()
+    peek = layout.get_workspace_peek_popover()
+    expect(peek).to_be_visible()
+    expect(peek.get_header()).to_contain_text(name)
+    expect(peek.get_banner()).to_contain_text("error", timeout=30_000)
+    page.mouse.move(0, 0)  # Dismiss the popover before the next action.
+    return workspace_id
+
+
+@user_story("to see the workspaces that need my attention sorted to the top of the switcher")
+def test_workspace_switcher_orders_by_attention_then_recency(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    layout = PlaywrightProjectLayoutPage(page=page)
+
+    # Oldest -> newest, interleaved across the tiers. Names are kept short and
+    # distinct: the branch-name preview slugifies the workspace name and caps it
+    # at 20 chars on a word boundary, so longer names could collide on the
+    # generated worktree branch. The first creation is a real (modal) workspace
+    # so the project is initialised before the API-based idle creations.
+    error_a = _make_error_workspace(page, layout, "Error A")
+    idle_a = _make_idle_workspace(page, "Idle A")
+    error_b = _make_error_workspace(page, layout, "Error B")
+    idle_b = _make_idle_workspace(page, "Idle B")
+    waiting = _make_waiting_workspace(page, "Waiting")  # last created → current + focused
+
+    # Expected top-to-bottom order: the waiting (current) workspace leads, then
+    # the error tier (newer "B" first), then the idle tier (newer "B" first).
+    # Note the names are alphabetically A-before-B, the OPPOSITE of the recency
+    # expectation — so a broken recency sort would fail rather than pass by luck.
+    expected_ids = [waiting, error_b, error_a, idle_b, idle_a]
+
+    wait_for_workspace_list_loaded(page)
+    palette = layout.open_command_palette()
+    palette.select_by_command_id("workspaces.switch")
+    expect(palette.get_breadcrumb()).to_be_visible()
+
+    rows = palette.get_items_in_group("workspaces")
+    expect(rows).to_have_count(len(expected_ids))
+
+    labels = {waiting: "waiting", error_b: "error_b", error_a: "error_a", idle_b: "idle_b", idle_a: "idle_a"}
+    expected_labels = [labels[ws_id] for ws_id in expected_ids]
+    actual_ids = [
+        (rows.nth(i).get_attribute("data-command-id") or "").removeprefix("workspaces.page.")
+        for i in range(rows.count())
+    ]
+    actual_labels = [labels.get(ws_id, ws_id) for ws_id in actual_ids]
+    assert actual_labels == expected_labels, f"switcher order {actual_labels} != expected {expected_labels}"
+
+    # The current workspace (last created) is the leading waiting row, marked
+    # "Current workspace" and disabled so selecting it can't self-navigate.
+    current_row = palette.get_item_in_group_by_command_id("workspaces", f"workspaces.page.{waiting}")
+    expect(current_row).to_contain_text("Current workspace")
+    expect(current_row).to_have_attribute("aria-disabled", "true")


### PR DESCRIPTION
## Summary

Improves the ordering and clarity of the command-palette **workspace switcher** (the `workspaces.switch` sub-page opened via Cmd+K / Cmd+P). Previously the list was alphabetical, which buried the workspaces that actually need attention and gave no signal when a listed workspace belonged to a different project than the one in focus.

Scope is intentionally limited to the switcher; the left sidebar already groups by repo and is left unchanged.

## What changed

**Attention-first, then recency sorting.** Each workspace is ranked by an attention tier, then by recency within the tier (newest activity first):

| Tier | Meaning |
|------|---------|
| Waiting | an agent is waiting for your input |
| Un-acked error | an agent errored and you haven't viewed it since |
| Unread | an unread reply |
| Running | an agent is working |
| Idle | everything else, including an error you've already viewed |

An already-viewed ("acked") error deliberately drops to the idle tier so a workspace you've already dealt with stops jumping the queue. Recency uses the newest task `updatedAt`, falling back to the workspace's `createdAt`. The ranking is emitted through each row's `order` field, so it applies to the empty-query list; once you type, the palette's fuzzy ranking takes over as before.

The attention ranking (`getWorkspaceAttentionRank`) reuses the same status-dot semantics as the row's icon, so the sort and the dot never disagree about what "needs attention" means.

**Cross-project annotation.** Rows that belong to a different project than the current one are tagged with a quiet right-aligned badge, gated so it only appears when the list actually spans more than one project. When there is no active workspace (Cmd+K from settings or home) there is no current project to contrast against, so every row is tagged; all paths guard against the null-current-project case. The project name also feeds fuzzy search, so you can filter the switcher by project.

## Tests

- **Unit** (`statusUtils.test.ts`, `dynamicProviders.test.ts`): per-tier ranking incl. the acked-error demotion, recency tiebreak, and every branch of the badge gating.
- **End-to-end** (`test_command_palette_workspace_switch.py`): drives five real workspaces (a focused waiting agent, two crashed-while-unfocused agents, two idle workspaces) and asserts the full rendered row order plus the current-workspace marker. The crash is gated on a `FakeClaudePause` sentinel rather than a wall-clock delay, so it fires while the workspace is unfocused with no CI-load race.

## Accessibility

The visible badge sits in an `aria-hidden` trailing slot, so the project name is also surfaced to assistive tech via a visually hidden label — otherwise two same-named workspaces in different projects would be indistinguishable to a screen reader.

(Sent by Claude)