### PR TITLE
Chase the growing bottom when restoring a cold chat (SCU-1819)

### DIFF
--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/__tests__/useAlphaScrollPersistence.test.tsx
@@ -40,6 +40,13 @@ const setScrollPosition = (el: HTMLDivElement, scrollTop: number, scrollHeight: 
   Object.defineProperty(el, "scrollHeight", { value: scrollHeight, writable: true, configurable: true });
 };
 
+// Grow only scrollHeight (scrollHeight is a read-only DOM prop; the mock backs
+// it with a redefinable data property). Simulates rows measuring taller than
+// their cold estimates and enlarging the virtual content after mount.
+const setScrollHeight = (el: HTMLDivElement, scrollHeight: number): void => {
+  Object.defineProperty(el, "scrollHeight", { value: scrollHeight, writable: true, configurable: true });
+};
+
 const createMockVirtualItem = (index: number, start: number, size: number): VirtualItem => ({
   index,
   start,
@@ -231,6 +238,129 @@ describe("useAlphaScrollPersistence", () => {
 
     // Content bottom 1100 + 600 = 1700 exceeds the max scroll (1500) — clamped.
     expect(el.scrollTop).toBe(1500);
+  });
+
+  it("keeps re-pinning a near-bottom restore as measurements grow the content after mount", () => {
+    // Cold task switch: off-screen rows start at their estimated heights, so the
+    // content is far shorter than its measured size. The first restore-to-bottom
+    // lands against that estimate; the real rows then measure taller over the
+    // next frames and the content grows underneath the reader. A one-shot
+    // re-assert fires once and stops, stranding the reader pages above the true
+    // bottom — the restore must chase the growing bottom until it converges.
+    const el = createMockScrollContainer(0, 1000, 800); // desktop height; cold scrollHeight 1000
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer([createMockVirtualItem(0, 0, 200)], 64);
+    const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+    const store = createStore();
+    // Saved pinned at the live bottom: the -64 pin-gap signature (PIN_BOTTOM_GAP).
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-3",
+      pixelOffset: 0,
+      distanceFromBottom: -64,
+    });
+
+    const machine = createScrollStateMachine();
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }), {
+      wrapper: wrapperFor(store),
+    });
+
+    // Cold apply: contentBottom (1000 - 64 - 800 = 136) + 64 = 200, clamped to
+    // the cold max scroll (1000 - 800 = 200).
+    expect(el.scrollTop).toBe(200);
+
+    // Rows measure taller across the next four frames, growing the content to
+    // 3000 — a monotonic cold-to-measured convergence, past the two frames a
+    // single deferred re-assert would cover.
+    act(() => {
+      setScrollHeight(el, 1500);
+      vi.advanceTimersByTime(16);
+      setScrollHeight(el, 2000);
+      vi.advanceTimersByTime(16);
+      setScrollHeight(el, 2500);
+      vi.advanceTimersByTime(16);
+      setScrollHeight(el, 3000);
+      vi.advanceTimersByTime(16);
+      // Let the loop observe the height stabilize and settle.
+      vi.advanceTimersByTime(160);
+    });
+
+    // Re-pinned to the true bottom: contentBottom (3000 - 64 - 800 = 2136) + 64
+    // = 2200, clamped to the grown max scroll (3000 - 800 = 2200) — not the cold
+    // 200, and not the ~1200 a single 2-frame re-assert would leave behind.
+    expect(el.scrollTop).toBe(2200);
+    // And it hands control back once the content stops growing.
+    expect(machine.getState().authority.kind).toBe("userControlled");
+  });
+
+  it("stops chasing the bottom when the user scrolls mid-restore", () => {
+    // The convergence loop must yield to a genuine takeover: once the user
+    // scrolls, it neither re-pins nor clobbers their position, exactly like the
+    // anchor path's deferred re-assert.
+    const el = createMockScrollContainer(0, 1000, 800);
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer([createMockVirtualItem(0, 0, 200)], 64);
+    const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+    const store = createStore();
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-3",
+      pixelOffset: 0,
+      distanceFromBottom: -64,
+    });
+
+    const machine = createScrollStateMachine();
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }), {
+      wrapper: wrapperFor(store),
+    });
+
+    // Cold apply landed at 200 (one write).
+    expect(el.scrollTopWrites).toEqual([200]);
+
+    act(() => {
+      machine.dispatch({ kind: "userScrolled" });
+      // Content keeps growing, but the user is now in control.
+      setScrollHeight(el, 3000);
+      vi.advanceTimersByTime(160);
+    });
+
+    // No further programmatic writes — the grown bottom is not chased.
+    expect(el.scrollTopWrites).toEqual([200]);
+    expect(machine.getState().authority.kind).toBe("userControlled");
+  });
+
+  it("hands control back even when the content never stops growing", () => {
+    // A task that streams a token every frame never gives the loop two
+    // consecutive stable frames. The frame cap must still settle it so the
+    // machine cannot be stranded in `restoring` (which withholds `settled` and
+    // suppresses saves) for the life of the stream.
+    const el = createMockScrollContainer(0, 1000, 800);
+    const ref = { current: el };
+    const virtualizer = createMockVirtualizer([createMockVirtualItem(0, 0, 200)], 64);
+    const messages = [{ id: "msg-1" }, { id: "msg-2" }, { id: "msg-3" }];
+    const store = createStore();
+    store.set(alphaScrollPositionAtomFamily("task-1"), {
+      firstVisibleMessageId: "msg-3",
+      pixelOffset: 0,
+      distanceFromBottom: -64,
+    });
+
+    const machine = createScrollStateMachine();
+    renderHook(() => useAlphaScrollPersistence(ref, virtualizer, "task-1", messages, machine, { current: false }), {
+      wrapper: wrapperFor(store),
+    });
+
+    // Grow the content every frame for more than the frame cap; the loop never
+    // sees two stable frames, so only the cap can end it.
+    act(() => {
+      let height = 1000;
+      for (let frame = 0; frame < 40; frame++) {
+        height += 100;
+        setScrollHeight(el, height);
+        vi.advanceTimersByTime(16);
+      }
+    });
+
+    // The cap handed control back rather than chasing the stream forever.
+    expect(machine.getState().authority.kind).toBe("userControlled");
   });
 
   it("restores to message position when saved", () => {

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -338,8 +338,17 @@ export const useAlphaScrollPersistence = (
         return;
       }
 
+      const beforeScrollTop = container.scrollTop;
       isProgrammaticScrollRef.current = true;
       applyScrollPosition();
+      // A re-pin that didn't move scrollTop fires no scroll event, so no
+      // listener will consume (and clear) the flag this frame — clear it now,
+      // otherwise it lingers until the next tick and a user scroll in that gap
+      // would be misread as programmatic. A move keeps the flag set for the
+      // scroll event it produces; the scroll handler clears it in a microtask.
+      if (container.scrollTop === beforeScrollTop) {
+        isProgrammaticScrollRef.current = false;
+      }
 
       const height = container.scrollHeight;
       stableFrames = height === lastHeight ? stableFrames + 1 : 0;

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -25,6 +25,19 @@ const cancelPendingRafs = (ids: Set<number>): void => {
   ids.clear();
 };
 
+/** A bottom-relative restore re-pins every animation frame while the mounted
+ *  rows replace their cold estimates with real measurements (which grows the
+ *  content height). Convergence is declared once the height holds steady for
+ *  this many consecutive frames. */
+const BOTTOM_CONVERGE_STABLE_FRAMES = 2;
+/** Hard cap on the re-pin chase, so a task whose content never stabilizes for
+ *  two consecutive frames (a live stream, a perpetually reflowing row) still
+ *  hands control back. Real cold-estimate convergence is a handful of frames, so
+ *  this only fires on genuinely never-settling content; kept tight (~0.5s at
+ *  60fps) so `restoring` — which withholds `settled` and suppresses saves — is
+ *  never held long past convergence. */
+const BOTTOM_CONVERGE_MAX_FRAMES = 30;
+
 type MessageRef = { id: string };
 
 export const useAlphaScrollPersistence = (
@@ -259,29 +272,72 @@ export const useAlphaScrollPersistence = (
       setSettleRender((count) => count + 1);
     }
 
-    // Safety-net re-assert after the virtualizer's settle window. The pre-paint
-    // settle already applied against swept measurements, so this is normally a
-    // no-op (writing an equal scrollTop fires no scroll event). It catches what
-    // the sweep cannot: rows whose async re-measurement (images, fonts, late
-    // reflows) lands after the settle render.
-    const id1 = requestAnimationFrame(() => {
-      pendingRafsRef.current.delete(id1);
-      const id2 = requestAnimationFrame(() => {
-        pendingRafsRef.current.delete(id2);
-        // Only re-assert while the machine is still `restoring`. A genuine user
-        // scroll during the restore window flips authority to `userControlled`
-        // (see useScrollStateMachine), so this skips the re-assert rather than
-        // snapping the view back to the saved anchor and clobbering them.
-        if (machine.getState().authority.kind === "restoring") {
-          applyScrollPosition();
-        }
-        // Settle: returns authority to `userControlled` (a no-op if the user
-        // already took over).
-        machine.dispatch({ kind: "restoreSettled" });
+    // Anchor restores land in one shot: the pre-paint sweep already resolved the
+    // anchor against swept measurements, so a single deferred re-assert after
+    // the virtualizer's settle window is enough to catch what the sweep cannot —
+    // rows whose async re-measurement (images, fonts, late reflows) lands after
+    // the settle render. Writing an equal scrollTop fires no scroll event, so
+    // this is normally a no-op.
+    if (resolution === "anchor") {
+      const id1 = requestAnimationFrame(() => {
+        pendingRafsRef.current.delete(id1);
+        const id2 = requestAnimationFrame(() => {
+          pendingRafsRef.current.delete(id2);
+          // Only re-assert while the machine is still `restoring`. A genuine user
+          // scroll during the restore window flips authority to `userControlled`
+          // (see useScrollStateMachine), so this skips the re-assert rather than
+          // snapping the view back to the saved anchor and clobbering them.
+          if (machine.getState().authority.kind === "restoring") {
+            applyScrollPosition();
+          }
+          // Settle: returns authority to `userControlled` (a no-op if the user
+          // already took over).
+          machine.dispatch({ kind: "restoreSettled" });
+        });
+        pendingRafsRef.current.add(id2);
       });
-      pendingRafsRef.current.add(id2);
-    });
-    pendingRafsRef.current.add(id1);
+      pendingRafsRef.current.add(id1);
+      return;
+    }
+
+    // Bottom-relative restores cannot settle in one shot. Their target is the
+    // *content bottom*, which only exists once the mounted rows have replaced
+    // their cold estimates with measured heights — a convergence that unfolds
+    // over several frames (and, on a cold app start, while the rows are still
+    // streaming in). A single deferred re-assert fires mid-convergence and
+    // strands the reader pages above the true bottom, because the content keeps
+    // growing after it settles. So re-pin every frame, re-resolving the bottom
+    // against the now-current geometry, until the content height holds steady
+    // for BOTTOM_CONVERGE_STABLE_FRAMES frames (converged) or the frame cap
+    // elapses (never-settling content) — then hand control back. A genuine user
+    // scroll flips authority out of `restoring` and ends the chase on the next
+    // frame with no final clobbering write. Saves stay suppressed throughout:
+    // the save handler ignores scrolls while authority is `restoring`.
+    let lastHeight = el.scrollHeight;
+    let stableFrames = 0;
+    let elapsedFrames = 0;
+    let rafId = 0;
+    const tick = (): void => {
+      pendingRafsRef.current.delete(rafId);
+      const container = scrollContainerRef.current;
+      if (!container || machine.getState().authority.kind !== "restoring") return;
+
+      applyScrollPosition();
+
+      const height = container.scrollHeight;
+      stableFrames = height === lastHeight ? stableFrames + 1 : 0;
+      lastHeight = height;
+      elapsedFrames += 1;
+
+      if (stableFrames >= BOTTOM_CONVERGE_STABLE_FRAMES || elapsedFrames >= BOTTOM_CONVERGE_MAX_FRAMES) {
+        machine.dispatch({ kind: "restoreSettled" });
+        return;
+      }
+      rafId = requestAnimationFrame(tick);
+      pendingRafsRef.current.add(rafId);
+    };
+    rafId = requestAnimationFrame(tick);
+    pendingRafsRef.current.add(rafId);
   }, [
     scrollContainerRef,
     virtualizer,

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -313,15 +313,32 @@ export const useAlphaScrollPersistence = (
     // scroll flips authority out of `restoring` and ends the chase on the next
     // frame with no final clobbering write. Saves stay suppressed throughout:
     // the save handler ignores scrolls while authority is `restoring`.
+    //
+    // Each re-pin is a programmatic scrollTop write, so the loop holds
+    // `isProgrammaticScrollRef` for the whole chase — the documented flag every
+    // chat scroll listener reads to tell a restore from a user scroll (like
+    // useAlphaAutoScroll's pinToBottom) — and clears it at every exit, so a
+    // scroll event from a re-pin is never misread and the flag never lingers
+    // past the restore.
     let lastHeight = el.scrollHeight;
     let stableFrames = 0;
     let elapsedFrames = 0;
     let rafId = 0;
+    const endConvergence = (): void => {
+      isProgrammaticScrollRef.current = false;
+    };
+
     const tick = (): void => {
       pendingRafsRef.current.delete(rafId);
       const container = scrollContainerRef.current;
-      if (!container || machine.getState().authority.kind !== "restoring") return;
+      // The user grabbed the scroll (or the container unmounted): stop chasing
+      // and leave their position untouched. Authority is already userControlled.
+      if (!container || machine.getState().authority.kind !== "restoring") {
+        endConvergence();
+        return;
+      }
 
+      isProgrammaticScrollRef.current = true;
       applyScrollPosition();
 
       const height = container.scrollHeight;
@@ -331,6 +348,7 @@ export const useAlphaScrollPersistence = (
 
       if (stableFrames >= BOTTOM_CONVERGE_STABLE_FRAMES || elapsedFrames >= BOTTOM_CONVERGE_MAX_FRAMES) {
         machine.dispatch({ kind: "restoreSettled" });
+        endConvergence();
         return;
       }
       rafId = requestAnimationFrame(tick);
@@ -346,6 +364,7 @@ export const useAlphaScrollPersistence = (
     sweepMountedMeasurements,
     machine,
     taskId,
+    isProgrammaticScrollRef,
   ]);
 
   // Restore scroll position synchronously before paint so the user never

--- a/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
+++ b/sculptor/frontend/src/pages/workspace/components/chat-alpha/hooks/useAlphaScrollPersistence.ts
@@ -323,6 +323,11 @@ export const useAlphaScrollPersistence = (
     let lastHeight = el.scrollHeight;
     let stableFrames = 0;
     let elapsedFrames = 0;
+    // The frame on which the content height last grew — the debug tell below. A
+    // value past ~2 means the content was still growing after the old single
+    // deferred re-assert would have fired, i.e. a case the one-shot restore
+    // would have stranded above the bottom.
+    let lastGrowthFrame = 0;
     let rafId = 0;
     const endConvergence = (): void => {
       isProgrammaticScrollRef.current = false;
@@ -351,11 +356,25 @@ export const useAlphaScrollPersistence = (
       }
 
       const height = container.scrollHeight;
-      stableFrames = height === lastHeight ? stableFrames + 1 : 0;
-      lastHeight = height;
       elapsedFrames += 1;
+      if (height === lastHeight) {
+        stableFrames += 1;
+      } else {
+        stableFrames = 0;
+        lastGrowthFrame = elapsedFrames;
+      }
+      lastHeight = height;
 
       if (stableFrames >= BOTTOM_CONVERGE_STABLE_FRAMES || elapsedFrames >= BOTTOM_CONVERGE_MAX_FRAMES) {
+        const didHitCap = stableFrames < BOTTOM_CONVERGE_STABLE_FRAMES;
+        // Debug: how long the re-pin chased the growing bottom. `lastGrowth`
+        // past ~2 (or a cap hit) flags a restore the old single deferred
+        // re-assert would have settled early and stranded above the bottom.
+        console.log(
+          `[alpha-scroll] bottom restore settled: frames=${elapsedFrames}, lastGrowth=${lastGrowthFrame}` +
+            `${didHitCap ? " (hit frame cap)" : ""}, distanceFromBottom=` +
+            `${Math.round(distanceFromContentBottom(container, virtualizer))}px`,
+        );
         machine.dispatch({ kind: "restoreSettled" });
         endConvergence();
         return;

--- a/sculptor/sculptor/testing/elements/alpha_chat_view.py
+++ b/sculptor/sculptor/testing/elements/alpha_chat_view.py
@@ -232,6 +232,34 @@ def get_last_turn_footer_viewport_gaps(page: Page) -> dict | None:
     )
 
 
+def wait_for_last_turn_footer_near_bottom(
+    page: Page, *, max_bottom_gap: int, min_bottom_gap: int = -6, timeout_ms: int = 30_000
+) -> None:
+    """Retry until the last turn footer sits near the viewport bottom.
+
+    An auto-retrying wait (Playwright ``wait_for_function``) rather than a
+    one-shot ``get_last_turn_footer_viewport_gaps`` read, so it can't snapshot a
+    frame before the footer has rendered or the restore has finished landing:
+    it resolves once the footer exists AND its bottom edge is within
+    ``[min_bottom_gap, max_bottom_gap]`` px of the viewport bottom (in view and
+    close to the bottom). ``min_bottom_gap`` defaults to a small negative edge
+    tolerance so a footer flush with the viewport bottom still counts as in view.
+    """
+    page.wait_for_function(
+        f"""({{ maxGap, minGap }}) => {{
+        const view = document.querySelector('[data-testid="{ElementIDs.ALPHA_CHAT_VIEW}"]');
+        const footers = document.querySelectorAll('[data-testid="{ElementIDs.TURN_FOOTER}"]');
+        if (!view || footers.length === 0) return false;
+        const v = view.getBoundingClientRect();
+        const f = footers[footers.length - 1].getBoundingClientRect();
+        const bottomGap = v.bottom - f.bottom;
+        return bottomGap >= minGap && bottomGap <= maxGap;
+    }}""",
+        arg={"maxGap": max_bottom_gap, "minGap": min_bottom_gap},
+        timeout=timeout_ms,
+    )
+
+
 def get_max_following_tail_gap(page: Page, frames: int = 18) -> float | None:
     """Over a short ``requestAnimationFrame`` burst, the max gap (px) from the last
     message's bottom edge UP to the viewport bottom.

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_restore.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_restore.py
@@ -1,0 +1,110 @@
+"""Integration test: reopening a task keeps a bottom-pinned reader at the bottom.
+
+Alpha-chat scroll positions persist in ``localStorage``
+(``sculptor-alpha-scroll:<taskId>``) so a full app restart restores where the
+reader left off (see ``common/state/atoms/alphaScroll.ts``). On a cold reload the
+virtualizer starts every off-screen row at its *estimated* height, so the content
+is far shorter than its measured size. A restore that resolves "the bottom"
+against that cold estimate lands short; the real rows then measure taller and grow
+the content underneath, stranding a reader who was at the bottom pages above it.
+The bottom restore must chase the growing bottom until the content converges (the
+re-pin loop in ``useAlphaScrollPersistence``), rather than applying once and
+settling mid-convergence.
+"""
+
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
+from sculptor.testing.elements.alpha_chat_view import get_last_turn_footer_viewport_gaps
+from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
+from sculptor.testing.elements.alpha_chat_view import wait_for_alpha_scroll_settled
+from sculptor.testing.elements.alpha_chat_view import wait_for_scroll_save_debounce
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.workspace_section import PlaywrightWorkspaceSection
+from sculptor.testing.playwright_utils import full_spa_reload
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# Tall responses (far above the cold 120px per-row estimate,
+# ESTIMATED_MESSAGE_HEIGHT in useAlphaVirtualizer) so a few turns overflow the
+# viewport by several screens and there is a real bottom to restore to.
+_TURN_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 80
+# Extra turns after the opening one. The FakeClaude harness reliably completes
+# only a few turns per task, so this stays small; the transcript is made tall by
+# the per-turn size rather than the turn count.
+_EXTRA_TURNS = 2
+
+# The pin gap the bottom sits above the viewport bottom (PIN_BOTTOM_GAP in
+# chat-alpha/scroll/geometry.ts).
+_PIN_BOTTOM_GAP_PX = 64
+# "At the bottom" == the last turn footer's bottom edge sits within the pin gap
+# plus one standard margin of the viewport bottom. A stranded restore leaves the
+# footer hundreds of px below the fold, so this generous band still separates
+# "at the bottom" from the bug cleanly.
+_FOOTER_BOTTOM_MARGIN_PX = _PIN_BOTTOM_GAP_PX + 72
+# Sub-pixel tolerance for "is this edge inside the viewport".
+_EDGE_TOLERANCE_PX = 6
+
+
+@user_story("to reopen a task I left at the bottom and still be at the bottom after a full reload")
+def test_reload_restores_scroll_to_bottom(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt=f'fake_claude:text `{{"text": "Turn 0. {_TURN_TEXT}"}}`',
+    )
+    chat_panel = task_page.get_chat_panel()
+    PlaywrightWorkspaceSection(page, "bottom").collapse_section()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    # Many more turns so the transcript is a long list of rows (a short chat's rows
+    # all mount at once and converge in a frame, hiding the bug). Each prompt is
+    # made unique (a turn index) so no two turns dedupe, and each turn completes
+    # before the next is sent so the count advances deterministically.
+    expected_count = 2
+    for turn in range(1, _EXTRA_TURNS + 1):
+        send_chat_message(chat_panel, f'fake_claude:text `{{"text": "Turn {turn}. {_TURN_TEXT}"}}`')
+        expected_count += 2
+        wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=expected_count)
+
+    view = get_alpha_chat_view(page)
+    expect(view).to_be_visible()
+    wait_for_alpha_scroll_settled(page)
+
+    # Persist an at-bottom position: a user scroll to (past) the bottom records
+    # distanceFromBottom at the pin — the -64 signature — into localStorage.
+    scroll_alpha_chat_by(page, 2000)
+    wait_for_scroll_save_debounce(page)
+
+    # Precondition: the last turn footer is at the bottom before the reload.
+    gaps_before = get_last_turn_footer_viewport_gaps(page)
+    assert gaps_before is not None and gaps_before["bottom_gap"] <= _FOOTER_BOTTOM_MARGIN_PX, (
+        f"precondition failed: the chat is not at the bottom before the reload (gaps={gaps_before})"
+    )
+
+    # The coldest possible restore: a full SPA teardown wipes the in-memory scroll
+    # atom, so the saved position is re-read from localStorage and resolved against
+    # a cold virtualizer whose rows re-measure taller after mount.
+    current_hash = page.url.split("#", 1)[1] if "#" in page.url else "/"
+    full_spa_reload(page, target_hash=f"#{current_hash}")
+
+    reloaded_chat_panel = task_page.get_chat_panel()
+    expect(get_alpha_chat_view(page)).to_be_visible()
+    wait_for_completed_message_count(chat_panel=reloaded_chat_panel, expected_message_count=expected_count)
+    wait_for_alpha_scroll_settled(page)
+
+    # The reload landed back at the bottom: the last turn footer is in view and
+    # close to the viewport bottom — not stranded pages above it.
+    gaps = get_last_turn_footer_viewport_gaps(page)
+    assert gaps is not None, "no turn footer rendered after the reload"
+    assert gaps["bottom_gap"] >= -_EDGE_TOLERANCE_PX, (
+        f"after the reload the last turn footer is cut off {-gaps['bottom_gap']}px below the fold; "
+        + "the restore stranded the reader above the bottom instead of chasing the growing content"
+    )
+    assert gaps["bottom_gap"] <= _FOOTER_BOTTOM_MARGIN_PX, (
+        f"after the reload the last turn footer sits {gaps['bottom_gap']}px above the viewport bottom "
+        + f"(expected <= {_FOOTER_BOTTOM_MARGIN_PX}px); the restore did not return to the bottom"
+    )

--- a/sculptor/tests/integration/frontend/test_alpha_scroll_restore.py
+++ b/sculptor/tests/integration/frontend/test_alpha_scroll_restore.py
@@ -12,12 +12,14 @@ re-pin loop in ``useAlphaScrollPersistence``), rather than applying once and
 settling mid-convergence.
 """
 
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import expect
 
 from sculptor.testing.elements.alpha_chat_view import get_alpha_chat_view
 from sculptor.testing.elements.alpha_chat_view import get_last_turn_footer_viewport_gaps
 from sculptor.testing.elements.alpha_chat_view import scroll_alpha_chat_by
 from sculptor.testing.elements.alpha_chat_view import wait_for_alpha_scroll_settled
+from sculptor.testing.elements.alpha_chat_view import wait_for_last_turn_footer_near_bottom
 from sculptor.testing.elements.alpha_chat_view import wait_for_scroll_save_debounce
 from sculptor.testing.elements.chat_panel import send_chat_message
 from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
@@ -79,11 +81,9 @@ def test_reload_restores_scroll_to_bottom(sculptor_instance_: SculptorInstance) 
     scroll_alpha_chat_by(page, 2000)
     wait_for_scroll_save_debounce(page)
 
-    # Precondition: the last turn footer is at the bottom before the reload.
-    gaps_before = get_last_turn_footer_viewport_gaps(page)
-    assert gaps_before is not None and gaps_before["bottom_gap"] <= _FOOTER_BOTTOM_MARGIN_PX, (
-        f"precondition failed: the chat is not at the bottom before the reload (gaps={gaps_before})"
-    )
+    # Precondition: the chat is at the bottom before the reload (retry until the
+    # footer settles there, rather than snapshotting a single frame).
+    wait_for_last_turn_footer_near_bottom(page, max_bottom_gap=_FOOTER_BOTTOM_MARGIN_PX)
 
     # The coldest possible restore: a full SPA teardown wipes the in-memory scroll
     # atom, so the saved position is re-read from localStorage and resolved against
@@ -96,15 +96,19 @@ def test_reload_restores_scroll_to_bottom(sculptor_instance_: SculptorInstance) 
     wait_for_completed_message_count(chat_panel=reloaded_chat_panel, expected_message_count=expected_count)
     wait_for_alpha_scroll_settled(page)
 
-    # The reload landed back at the bottom: the last turn footer is in view and
-    # close to the viewport bottom — not stranded pages above it.
-    gaps = get_last_turn_footer_viewport_gaps(page)
-    assert gaps is not None, "no turn footer rendered after the reload"
-    assert gaps["bottom_gap"] >= -_EDGE_TOLERANCE_PX, (
-        f"after the reload the last turn footer is cut off {-gaps['bottom_gap']}px below the fold; "
-        + "the restore stranded the reader above the bottom instead of chasing the growing content"
-    )
-    assert gaps["bottom_gap"] <= _FOOTER_BOTTOM_MARGIN_PX, (
-        f"after the reload the last turn footer sits {gaps['bottom_gap']}px above the viewport bottom "
-        + f"(expected <= {_FOOTER_BOTTOM_MARGIN_PX}px); the restore did not return to the bottom"
-    )
+    # The reload must land back at the bottom: the last turn footer in view and
+    # close to the viewport bottom, not stranded pages above it. A retrying wait
+    # (per use_expect_not_assert) so a footer that renders — or a chase that
+    # converges — a beat late does not read as a failure; the one-shot read only
+    # runs on timeout, to turn the raw wait error into an actionable geometry.
+    try:
+        wait_for_last_turn_footer_near_bottom(
+            page, max_bottom_gap=_FOOTER_BOTTOM_MARGIN_PX, min_bottom_gap=-_EDGE_TOLERANCE_PX
+        )
+    except PlaywrightTimeoutError:
+        gaps = get_last_turn_footer_viewport_gaps(page)
+        raise AssertionError(
+            f"after the reload the last turn footer did not land at the bottom (gaps={gaps}); "
+            + f"expected bottom_gap in [{-_EDGE_TOLERANCE_PX}, {_FOOTER_BOTTOM_MARGIN_PX}] px — the "
+            + "restore stranded the reader above the bottom or cut the footer off below the fold"
+        )


### PR DESCRIPTION
## Problem

A chat left scrolled to the very bottom restores **short of the bottom** on a cold reload (full app restart) or a task switch — the reader lands a few pages (up to roughly half the transcript) above where they left off.

Root cause: the at-bottom restore in `useAlphaScrollPersistence` resolves the content bottom against the virtualizer's **cold, estimated** row heights (120px/row) and then fires a **single** re-assert two animation frames later. On a long transcript the off-screen rows re-measure taller over many frames after mount, growing the content underneath the reader; the one-shot re-assert settles mid-convergence, so the view is stranded above the bottom. The pre-paint settle work handled the message-anchored path but explicitly left the bottom-relative path to that single re-assert.

Diagnosed from a live in-app trace: restore pinned to a ~12,000px cold estimate, the content grew to ~22,000px *after* the re-assert settled, leaving the reader ~10,600px above the bottom.

## Fix

Replace the single deferred re-assert on the **bottom** restore path with a bounded convergence loop: re-pin to the content bottom every frame, re-resolving against the now-current geometry, until the content height holds steady for two frames (converged) or a ~0.5s frame cap elapses (never-settling content such as a live stream). A genuine user scroll flips authority out of `restoring` and ends the chase with no clobbering write. The re-pins are flagged as programmatic scrolls (held across the chase, cleared at every exit), matching `useAlphaAutoScroll`'s pin-to-bottom convention. The message-anchored path (the pre-paint sweep and settle) is unchanged.

## Tests

- **Unit** (`useAlphaScrollPersistence.test.tsx`): a near-bottom restore chasing content that grows after mount (fails on the old single re-assert, passes with the loop); a user takeover that stops the chase without clobbering; a never-settling stream that still hands control back via the frame cap.
- **Integration** (`test_alpha_scroll_restore.py`): a real-browser reload round-trips the persisted position through localStorage and asserts the last turn footer lands at the bottom. Validated fail-first (it fails when the loop is capped to a single frame).

The deterministic fail-first proof lives in the unit test; the FakeClaude harness caps a task at ~3 completed turns, too few rows to reproduce the extreme stranding in-browser, so the integration test guards the end-to-end invariant (reload → localStorage → cold restore → at the bottom).

(Sent by Claude)
