### PR TITLE
[SCU-1818] Loading skeletons for the sidebar, panel area, and recent-workspaces list

### DIFF
--- a/sculptor/frontend/src/components/nav/SidebarLoadingSkeleton.module.scss
+++ b/sculptor/frontend/src/components/nav/SidebarLoadingSkeleton.module.scss
@@ -1,0 +1,73 @@
+// Loading skeleton for the sidebar repo list. Geometry mirrors
+// SidebarRepoGroup's real repo header + workspace rows so the rail doesn't
+// reflow when the actual list swaps in.
+
+.skeleton {
+  // Delayed fade-in so a fast WebSocket reconnect never flashes a skeleton:
+  // `both` fill keeps the group fully transparent through the delay, then it
+  // fades in only if loading is still going after the delay elapses. The real
+  // list, when it arrives sooner, unmounts this before the fade ever starts.
+  animation: sidebar-skeleton-reveal 0.15s ease-out 0.2s both;
+}
+
+@keyframes sidebar-skeleton-reveal {
+  from {
+    opacity: 0%;
+  }
+
+  to {
+    opacity: 100%;
+  }
+}
+
+// Mirrors SidebarRepoGroup .repoGroup: a tight column with the same inter-row
+// gap and inter-group spacing.
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: var(--space-1);
+}
+
+// Mirrors .repoHeader — same pill height and horizontal padding so the header
+// bar lands where the real repo name does.
+.header {
+  align-items: center;
+  display: flex;
+  gap: var(--space-2);
+  min-height: 28px;
+  padding: 0 var(--space-2);
+}
+
+// Mirrors .workspaceRow — same pill height, indented past the header via the
+// same padding-left so the hierarchy reads while loading.
+.row {
+  align-items: center;
+  display: flex;
+  min-height: 28px;
+  padding: 0 var(--space-2) 0 var(--space-5);
+}
+
+// Stand-in for the repo chevron: a small fixed square matching its 16px glyph.
+.chevron {
+  border-radius: var(--radius-1);
+  flex-shrink: 0;
+  height: 16px;
+  width: 16px;
+}
+
+// A text-line placeholder bar; width is set inline per row for an uneven,
+// content-like silhouette.
+.bar {
+  border-radius: var(--radius-1);
+  height: var(--space-2);
+}
+
+// Honour reduced-motion: skip the fade but keep the anti-flash delay, so the
+// skeleton still only appears once loading has genuinely dragged on. (Radix
+// Skeleton drops its own shimmer under this query independently.)
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation-duration: 0.01ms;
+  }
+}

--- a/sculptor/frontend/src/components/nav/SidebarLoadingSkeleton.module.scss
+++ b/sculptor/frontend/src/components/nav/SidebarLoadingSkeleton.module.scss
@@ -7,7 +7,7 @@
   // `both` fill keeps the group fully transparent through the delay, then it
   // fades in only if loading is still going after the delay elapses. The real
   // list, when it arrives sooner, unmounts this before the fade ever starts.
-  animation: sidebar-skeleton-reveal 0.15s ease-out 0.2s both;
+  animation: sidebar-skeleton-reveal var(--duration-fast) var(--ease-out) var(--duration-normal) both;
 }
 
 @keyframes sidebar-skeleton-reveal {

--- a/sculptor/frontend/src/components/nav/SidebarLoadingSkeleton.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarLoadingSkeleton.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from "@radix-ui/themes";
+import type { ReactElement } from "react";
+
+import { ElementIds } from "~/api";
+
+import styles from "./SidebarLoadingSkeleton.module.scss";
+
+// A couple of placeholder repo groups of uneven shape (varied header and row
+// widths, different row counts) so the skeleton reads as content-in-progress
+// rather than a uniform block. Purely decorative — the real list replaces it the
+// instant the first snapshot lands.
+const PLACEHOLDER_GROUPS: ReadonlyArray<{ headerWidth: string; rowWidths: ReadonlyArray<string> }> = [
+  { headerWidth: "55%", rowWidths: ["78%", "64%", "71%"] },
+  { headerWidth: "42%", rowWidths: ["70%", "58%"] },
+];
+
+/**
+ * Placeholder skeleton for the sidebar's repo list, shown while the first
+ * workspace snapshot is still in flight (see `isSidebarLoadingAtom`). Its
+ * bars mirror the real repo-header and workspace-row geometry so the rail
+ * doesn't reflow when the data arrives.
+ *
+ * The whole group fades in after a short delay (see the stylesheet) so a fast
+ * reconnect never flashes a skeleton — only a slow/cold backend surfaces it.
+ * `aria-hidden` keeps the decorative bars out of the accessibility tree.
+ */
+export const SidebarLoadingSkeleton = (): ReactElement => {
+  return (
+    <div className={styles.skeleton} aria-hidden="true" data-testid={ElementIds.SIDEBAR_LOADING_SKELETON}>
+      {PLACEHOLDER_GROUPS.map((group, groupIndex) => (
+        <div key={groupIndex} className={styles.group}>
+          <div className={styles.header}>
+            <Skeleton className={styles.chevron} />
+            <Skeleton className={styles.bar} style={{ width: group.headerWidth }} />
+          </div>
+          {group.rowWidths.map((rowWidth, rowIndex) => (
+            <div key={rowIndex} className={styles.row}>
+              <Skeleton className={styles.bar} style={{ width: rowWidth }} />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.test.tsx
@@ -80,6 +80,41 @@ describe("WorkspaceSidebar nav buttons", () => {
   });
 });
 
+describe("WorkspaceSidebar loading state", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+  });
+
+  it("shows the loading skeleton before the first workspace snapshot arrives", () => {
+    // `workspaceIdsAtom` defaults to `undefined` (its not-yet-loaded sentinel).
+    // The sidebar can't tell that from an empty list without this signal, so the
+    // rail would otherwise render blank during the post-refresh reconnect.
+    seedProject(store, "p1");
+    renderWithProviders(<Sidebar />, { store });
+
+    expect(screen.getByTestId(ElementIds.SIDEBAR_LOADING_SKELETON)).toBeVisible();
+    // The real repo list is withheld while loading, so a seeded repo's group
+    // (and its "No workspaces yet" hint) must not show through the skeleton.
+    expect(screen.queryByTestId(ElementIds.SIDEBAR_REPO_GROUP)).toBeNull();
+  });
+
+  it("replaces the skeleton with the list once the first snapshot lands", () => {
+    // The first frame writes an array — even an empty one — flipping the list out
+    // of its loading sentinel.
+    store.set(workspaceIdsAtom, []);
+    renderWithProviders(<Sidebar />, { store });
+
+    expect(screen.queryByTestId(ElementIds.SIDEBAR_LOADING_SKELETON)).toBeNull();
+  });
+});
+
 describe("WorkspaceSidebar repo groups", () => {
   let store: ReturnType<typeof createStore>;
 

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
@@ -38,8 +38,13 @@ import { adjustSidebarDragCountAtom, isSidebarDragActiveAtom } from "./navAtoms.
 import navItemStyles from "./NavItem.module.scss";
 import { NavItem } from "./NavItem.tsx";
 import { sidebarCollisionDetection, sidebarDndModifiers, useSidebarDndSensors } from "./sidebarDnd.ts";
+import { SidebarLoadingSkeleton } from "./SidebarLoadingSkeleton.tsx";
 import { SidebarRepoGroup } from "./SidebarRepoGroup.tsx";
-import { reorderSidebarRepoGroupAtom, sidebarWorkspaceGroupsAtom } from "./sidebarWorkspaceOrder.ts";
+import {
+  isSidebarLoadingAtom,
+  reorderSidebarRepoGroupAtom,
+  sidebarWorkspaceGroupsAtom,
+} from "./sidebarWorkspaceOrder.ts";
 import styles from "./WorkspaceSidebar.module.scss";
 
 /** Smallest sidebar width the resize handle allows, in pixels. */
@@ -64,6 +69,11 @@ export const WorkspaceSidebar = (): ReactElement | null => {
   // workspaces yet), shared with keyboard workspace cycling so the two can't
   // drift (see sidebarWorkspaceOrder).
   const repoGroups = useAtomValue(sidebarWorkspaceGroupsAtom);
+  // True only while the first workspace snapshot is still in flight. Lets the
+  // repo list show a skeleton instead of a blank rail during that window
+  // (notably after a hard refresh), without conflating it with a genuinely
+  // empty list.
+  const isLoading = useAtomValue(isSidebarLoadingAtom);
   const setRenamingWorkspaceId = useSetAtom(renamingWorkspaceIdAtom);
   // The workspace→last-agent map is only consulted inside the click handler, so
   // read it lazily from the store rather than subscribing: the whole sidebar
@@ -287,31 +297,41 @@ export const WorkspaceSidebar = (): ReactElement | null => {
         </nav>
 
         <div className={styles.repoList}>
+          {/* While the first workspace snapshot is still in flight, show a
+            skeleton rather than a blank rail — the list can't yet tell "loading"
+            from "loaded and empty", so a bare empty map would read as "you have
+            nothing" during the reconnect window (e.g. after a hard refresh). */}
+          {isLoading && <SidebarLoadingSkeleton />}
           {/* One group per repo, including repos with no workspaces yet (they show
             a "No workspaces yet" hint). Empty until the first repo is added via the
             "Add repo" button in the bottom actions. */}
-          <DndContext
-            sensors={groupDndSensors}
-            collisionDetection={sidebarCollisionDetection}
-            modifiers={sidebarDndModifiers}
-            onDragStart={beginOwnedDrag}
-            onDragEnd={handleGroupDragEnd}
-            onDragCancel={endOwnedDrag}
-          >
-            <SortableContext items={repoGroups.map((group) => group.projectId)} strategy={verticalListSortingStrategy}>
-              {repoGroups.map((group) => (
-                <SidebarRepoGroup
-                  key={group.projectId}
-                  group={group}
-                  actions={workspaceActions}
-                  openInRuntime={openInRuntime}
-                  onWorkspaceClick={handleWorkspaceClick}
-                  onWorkspaceHover={handleWorkspaceHover}
-                  onBeginDelete={setDeleteTarget}
-                />
-              ))}
-            </SortableContext>
-          </DndContext>
+          {!isLoading && (
+            <DndContext
+              sensors={groupDndSensors}
+              collisionDetection={sidebarCollisionDetection}
+              modifiers={sidebarDndModifiers}
+              onDragStart={beginOwnedDrag}
+              onDragEnd={handleGroupDragEnd}
+              onDragCancel={endOwnedDrag}
+            >
+              <SortableContext
+                items={repoGroups.map((group) => group.projectId)}
+                strategy={verticalListSortingStrategy}
+              >
+                {repoGroups.map((group) => (
+                  <SidebarRepoGroup
+                    key={group.projectId}
+                    group={group}
+                    actions={workspaceActions}
+                    openInRuntime={openInRuntime}
+                    onWorkspaceClick={handleWorkspaceClick}
+                    onWorkspaceHover={handleWorkspaceHover}
+                    onBeginDelete={setDeleteTarget}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+          )}
         </div>
 
         <div className={styles.spacer} />

--- a/sculptor/frontend/src/components/nav/sidebarWorkspaceOrder.ts
+++ b/sculptor/frontend/src/components/nav/sidebarWorkspaceOrder.ts
@@ -98,6 +98,17 @@ export const sidebarWorkspaceGroupsAtom = atom<ReadonlyArray<RepoGroup>>((get) =
   groupWorkspacesByRepo(get(workspacesArrayAtom) ?? [], get(projectsArrayAtom), get(sidebarOrderAtom)),
 );
 
+// True while the first workspace snapshot is still in flight, so the sidebar can
+// show a loading skeleton instead of a blank rail (e.g. right after a hard
+// refresh, before the reconnecting WebSocket delivers the first frame).
+//
+// `workspacesArrayAtom` is `undefined` only until that first frame lands — the
+// frame always writes an array, even an empty one — so this cleanly separates
+// "not loaded yet" from "loaded and genuinely empty", a distinction the groups
+// atom above deliberately erases with its `?? []` (keyboard cycling and drag
+// ordering want a concrete array regardless).
+export const isSidebarLoadingAtom = atom<boolean>((get) => get(workspacesArrayAtom) === undefined);
+
 // The sidebar's workspaces flattened into their visible top-to-bottom order, so
 // keyboard cycling steps through the same list the user sees.
 export const sidebarOrderedWorkspacesAtom = atom<ReadonlyArray<Workspace>>((get) =>

--- a/sculptor/frontend/src/components/sections/SectionBody.tsx
+++ b/sculptor/frontend/src/components/sections/SectionBody.tsx
@@ -9,8 +9,9 @@ import type { ReactElement } from "react";
 import { createElement, memo } from "react";
 
 import { EmptySectionState } from "./EmptySectionState.tsx";
-import { activePanelComponentInSubSectionAtom } from "./registry/panelRegistry.ts";
+import { activePanelComponentInSubSectionAtom, isSubSectionPanelLoadingAtom } from "./registry/panelRegistry.ts";
 import styles from "./SectionBody.module.scss";
+import { SectionLoadingState } from "./SectionLoadingState.tsx";
 import type { SubSectionId } from "./sectionTypes.ts";
 
 type SectionBodyProps = { subSection: SubSectionId };
@@ -20,11 +21,17 @@ const SectionBodyComponent = ({ subSection }: SectionBodyProps): ReactElement =>
   // createElement renders it without the compiler mistaking the local binding
   // for a component defined during render.
   const activePanelComponent = useAtomValue(activePanelComponentInSubSectionAtom(subSection));
+  // When no component resolves, tell "the placed panel is still loading (agent
+  // snapshot not in yet)" apart from "this section is genuinely empty" — a bare
+  // undefined component can't, so a reload would flash the Add-panel launcher.
+  const isPanelLoading = useAtomValue(isSubSectionPanelLoadingAtom(subSection));
 
   return (
     <div className={styles.content}>
       {activePanelComponent !== undefined ? (
         createElement(activePanelComponent)
+      ) : isPanelLoading ? (
+        <SectionLoadingState />
       ) : (
         <EmptySectionState subSection={subSection} />
       )}

--- a/sculptor/frontend/src/components/sections/SectionLoadingState.module.scss
+++ b/sculptor/frontend/src/components/sections/SectionLoadingState.module.scss
@@ -7,7 +7,7 @@
   // it transparent through the delay, then it fades in only if the panel is still
   // resolving. The real panel, when it registers sooner, unmounts this before the
   // fade ever starts.
-  animation: section-loading-reveal 0.15s ease-out 0.2s both;
+  animation: section-loading-reveal var(--duration-fast) var(--ease-out) var(--duration-normal) both;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);

--- a/sculptor/frontend/src/components/sections/SectionLoadingState.module.scss
+++ b/sculptor/frontend/src/components/sections/SectionLoadingState.module.scss
@@ -1,0 +1,46 @@
+// Loading placeholder for a section body — a stack of skeleton lines filling the
+// content area from the top, where a panel's own content would begin.
+
+.loading {
+
+  // Delayed fade-in so a fast resolve never flashes a skeleton: `both` fill keeps
+  // it transparent through the delay, then it fades in only if the panel is still
+  // resolving. The real panel, when it registers sooner, unmounts this before the
+  // fade ever starts.
+  animation: section-loading-reveal 0.15s ease-out 0.2s both;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  // Fill the section body so the percentage-width lines have a stable basis
+  // (the parent `.content` is a flex column, but don't rely on its cross-axis
+  // stretch — an explicit width keeps the lines sized in any container).
+  width: 100%;
+}
+
+@keyframes section-loading-reveal {
+  from {
+    opacity: 0%;
+  }
+
+  to {
+    opacity: 100%;
+  }
+}
+
+// A text-line placeholder bar; width is set inline per line for an uneven,
+// content-like silhouette.
+.line {
+  border-radius: var(--radius-1);
+  flex-shrink: 0;
+  height: var(--space-2);
+}
+
+// Honour reduced-motion: skip the fade but keep the anti-flash delay, so the
+// skeleton still only appears once resolving has genuinely dragged on. (Radix
+// Skeleton drops its own shimmer under this query independently.)
+@media (prefers-reduced-motion: reduce) {
+  .loading {
+    animation-duration: 0.01ms;
+  }
+}

--- a/sculptor/frontend/src/components/sections/SectionLoadingState.tsx
+++ b/sculptor/frontend/src/components/sections/SectionLoadingState.tsx
@@ -1,0 +1,25 @@
+// The section body's loading placeholder: a few skeleton lines shown while a
+// placed panel is still resolving because the agent/task snapshot hasn't arrived
+// yet (see isSubSectionPanelLoadingAtom). Deliberately panel-agnostic — a chat,
+// terminal, and diff panel all read as "content on its way" behind these lines —
+// rather than mimicking one panel's chrome.
+
+import { Skeleton } from "@radix-ui/themes";
+import type { ReactElement } from "react";
+
+import { ElementIds } from "~/api";
+
+import styles from "./SectionLoadingState.module.scss";
+
+// Uneven widths so the block reads as loading content, not a filled rectangle.
+const LINE_WIDTHS: ReadonlyArray<string> = ["58%", "82%", "70%", "46%", "76%", "62%"];
+
+export const SectionLoadingState = (): ReactElement => {
+  return (
+    <div className={styles.loading} aria-hidden="true" data-testid={ElementIds.SECTION_LOADING_STATE}>
+      {LINE_WIDTHS.map((width, index) => (
+        <Skeleton key={index} className={styles.line} style={{ width }} />
+      ))}
+    </div>
+  );
+};

--- a/sculptor/frontend/src/components/sections/registry/panelRegistry.test.ts
+++ b/sculptor/frontend/src/components/sections/registry/panelRegistry.test.ts
@@ -4,6 +4,7 @@ import type { ComponentType } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { TaskStatus } from "~/api";
+import { taskIdsAtom } from "~/common/state/atoms/tasks.ts";
 
 import { EMPTY_WORKSPACE_LAYOUT } from "../persistence/types.ts";
 import { activeWorkspaceIdAtom, workspaceLayoutAtom } from "../sectionAtoms.ts";
@@ -14,6 +15,7 @@ import {
   buildExtensionPanelDefinitions,
   buildStaticPanelDefinitions,
   isMultiInstanceKind,
+  isSubSectionPanelLoadingAtom,
   panelRegistriesEqual,
   panelRegistryAtom,
   registerPanelComponent,
@@ -248,5 +250,68 @@ describe("resolvedActivePanelIdInSubSectionAtom", () => {
     expect(store.get(resolvedActivePanelIdInSubSectionAtom("left"))).toBe(EXTENSION_PANEL_ID);
     expect(store.get(activePanelComponentInSubSectionAtom("left"))).toBe(extensionComponent);
     expect(store.get(workspaceLayoutAtom).activePanel.left).toBe(EXTENSION_PANEL_ID);
+  });
+});
+
+describe("isSubSectionPanelLoadingAtom", () => {
+  // A layout whose center names an agent panel — the reload state where the
+  // layout is restored from localStorage but the agent panel isn't registered
+  // yet because the task snapshot hasn't arrived.
+  const seedWithAgentPanel = (): ReturnType<typeof createStore> => {
+    const store = createStore();
+    store.set(activeWorkspaceIdAtom, "ws-agent-loading");
+    store.set(workspaceLayoutAtom, {
+      ...EMPTY_WORKSPACE_LAYOUT,
+      placement: { "agent:t1": "center" },
+      order: { center: ["agent:t1"] },
+      activePanel: { center: "agent:t1" },
+      expanded: { center: true },
+    });
+    return store;
+  };
+
+  it("reports loading when a placed agent panel is unresolved and tasks haven't loaded", () => {
+    const store = seedWithAgentPanel();
+    // `taskIdsAtom` left at its `undefined` default (task snapshot in flight),
+    // registry empty (the agent panel has no definition yet).
+    store.set(panelRegistryAtom, buildStaticPanelDefinitions());
+
+    expect(store.get(activePanelComponentInSubSectionAtom("center"))).toBeUndefined();
+    expect(store.get(isSubSectionPanelLoadingAtom("center"))).toBe(true);
+  });
+
+  it("reports NOT loading once the task snapshot has arrived, even if still unresolved", () => {
+    const store = seedWithAgentPanel();
+    store.set(panelRegistryAtom, buildStaticPanelDefinitions());
+    // The first task frame lands (agentless: an empty array is still "loaded").
+    store.set(taskIdsAtom, []);
+
+    // Component is still unresolved, but the section is now genuinely empty — the
+    // empty-state launcher should show, not the loading placeholder.
+    expect(store.get(activePanelComponentInSubSectionAtom("center"))).toBeUndefined();
+    expect(store.get(isSubSectionPanelLoadingAtom("center"))).toBe(false);
+  });
+
+  it("reports NOT loading once the agent panel resolves to a component", () => {
+    const store = seedWithAgentPanel();
+    // The agent panel registers (its component becomes resolvable).
+    store.set(panelRegistryAtom, [
+      ...buildStaticPanelDefinitions(),
+      ...deriveDynamicPanels([makeAgent({ taskId: "t1" })], []),
+    ]);
+
+    expect(store.get(activePanelComponentInSubSectionAtom("center"))).toBeDefined();
+    expect(store.get(isSubSectionPanelLoadingAtom("center"))).toBe(false);
+  });
+
+  it("reports NOT loading for a genuinely empty sub-section while tasks load", () => {
+    // No panel placed in center; the load window must not paint a loading
+    // placeholder over an empty section (it would flash then clear to the launcher).
+    const store = createStore();
+    store.set(activeWorkspaceIdAtom, "ws-empty-center");
+    store.set(workspaceLayoutAtom, EMPTY_WORKSPACE_LAYOUT);
+    store.set(panelRegistryAtom, buildStaticPanelDefinitions());
+
+    expect(store.get(isSubSectionPanelLoadingAtom("center"))).toBe(false);
   });
 });

--- a/sculptor/frontend/src/components/sections/registry/panelRegistry.ts
+++ b/sculptor/frontend/src/components/sections/registry/panelRegistry.ts
@@ -12,6 +12,7 @@ import type { LucideIcon } from "lucide-react";
 import { FileText, GitBranch, GitCommitVertical, Globe, ListChecks, NotebookPen, Sparkles, Zap } from "lucide-react";
 import type { ComponentType } from "react";
 
+import { tasksArrayAtom } from "../../../common/state/atoms/tasks.ts";
 import type { AgentDotStatus } from "../../statusDot/statusUtils.ts";
 import { activePanelIdInSubSectionAtom, panelsInSubSectionAtom } from "../sectionAtoms.ts";
 import type { PanelId, SubSectionId } from "../sectionTypes.ts";
@@ -246,5 +247,33 @@ export const activePanelComponentInSubSectionAtom = atomFamily((subSection: SubS
       return undefined;
     }
     return get(panelRegistryAtom).find((definition) => definition.id === activePanelId)?.component;
+  }),
+);
+
+// True while a sub-section has a placed panel that currently resolves to NO
+// component ONLY because the agent/task snapshot hasn't arrived yet. Agent panels
+// are registered off `tasksArrayAtom` (via useWorkspaceDynamicPanels), which is
+// `undefined` until the first task frame — so on a reload the layout still names
+// an `agent:<taskId>` panel the registry can't resolve, and the sub-section would
+// otherwise fall through to the "Add panel" empty state as if the workspace were
+// empty. SectionBody reads this to show a loading placeholder for that window
+// instead; the resolved-component undefined check alone can't tell "agent panel
+// still loading" from "genuinely empty section".
+//
+// It flips false the moment the task snapshot arrives: the placed panel then either
+// registers (a component resolves, so this is already false) or its task is gone
+// (the section is genuinely empty and correctly shows the empty state). Guarding on
+// a non-empty placement keeps a truly empty sub-section showing its launcher even
+// during the load window.
+export const isSubSectionPanelLoadingAtom = atomFamily((subSection: SubSectionId) =>
+  atom((get): boolean => {
+    if (get(activePanelComponentInSubSectionAtom(subSection)) !== undefined) {
+      return false;
+    }
+
+    if (get(tasksArrayAtom) !== undefined) {
+      return false;
+    }
+    return get(panelsInSubSectionAtom(subSection)).length > 0;
   }),
 );

--- a/sculptor/frontend/src/components/sections/registry/panelRegistry.ts
+++ b/sculptor/frontend/src/components/sections/registry/panelRegistry.ts
@@ -12,7 +12,7 @@ import type { LucideIcon } from "lucide-react";
 import { FileText, GitBranch, GitCommitVertical, Globe, ListChecks, NotebookPen, Sparkles, Zap } from "lucide-react";
 import type { ComponentType } from "react";
 
-import { tasksArrayAtom } from "../../../common/state/atoms/tasks.ts";
+import { taskIdsAtom } from "../../../common/state/atoms/tasks.ts";
 import type { AgentDotStatus } from "../../statusDot/statusUtils.ts";
 import { activePanelIdInSubSectionAtom, panelsInSubSectionAtom } from "../sectionAtoms.ts";
 import type { PanelId, SubSectionId } from "../sectionTypes.ts";
@@ -252,13 +252,20 @@ export const activePanelComponentInSubSectionAtom = atomFamily((subSection: SubS
 
 // True while a sub-section has a placed panel that currently resolves to NO
 // component ONLY because the agent/task snapshot hasn't arrived yet. Agent panels
-// are registered off `tasksArrayAtom` (via useWorkspaceDynamicPanels), which is
-// `undefined` until the first task frame — so on a reload the layout still names
+// are registered off the task snapshot (via useWorkspaceDynamicPanels), which
+// isn't loaded until the first task frame — so on a reload the layout still names
 // an `agent:<taskId>` panel the registry can't resolve, and the sub-section would
 // otherwise fall through to the "Add panel" empty state as if the workspace were
 // empty. SectionBody reads this to show a loading placeholder for that window
 // instead; the resolved-component undefined check alone can't tell "agent panel
 // still loading" from "genuinely empty section".
+//
+// The loaded-vs-loading signal is `taskIdsAtom` (the ids list, `undefined` until
+// the first frame), NOT `tasksArrayAtom`: the array subscribes to every task
+// object and would rebuild on each streaming tick, so reading it here would
+// re-evaluate this atom on every token update. The ids list only changes when an
+// agent is created or deleted, and `taskIdsAtom === undefined` iff
+// `tasksArrayAtom === undefined`, so this is equivalent but far cheaper.
 //
 // It flips false the moment the task snapshot arrives: the placed panel then either
 // registers (a component resolves, so this is already false) or its task is gone
@@ -271,7 +278,7 @@ export const isSubSectionPanelLoadingAtom = atomFamily((subSection: SubSectionId
       return false;
     }
 
-    if (get(tasksArrayAtom) !== undefined) {
+    if (get(taskIdsAtom) !== undefined) {
       return false;
     }
     return get(panelsInSubSectionAtom(subSection)).length > 0;

--- a/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.module.scss
+++ b/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.module.scss
@@ -67,7 +67,7 @@
 // keeps Radix's pulse.
 .branchSkeletonWrap {
   align-items: center;
-  animation: workspace-row-branch-skeleton-reveal 0.15s ease-out 0.2s both;
+  animation: workspace-row-branch-skeleton-reveal var(--duration-fast) var(--ease-out) var(--duration-normal) both;
   display: inline-flex;
   flex-shrink: 0;
 }

--- a/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.module.scss
+++ b/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.module.scss
@@ -61,6 +61,39 @@
   will-change: color;
 }
 
+// Placeholder shown where the branch label goes, until the workspace's current
+// branch streams in. The wrapper owns a delayed fade-in so a fast load never
+// flashes it (the branch usually lands within the delay); the inner Skeleton
+// keeps Radix's pulse.
+.branchSkeletonWrap {
+  align-items: center;
+  animation: workspace-row-branch-skeleton-reveal 0.15s ease-out 0.2s both;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+@keyframes workspace-row-branch-skeleton-reveal {
+  from {
+    opacity: 0%;
+  }
+
+  to {
+    opacity: 100%;
+  }
+}
+
+.branchSkeleton {
+  border-radius: var(--radius-1);
+  height: var(--space-2);
+  width: 72px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .branchSkeletonWrap {
+    animation-duration: 0.01ms;
+  }
+}
+
 .rightGroup {
   align-items: center;
   display: flex;

--- a/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.tsx
+++ b/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.tsx
@@ -1,4 +1,4 @@
-import { ContextMenu, IconButton } from "@radix-ui/themes";
+import { ContextMenu, IconButton, Skeleton } from "@radix-ui/themes";
 import { useAtomValue } from "jotai";
 import { Trash2 } from "lucide-react";
 import type { ReactElement } from "react";
@@ -47,7 +47,13 @@ export const WorkspaceRow = ({
 }: WorkspaceRowProps): ReactElement => {
   const prDefaultTargetBranch = useAtomValue(prDefaultTargetBranchAtom);
   const branchInfo = useWorkspaceBranch(workspace.objectId);
-  const displayBranch = branchInfo?.currentBranch ?? workspace.sourceBranch;
+  // The workspace's own working branch arrives via the WebSocket stream (the
+  // branch poller publishes it for every workspace with a worktree); until it
+  // does, `branchInfo` is null. Don't fall back to `workspace.sourceBranch` —
+  // that's the DIFFERENT base branch the workspace was forked from, so the row
+  // would flash the wrong branch before the real one lands. Show a skeleton until
+  // `currentBranch` is known instead.
+  const currentBranch = branchInfo?.currentBranch;
   const gitProvider = useGitProvider(workspace.projectId);
 
   const rowContent = (
@@ -65,15 +71,21 @@ export const WorkspaceRow = ({
 
       <div className={styles.leftGroup}>
         <span className={styles.name}>{workspace.description}</span>
-        {displayBranch && (
+        {currentBranch !== undefined ? (
           <span className={styles.branch} data-testid={ElementIds.WORKSPACE_ROW_BRANCH}>
-            {displayBranch}
+            {currentBranch}
+          </span>
+        ) : (
+          // Branch not yet streamed in — a delayed-reveal skeleton so a fast load
+          // shows nothing then the real branch, and never the wrong one.
+          <span className={styles.branchSkeletonWrap} data-testid={ElementIds.WORKSPACE_ROW_BRANCH_SKELETON}>
+            <Skeleton className={styles.branchSkeleton} />
           </span>
         )}
       </div>
 
       <div className={styles.rightGroup}>
-        {displayBranch && (
+        {currentBranch !== undefined && (
           <div className={styles.prButton} onClick={(e) => e.stopPropagation()}>
             <PrButton
               workspaceId={workspace.objectId}

--- a/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.tsx
+++ b/sculptor/frontend/src/pages/add-workspace/components/WorkspaceRow.tsx
@@ -10,10 +10,10 @@ import { formatRelativeTime } from "~/common/formatRelativeTime.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { prDefaultTargetBranchAtom } from "~/common/state/atoms/userConfig.ts";
 import { useGitProvider } from "~/common/state/hooks/useGitProvider.ts";
-import { useWorkspaceBranch } from "~/common/state/hooks/useWorkspaceBranch.ts";
 import { computeWorkspaceDotStatus, EMPTY_WORKSPACE_DOT_STATUS, WorkspaceStatusDots } from "~/components/statusDot";
 import { PrButton } from "~/pages/workspace/components/PrButton.tsx";
 
+import { useWorkspaceRowBranch } from "./useWorkspaceRowBranch.ts";
 import styles from "./WorkspaceRow.module.scss";
 
 type WorkspaceRowProps = {
@@ -46,14 +46,11 @@ export const WorkspaceRow = ({
   onDelete,
 }: WorkspaceRowProps): ReactElement => {
   const prDefaultTargetBranch = useAtomValue(prDefaultTargetBranchAtom);
-  const branchInfo = useWorkspaceBranch(workspace.objectId);
-  // The workspace's own working branch arrives via the WebSocket stream (the
-  // branch poller publishes it for every workspace with a worktree); until it
-  // does, `branchInfo` is null. Don't fall back to `workspace.sourceBranch` —
-  // that's the DIFFERENT base branch the workspace was forked from, so the row
-  // would flash the wrong branch before the real one lands. Show a skeleton until
-  // `currentBranch` is known instead.
-  const currentBranch = branchInfo?.currentBranch;
+  // The workspace's own working branch streams in over the WebSocket. Until it
+  // arrives the row shows a skeleton rather than flashing `sourceBranch` (the
+  // base branch it was forked from); after a grace window it falls back to
+  // `sourceBranch` so the skeleton can't become permanent (see the hook).
+  const { branch, isLoading: isBranchLoading } = useWorkspaceRowBranch(workspace.objectId, workspace.sourceBranch);
   const gitProvider = useGitProvider(workspace.projectId);
 
   const rowContent = (
@@ -71,30 +68,31 @@ export const WorkspaceRow = ({
 
       <div className={styles.leftGroup}>
         <span className={styles.name}>{workspace.description}</span>
-        {currentBranch !== undefined ? (
-          <span className={styles.branch} data-testid={ElementIds.WORKSPACE_ROW_BRANCH}>
-            {currentBranch}
-          </span>
-        ) : (
+        {isBranchLoading ? (
           // Branch not yet streamed in — a delayed-reveal skeleton so a fast load
           // shows nothing then the real branch, and never the wrong one.
           <span className={styles.branchSkeletonWrap} data-testid={ElementIds.WORKSPACE_ROW_BRANCH_SKELETON}>
             <Skeleton className={styles.branchSkeleton} />
           </span>
-        )}
+        ) : branch !== null ? (
+          <span className={styles.branch} data-testid={ElementIds.WORKSPACE_ROW_BRANCH}>
+            {branch}
+          </span>
+        ) : null}
       </div>
 
       <div className={styles.rightGroup}>
-        {currentBranch !== undefined && (
-          <div className={styles.prButton} onClick={(e) => e.stopPropagation()}>
-            <PrButton
-              workspaceId={workspace.objectId}
-              targetBranch={prDefaultTargetBranch}
-              hideCreateAction
-              gitProvider={gitProvider}
-            />
-          </div>
-        )}
+        {/* PrButton reads its own PR status and renders nothing when there is no
+            PR (hideCreateAction), so its visibility is driven by PR state — not
+            gated on the branch, which it doesn't consume. */}
+        <div className={styles.prButton} onClick={(e) => e.stopPropagation()}>
+          <PrButton
+            workspaceId={workspace.objectId}
+            targetBranch={prDefaultTargetBranch}
+            hideCreateAction
+            gitProvider={gitProvider}
+          />
+        </div>
         <span className={styles.repo}>{workspace.projectName}</span>
         <span className={styles.time}>{formatRelativeTime(workspace.lastActivityAt)}</span>
         <IconButton

--- a/sculptor/frontend/src/pages/add-workspace/components/useWorkspaceRowBranch.test.tsx
+++ b/sculptor/frontend/src/pages/add-workspace/components/useWorkspaceRowBranch.test.tsx
@@ -1,0 +1,80 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceBranchInfo } from "~/api";
+import { workspaceBranchAtomFamily } from "~/common/state/atoms/workspaceBranch.ts";
+
+import { BRANCH_LOAD_GRACE_MS, useWorkspaceRowBranch } from "./useWorkspaceRowBranch.ts";
+
+type Store = ReturnType<typeof createStore>;
+
+const createWrapper = (store: Store) => {
+  return ({ children }: { children: ReactNode }): ReactElement => <Provider store={store}>{children}</Provider>;
+};
+
+const setBranch = (store: Store, workspaceId: string, currentBranch: string): void => {
+  store.set(workspaceBranchAtomFamily(workspaceId), { currentBranch, workspaceId } as WorkspaceBranchInfo);
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useWorkspaceRowBranch", () => {
+  it("reports loading (no branch) while the current branch hasn't streamed in yet", () => {
+    const store = createStore();
+    const { result } = renderHook(() => useWorkspaceRowBranch("ws1", "main"), { wrapper: createWrapper(store) });
+
+    expect(result.current).toEqual({ branch: null, isLoading: true });
+  });
+
+  it("shows the current branch and never the source branch once it arrives", () => {
+    const store = createStore();
+    setBranch(store, "ws1", "dev/feature");
+    const { result } = renderHook(() => useWorkspaceRowBranch("ws1", "main"), { wrapper: createWrapper(store) });
+
+    expect(result.current).toEqual({ branch: "dev/feature", isLoading: false });
+  });
+
+  it("swaps the skeleton for the real branch when it streams in later, skipping the source branch", () => {
+    const store = createStore();
+    const { result } = renderHook(() => useWorkspaceRowBranch("ws1", "main"), { wrapper: createWrapper(store) });
+
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => setBranch(store, "ws1", "dev/feature"));
+
+    expect(result.current).toEqual({ branch: "dev/feature", isLoading: false });
+  });
+
+  it("falls back to the source branch after the grace window so the skeleton can't be permanent", () => {
+    const store = createStore();
+    const { result } = renderHook(() => useWorkspaceRowBranch("ws1", "main"), { wrapper: createWrapper(store) });
+
+    expect(result.current).toEqual({ branch: null, isLoading: true });
+
+    act(() => {
+      vi.advanceTimersByTime(BRANCH_LOAD_GRACE_MS);
+    });
+
+    expect(result.current).toEqual({ branch: "main", isLoading: false });
+  });
+
+  it("shows nothing (no skeleton) after the grace window when there is no source branch either", () => {
+    const store = createStore();
+    const { result } = renderHook(() => useWorkspaceRowBranch("ws1", null), { wrapper: createWrapper(store) });
+
+    act(() => {
+      vi.advanceTimersByTime(BRANCH_LOAD_GRACE_MS);
+    });
+
+    expect(result.current).toEqual({ branch: null, isLoading: false });
+  });
+});

--- a/sculptor/frontend/src/pages/add-workspace/components/useWorkspaceRowBranch.ts
+++ b/sculptor/frontend/src/pages/add-workspace/components/useWorkspaceRowBranch.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+
+import { useWorkspaceBranch } from "~/common/state/hooks/useWorkspaceBranch.ts";
+
+// How long to show the branch skeleton before falling back to the source branch.
+// The workspace's current branch normally streams in well under this. The cap
+// exists because the branch poller only publishes a current branch for a
+// workspace whose git working directory resolves — a workspace whose
+// environment was never created (no agent has ever run) or whose worktree is
+// gone never emits one. Without a cap those rows, which do appear in the recent
+// list, would pulse a skeleton forever; after the grace window they fall back to
+// the source branch instead.
+export const BRANCH_LOAD_GRACE_MS = 2000;
+
+export type WorkspaceRowBranch = {
+  // The branch to display, or null when none is known (no current branch and no
+  // source branch). The row renders nothing for null.
+  branch: string | null;
+  // True only while still waiting for the current branch within the grace
+  // window — the row shows a skeleton then.
+  isLoading: boolean;
+};
+
+/**
+ * Resolve the branch label for a recent-workspace row.
+ *
+ * Prefers the workspace's own current branch, which streams in over the
+ * WebSocket. Until it arrives this reports `isLoading` so the row can show a
+ * skeleton rather than flashing `sourceBranch` — the DIFFERENT base branch the
+ * workspace was forked from. If the current branch hasn't arrived within
+ * {@link BRANCH_LOAD_GRACE_MS} it falls back to `sourceBranch`, so the skeleton
+ * can never become permanent for a workspace whose branch is never published.
+ */
+export const useWorkspaceRowBranch = (workspaceId: string, sourceBranch: string | null): WorkspaceRowBranch => {
+  const branchInfo = useWorkspaceBranch(workspaceId);
+  const currentBranch = branchInfo?.currentBranch;
+  const [hasGraceElapsed, setHasGraceElapsed] = useState(false);
+
+  useEffect(() => {
+    // Once the current branch is known there is nothing to wait for; the effect
+    // cleanup clears any pending timer from the loading window.
+    if (currentBranch !== undefined) {
+      return undefined;
+    }
+    const timer = setTimeout((): void => setHasGraceElapsed(true), BRANCH_LOAD_GRACE_MS);
+    return (): void => clearTimeout(timer);
+  }, [currentBranch]);
+
+  if (currentBranch !== undefined) {
+    return { branch: currentBranch, isLoading: false };
+  }
+
+  if (hasGraceElapsed) {
+    return { branch: sourceBranch, isLoading: false };
+  }
+  return { branch: null, isLoading: true };
+};

--- a/sculptor/frontend/src/stories/custom/SectionLoadingState.stories.tsx
+++ b/sculptor/frontend/src/stories/custom/SectionLoadingState.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+
+import { SectionLoadingState } from "~/components/sections/SectionLoadingState";
+
+/**
+ * Renders the section-body loading placeholder inside a panel-sized box that
+ * mimics a section's content area, so the skeleton geometry can be eyeballed the
+ * way it appears while an agent panel is still resolving after a hard refresh.
+ */
+const Wrapper = (): ReactElement => (
+  <div style={{ background: "var(--color-panel-solid)", width: "620px", height: "360px", display: "flex" }}>
+    <SectionLoadingState />
+  </div>
+);
+
+const meta = {
+  title: "Custom/SectionLoadingState",
+  component: Wrapper,
+} satisfies Meta<typeof Wrapper>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/sculptor/frontend/src/stories/custom/SidebarLoadingSkeleton.stories.tsx
+++ b/sculptor/frontend/src/stories/custom/SidebarLoadingSkeleton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactElement } from "react";
+
+import { SidebarLoadingSkeleton } from "~/components/nav/SidebarLoadingSkeleton";
+
+/**
+ * Renders the sidebar loading skeleton inside a rail-width, `--gray-2` column
+ * that mimics the real sidebar's `.repoList` padding, so the placeholder
+ * geometry can be eyeballed the way it appears after a hard refresh.
+ */
+const Wrapper = (): ReactElement => (
+  <div style={{ background: "var(--gray-2)", width: "240px", height: "100%" }}>
+    <div style={{ padding: "var(--space-1) var(--space-2)" }}>
+      <SidebarLoadingSkeleton />
+    </div>
+  </div>
+);
+
+const meta = {
+  title: "Custom/SidebarLoadingSkeleton",
+  component: Wrapper,
+} satisfies Meta<typeof Wrapper>;
+
+// eslint-disable-next-line import/no-default-export
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -592,6 +592,10 @@ class ElementIDs(StrEnum):
     WORKSPACE_NAME_INPUT = "WORKSPACE_NAME_INPUT"
     WORKSPACE_ROW = "WORKSPACE_ROW"
     WORKSPACE_ROW_BRANCH = "WORKSPACE_ROW_BRANCH"
+    # Placeholder shown in place of a recent-workspace row's branch label while
+    # the workspace's current branch is still streaming in (so the row never
+    # flashes the source branch it was forked from).
+    WORKSPACE_ROW_BRANCH_SKELETON = "WORKSPACE_ROW_BRANCH_SKELETON"
     WORKSPACE_SEARCH_INPUT = "WORKSPACE_SEARCH_INPUT"
     ADD_WORKSPACE_EMPTY_STATE = "ADD_WORKSPACE_EMPTY_STATE"
 
@@ -618,6 +622,10 @@ class ElementIDs(StrEnum):
     # beneath a repo that has no workspaces.
     SIDEBAR_ADD_REPO_BUTTON = "SIDEBAR_ADD_REPO_BUTTON"
     SIDEBAR_NO_WORKSPACES_HINT = "SIDEBAR_NO_WORKSPACES_HINT"
+    # Placeholder skeleton shown in the repo-list area while the first workspace
+    # snapshot is still in flight (e.g. right after a hard refresh), before the
+    # list is known to be empty or populated.
+    SIDEBAR_LOADING_SKELETON = "SIDEBAR_LOADING_SKELETON"
 
     # The PaletteDialog shell's dimmed overlay, rendered for every open.
     PALETTE_DIALOG_OVERLAY = "PALETTE_DIALOG_OVERLAY"
@@ -654,6 +662,10 @@ class ElementIDs(StrEnum):
     SECTION_MAXIMIZE_BUTTON = "SECTION_MAXIMIZE_BUTTON"
     SECTION_ACTIVE_RING = "SECTION_ACTIVE_RING"
     SECTION_EMPTY_STATE = "SECTION_EMPTY_STATE"
+    # Placeholder shown in a section body while its placed panel is still
+    # resolving because the agent/task snapshot hasn't arrived yet (e.g. after a
+    # hard refresh), in place of the empty-state launcher.
+    SECTION_LOADING_STATE = "SECTION_LOADING_STATE"
     SECTION_SPLIT_SUBSECTION = "SECTION_SPLIT_SUBSECTION"
     # The collapsed-section drop overlay floating at a window edge during a panel
     # drag; suffixed with the section id (e.g. f"{SECTION_DROP_OVERLAY}-bottom").


### PR DESCRIPTION
## What

Adds loading skeletons across the frontend so several surfaces stop showing empty or wrong content while data is still streaming in over the WebSocket on startup / hard refresh (Cmd-R). Each surface previously couldn't tell "still loading" from "loaded and empty".

### Sidebar
The left workspace sidebar rendered a **blank rail** until the first workspace snapshot arrived. Added `SidebarLoadingSkeleton`, gated on a new `isSidebarLoadingAtom` (`workspacesArrayAtom === undefined`) — recovering the loading-vs-empty signal the sidebar's `?? []` had erased.

### Panel area
`SectionBody` showed the **"Add panel" empty state** while an agent panel's component was still registering off the not-yet-loaded task snapshot (`tasksArrayAtom` is `undefined` until the first task frame). Added `SectionLoadingState`, gated on `isSubSectionPanelLoadingAtom` (unresolved component + tasks still loading + a panel actually placed). It flips off the instant tasks load, so a genuinely empty section still shows its launcher.

### Recent-workspaces list
Rows **flashed the source/base branch** before the workspace's actual current branch streamed in. Now shows a skeleton until `currentBranch` is known (`useWorkspaceRowBranch`), falling back to the source branch after a grace window so the skeleton can never become permanent for a workspace that never publishes a branch (a never-run worktree, or one whose worktree is gone). The PR badge is decoupled from the branch — it derives visibility from PR status, which it already reads.

### Shared
All skeletons use a ~200ms delayed reveal so fast loads never flash a placeholder, honour `prefers-reduced-motion`, and use design tokens for the reveal animation.

## Testing
- Unit tests for `isSidebarLoadingAtom`, `isSubSectionPanelLoadingAtom` (a 4-case loading/loaded-empty/resolved/genuinely-empty matrix), and `useWorkspaceRowBranch` (loading / resolve / bounded source-branch fallback).
- `just format`, `just check`, and `just test-unit` all pass.
- Storybook screenshots captured for each skeleton in light and dark themes.

Reviewed with `/code-review-checklist`; the flagged branch-skeleton "forever" risk and PR-badge coupling are addressed in the second commit.

SCU-1818

(Sent by Claude)
