### PR TITLE
[SCU-1770] Boundary-aware notification-turn accounting with a sliding idle backstop

### DIFF
--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -392,32 +392,62 @@ class ClaudeOutputProcessor:
         self._awaiting_notification_turn_init: bool = False
         self._pending_notification_turn_results: int = 0
         # SCU-1770: ``_notification_reset_pending_result`` is set when a
-        # task-notification consumes found_final_message (the True→False reset
-        # above) and is cleared by the follow-up turn's ``system/init`` or by a
-        # ``result``. While set, the follow-up turn is ALREADY accounted for by
-        # the reset, so (a) further coalesced notifications in the same cluster
-        # must not add a second accounting via _awaiting_notification_turn_init,
-        # and (b) the init must not promote that flag into
-        # _pending_notification_turn_results. Without this, a cluster of
-        # notifications delivered as one follow-up turn (the CLI coalesces
-        # them) double-counts that turn — the counter then absorbs the
-        # invocation's real final result and the loop waits forever.
+        # task-notification arrives at a turn boundary (consuming
+        # found_final_message) and is cleared by the follow-up turn's
+        # ``system/init`` or by a ``result``. While set, the follow-up turn is
+        # ALREADY accounted for: the CLI coalesces every notification pending
+        # at a turn boundary into the ONE follow-up turn it starts next, so
+        # further boundary notifications in the same cluster keep this flag
+        # (rather than adding a second accounting) and the init consumes it
+        # WITHOUT promoting anything into _pending_notification_turn_results.
+        # Counting cluster members individually double-counts the single
+        # follow-up turn — the counter then absorbs the invocation's real
+        # final result and the loop waits forever.
         self._notification_reset_pending_result: bool = False
-        # SCU-1770 idle backstop: timestamp armed whenever found_final_message
-        # is knocked back to False at a turn boundary (the notification reset
-        # above, or the notification-turn result absorption in
-        # _parse_stream_end_response) — i.e. whenever the loop is waiting for a
-        # follow-up turn that cannot be locally guaranteed to arrive. Any
-        # parsed stream frame disarms it (the follow-up is arriving); if the
-        # CLI instead stays silent for the grace period with no pending
-        # background task or wakeup, the loop concludes the invocation is
-        # complete rather than waiting forever. Control-protocol frames
-        # (context-usage responses, permission requests) do NOT disarm it —
-        # the CLI emits those at turn boundaries without implying a follow-up
-        # turn.
-        self._notification_followup_armed_at: float | None = None
-        # Instance attribute (not a module constant) so tests can shrink it.
+        # True when the current pending reset covers MORE than one boundary
+        # notification. The coalescing assumption above is how the CLI almost
+        # always behaves, but a completion can race past the follow-up turn's
+        # prompt construction, in which case the CLI answers the cluster with
+        # TWO turns. A multi-notification cluster therefore makes the
+        # answering turn's result linger briefly (see
+        # _cluster_split_linger_seconds) instead of ending the invocation
+        # instantly, so a split-off second turn is not cut off. Consumed by
+        # ``system/init`` into _linger_after_cluster_turn.
+        self._notification_cluster_extra: bool = False
+        self._linger_after_cluster_turn: bool = False
+        # True between a turn's ``system/init`` and its ``result``. Used to
+        # classify a task-notification that arrives while found_final_message
+        # is False: with no turn active and a follow-up owed it is a turn-
+        # boundary notification (it joins _notification_reset_pending_result);
+        # with a turn active it is an inline mid-turn notification (SCU-267)
+        # or the pre-turn SCU-1660 case, handled via
+        # _awaiting_notification_turn_init.
+        self._turn_active: bool = False
+        # SCU-1770 idle backstop: a deadline set whenever found_final_message
+        # is knocked back to False at a turn boundary (a notification reset,
+        # a notification-turn result absorption, or the split-cluster linger)
+        # — i.e. whenever the loop is waiting for a follow-up turn that cannot
+        # be locally guaranteed to arrive. Every successfully parsed stream
+        # frame slides the deadline forward (the CLI is alive; only true
+        # silence counts against the grace) and the follow-up turn's
+        # ``system/init`` clears it. If instead the CLI stays silent past the
+        # deadline with no pending background task or wakeup, the loop
+        # concludes the invocation is complete rather than waiting forever.
+        # Control-protocol frames (context-usage responses, permission
+        # requests) and non-JSON noise do not slide it — the CLI emits control
+        # frames at turn boundaries without implying a follow-up turn.
+        self._followup_owed_deadline: float | None = None
+        # Grace used at the last arm; deadline refreshes reuse it so a linger
+        # keeps its short window and a notification wait keeps its long one.
+        self._followup_owed_grace_seconds: float = 30.0
+        # Instance attributes (not module constants) so tests can shrink them.
+        # The follow-up grace bounds how long a silent wait for a predicted
+        # follow-up turn can last. The linger only needs to cover the gap
+        # between a cluster-answering turn's result and a split-off second
+        # turn's init — the CLI starts that turn immediately, so this stays
+        # short to keep cluster turn-ends snappy.
         self._notification_followup_grace_seconds: float = 30.0
+        self._cluster_split_linger_seconds: float = 2.0
         # Last time we received any stdout line from the CLI. Used to detect
         # hangs where the CLI stops producing output after an interrupt.
         self._last_output_time: float = time.monotonic()
@@ -534,36 +564,39 @@ class ClaudeOutputProcessor:
                 if not self.found_final_message:
                     # SCU-1770 idle backstop: found_final_message was knocked
                     # back to False at a turn boundary (a task-notification
-                    # reset or a notification-turn result absorption) and the
-                    # CLI has produced no stream frame since. The predicted
-                    # follow-up turn cannot be locally guaranteed to arrive
-                    # (notification/turn accounting is heuristic — see the
-                    # coalescing double-count this backstops); after the grace
-                    # period of true silence with nothing else pending,
-                    # conclude the invocation is complete so the loop exits
-                    # and the terminal RequestSuccess is emitted instead of
-                    # streaming forever. Long-running quiet tools are safe:
-                    # the backstop is only armed at turn boundaries and any
-                    # stream frame (e.g. the follow-up turn's init) disarms
-                    # it before such a tool can start.
+                    # reset, a notification-turn result absorption, or the
+                    # split-cluster linger) and the CLI has produced no stream
+                    # frame since. The predicted follow-up turn cannot be
+                    # locally guaranteed to arrive (notification/turn
+                    # accounting is heuristic — see the coalescing model this
+                    # backstops); after the grace period of true silence with
+                    # nothing else pending, conclude the invocation is
+                    # complete so the loop exits and the terminal
+                    # RequestSuccess is emitted instead of streaming forever.
+                    # Long-running quiet tools are safe: the deadline only
+                    # exists at turn boundaries and the follow-up turn's init
+                    # clears it before such a tool can start.
                     if (
-                        self._notification_followup_armed_at is not None
+                        self._followup_owed_deadline is not None
                         and not self._pending_background_tasks
                         and not self._pending_wakeup
-                        and now - self._notification_followup_armed_at >= self._notification_followup_grace_seconds
+                        and now >= self._followup_owed_deadline
                     ):
                         logger.info(
-                            "Notification follow-up turn never arrived after {:.0f}s of silence; concluding the invocation is complete (pending_notification_turn_results={}, awaiting_notification_turn_init={})",
-                            now - self._notification_followup_armed_at,
+                            "Notification follow-up turn never arrived within the {:.0f}s grace; concluding the invocation is complete (pending_notification_turn_results={}, awaiting_notification_turn_init={}, lingered_for_split_cluster={})",
+                            self._followup_owed_grace_seconds,
                             self._pending_notification_turn_results,
                             self._awaiting_notification_turn_init,
+                            self._linger_after_cluster_turn,
                         )
                         self.found_final_message = True
                         self._final_message_time = now
                         self._pending_notification_turn_results = 0
                         self._awaiting_notification_turn_init = False
                         self._notification_reset_pending_result = False
-                        self._notification_followup_armed_at = None
+                        self._notification_cluster_extra = False
+                        self._linger_after_cluster_turn = False
+                        self._followup_owed_deadline = None
                         continue
                     # Detect hung CLI after interrupt: if we sent an interrupt
                     # but no stdout line has arrived for _idle_timeout_seconds
@@ -738,18 +771,23 @@ class ClaudeOutputProcessor:
                 continue
 
             # A successfully parsed frame (even one the parser drops to None)
-            # is real CLI activity, so it disarms the notification-followup
-            # idle backstop: the follow-up turn the arming reset was waiting on
-            # is arriving (handlers re-arm at the next silent reset point).
-            # Placed AFTER the parse — a malformed/non-JSON line degrades to a
-            # warning via the except above and must NOT defuse the backstop
-            # during the very silence it exists to detect (recurring CLI debug
-            # output would otherwise keep it from ever firing). Control-protocol
-            # frames (context-usage responses, permission requests) are already
+            # is real CLI activity, so it slides the notification-followup
+            # idle backstop's deadline forward: the grace measures TRUE
+            # silence, and only the owed turn's ``system/init`` (handled in
+            # _parse_init_response) actually clears the deadline. Sliding
+            # rather than disarming means interleaved frames that are not the
+            # follow-up turn (cluster notifications, progress ticks from other
+            # tasks) cannot leave the wait unprotected. Placed AFTER the parse
+            # — a malformed/non-JSON line degrades to a warning via the except
+            # above and must NOT postpone the backstop during the very silence
+            # it exists to detect (recurring CLI debug output would otherwise
+            # keep it from ever firing). Control-protocol frames
+            # (context-usage responses, permission requests) are already
             # excluded: they short-circuit with their own `continue` above,
             # since the CLI emits them at turn boundaries without implying a
             # follow-up turn. (SCU-1770)
-            self._notification_followup_armed_at = None
+            if self._followup_owed_deadline is not None:
+                self._followup_owed_deadline = time.monotonic() + self._followup_owed_grace_seconds
 
             if result is None:
                 continue
@@ -856,37 +894,43 @@ class ClaudeOutputProcessor:
                     self._completed_pending_deferred_deadline = None
                 # A new turn (init → assistant → result) always follows a
                 # task_notification. Keep the loop open for it — but the way we
-                # do that depends on whether the user's own message turn has
-                # already ended:
+                # do that depends on where in the turn structure it arrived:
                 #
-                #  - found_final_message is True: the common ordering — the
-                #    user's turn finished, THEN the background task completed.
-                #    The notification's follow-up turn is the LAST turn, so
-                #    clearing found_final_message here (and letting the
-                #    follow-up's result set it again) is exactly right.
+                #  - At a turn boundary: either found_final_message is True
+                #    (the common ordering — the user's turn finished, THEN the
+                #    background task completed) or found_final_message is
+                #    False with no turn active because the loop is already
+                #    waiting on a predicted follow-up turn (an earlier
+                #    boundary notification's reset, a notification-turn result
+                #    absorption, or the split-cluster linger). Every
+                #    notification pending at a boundary is coalesced by the
+                #    CLI into the ONE follow-up turn it starts next, so they
+                #    all share a single pending reset — the second and later
+                #    cluster members only mark _notification_cluster_extra so
+                #    the answering turn's result lingers for a possible
+                #    split-off second turn.
                 #
-                #  - found_final_message is False: the notification arrived
-                #    BEFORE the user's turn produced a result. Either the CLI is
-                #    delivering it ahead of the user's prompt as its own turn
-                #    (SCU-1660), or it is an inline mid-turn notification with no
-                #    new request cycle (SCU-267). We cannot yet tell which, so
-                #    arm the flag; _parse_init_response confirms the former if a
-                #    fresh init follows, and _parse_stream_end_response drops it
-                #    for the latter.
-                if self.found_final_message:
+                #  - Mid-turn or pre-turn (a turn is active, or nothing is
+                #    owed yet): the notification arrived BEFORE the current
+                #    turn produced a result. Either the CLI is delivering it
+                #    ahead of the user's prompt as its own turn (SCU-1660), or
+                #    it is an inline mid-turn notification with no new request
+                #    cycle (SCU-267). We cannot yet tell which, so arm the
+                #    flag; _parse_init_response confirms the former if a fresh
+                #    init follows, and _parse_stream_end_response drops it for
+                #    the latter. No idle backstop here: a long quiet tool in
+                #    the active turn must not trip it.
+                at_turn_boundary = self.found_final_message or (
+                    self._followup_owed_deadline is not None and not self._turn_active
+                )
+                if at_turn_boundary:
+                    if self._notification_reset_pending_result:
+                        self._notification_cluster_extra = True
                     self.found_final_message = False
                     self._notification_reset_pending_result = True
-                    self._notification_followup_armed_at = time.monotonic()
+                    self._arm_followup_backstop(self._notification_followup_grace_seconds)
                 else:
                     self._awaiting_notification_turn_init = True
-                    if self._notification_reset_pending_result:
-                        # Part of a coalesced cluster: an earlier notification
-                        # already reset found_final_message and the single
-                        # follow-up turn will answer the whole cluster. The
-                        # armed flag above will be discarded (not promoted) by
-                        # _parse_init_response; refresh the idle backstop while
-                        # the cluster keeps arriving. (SCU-1770)
-                        self._notification_followup_armed_at = time.monotonic()
                 # final_workflow_entries doubles as the workflow marker on the
                 # persisted notification: an empty tuple (not None) for a
                 # workflow that never reported a tree, so history replay can
@@ -1151,6 +1195,14 @@ class ClaudeOutputProcessor:
                     now=now,
                 )
 
+    def _arm_followup_backstop(self, grace_seconds: float) -> None:
+        """Start (or restart) the idle backstop: the loop is at a turn boundary
+        waiting for a follow-up turn that cannot be locally guaranteed to
+        arrive. Parsed frames slide the deadline; the turn's init clears it;
+        expiry concludes the invocation. (SCU-1770)"""
+        self._followup_owed_grace_seconds = grace_seconds
+        self._followup_owed_deadline = time.monotonic() + grace_seconds
+
     def _parse_init_response(self, result: ParsedInitResponse) -> None:
         session_id = result.session_id
         self._session_id = session_id
@@ -1159,6 +1211,12 @@ class ClaudeOutputProcessor:
         self.session_id_written_event.set()
         logger.info("Stored session_id: {}", session_id)
 
+        # A turn is starting: the owed follow-up (if any) is arriving, so the
+        # idle backstop no longer applies — from here on, tool execution can
+        # legitimately be silent for arbitrarily long.
+        self._turn_active = True
+        self._followup_owed_deadline = None
+
         # A task-notification that arrived before the user's turn ended armed
         # _awaiting_notification_turn_init. This init is a fresh request cycle,
         # which confirms the notification was delivered as its own turn ahead
@@ -1166,17 +1224,20 @@ class ClaudeOutputProcessor:
         # it to a pending notification-turn result so _parse_stream_end_response
         # skips that turn's result and keeps the loop open for the user's turn.
         #
-        # Exception (SCU-1770): when found_final_message is False because a
-        # notification RESET it (rather than because the user's turn is still
-        # running), this init IS the follow-up turn that the reset already
-        # accounts for. The CLI coalesces a cluster of notifications into that
-        # one follow-up turn; the cluster's later notifications armed
-        # _awaiting_notification_turn_init, and promoting it here would count
-        # the same turn twice — the counter then absorbs the invocation's real
-        # final result and the loop never exits.
+        # Exception (SCU-1770): when a boundary notification RESET
+        # found_final_message, this init IS the follow-up turn that the reset
+        # already accounts for — it answers the WHOLE cluster of boundary
+        # notifications pending at that moment, so nothing is promoted into
+        # _pending_notification_turn_results (counting cluster members
+        # individually would absorb the invocation's real final result and
+        # the loop would never exit). A multi-notification cluster instead
+        # carries a small risk that the CLI split it into two turns, recorded
+        # in _linger_after_cluster_turn for the result handler.
         if self._notification_reset_pending_result:
             self._notification_reset_pending_result = False
             self._awaiting_notification_turn_init = False
+            self._linger_after_cluster_turn = self._notification_cluster_extra
+            self._notification_cluster_extra = False
         elif self._awaiting_notification_turn_init:
             self._awaiting_notification_turn_init = False
             self._pending_notification_turn_results += 1
@@ -1290,9 +1351,11 @@ class ClaudeOutputProcessor:
 
         self.found_final_message = True
         self._final_message_time = time.monotonic()
+        self._turn_active = False
         # A result answers any outstanding notification reset; a notification
         # arriving after this point flips found_final_message afresh.
         self._notification_reset_pending_result = False
+        self._notification_cluster_extra = False
 
         # SCU-1660: if this result terminates a task-notification turn the CLI
         # delivered ahead of the user's own message turn, it is not the end of
@@ -1301,9 +1364,23 @@ class ClaudeOutputProcessor:
         if self._pending_notification_turn_results > 0:
             self._pending_notification_turn_results -= 1
             self.found_final_message = False
+            self._linger_after_cluster_turn = False
             # Waiting again for a turn that cannot be locally guaranteed to
             # arrive — arm the idle backstop (SCU-1770).
-            self._notification_followup_armed_at = time.monotonic()
+            self._arm_followup_backstop(self._notification_followup_grace_seconds)
+        elif self._linger_after_cluster_turn:
+            # This turn answered a MULTI-notification cluster. The CLI almost
+            # always coalesces the whole cluster into this one turn, but a
+            # completion can race past the turn's prompt construction and be
+            # answered by a second turn instead. Linger briefly (instead of
+            # ending the invocation instantly) so that second turn's init —
+            # which the CLI starts immediately when it exists — is picked up;
+            # if nothing arrives, the backstop concludes the invocation after
+            # the short linger. Single-notification follow-ups skip this and
+            # keep the zero-delay exit. (SCU-1770)
+            self._linger_after_cluster_turn = False
+            self.found_final_message = False
+            self._arm_followup_backstop(self._cluster_split_linger_seconds)
         # A notification that never started a fresh request cycle before this
         # result was an inline mid-turn notification (SCU-267), not a separate
         # turn — drop the pending classification so it doesn't leak into a later

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor.py
@@ -573,9 +573,10 @@ class ClaudeOutputProcessor:
                     # nothing else pending, conclude the invocation is
                     # complete so the loop exits and the terminal
                     # RequestSuccess is emitted instead of streaming forever.
-                    # Long-running quiet tools are safe: the deadline only
-                    # exists at turn boundaries and the follow-up turn's init
-                    # clears it before such a tool can start.
+                    # Long-running quiet tools are safe: the deadline is never
+                    # armed while a turn is active (every arm site is a turn
+                    # boundary and the notification handler skips arming
+                    # mid-turn), and a turn's init clears any armed deadline.
                     if (
                         self._followup_owed_deadline is not None
                         and not self._pending_background_tasks
@@ -583,11 +584,10 @@ class ClaudeOutputProcessor:
                         and now >= self._followup_owed_deadline
                     ):
                         logger.info(
-                            "Notification follow-up turn never arrived within the {:.0f}s grace; concluding the invocation is complete (pending_notification_turn_results={}, awaiting_notification_turn_init={}, lingered_for_split_cluster={})",
+                            "Notification follow-up turn never arrived within the {:.0f}s grace; concluding the invocation is complete (pending_notification_turn_results={}, awaiting_notification_turn_init={})",
                             self._followup_owed_grace_seconds,
                             self._pending_notification_turn_results,
                             self._awaiting_notification_turn_init,
-                            self._linger_after_cluster_turn,
                         )
                         self.found_final_message = True
                         self._final_message_time = now
@@ -910,16 +910,26 @@ class ClaudeOutputProcessor:
                 #    the answering turn's result lingers for a possible
                 #    split-off second turn.
                 #
-                #  - Mid-turn or pre-turn (a turn is active, or nothing is
-                #    owed yet): the notification arrived BEFORE the current
-                #    turn produced a result. Either the CLI is delivering it
-                #    ahead of the user's prompt as its own turn (SCU-1660), or
-                #    it is an inline mid-turn notification with no new request
-                #    cycle (SCU-267). We cannot yet tell which, so arm the
-                #    flag; _parse_init_response confirms the former if a fresh
-                #    init follows, and _parse_stream_end_response drops it for
-                #    the latter. No idle backstop here: a long quiet tool in
-                #    the active turn must not trip it.
+                #    found_final_message can also be True while a turn is
+                #    ACTIVE: a deferred completion (task_updated) makes the
+                #    CLI start an event-delivery turn whose init does not
+                #    consume the previous result's flag. The reset below still
+                #    applies (the loop must stay open past momentary
+                #    pending-task/queue emptiness until this turn's own
+                #    result), but the idle backstop must NOT be armed — the
+                #    active turn may legitimately run a long silent tool, and
+                #    its result is the guaranteed conclusion.
+                #
+                #  - Mid-turn or pre-turn with found_final_message False (a
+                #    turn is running, or nothing is owed yet): the
+                #    notification arrived BEFORE the current turn produced a
+                #    result. Either the CLI is delivering it ahead of the
+                #    user's prompt as its own turn (SCU-1660), or it is an
+                #    inline mid-turn notification with no new request cycle
+                #    (SCU-267). We cannot yet tell which, so arm the flag;
+                #    _parse_init_response confirms the former if a fresh init
+                #    follows, and _parse_stream_end_response drops it for the
+                #    latter. No idle backstop here either.
                 at_turn_boundary = self.found_final_message or (
                     self._followup_owed_deadline is not None and not self._turn_active
                 )
@@ -928,7 +938,8 @@ class ClaudeOutputProcessor:
                         self._notification_cluster_extra = True
                     self.found_final_message = False
                     self._notification_reset_pending_result = True
-                    self._arm_followup_backstop(self._notification_followup_grace_seconds)
+                    if not self._turn_active:
+                        self._arm_followup_backstop(self._notification_followup_grace_seconds)
                 else:
                     self._awaiting_notification_turn_init = True
                 # final_workflow_entries doubles as the workflow marker on the

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -2245,3 +2245,177 @@ class TestNotificationCoalescingAndIdleBackstop:
 
         assert completed is True
         assert "LATE-TOOL-SYNTHESIS" in _collect_text(_drain_queue(processor.output_message_queue))
+
+    @pytest.mark.timeout(30)
+    def test_split_cluster_second_followup_turn_is_processed(self) -> None:
+        """Two notifications land before the follow-up init but the CLI answers
+        them with TWO separate turns (a completion raced past the first turn's
+        prompt construction). The multi-notification cluster must make the
+        first answering turn's result linger so the second turn is processed
+        instead of the loop exiting at the first result and discarding it."""
+        session_id = "s-split"
+        frames = [
+            make_task_started_message(
+                task_id="sub-a", tool_use_id="toolu-a", description="A", task_type="local_agent"
+            ),
+            make_task_started_message(
+                task_id="sub-b", tool_use_id="toolu-b", description="B", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched two.")]),
+            make_end_message(session_id=session_id),
+            # Both notifications arrive at the turn boundary...
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_task_notification_message(
+                task_id="sub-b", tool_use_id="toolu-b", status="completed", summary="B done"
+            ),
+            # ...but the CLI answers them with two turns, not one.
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-t1", [make_text_block("TURN-ONE-REACTION")]),
+            make_end_message(session_id=session_id),
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-t2", [make_text_block("TURN-TWO-REACTION")]),
+            make_end_message(session_id=session_id),
+        ]
+
+        emitted, processor = _run_process_output_returning_processor(frames)
+
+        assert processor.found_final_message is True
+        assert processor._pending_notification_turn_results == 0
+        text = _collect_text(emitted)
+        assert "TURN-ONE-REACTION" in text
+        assert "TURN-TWO-REACTION" in text, (
+            "the split-off second follow-up turn was cut off: the loop exited at the first turn's result"
+        )
+
+    @pytest.mark.timeout(30)
+    def test_coalesced_cluster_lingers_briefly_then_concludes(self) -> None:
+        """The flip side of the split-cluster linger: when the CLI DOES
+        coalesce a multi-notification cluster into one turn, the linger after
+        that turn's result must expire on its own and conclude the invocation
+        (no second turn is coming)."""
+        session_id = "s-coalesced"
+        frames = [
+            make_task_started_message(
+                task_id="sub-a", tool_use_id="toolu-a", description="A", task_type="local_agent"
+            ),
+            make_task_started_message(
+                task_id="sub-b", tool_use_id="toolu-b", description="B", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched two.")]),
+            make_end_message(session_id=session_id),
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_task_notification_message(
+                task_id="sub-b", tool_use_id="toolu-b", status="completed", summary="B done"
+            ),
+            # One coalesced answering turn, then nothing.
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-cluster", [make_text_block("CLUSTER-SYNTHESIS")]),
+            make_end_message(session_id=session_id),
+        ]
+        processor, _ = self._build_idle_processor(frames, grace_seconds=5.0)
+        processor._cluster_split_linger_seconds = 0.2
+
+        completed = processor._process_output()
+
+        assert completed is True
+        assert processor.found_final_message is True
+        assert processor._pending_notification_turn_results == 0
+
+    @pytest.mark.timeout(30)
+    def test_single_notification_followup_exits_without_linger(self) -> None:
+        """A single-notification follow-up turn must keep the zero-delay exit:
+        the split-cluster linger only applies when MORE than one boundary
+        notification shared the answering turn. The linger here is set far
+        beyond the assertion bound, so any regression that lingers on single
+        notifications fails the elapsed check."""
+        session_id = "s-single"
+        frames = [
+            make_task_started_message(
+                task_id="sub-a", tool_use_id="toolu-a", description="A", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched.")]),
+            make_end_message(session_id=session_id),
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-t1", [make_text_block("REACTION")]),
+            make_end_message(session_id=session_id),
+        ]
+        processor, _ = self._build_idle_processor(frames, grace_seconds=300.0)
+        processor._cluster_split_linger_seconds = 300.0
+
+        start = time.monotonic()
+        completed = processor._process_output()
+        elapsed = time.monotonic() - start
+
+        assert completed is True
+        assert processor.found_final_message is True
+        assert elapsed < 5.0, "a single-notification follow-up turn must end the invocation without lingering"
+
+    @pytest.mark.timeout(30)
+    def test_notification_during_post_absorption_wait_is_answered_by_next_turn(self) -> None:
+        """A notification that arrives during the silent wait AFTER a
+        notification-turn result was absorbed (the SCU-1660 ordering: the CLI
+        delivered a pending notification as its own turn ahead of the user's
+        prompt) is a turn-boundary notification: the user's turn answers it,
+        and that turn's result must end the invocation. Counting it via the
+        SCU-1660 path instead makes the user's own result get absorbed."""
+        session_id = "s-boundary"
+        frames = [
+            # Pending notification delivered ahead of the user's turn.
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-notif-turn", [make_text_block("NOTIF-TURN")]),
+            make_end_message(session_id=session_id),
+            # That result was absorbed; during the wait for the user's turn a
+            # second background task completes.
+            make_task_notification_message(
+                task_id="sub-b", tool_use_id="toolu-b", status="completed", summary="B done"
+            ),
+            # The user's turn answers it (coalesced) and ends the invocation.
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-user-turn", [make_text_block("USER-TURN")]),
+            make_end_message(session_id=session_id),
+        ]
+
+        emitted, processor = _run_process_output_returning_processor(frames)
+
+        assert processor.found_final_message is True, (
+            "the user's own result was absorbed by the notification-turn counter"
+        )
+        assert processor._pending_notification_turn_results == 0
+        assert "USER-TURN" in _collect_text(emitted)
+
+    @pytest.mark.timeout(30)
+    def test_notification_during_post_absorption_wait_keeps_backstop_armed(self) -> None:
+        """Same boundary notification as above, but the follow-up turn never
+        arrives. The notification frame itself must not leave the wait
+        unprotected — the idle backstop has to stay armed and conclude the
+        invocation instead of parking the loop forever."""
+        session_id = "s-boundary-idle"
+        frames = [
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_init_message(session_id=session_id),
+            make_assistant_message("msg-notif-turn", [make_text_block("NOTIF-TURN")]),
+            make_end_message(session_id=session_id),
+            make_task_notification_message(
+                task_id="sub-b", tool_use_id="toolu-b", status="completed", summary="B done"
+            ),
+            # No further turn ever arrives.
+        ]
+        processor, _ = self._build_idle_processor(frames, grace_seconds=0.3)
+
+        completed = processor._process_output()
+
+        assert completed is True
+        assert processor.found_final_message is True
+        assert processor._pending_notification_turn_results == 0

--- a/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
+++ b/sculptor/sculptor/agents/default/claude_code_sdk/output_processor_test.py
@@ -2247,6 +2247,57 @@ class TestNotificationCoalescingAndIdleBackstop:
         assert "LATE-TOOL-SYNTHESIS" in _collect_text(_drain_queue(processor.output_message_queue))
 
     @pytest.mark.timeout(30)
+    def test_notification_inside_deferred_delivery_turn_does_not_arm_backstop(self) -> None:
+        """A deferred completion (task_updated) makes the CLI start an
+        event-delivery turn whose init does NOT consume found_final_message —
+        so the task's notification lands mid-turn with the flag still True.
+        The handler must keep the loop open (the reset) WITHOUT arming the
+        idle backstop: the active turn may run a long silent tool, and an
+        armed deadline would fire during it and cut off the turn's late
+        content. The silence here is 3x the grace, so a wrongly armed
+        backstop fires during it and LATE-SYNTHESIS goes missing."""
+        session_id = "s-deferred-midturn"
+        pre_silence = [
+            make_task_started_message(
+                task_id="sub-a", tool_use_id="toolu-a", description="A", task_type="local_agent"
+            ),
+            make_assistant_message("msg-main", [make_text_block("Launched.")]),
+            make_end_message(session_id=session_id),
+            # Subagent completes via task_updated (deferred cleanup path).
+            _make_task_updated_message(task_id="sub-a", status="completed"),
+            # The event-delivery turn starts; found_final_message stays True
+            # through this init (only wakeup inits reset it).
+            make_init_message(session_id=session_id),
+            # The task's notification is delivered inside that turn.
+            make_task_notification_message(
+                task_id="sub-a", tool_use_id="toolu-a", status="completed", summary="A done"
+            ),
+            make_assistant_message("msg-working", [make_text_block("Reacting to the subagent result...")]),
+            # ... the turn now runs a long, silent tool ...
+        ]
+        post_silence = [
+            make_assistant_message("msg-late", [make_text_block("LATE-SYNTHESIS")]),
+            make_end_message(session_id=session_id),
+        ]
+        grace_seconds = 0.2
+        processor, input_queue = self._build_idle_processor(pre_silence, grace_seconds=grace_seconds)
+
+        def feed_late_frames() -> None:
+            time.sleep(grace_seconds * 3)
+            for d in post_silence:
+                input_queue.put((json.dumps(d), True))
+
+        feeder = Thread(target=feed_late_frames)
+        feeder.start()
+        completed = processor._process_output()
+        feeder.join()
+
+        assert completed is True
+        assert "LATE-SYNTHESIS" in _collect_text(_drain_queue(processor.output_message_queue)), (
+            "the backstop was armed inside the active delivery turn and cut off its late content"
+        )
+
+    @pytest.mark.timeout(30)
     def test_split_cluster_second_followup_turn_is_processed(self) -> None:
         """Two notifications land before the follow-up init but the CLI answers
         them with TWO separate turns (a completion raced past the first turn's

--- a/sculptor/tests/integration/real_claude/test_claude_code_terminal_agent.py
+++ b/sculptor/tests/integration/real_claude/test_claude_code_terminal_agent.py
@@ -145,7 +145,10 @@ def test_claude_code_terminal_agent(sculptor_instance_: SculptorInstance) -> Non
     expect(registered_item).to_be_visible()
     registered_item.click()
 
-    claude_tab = panel_tabs.get_panel_tab_by_name("Claude CLI 1").first
+    # The bundled registration and the SDK agent share the "Claude" naming
+    # prefix, and the workspace's main (empty-prompt) SDK agent already claimed
+    # "Claude 1" at creation — so the registered terminal agent is "Claude 2".
+    claude_tab = panel_tabs.get_panel_tab_by_name("Claude 2").first
     expect(claude_tab).to_be_visible()
     expect(get_agent_terminal_panel(page)).to_be_visible()
     expect(get_agent_terminal_textarea(page)).to_be_attached()
@@ -157,7 +160,7 @@ def test_claude_code_terminal_agent(sculptor_instance_: SculptorInstance) -> Non
     # at startup would make a post-restart `--resume` fail ("No conversation
     # found with session ID"). A message-less agent must instead restart via
     # the plain launch command.
-    assert _read_terminal_session_id(sculptor_instance_.sculptor_folder, "Claude CLI 1") is None, (
+    assert _read_terminal_session_id(sculptor_instance_.sculptor_folder, "Claude 2") is None, (
         "session id persisted before any message — startup-captured ids are not resumable"
     )
 
@@ -168,7 +171,7 @@ def test_claude_code_terminal_agent(sculptor_instance_: SculptorInstance) -> Non
     deadline = time.monotonic() + 90.0
     session_id: str | None = None
     while time.monotonic() < deadline:
-        session_id = _read_terminal_session_id(sculptor_instance_.sculptor_folder, "Claude CLI 1")
+        session_id = _read_terminal_session_id(sculptor_instance_.sculptor_folder, "Claude 2")
         if session_id:
             break
         page.wait_for_timeout(1_000)

--- a/sculptor/tests/integration/real_claude/test_claude_code_terminal_agent.py
+++ b/sculptor/tests/integration/real_claude/test_claude_code_terminal_agent.py
@@ -143,12 +143,21 @@ def test_claude_code_terminal_agent(sculptor_instance_: SculptorInstance) -> Non
     dropdown.open_agent_type_submenu()
     registered_item = dropdown.get_agent_type_item_registered("claude-code")
     expect(registered_item).to_be_visible()
+    labels_before = {tab.inner_text().strip() for tab in panel_tabs.get_agent_tabs().all()}
     registered_item.click()
 
-    # The bundled registration and the SDK agent share the "Claude" naming
-    # prefix, and the workspace's main (empty-prompt) SDK agent already claimed
-    # "Claude 1" at creation — so the registered terminal agent is "Claude 2".
-    claude_tab = panel_tabs.get_panel_tab_by_name("Claude 2").first
+    # The tab is auto-named "<display name> N" from a numbering pool shared by
+    # every "Claude"-prefixed agent (the workspace's main SDK agent claims
+    # "Claude 1" at creation), so capture the created tab's actual title
+    # instead of assuming a number.
+    expect(panel_tabs.get_agent_tabs()).to_have_count(len(labels_before) + 1)
+    new_labels = {tab.inner_text().strip() for tab in panel_tabs.get_agent_tabs().all()} - labels_before
+    assert len(new_labels) == 1, f"expected exactly one new agent tab, got {new_labels or 'none'}"
+    task_title = new_labels.pop()
+    assert task_title.startswith("Claude"), (
+        f"registered agent tab should be named from the registration's display name, got {task_title!r}"
+    )
+    claude_tab = panel_tabs.get_panel_tab_by_name(task_title).first
     expect(claude_tab).to_be_visible()
     expect(get_agent_terminal_panel(page)).to_be_visible()
     expect(get_agent_terminal_textarea(page)).to_be_attached()
@@ -160,7 +169,7 @@ def test_claude_code_terminal_agent(sculptor_instance_: SculptorInstance) -> Non
     # at startup would make a post-restart `--resume` fail ("No conversation
     # found with session ID"). A message-less agent must instead restart via
     # the plain launch command.
-    assert _read_terminal_session_id(sculptor_instance_.sculptor_folder, "Claude 2") is None, (
+    assert _read_terminal_session_id(sculptor_instance_.sculptor_folder, task_title) is None, (
         "session id persisted before any message — startup-captured ids are not resumable"
     )
 
@@ -171,7 +180,7 @@ def test_claude_code_terminal_agent(sculptor_instance_: SculptorInstance) -> Non
     deadline = time.monotonic() + 90.0
     session_id: str | None = None
     while time.monotonic() < deadline:
-        session_id = _read_terminal_session_id(sculptor_instance_.sculptor_folder, "Claude 2")
+        session_id = _read_terminal_session_id(sculptor_instance_.sculptor_folder, task_title)
         if session_id:
             break
         page.wait_for_timeout(1_000)


### PR DESCRIPTION
## What

Follow-up hardening of `ClaudeOutputProcessor`'s task-notification/turn accounting (SCU-1770). A review of the landed fix surfaced two missed edge cases, both empirically confirmed; this PR restructures the accounting around an explicit turn-boundary model instead of patching each case:

- **Boundary-aware classification.** A new `_turn_active` flag (init → True, result → False) lets the notification handler distinguish turn-boundary notifications from mid-turn/pre-turn ones. A notification arriving during the silent wait after an absorbed notification-turn result is now treated as a boundary notification that the next turn answers — previously it was mis-counted via the SCU-1660 path, which absorbed the next turn's real result and (worse) left the loop parked with the backstop defused.
- **Sliding deadline instead of disarm/re-arm.** The idle backstop (`_followup_owed_deadline`) is now refreshed by any parsed frame and cleared only by a turn's init, so the grace measures true silence and interleaved frames (cluster notifications, progress ticks) can never leave a wait unprotected. Non-JSON noise and control-protocol frames still don't touch it. The backstop is never armed while a turn is active, so long silent tools cannot trip it.
- **Split-cluster linger.** The accounting assumes the CLI coalesces all boundary notifications into one follow-up turn. When a cluster had ≥2 notifications, the answering turn's result now lingers briefly (2s) instead of ending the invocation instantly — if a completion raced past the turn's prompt construction and the CLI answers with a second turn, that turn is processed instead of silently discarded. Single-notification follow-ups keep the zero-delay exit.

Also fixes the `real_claude` terminal-agent test, broken on `main` since the bundled registration was renamed to "Claude": the main SDK agent claims "Claude 1" from the shared naming pool at workspace creation, so the registered terminal agent the test adds is titled "Claude 2" (separate commit, easy to split out if preferred).

## Testing

- 6 new regression tests in `output_processor_test.py` (74 total pass). The correctness tests fail against the previous code — including one that hangs into its timeout guard — and the linger tests pin the zero-delay single-notification exit with a 300s linger that would blow the suite timeout on regression.
- Full `real_claude` integration suite run locally against the real CLI: green (the one failure was the pre-existing terminal-agent test breakage fixed here, re-run individually to green).
- `just format` / `just check` / `just test-unit` green.
- Self-review pass (code-review-checklist) found one further edge — a notification landing inside a deferred-completion delivery turn (where `found_final_message` is still True) armed the backstop mid-turn — fixed in the third commit with its own repro-derived regression test.

## Known residual (deliberate)

If a *single* boundary notification joins a wait whose owed turn's prompt was already constructed, and the CLI answers it with a separate later turn, that turn can still be cut off (bounded content loss, not a hang — the backstop covers the hang variant). Covering it would extend the 2s linger to every notification that arrives during an owed wait, penalizing common serial-completion chains for a double race. Deferred deliberately.

(Sent by Claude)