### PR TITLE
Rename a sidebar workspace by double-clicking its name

### DIFF
--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -346,8 +346,6 @@ export const SidebarRepoGroup = ({
     return endOwnedDrag;
   }, [isRepoCollapsed, endOwnedDrag]);
 
-  // Reference-stable (the rows are memoized on their props): the rename
-  // callbacks depend only on reference-stable atom setters and the store.
   const handleBeginRename = useCallback(
     (workspaceId: string): void => {
       setRenamingWorkspaceId(workspaceId);
@@ -355,6 +353,8 @@ export const SidebarRepoGroup = ({
     [setRenamingWorkspaceId],
   );
 
+  // Reference-stable (the rows are memoized on their props): the rename
+  // callbacks depend only on reference-stable atom setters and the store.
   const handleRenameCommit = useCallback(
     (workspaceId: string, newName: string): void => {
       setRenamingWorkspaceId(null);

--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -153,7 +153,14 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
               // After the listeners spread so this composed handler REPLACES the
               // sensor's raw onKeyDown (it delegates every non-Enter key back to it).
               onKeyDown={handleKeyDown}
-              onClick={() => onNavigate(workspace.objectId)}
+              // Ignore the second click of a double-click (event.detail > 1) so the
+              // rename gesture doesn't also navigate a second time on its way in.
+              onClick={(event) => {
+                if (event.detail > 1) {
+                  return;
+                }
+                onNavigate(workspace.objectId);
+              }}
               onDoubleClick={() => onBeginRename(workspace.objectId)}
               onMouseEnter={() => onHover(workspace.objectId)}
               data-testid={ElementIds.SIDEBAR_WORKSPACE_ROW}

--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -72,6 +72,7 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
   destructiveColor,
   onNavigate,
   onHover,
+  onBeginRename,
   onRenameCommit,
   onRenameCancel,
   onBeginDelete,
@@ -84,6 +85,7 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
   destructiveColor: ReturnType<typeof useThemeDangerColor>;
   onNavigate: (workspaceId: string) => void;
   onHover: (workspaceId: string) => void;
+  onBeginRename: (workspaceId: string) => void;
   onRenameCommit: (workspaceId: string, newName: string) => void;
   onRenameCancel: () => void;
   onBeginDelete: (workspace: Workspace) => void;
@@ -152,6 +154,7 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
               // sensor's raw onKeyDown (it delegates every non-Enter key back to it).
               onKeyDown={handleKeyDown}
               onClick={() => onNavigate(workspace.objectId)}
+              onDoubleClick={() => onBeginRename(workspace.objectId)}
               onMouseEnter={() => onHover(workspace.objectId)}
               data-testid={ElementIds.SIDEBAR_WORKSPACE_ROW}
               data-workspace-id={workspace.objectId}
@@ -338,6 +341,13 @@ export const SidebarRepoGroup = ({
 
   // Reference-stable (the rows are memoized on their props): the rename
   // callbacks depend only on reference-stable atom setters and the store.
+  const handleBeginRename = useCallback(
+    (workspaceId: string): void => {
+      setRenamingWorkspaceId(workspaceId);
+    },
+    [setRenamingWorkspaceId],
+  );
+
   const handleRenameCommit = useCallback(
     (workspaceId: string, newName: string): void => {
       setRenamingWorkspaceId(null);
@@ -481,6 +491,7 @@ export const SidebarRepoGroup = ({
                   destructiveColor={dangerColor}
                   onNavigate={onWorkspaceClick}
                   onHover={onWorkspaceHover}
+                  onBeginRename={handleBeginRename}
                   onRenameCommit={handleRenameCommit}
                   onRenameCancel={handleRenameCancel}
                   onBeginDelete={onBeginDelete}

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, screen } from "@testing-library/react";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { createStore } from "jotai";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -113,5 +113,17 @@ describe("WorkspaceSidebar repo groups", () => {
     renderWithProviders(<Sidebar />, { store });
 
     expect(screen.getByTestId(ElementIds.SIDEBAR_REPO_ADD_WORKSPACE)).toBeVisible();
+  });
+
+  it("enters inline rename mode when a workspace row is double-clicked", async () => {
+    seedProject(store, "p1");
+    seedWorkspaces(store, ["w1"]);
+    renderWithProviders(<Sidebar />, { store });
+
+    expect(screen.queryByTestId(ElementIds.INLINE_RENAME_INPUT)).toBeNull();
+
+    fireEvent.doubleClick(screen.getByTestId(ElementIds.SIDEBAR_WORKSPACE_ROW));
+
+    expect(await screen.findByTestId(ElementIds.INLINE_RENAME_INPUT)).toBeVisible();
   });
 });

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
@@ -117,8 +117,9 @@ describe("WorkspaceSidebar repo groups", () => {
   });
 
   it("enters inline rename mode when a workspace row is double-clicked", async () => {
-    // user.dblClick fires the real click → click → dblclick sequence, so this also
-    // covers the row's onClick guard against navigating on the second click.
+    // user.dblClick fires the real click → click → dblclick sequence, so the
+    // clicks that precede a dblclick are exercised and shown not to block the row
+    // from entering rename mode.
     const user = userEvent.setup();
     seedProject(store, "p1");
     seedWorkspaces(store, ["w1"]);

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createStore } from "jotai";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -116,13 +117,16 @@ describe("WorkspaceSidebar repo groups", () => {
   });
 
   it("enters inline rename mode when a workspace row is double-clicked", async () => {
+    // user.dblClick fires the real click → click → dblclick sequence, so this also
+    // covers the row's onClick guard against navigating on the second click.
+    const user = userEvent.setup();
     seedProject(store, "p1");
     seedWorkspaces(store, ["w1"]);
     renderWithProviders(<Sidebar />, { store });
 
     expect(screen.queryByTestId(ElementIds.INLINE_RENAME_INPUT)).toBeNull();
 
-    fireEvent.doubleClick(screen.getByTestId(ElementIds.SIDEBAR_WORKSPACE_ROW));
+    await user.dblClick(screen.getByTestId(ElementIds.SIDEBAR_WORKSPACE_ROW));
 
     expect(await screen.findByTestId(ElementIds.INLINE_RENAME_INPUT)).toBeVisible();
   });


### PR DESCRIPTION
## What

Double-clicking a workspace's name in the sidebar now enters inline rename mode, so the name can be edited directly in place.

## Why

Renaming a workspace previously required opening the row's actions menu (or the command palette) and choosing "Rename workspace". Double-clicking the name — the conventional rename gesture — did nothing.

## How

Bind the workspace name's `onDoubleClick` to the same `beginRename` flow the "Rename workspace" action drives. A double-click switches the row into its existing `InlineRenameInput`, reusing the single optimistic rename mutation rather than forking a new path. The handler is passed down as a reference-stable callback so the row's memoization (and its status-tick render isolation) is preserved.

## Testing

- Added a unit test in `WorkspaceSidebar.test.tsx` that double-clicks a workspace row and asserts the inline rename input appears. Verified it fails without the binding and passes with it.
- `just format`, `just check` (typecheck, lint, ratchets, hygiene), and the frontend unit suite all pass.

## Note

A real double-click fires two single-clicks first, so it navigates to the workspace and then opens the rename input on it — benign (you land on the row you're renaming), but happy to suppress the navigation on double-click if reviewers prefer.

Linear: SCU-1814

(Sent by Claude)
