### PR TITLE
Select pi's model in the New Workspace modal, before the workspace exists

### DIFF
--- a/agent_docs/no-usable-model-guard/design.md
+++ b/agent_docs/no-usable-model-guard/design.md
@@ -16,8 +16,9 @@ Two coupled defects:
 
 ## Decision 1 — empty the catalog for an unusable selection
 
-Wherever the catalog is computed (start-time fetch, live credential refresh, and the
-pre-message probe): if the selected model's provider is unauthenticated **and** no
+Wherever the catalog is computed (start-time fetch, live credential refresh, the
+pre-message probe, and the pre-workspace modal probe — see
+`agent_docs/pi-modal-model-picker/spec.md`): if the selected model's provider is unauthenticated **and** no
 authenticated fallback exists, drop the selection (`current_model → None`) so curation yields
 `[]`. Emit that empty catalog rather than falling back to the built-in list.
 

--- a/agent_docs/pi-auth/architecture.md
+++ b/agent_docs/pi-auth/architecture.md
@@ -25,6 +25,12 @@ credentials change; an empty catalog shows a verbatim actionable
 
 ## Current Architecture
 
+> **Amended — see `agent_docs/pi-modal-model-picker/spec.md`.** The diagram below
+> shows catalog discovery beginning at agent start
+> (`fetch_available_models_probe` / `_fetch_models_into_state`). The same probe
+> also runs host-side, before any workspace exists, to feed a pi model picker in
+> the New Workspace modal — agent start is not the earliest discovery point.
+
 ```
                        SETTINGS (global route /settings)
   ┌───────────────────────────────────────────────────────────────┐

--- a/agent_docs/pi-modal-model-picker/spec.md
+++ b/agent_docs/pi-modal-model-picker/spec.md
@@ -1,0 +1,194 @@
+# Pre-workspace pi model picker — spec
+
+Make pi model selection possible in the New Workspace modal, so a pi creation
+carries a real, validated model and the initial prompt is valid by
+construction.
+
+## Problem
+
+A pi agent created from the New Workspace modal with an initial prompt can
+crash before the user can intervene: the prompt is queued at creation and
+processed at startup, but pi's model is only selectable after the workspace
+starts. For a user with no authenticated pi provider, the first turn runs
+against a model that cannot run; the resulting auth failure (`PiCrashError`)
+is uncaught on the prompt-turn path and tears the whole agent down.
+
+The contract is dishonest in two places:
+
+- The modal shows a hint ("Select your model after the workspace starts")
+  instead of a model picker, so a pi creation cannot express a model
+  selection.
+- The backend rejects any prompt without a model, so the frontend sends a
+  **placeholder Claude model** with pi prompts — a value pi discards. The
+  queued message therefore looks valid while naming no usable model.
+
+The in-workspace composer refuses to send when the catalog has no usable
+model (`hasNoUsableModel`), but the modal path never passes through the
+composer, so nothing validates a pi prompt before the agent processes it.
+
+## Fact base
+
+The design rests on facts the codebase already relies on elsewhere:
+
+- **Catalog discovery is headless.** `PiAgent.fetch_available_models_probe`
+  enumerates pi's catalog by running `pi --mode rpc --no-extensions` as a
+  short-lived subprocess and issuing the `get_available_models` / `get_state`
+  RPCs — no TTY, no agent session, no interaction. Only *authentication*
+  (`/login`) is interactive.
+- **The authenticated-provider set needs no pi at all.**
+  `compute_authenticated_provider_ids()` is a read of pi's `auth.json` plus
+  env-var detection.
+- **Execution environments are local.** Agents run on the user's machine with
+  the user's `$HOME`, so a host-side probe sees the same binary, `auth.json`,
+  and ambient env an in-workspace probe sees. The Settings login flow already
+  runs the pi binary host-side with no workspace.
+
+Therefore pi's catalog is knowable before any workspace exists, and the modal
+can offer the same picker the composer has.
+
+## Design
+
+### 1. Global catalog endpoint
+
+`GET /api/v1/pi/models` — the host-side equivalent of the in-task probe.
+(pi-named, matching the existing `pi/providers/*` and `pi/login` surfaces;
+the modal is inherently harness-aware — it picks the agent type — unlike the
+composer, which never branches on harness identity.) Extract the probe's
+core (spawn `pi --mode rpc`, two RPCs, curate, authenticated-filter) into a
+helper that does not require an `AgentExecutionEnvironment`:
+
+- **binary**: resolved through the dependency-management service
+  (managed-or-custom), exactly as the Settings login flow resolves it;
+- **session dir**: a throwaway directory under Sculptor's own state dir;
+- **env**: the backend process env + PATH plus the configured pi api-key env
+  vars — the same inputs the in-task probe merges.
+
+Response: `{ available_models: list[ModelOption], default_model: ModelOption
+| None }`, where `default_model` is pi's own current model when usable.
+Curation and the authenticated filter are shared code with the in-task probe
+so the two surfaces cannot disagree. Best-effort like the in-task probe: any
+failure yields an empty catalog, not an error.
+
+**Freshness requirement:** the modal must reflect credential changes made
+while it is open — a login round-trip through Settings is picked up on
+return. On-demand client fetch with re-query (e.g. on focus) satisfies this;
+there is no server-side cache to invalidate.
+
+### 2. Modal: a real pi model picker
+
+Replace the pi hint in the New Workspace form's agent-settings row with the
+shared `ModelSelector` in backend-models mode, fed by the endpoint.
+
+One rule governs submission — the composer's `hasNoUsableModel` predicate
+applied one screen earlier, sharing its empty-state copy:
+
+> **A pi prompt is submittable only against a resolved, non-empty catalog
+> with a selection. A promptless create never waits on the catalog.**
+
+Everything else derives from that rule and the observed catalog state: while
+resolving, the picker is disabled and Create is blocked only if a prompt is
+present; when populated, the picker preselects `default_model` and the
+selection is a `ModelOption` identity `(provider, model_id)`; when empty, the
+existing no-usable-model surface renders ("No models available" + the login
+CTA routing to Settings → Pi) and a prompt cannot be submitted. Creating the
+workspace without a prompt is always available — a promptless pi agent is
+safe, and post-start selection still exists for it.
+
+### 3. Honest create contract
+
+`CreateAgentRequest` carries the model on the harness's own terms:
+
+- Claude: `model: LLMModel` (unchanged).
+- pi: a new optional `backend_model` carrying the chosen `ModelOption`
+  (provider, model id, display name — so the seeded selection can render in
+  the switcher before pi confirms it). The placeholder Claude `model` is no
+  longer sent for pi, and `StartTaskRequest.model` becomes optional to match.
+
+**Invariant:** `model` and `backend_model` are mutually exclusive — a create
+names its model on exactly one harness's terms, or (promptless) not at all.
+
+Validation when a pi create carries a prompt: `backend_model` is required,
+and its `provider` must be in `compute_authenticated_provider_ids()` at
+create time — an instant host-side check; otherwise 422 with an actionable
+message. Full catalog-membership re-validation is deliberately skipped:
+provider auth is the crash class, and the `model_id` came from the probe
+moments earlier.
+
+The create transaction persists the accepted selection as the task's
+`current_model`. No set-model message is enqueued — there is no live agent
+yet; the wrapper's start-time adoption consumes `current_model`.
+(`ChatInputUserMessage.model_name` and `AgentTaskInputsV2.default_model` are
+already nullable; pi creates leave them unset.)
+
+### 4. Startup adoption
+
+The pi wrapper already reconciles pi to task state: it is constructed with
+`preselected_model = task_state.current_model` and issues pi's `set_model`
+during start. With `current_model` seeded at create, the queued initial
+prompt runs under the validated selection. The ordering the crash violated —
+auth determined → catalog known → selection validated → prompt processed —
+now holds by construction, because each step happens before the workspace is
+created.
+
+### 5. Defense in depth
+
+Create-time validation is a point-in-time check; credentials can change
+between create and start. Two backstops:
+
+- The start-time reselect already drops or switches an unauthenticated
+  selection when the wrapper fetches the catalog.
+- `_run_prompt_turn` converts the turn pump's `PiCrashError` onto the
+  contained `AgentClientError` rail (`PiTurnError`), so the existing per-turn
+  error block (which carries the login CTA) is emitted instead of the
+  exception killing the agent — the same containment `_run_wake_turn` already
+  has. A doomed turn becomes a recoverable error in a live agent.
+
+Each layer is the sole enforcer at its own trust boundary: the modal gate
+(client), the create 422 (API, the sole server-side pre-persistence check),
+the start-time reselect (agent boot), the composer guard (live session), and
+containment (runtime backstop). The modal and composer share one predicate
+and one empty-state copy so they cannot drift.
+
+Turn admission stays simple: drive the turn, contain the failure. No
+parking/holding of queued prompts.
+
+## Deletions
+
+- The modal hint ("Select your model after the workspace starts"), its
+  `NEW_WORKSPACE_PI_SETTINGS_HINT` element id, and every test asserting it.
+- The placeholder-Claude-model contract for pi prompts in
+  `useCreateWorkspace` and the tests locking it in.
+- The unconditional "Model is required when providing a prompt" 422 in
+  `create_workspace_agent` (superseded by the per-harness requirement above).
+- Documentation claims that pi's models are only knowable after the workspace
+  starts.
+
+## Non-goals
+
+- Remote execution environments. The design leans on locality — the same
+  assumption the login flow and `auth.json` sharing already lean on.
+- Embedding the login terminal in the modal (the CTA routes to Settings).
+- pi-core changes; the post-start composer, `set_model`, and
+  credential-refresh flows are untouched.
+- Unifying Claude and pi create-model representations under one
+  `ModelOption`-shaped field (Claude's `model_id` is already the `LLMModel`
+  value) — a real representation cleanup, but it touches the Claude create
+  path this change otherwise leaves alone. Deferred; the exclusivity
+  invariant carries the constraint.
+
+## Testing
+
+- **Endpoint**: catalog under fake `auth.json`/env permutations —
+  authenticated, empty, probe failure → empty.
+- **Modal**: the admission rule across catalog states — prompt submission
+  blocked while resolving and when empty; populated → create request carries
+  `(provider, model_id)` and no Claude placeholder; promptless create never
+  blocked.
+- **Create validation**: pi prompt without `backend_model` → 422;
+  unauthenticated provider → 422; `current_model` seeded on accept; `model` +
+  `backend_model` together rejected.
+- **End-to-end**: unauthenticated pi + modal prompt → blocked in the modal,
+  no crash; authenticated → prompt runs under the selected model
+  (`set_model` observed at start).
+- **Containment**: an auth-shaped failure on a prompt turn renders the error
+  block and the agent stays alive.

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.tsx
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.tsx
@@ -176,26 +176,6 @@ describe("useCreateWorkspace agent-type gating", () => {
     expect(body.enterPlanMode).toBe(true);
   });
 
-  it("sends the prompt (and a placeholder model) for a pi agent, but omits effort/fast/plan", async () => {
-    const { result } = renderCreateWorkspaceHook();
-
-    await result.current.createWorkspace(
-      baseArgs({ agentTypeValue: "pi" as StoredAgentType, prompt: "help me get started", enterPlanMode: true }),
-    );
-
-    const body = getAgentRequestBody();
-    expect(body.agentType).toBe("pi");
-    // The prompt the user typed must reach pi, not be silently dropped.
-    expect(body.prompt).toBe("help me get started");
-    // pi ignores the model (it picks from its own in-task catalog), but the
-    // backend requires one alongside a prompt, so a placeholder default rides along.
-    expect(body.model).toBe(LlmModel.CLAUDE_4_OPUS);
-    // These Claude-only per-prompt settings do not apply to a pi create.
-    expect(body.effort).toBeUndefined();
-    expect(body.fastMode).toBeUndefined();
-    expect(body.enterPlanMode).toBeUndefined();
-  });
-
   it("omits the prompt and model for a pi agent when no prompt was typed", async () => {
     const { result } = renderCreateWorkspaceHook();
 
@@ -204,8 +184,34 @@ describe("useCreateWorkspace agent-type gating", () => {
     const body = getAgentRequestBody();
     expect(body.agentType).toBe("pi");
     expect(body.prompt).toBeUndefined();
-    // No prompt → the backend does not require a model, so pi starts on its own default.
+    // No prompt → the backend requires neither `model` nor `backendModel`; pi
+    // starts on its own default and the selection is made post-start.
     expect(body.model).toBeUndefined();
+    expect(body.backendModel).toBeUndefined();
+  });
+
+  it("sends backendModel (and no Claude model) for a pi agent with a prompt", async () => {
+    const { result } = renderCreateWorkspaceHook();
+
+    const piBackendModel: ApiModule.ModelOption = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4",
+      displayName: "Claude Sonnet 4",
+    };
+    await result.current.createWorkspace(
+      baseArgs({ agentTypeValue: "pi" as StoredAgentType, prompt: "build me a thing", piBackendModel }),
+    );
+
+    const body = getAgentRequestBody();
+    expect(body.agentType).toBe("pi");
+    expect(body.prompt).toBe("build me a thing");
+    // pi names its model on `backendModel` alone — never the Claude placeholder,
+    // and none of the Claude per-prompt settings ride along.
+    expect(body.backendModel).toEqual(piBackendModel);
+    expect(body.model).toBeUndefined();
+    expect(body.effort).toBeUndefined();
+    expect(body.fastMode).toBeUndefined();
+    expect(body.enterPlanMode).toBeUndefined();
   });
 
   it("never sends a prompt or model for a terminal agent", async () => {

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
@@ -2,7 +2,7 @@ import { useSetAtom } from "jotai";
 import { posthog } from "posthog-js";
 import { useCallback, useState } from "react";
 
-import type { EffortLevel, LlmModel, TerminalAgentRegistration } from "~/api";
+import type { EffortLevel, LlmModel, ModelOption, TerminalAgentRegistration } from "~/api";
 import { createWorkspaceAgent, createWorkspaceV2, WorkspaceInitializationStrategy } from "~/api";
 import { HTTPException } from "~/common/Errors.ts";
 import { useImbueNavigate } from "~/common/NavigateUtils.ts";
@@ -22,8 +22,9 @@ type CreateWorkspaceArgs = {
   /** Workspace title; falls back to "Untitled workspace" when blank. */
   workspaceName: string;
   /**
-   * First-agent prompt; empty seeds an agent with no prompt. Only sent for
-   * Claude agents — other agent types always start in the waiting state.
+   * First-agent prompt; empty seeds an agent with no prompt. Sent for Claude and
+   * pi (both take an initial prompt); terminal/registered agents ignore it and
+   * always start in the waiting state.
    */
   prompt: string;
   mode: WorkspaceInitializationStrategy;
@@ -37,6 +38,12 @@ type CreateWorkspaceArgs = {
   registrations: ReadonlyArray<TerminalAgentRegistration>;
   /** Creation-time model for Claude agents. */
   defaultModel: string;
+  /**
+   * The pi model selection (provider + model_id) for a pi agent created WITH a
+   * prompt, sent as `backend_model`. A pi prompt requires it; a promptless pi
+   * create omits it. Ignored for Claude/terminal/registered.
+   */
+  piBackendModel?: ModelOption;
   /** Per-prompt thinking effort for the first Claude agent (defaults apply when omitted). */
   effort?: EffortLevel;
   /** Whether the first Claude agent starts in fast mode. */
@@ -144,13 +151,12 @@ export const useCreateWorkspace = (): UseCreateWorkspaceReturn => {
         const isClaudeAgent = effectiveAgentType === "claude";
         const isPiAgent = effectiveAgentType === "pi";
         const initialPrompt = isClaudeAgent || isPiAgent ? args.prompt.trim() || undefined : undefined;
-        // Claude seeds its model at create and consumes the per-prompt agent
-        // settings (effort / fast / plan). pi ignores all of them: it picks its
-        // model from its own in-task catalog and enters plan mode from the chat.
-        // The backend still requires a model whenever a prompt is present, so pi
-        // rides a placeholder default in that case only — the same Claude
-        // model_name every live pi message already carries and pi discards.
-        const shouldSendModel = isClaudeAgent || (isPiAgent && initialPrompt !== undefined);
+        // Each harness names its model on its own terms: Claude seeds `model` and
+        // consumes the per-prompt settings (effort / fast / plan); pi seeds
+        // `backend_model` (the chosen provider + model_id) and ignores the rest.
+        // A pi prompt requires the selection; a promptless pi create sends
+        // neither field, and the two are mutually exclusive on the backend.
+        const backendModel = isPiAgent && initialPrompt !== undefined ? args.piBackendModel : undefined;
 
         // Create the first agent in the background — the caller's create flow
         // is done once the workspace exists. Failures surface via the global
@@ -161,7 +167,8 @@ export const useCreateWorkspace = (): UseCreateWorkspaceReturn => {
             const agentResponse = await createWorkspaceAgent({
               path: { workspace_id: workspaceId },
               body: {
-                model: shouldSendModel ? (args.defaultModel as LlmModel) : undefined,
+                model: isClaudeAgent ? (args.defaultModel as LlmModel) : undefined,
+                backendModel,
                 effort: isClaudeAgent ? args.effort : undefined,
                 fastMode: isClaudeAgent ? args.fastMode : undefined,
                 enterPlanMode: isClaudeAgent ? args.enterPlanMode : undefined,

--- a/sculptor/frontend/src/common/state/hooks/usePiModels.test.tsx
+++ b/sculptor/frontend/src/common/state/hooks/usePiModels.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import type { RenderHookResult } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ModelOption } from "~/api";
+import { queryClient } from "~/common/queryClient";
+
+import { usePiModels } from "./usePiModels";
+
+const { mockGetPiModels } = vi.hoisted(() => ({ mockGetPiModels: vi.fn() }));
+
+vi.mock("~/api", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return { ...original, getPiModels: mockGetPiModels };
+});
+
+const Wrapper = ({ children }: { children: ReactNode }): ReactElement => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+const PI_MODEL: ModelOption = { provider: "anthropic", modelId: "claude-opus-4-8", displayName: "Claude Opus 4.8" };
+const populatedCatalog = { data: { availableModels: [PI_MODEL], defaultModel: PI_MODEL } };
+
+type PiModelsHookResult = ReturnType<typeof usePiModels>;
+
+const renderPiModels = (): RenderHookResult<PiModelsHookResult, unknown> =>
+  renderHook(() => usePiModels({ enabled: true }), { wrapper: Wrapper });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // TanStack Query's cache is a process-wide singleton; wipe it so each test
+  // starts from a known empty state.
+  queryClient.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("usePiModels", () => {
+  it("returns the fetched catalog with pi's default preselectable", async () => {
+    mockGetPiModels.mockResolvedValue(populatedCatalog);
+    const { result } = renderPiModels();
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.availableModels).toEqual([PI_MODEL]);
+    expect(result.current.defaultModel).toEqual(PI_MODEL);
+  });
+
+  it("resolves an initial fetch failure to the empty catalog, not a stranded loading state", async () => {
+    // Consumers key "still resolving" on `data === undefined`; an unreachable
+    // backend must land them in the empty state (with its login CTA), not in a
+    // loading state nothing ever advances.
+    mockGetPiModels.mockRejectedValue(new Error("backend unreachable"));
+    const { result } = renderPiModels();
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual({ availableModels: [], defaultModel: null });
+    expect(result.current.availableModels).toEqual([]);
+    expect(result.current.defaultModel).toBeNull();
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("keeps the last-known catalog when a refetch fails", async () => {
+    // A transient blip during a focus-driven refetch must not swap a populated
+    // picker for the empty state's "go authenticate" advice.
+    mockGetPiModels.mockResolvedValue(populatedCatalog);
+    const { result } = renderPiModels();
+    await waitFor(() => expect(result.current.availableModels).toEqual([PI_MODEL]));
+
+    mockGetPiModels.mockRejectedValue(new Error("backend unreachable"));
+    result.current.refetch();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.availableModels).toEqual([PI_MODEL]);
+    expect(result.current.defaultModel).toEqual(PI_MODEL);
+  });
+});

--- a/sculptor/frontend/src/common/state/hooks/usePiModels.ts
+++ b/sculptor/frontend/src/common/state/hooks/usePiModels.ts
@@ -8,11 +8,14 @@ import { SCULPTOR_QUERY_KEY_PREFIX } from "../../queryClient.ts";
 
 const PI_MODELS_QUERY_KEY = [SCULPTOR_QUERY_KEY_PREFIX, "pi", "models"] as const;
 
+// One stable identity for "no catalog", shared by every errored render.
+const EMPTY_PI_CATALOG: PiModelsResponse = { availableModels: [], defaultModel: null };
+
 const fetchPiModels = async (signal: AbortSignal): Promise<PiModelsResponse> => {
   // Plain global read: skip the request tracker's WS-ack wait (this endpoint
   // never publishes a stream update to acknowledge).
   const { data } = await getPiModels({ meta: { signal, skipWsAck: true } });
-  return data ?? { availableModels: [], defaultModel: null };
+  return data;
 };
 
 type UsePiModelsResult = BackendQueryResult<PiModelsResponse | undefined> & {
@@ -33,7 +36,9 @@ type UsePiModelsResult = BackendQueryResult<PiModelsResponse | undefined> & {
  * cache to invalidate, so freshness is client-driven: `staleTime: 0` plus a
  * window-focus refetch means a login round-trip through Settings → Pi is picked
  * up when focus returns, without stranding a stale empty catalog. Best-effort
- * like the endpoint — a probe failure yields an empty catalog, never an error.
+ * like the endpoint — a fetch failure with nothing cached resolves to the empty
+ * catalog (the picker's empty state, not a loading state nothing advances),
+ * while a failed refetch keeps the last-known catalog.
  */
 export const usePiModels = ({ enabled }: { enabled: boolean }): UsePiModelsResult => {
   const query = useQuery({
@@ -44,10 +49,14 @@ export const usePiModels = ({ enabled }: { enabled: boolean }): UsePiModelsResul
     refetchOnWindowFocus: true,
     retry: false,
   });
+  // `data === undefined` means exactly "not resolved yet": TanStack retains the
+  // last-good data across a failed refetch, so the empty-catalog fold engages
+  // only when a fetch fails with nothing cached.
+  const data = query.data ?? (query.isError ? EMPTY_PI_CATALOG : undefined);
   return {
-    data: query.data,
-    availableModels: query.data?.availableModels ?? [],
-    defaultModel: query.data?.defaultModel ?? null,
+    data,
+    availableModels: data?.availableModels ?? [],
+    defaultModel: data?.defaultModel ?? null,
     isPending: query.isPending,
     isFetching: query.isFetching,
     isError: query.isError,

--- a/sculptor/frontend/src/common/state/hooks/usePiModels.ts
+++ b/sculptor/frontend/src/common/state/hooks/usePiModels.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { ModelOption, PiModelsResponse } from "~/api";
+import { getPiModels } from "~/api";
+
+import type { BackendQueryResult } from "../../queryClient.ts";
+import { SCULPTOR_QUERY_KEY_PREFIX } from "../../queryClient.ts";
+
+const PI_MODELS_QUERY_KEY = [SCULPTOR_QUERY_KEY_PREFIX, "pi", "models"] as const;
+
+const fetchPiModels = async (signal: AbortSignal): Promise<PiModelsResponse> => {
+  // Plain global read: skip the request tracker's WS-ack wait (this endpoint
+  // never publishes a stream update to acknowledge).
+  const { data } = await getPiModels({ meta: { signal, skipWsAck: true } });
+  return data ?? { availableModels: [], defaultModel: null };
+};
+
+type UsePiModelsResult = BackendQueryResult<PiModelsResponse | undefined> & {
+  /** `data?.availableModels ?? []` — the picker renders from an empty list while resolving. */
+  availableModels: ReadonlyArray<ModelOption>;
+  /** pi's own current model when usable, else null — the picker preselects it. */
+  defaultModel: ModelOption | null;
+};
+
+/**
+ * Fetch pi's curated, authenticated-only model catalog probed on the host — the
+ * pre-workspace twin of the in-task catalog, feeding the New Workspace modal's
+ * pi model picker.
+ *
+ * `enabled` gates the fetch on pi actually being the selected agent type, so the
+ * probe (a short-lived pi subprocess) runs only when the picker is on screen and
+ * its latency hides behind the user typing a prompt. There is no server-side
+ * cache to invalidate, so freshness is client-driven: `staleTime: 0` plus a
+ * window-focus refetch means a login round-trip through Settings → Pi is picked
+ * up when focus returns, without stranding a stale empty catalog. Best-effort
+ * like the endpoint — a probe failure yields an empty catalog, never an error.
+ */
+export const usePiModels = ({ enabled }: { enabled: boolean }): UsePiModelsResult => {
+  const query = useQuery({
+    queryKey: PI_MODELS_QUERY_KEY,
+    queryFn: ({ signal }) => fetchPiModels(signal),
+    enabled,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    retry: false,
+  });
+  return {
+    data: query.data,
+    availableModels: query.data?.availableModels ?? [],
+    defaultModel: query.data?.defaultModel ?? null,
+    isPending: query.isPending,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};

--- a/sculptor/frontend/src/components/AgentSettingsControls.tsx
+++ b/sculptor/frontend/src/components/AgentSettingsControls.tsx
@@ -22,13 +22,14 @@ type AgentSettingsControlsProps = {
 /**
  * The right-side toolbar block of a Claude first agent's per-prompt settings —
  * plan mode, fast mode (when the model supports it), thinking effort, and model.
- * The new-workspace modal renders this beneath its prompt textarea for a Claude
- * first agent. Non-Claude harnesses don't consume any of these at create (pi
- * picks its model from its own in-task catalog and plans from the chat; terminal
- * agents have no model), so the modal renders its own hint in place of this
- * block rather than gating the controls one by one. The fast-mode toggle is
- * gated on `getModelCapabilities(model).supportsFastMode` here (rather than at
- * every callsite) so consumers only have to pass the selected model.
+ * This block is Claude-only: the new-workspace modal renders it beneath its
+ * prompt textarea for a Claude first agent. The other harnesses don't consume
+ * these controls at create — pi drives its own backend-sourced model picker in
+ * the modal (a separate block), and terminal/registered agents have no model —
+ * so the modal chooses the block by agent type rather than gating these controls
+ * one by one. The fast-mode toggle is gated on
+ * `getModelCapabilities(model).supportsFastMode` here (rather than at every
+ * callsite) so consumers only have to pass the selected model.
  *
  * ChatInput renders a parallel copy of this toolbar block that adds
  * capability-gated disabled states and a backend-model selector it needs in

--- a/sculptor/frontend/src/components/newWorkspace/AgentTypeSelect.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/AgentTypeSelect.tsx
@@ -17,6 +17,12 @@ type AgentTypeSelectProps = {
   /** The stored agent type (e.g. "claude", "registered:<id>"). */
   value: StoredAgentType;
   onChange: (value: StoredAgentType) => void;
+  /**
+   * Called after the "Install Pi" entry routes to Settings → Pi. A host that
+   * overlays the settings page (the new-workspace dialog) dismisses itself
+   * here so the navigation is actually visible; inline hosts omit it.
+   */
+  onRouteToPiSettings?: () => void;
   className?: string;
 };
 
@@ -26,7 +32,12 @@ type AgentTypeSelectProps = {
  * available; pi is an optional harness, so while no usable pi binary is resolved
  * its entry reads "Install Pi" and choosing it routes to Settings → Pi.
  */
-export const AgentTypeSelect = ({ value, onChange, className }: AgentTypeSelectProps): ReactElement => {
+export const AgentTypeSelect = ({
+  value,
+  onChange,
+  onRouteToPiSettings,
+  className,
+}: AgentTypeSelectProps): ReactElement => {
   // State and hooks
   const { registrations, refetch: refreshRegistrations } = useTerminalAgentRegistrations();
   const { isPiAvailable, openPiSettings, refreshPiAvailability } = usePiAgentOption();
@@ -54,6 +65,7 @@ export const AgentTypeSelect = ({ value, onChange, className }: AgentTypeSelectP
         // launch.
         if (next === "pi" && !isPiAvailable) {
           openPiSettings();
+          onRouteToPiSettings?.();
           return;
         }
         onChange(next as StoredAgentType);

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -1,10 +1,12 @@
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createStore } from "jotai";
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ModelOption, Project } from "~/api";
+import type { DependenciesStatus, ModelOption, Project } from "~/api";
 import { ElementIds, WorkspaceInitializationStrategy } from "~/api";
+import { dependenciesStatusAtom } from "~/common/state/atoms/dependenciesStatus.ts";
 import { updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { renderWithProviders } from "~/common/testUtils.tsx";
 import { SettingsSection } from "~/pages/settings/sections.ts";
@@ -356,5 +358,30 @@ describe("NewWorkspaceForm", () => {
         ),
       );
     });
+  });
+
+  it("dismisses the dialog when Install Pi routes to settings from the agent picker", async () => {
+    // With no usable pi binary, the picker's pi entry reads "Install Pi" and
+    // routes to Settings — which lands underneath the host dialog, so choosing
+    // it must dismiss the dialog exactly like the model picker's CTA.
+    const onDismiss = vi.fn();
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    store.set(dependenciesStatusAtom, {
+      git: { installed: true },
+      claude: { installed: false },
+      pi: { installed: false },
+      gh: { installed: false },
+    } as DependenciesStatus);
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={onDismiss} />, { store });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId(ElementIds.ADD_WORKSPACE_AGENT_TYPE_SELECT));
+    const piOption = await screen.findByTestId(ElementIds.AGENT_TYPE_OPTION_PI);
+    expect(piOption).toHaveTextContent("Install Pi");
+    await user.click(piOption);
+
+    expect(mockOpenSettings).toHaveBeenCalledWith(SettingsSection.PI);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -3,20 +3,23 @@ import { createStore } from "jotai";
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Project } from "~/api";
-import { ElementIds } from "~/api";
+import type { ModelOption, Project } from "~/api";
+import { ElementIds, WorkspaceInitializationStrategy } from "~/api";
 import { updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { renderWithProviders } from "~/common/testUtils.tsx";
 
-import { keepNewWorkspaceModalOpenAtom } from "./newWorkspaceAtoms.ts";
+import { keepNewWorkspaceModalOpenAtom, lastWorkspaceCreationSettingsAtom } from "./newWorkspaceAtoms.ts";
 import { NewWorkspaceForm } from "./NewWorkspaceForm.tsx";
 
 // What is under test is the form's own behavior — seeding, submit, and the
 // post-create callbacks — so everything that reaches the backend is stubbed at
 // its module seam: the project fetches, the create flow, the per-repo branch
-// info, the terminal-agent registrations, and the debounced branch-name
-// preview/validation queries.
-const { mockCreateWorkspace } = vi.hoisted(() => ({ mockCreateWorkspace: vi.fn() }));
+// info, the terminal-agent registrations, the debounced branch-name
+// preview/validation queries, and the pi model catalog.
+const { mockCreateWorkspace, mockUsePiModels } = vi.hoisted(() => ({
+  mockCreateWorkspace: vi.fn(),
+  mockUsePiModels: vi.fn(),
+}));
 
 vi.mock("~/api", async (importOriginal) => {
   const original = await importOriginal();
@@ -35,6 +38,49 @@ vi.mock("~/common/state/hooks/useCreateWorkspace.ts", () => ({
     createWorkspace: mockCreateWorkspace,
   }),
 }));
+
+// The host-side pi catalog. Mocked so the admission-rule tests can drive the
+// three catalog states (resolving / populated / empty) the modal must handle.
+vi.mock("~/common/state/hooks/usePiModels.ts", () => ({
+  usePiModels: (): unknown => mockUsePiModels(),
+}));
+
+const PI_MODEL_DEFAULT: ModelOption = { provider: "anthropic", modelId: "sonnet", displayName: "Sonnet" };
+const PI_MODEL_OTHER: ModelOption = { provider: "openai", modelId: "gpt", displayName: "GPT" };
+
+// usePiModels' return shape, one factory per catalog state. Each returns a fresh
+// object; a test hands one to `mockReturnValue` so the reference stays stable
+// across renders (the preselect effect keys on `data` identity).
+const piModelsResolving = (): unknown => ({
+  data: undefined,
+  availableModels: [],
+  defaultModel: null,
+  isPending: true,
+  isFetching: true,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+});
+const piModelsPopulated = (): unknown => ({
+  data: { availableModels: [PI_MODEL_DEFAULT, PI_MODEL_OTHER], defaultModel: PI_MODEL_DEFAULT },
+  availableModels: [PI_MODEL_DEFAULT, PI_MODEL_OTHER],
+  defaultModel: PI_MODEL_DEFAULT,
+  isPending: false,
+  isFetching: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+});
+const piModelsEmpty = (): unknown => ({
+  data: { availableModels: [], defaultModel: null },
+  availableModels: [],
+  defaultModel: null,
+  isPending: false,
+  isFetching: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+});
 
 vi.mock("~/common/state/hooks/useRepoInfo.ts", () => ({
   useRepoInfo: (): unknown => ({
@@ -79,6 +125,19 @@ const renderForm = (
   return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} {...props} />, { store });
 };
 
+// Seed pi as the first-agent type via the last-create settings (pi availability
+// fails open in the test, so the seed is honored) and start on the selected repo.
+const renderPiForm = (props: Partial<FormProps> = {}): ReturnType<typeof renderWithProviders> => {
+  const store = createStore();
+  store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+  store.set(lastWorkspaceCreationSettingsAtom, {
+    projectId: "p1",
+    agentType: "pi",
+    initStrategy: WorkspaceInitializationStrategy.WORKTREE,
+  });
+  return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} {...props} />, { store });
+};
+
 // The Create button stays disabled until the (mocked) project fetch resolves a
 // selection, so wait for it to enable before clicking.
 const clickCreate = async (): Promise<void> => {
@@ -90,6 +149,9 @@ const clickCreate = async (): Promise<void> => {
 describe("NewWorkspaceForm", () => {
   beforeEach(() => {
     mockCreateWorkspace.mockResolvedValue({ ok: true, workspaceId: "w1" });
+    // Default the catalog to still-resolving; the Claude tests never read it, and
+    // the pi tests override per case.
+    mockUsePiModels.mockReturnValue(piModelsResolving());
   });
 
   // vitest runs with `globals: false`, so RTL's automatic post-test cleanup
@@ -98,6 +160,7 @@ describe("NewWorkspaceForm", () => {
   afterEach(() => {
     cleanup();
     mockCreateWorkspace.mockReset();
+    mockUsePiModels.mockReset();
     window.localStorage.clear();
   });
 
@@ -195,5 +258,78 @@ describe("NewWorkspaceForm", () => {
     // ...and the still-open dialog returns to the request's seeded branch name
     // (not the auto preview).
     await waitFor(() => expect(branchInput).toHaveValue("linear/scu-1-fix"));
+  });
+
+  // The spec's one rule: a pi prompt is submittable only against a resolved,
+  // non-empty catalog with a selection; a promptless create never waits on it.
+  describe("pi model picker admission rule", () => {
+    it("renders the pi model picker in place of the Claude controls", async () => {
+      mockUsePiModels.mockReturnValue(piModelsPopulated());
+      renderPiForm();
+
+      await waitFor(() => expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_CREATE_BUTTON)).toBeEnabled());
+      expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_MODEL_PICKER)).toBeInTheDocument();
+    });
+
+    it("keeps a promptless pi create enabled while the catalog is still resolving", async () => {
+      mockUsePiModels.mockReturnValue(piModelsResolving());
+      renderPiForm();
+
+      // No prompt → the create never waits on the catalog, even mid-probe.
+      await waitFor(() => expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_CREATE_BUTTON)).toBeEnabled());
+    });
+
+    it("blocks a pi prompt while the catalog is resolving, and re-enables when the prompt clears", async () => {
+      mockUsePiModels.mockReturnValue(piModelsResolving());
+      renderPiForm();
+
+      const createButton = screen.getByTestId(ElementIds.NEW_WORKSPACE_CREATE_BUTTON);
+      const promptTextarea = screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA);
+      // Promptless baseline: repo/branch are satisfied, so the only thing that can
+      // disable the button from here is the pi admission gate.
+      await waitFor(() => expect(createButton).toBeEnabled());
+
+      fireEvent.change(promptTextarea, { target: { value: "do a thing" } });
+      await waitFor(() => expect(createButton).toBeDisabled());
+
+      fireEvent.change(promptTextarea, { target: { value: "" } });
+      await waitFor(() => expect(createButton).toBeEnabled());
+    });
+
+    it("blocks a pi prompt when the catalog is empty and offers the login CTA", async () => {
+      mockUsePiModels.mockReturnValue(piModelsEmpty());
+      renderPiForm();
+
+      const createButton = screen.getByTestId(ElementIds.NEW_WORKSPACE_CREATE_BUTTON);
+      await waitFor(() => expect(createButton).toBeEnabled());
+
+      fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+        target: { value: "do a thing" },
+      });
+      await waitFor(() => expect(createButton).toBeDisabled());
+      // The no-usable-model surface routes the user to authenticate a provider.
+      expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE)).toBeInTheDocument();
+    });
+
+    it("enables a pi prompt against a populated catalog and creates with the default model preselected", async () => {
+      mockUsePiModels.mockReturnValue(piModelsPopulated());
+      renderPiForm();
+
+      const createButton = screen.getByTestId(ElementIds.NEW_WORKSPACE_CREATE_BUTTON);
+      await waitFor(() => expect(createButton).toBeEnabled());
+
+      fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+        target: { value: "do a thing" },
+      });
+      // The default model is preselected, so the prompt stays submittable.
+      await waitFor(() => expect(createButton).toBeEnabled());
+
+      fireEvent.click(createButton);
+      await waitFor(() =>
+        expect(mockCreateWorkspace).toHaveBeenCalledWith(
+          expect.objectContaining({ agentTypeValue: "pi", prompt: "do a thing", piBackendModel: PI_MODEL_DEFAULT }),
+        ),
+      );
+    });
   });
 });

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -7,6 +7,7 @@ import type { ModelOption, Project } from "~/api";
 import { ElementIds, WorkspaceInitializationStrategy } from "~/api";
 import { updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { renderWithProviders } from "~/common/testUtils.tsx";
+import { SettingsSection } from "~/pages/settings/sections.ts";
 
 import { keepNewWorkspaceModalOpenAtom, lastWorkspaceCreationSettingsAtom } from "./newWorkspaceAtoms.ts";
 import { NewWorkspaceForm } from "./NewWorkspaceForm.tsx";
@@ -43,6 +44,13 @@ vi.mock("~/common/state/hooks/useCreateWorkspace.ts", () => ({
 // three catalog states (resolving / populated / empty) the modal must handle.
 vi.mock("~/common/state/hooks/usePiModels.ts", () => ({
   usePiModels: (): unknown => mockUsePiModels(),
+}));
+
+// Settings navigation is a route change; the CTA tests only assert the form
+// asks for the right section.
+const { mockOpenSettings } = vi.hoisted(() => ({ mockOpenSettings: vi.fn() }));
+vi.mock("~/common/state/hooks/useOpenSettings.ts", () => ({
+  useOpenSettings: (): unknown => mockOpenSettings,
 }));
 
 const PI_MODEL_DEFAULT: ModelOption = { provider: "anthropic", modelId: "sonnet", displayName: "Sonnet" };
@@ -122,7 +130,7 @@ const renderForm = (
   if (options.keepOpen) {
     store.set(keepNewWorkspaceModalOpenAtom, true);
   }
-  return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} {...props} />, { store });
+  return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} {...props} />, { store });
 };
 
 // Seed pi as the first-agent type via the last-create settings (pi availability
@@ -135,7 +143,7 @@ const renderPiForm = (props: Partial<FormProps> = {}): ReturnType<typeof renderW
     agentType: "pi",
     initStrategy: WorkspaceInitializationStrategy.WORKTREE,
   });
-  return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} {...props} />, { store });
+  return renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} {...props} />, { store });
 };
 
 // The Create button stays disabled until the (mocked) project fetch resolves a
@@ -309,6 +317,23 @@ describe("NewWorkspaceForm", () => {
       await waitFor(() => expect(createButton).toBeDisabled());
       // The no-usable-model surface routes the user to authenticate a provider.
       expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE)).toBeInTheDocument();
+    });
+
+    it("routes the empty-state CTA to pi settings and dismisses the dialog", async () => {
+      // The settings page opens underneath the host dialog, so the CTA must
+      // also dismiss it — otherwise the modal keeps covering the page it opened.
+      mockUsePiModels.mockReturnValue(piModelsEmpty());
+      const onDismiss = vi.fn();
+      renderPiForm({ onDismiss });
+
+      fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+        target: { value: "do a thing" },
+      });
+      await waitFor(() => expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE));
+      expect(mockOpenSettings).toHaveBeenCalledWith(SettingsSection.PI);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
     it("enables a pi prompt against a populated catalog and creates with the default model preselected", async () => {

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -50,7 +50,7 @@ const PI_MODEL_OTHER: ModelOption = { provider: "openai", modelId: "gpt", displa
 
 // usePiModels' return shape, one factory per catalog state. Each returns a fresh
 // object; a test hands one to `mockReturnValue` so the reference stays stable
-// across renders (the preselect effect keys on `data` identity).
+// across renders.
 const piModelsResolving = (): unknown => ({
   data: undefined,
   availableModels: [],
@@ -260,7 +260,7 @@ describe("NewWorkspaceForm", () => {
     await waitFor(() => expect(branchInput).toHaveValue("linear/scu-1-fix"));
   });
 
-  // The spec's one rule: a pi prompt is submittable only against a resolved,
+  // The one admission rule: a pi prompt is submittable only against a resolved,
   // non-empty catalog with a selection; a promptless create never waits on it.
   describe("pi model picker admission rule", () => {
     it("renders the pi model picker in place of the Claude controls", async () => {

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -498,4 +498,42 @@ describe("NewWorkspaceForm", () => {
     expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("Seeded title");
     expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("Seeded prompt");
   });
+
+  it("does not stash a caller seed the user never touched, so the next plain open starts fresh", () => {
+    // The first-run auto-open seeds the prompt with the `/sculptor:help`
+    // onboarding text via `initialPrompt`. Dismissed untouched, that seed is
+    // the caller's, not the user's draft — it must not ride the stash into the
+    // next plain open (the sidebar's New Workspace button / Cmd-T), which
+    // carries no seed of its own. The onboarding prefill belongs to the
+    // auto-open only.
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    renderWithProviders(
+      <NewWorkspaceForm initialPrompt="/sculptor:help onboarding" onCreated={vi.fn()} onDismiss={vi.fn()} />,
+      { store },
+    );
+    // Dismiss without touching the seeded prompt.
+    cleanup();
+
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("");
+  });
+
+  it("stashes a caller seed once the user edits it, so their own content survives the reopen", () => {
+    // Editing the seeded prompt makes it the user's content; it then rides the
+    // stash like anything else typed.
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    renderWithProviders(
+      <NewWorkspaceForm initialPrompt="/sculptor:help onboarding" onCreated={vi.fn()} onDismiss={vi.fn()} />,
+      { store },
+    );
+    fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+      target: { value: "my own task" },
+    });
+    cleanup();
+
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("my own task");
+  });
 });

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -472,6 +472,43 @@ describe("NewWorkspaceForm", () => {
     expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("");
   });
 
+  it("does not stash an untouched seeded open — the prefill belongs to the auto-open only", () => {
+    // First-run auto-open: the app seeds the prompt; the user dismisses
+    // without editing. An unedited prefill is not the user's work, so the
+    // sidebar reopen is a plain open with no prefill.
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    renderWithProviders(
+      <NewWorkspaceForm initialPrompt="/sculptor:help get started" onCreated={vi.fn()} onDismiss={vi.fn()} />,
+      { store },
+    );
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("/sculptor:help get started");
+    cleanup();
+
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("");
+  });
+
+  it("stashes edited fields while an untouched seed still stays out", () => {
+    // The seed masking is per-field: editing the title makes it the user's
+    // content, but the untouched seeded prompt still belongs to the auto-open
+    // only and must not ride along into the next plain open.
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    renderWithProviders(
+      <NewWorkspaceForm initialPrompt="/sculptor:help get started" onCreated={vi.fn()} onDismiss={vi.fn()} />,
+      { store },
+    );
+    fireEvent.change(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT), {
+      target: { value: "My onboarding workspace" },
+    });
+    cleanup();
+
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("My onboarding workspace");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("");
+  });
+
   it("lets an explicit open seed beat a stashed draft", () => {
     const store = createStore();
     store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.test.tsx
@@ -11,7 +11,11 @@ import { updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { renderWithProviders } from "~/common/testUtils.tsx";
 import { SettingsSection } from "~/pages/settings/sections.ts";
 
-import { keepNewWorkspaceModalOpenAtom, lastWorkspaceCreationSettingsAtom } from "./newWorkspaceAtoms.ts";
+import {
+  keepNewWorkspaceModalOpenAtom,
+  lastWorkspaceCreationSettingsAtom,
+  newWorkspaceDraftAtom,
+} from "./newWorkspaceAtoms.ts";
 import { NewWorkspaceForm } from "./NewWorkspaceForm.tsx";
 
 // What is under test is the form's own behavior — seeding, submit, and the
@@ -375,6 +379,9 @@ describe("NewWorkspaceForm", () => {
     } as DependenciesStatus);
     renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={onDismiss} />, { store });
 
+    fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+      target: { value: "keep me" },
+    });
     const user = userEvent.setup();
     await user.click(screen.getByTestId(ElementIds.ADD_WORKSPACE_AGENT_TYPE_SELECT));
     const piOption = await screen.findByTestId(ElementIds.AGENT_TYPE_OPTION_PI);
@@ -383,5 +390,112 @@ describe("NewWorkspaceForm", () => {
 
     expect(mockOpenSettings).toHaveBeenCalledWith(SettingsSection.PI);
     expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    // The forced exit stashes the entries; the next open restores them.
+    cleanup();
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("keep me");
+  });
+
+  it("restores the form's entries on the reopen after the empty-state CTA routed to settings", async () => {
+    mockUsePiModels.mockReturnValue(piModelsEmpty());
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    store.set(lastWorkspaceCreationSettingsAtom, {
+      projectId: "p1",
+      agentType: "pi",
+      initStrategy: WorkspaceInitializationStrategy.WORKTREE,
+    });
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+
+    fireEvent.change(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT), {
+      target: { value: "My workspace" },
+    });
+    fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+      target: { value: "do a thing" },
+    });
+    await waitFor(() => expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE)).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId(ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE));
+
+    // The authentication round-trip must not cost the user their entries.
+    cleanup();
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("My workspace");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("do a thing");
+
+    // Dismissing the restored form re-stashes it: the entries survive until a
+    // create consumes them.
+    cleanup();
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("My workspace");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("do a thing");
+  });
+
+  it("restores the form's entries after any dismissal — Escape and overlay clicks included", () => {
+    // Every dismissal unmounts the form; the stash rides the unmount, so an
+    // accidental Escape or stray overlay click costs nothing.
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+
+    fireEvent.change(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT), {
+      target: { value: "Half-typed" },
+    });
+    fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+      target: { value: "an accidental escape" },
+    });
+    cleanup();
+
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("Half-typed");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("an accidental escape");
+  });
+
+  it("clears the stash on a successful create so the next open starts fresh", async () => {
+    const onCreated = vi.fn();
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    renderWithProviders(<NewWorkspaceForm onCreated={onCreated} onDismiss={vi.fn()} />, { store });
+
+    fireEvent.change(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT), {
+      target: { value: "Shipped" },
+    });
+    fireEvent.change(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA), {
+      target: { value: "created, not drafted" },
+    });
+    await clickCreate();
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    cleanup();
+
+    renderWithProviders(<NewWorkspaceForm onCreated={vi.fn()} onDismiss={vi.fn()} />, { store });
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("");
+  });
+
+  it("lets an explicit open seed beat a stashed draft", () => {
+    const store = createStore();
+    store.set(updateProjectsAtom, [{ objectId: "p1", name: "Repo One" } as Project]);
+    store.set(newWorkspaceDraftAtom, {
+      projectId: "p1",
+      title: "Draft title",
+      prompt: "draft prompt",
+      branchNameOverride: null,
+      mode: WorkspaceInitializationStrategy.WORKTREE,
+      sourceBranch: undefined,
+      agentTypeValue: "claude",
+      piSelectionOverride: undefined,
+    });
+    renderWithProviders(
+      <NewWorkspaceForm
+        initialTitle="Seeded title"
+        initialPrompt="Seeded prompt"
+        onCreated={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+      { store },
+    );
+
+    expect(screen.getByTestId(ElementIds.WORKSPACE_NAME_INPUT)).toHaveValue("Seeded title");
+    expect(screen.getByTestId(ElementIds.NEW_WORKSPACE_PROMPT_TEXTAREA)).toHaveValue("Seeded prompt");
   });
 });

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -35,9 +35,11 @@ import { AgentTypeSelect } from "~/components/newWorkspace/AgentTypeSelect.tsx";
 import { BranchNameField } from "~/components/newWorkspace/BranchNameField.tsx";
 import { useBranchNamePreview } from "~/components/newWorkspace/hooks/useBranchNamePreview.ts";
 import { ModeSelect } from "~/components/newWorkspace/ModeSelect.tsx";
+import type { NewWorkspaceDraft } from "~/components/newWorkspace/newWorkspaceAtoms.ts";
 import {
   keepNewWorkspaceModalOpenAtom,
   lastWorkspaceCreationSettingsAtom,
+  newWorkspaceDraftAtom,
 } from "~/components/newWorkspace/newWorkspaceAtoms.ts";
 import { RepoSelector } from "~/components/RepoSelector.tsx";
 import { resolveStoredAgentType } from "~/components/sections/addPanelCore.ts";
@@ -93,9 +95,12 @@ type NewWorkspaceFormProps = {
  * The new-workspace form: a borderless title input, an auto-growing
  * prompt textarea, a breadcrumb row of context pills (repo / agent type / mode /
  * branch), and a footer (keep-open switch + Cmd+Enter hint + Create). Field
- * values are LOCAL component state (the modal is ephemeral), seeded from
- * `lastWorkspaceCreationSettingsAtom` and the preset repo. Reuses this branch's
- * RepoSelector / BranchSelector / BranchNameField and the factored create hook.
+ * values are LOCAL component state, seeded from the open request's explicit
+ * seeds, then the session draft (`newWorkspaceDraftAtom`, stashed on every
+ * dismissal and cleared by a successful create), then
+ * `lastWorkspaceCreationSettingsAtom` and the preset repo. Reuses this
+ * branch's RepoSelector / BranchSelector / BranchNameField and the factored
+ * create hook.
  */
 export const NewWorkspaceForm = ({
   presetProjectId,
@@ -116,6 +121,9 @@ export const NewWorkspaceForm = ({
   const defaultEffortLevel = useAtomValue(defaultEffortLevelAtom);
   const isDefaultFastMode = useAtomValue(isDefaultFastModeAtom);
   const [isKeepOpen, setIsKeepOpen] = useAtom(keepNewWorkspaceModalOpenAtom);
+  // The session draft: read by the seed initializers below, rewritten by the
+  // unmount stash whenever the dialog closes, cleared by a successful create.
+  const [draft, setDraft] = useAtom(newWorkspaceDraftAtom);
 
   // Per-prompt agent-settings overrides — model / effort / fast mode / plan
   // mode. Seeded once from the user's defaults; surfaced beneath the prompt only
@@ -129,33 +137,42 @@ export const NewWorkspaceForm = ({
   // The user's explicit pick in the pi model picker, if any. The effective
   // selection is derived from this plus the catalog (below) so it can never drift
   // out of the catalog; an unset override means "use pi's default".
-  const [piSelectionOverride, setPiSelectionOverride] = useState<ModelOption | undefined>(undefined);
-
-  // State and hooks — seed the local form state once, from the preset repo (if
-  // any) then the MRU settings. Reading the seed lazily keeps it a mount-time
-  // snapshot the user can freely change without it being clobbered by later
-  // atom updates.
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
-    () => presetProjectId ?? lastSettings?.projectId ?? null,
+  const [piSelectionOverride, setPiSelectionOverride] = useState<ModelOption | undefined>(
+    () => draft?.piSelectionOverride,
   );
-  const [workspaceName, setWorkspaceName] = useState<string>(() => initialTitle ?? "");
-  const [prompt, setPrompt] = useState<string>(() => initialPrompt ?? "");
+
+  // State and hooks — seed the local form state once: the open request's
+  // explicit seeds win, then a stashed draft, then the MRU settings. Reading
+  // the seed lazily keeps it a mount-time snapshot the user can freely change
+  // without it being clobbered by later atom updates.
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+    () => presetProjectId ?? draft?.projectId ?? lastSettings?.projectId ?? null,
+  );
+  const [workspaceName, setWorkspaceName] = useState<string>(() => initialTitle ?? draft?.title ?? "");
+  const [prompt, setPrompt] = useState<string>(() => initialPrompt ?? draft?.prompt ?? "");
   const [mode, setMode] = useState<WorkspaceInitializationStrategy>(
-    () => lastSettings?.initStrategy ?? WorkspaceInitializationStrategy.WORKTREE,
+    () => draft?.mode ?? lastSettings?.initStrategy ?? WorkspaceInitializationStrategy.WORKTREE,
   );
   const [agentTypeValue, setAgentTypeValue] = useState<StoredAgentType>(() => {
-    const seed = lastSettings?.agentType ?? lastUsedAgentType;
+    const seed = draft?.agentTypeValue ?? lastSettings?.agentType ?? lastUsedAgentType;
     // Normalize the remembered seed. A bare "terminal" stays: it is a
     // legitimate first-agent choice here. pi can be the remembered seed while no
     // usable pi binary is resolved; preset Claude rather than a pi that cannot
     // launch (the picker still lists pi as "Install Pi").
     return seed === "pi" && !isPiAvailable ? "claude" : resolveStoredAgentType(seed);
   });
-  const [userSelectedBranch, setUserSelectedBranch] = useState<string | undefined>(() => lastSettings?.sourceBranch);
+  // A draft replaces the MRU branch seed even when it holds no explicit pick —
+  // its `sourceBranch: undefined` means the user was on the repo's current
+  // branch, not that the field should fall back to another repo's memory.
+  const [userSelectedBranch, setUserSelectedBranch] = useState<string | undefined>(() =>
+    draft !== undefined ? draft.sourceBranch : lastSettings?.sourceBranch,
+  );
   // `null` means "use the auto-filled preview"; any string means the user has
   // taken over. Both the value and the manual flag collapse into one piece of
   // state so they can never disagree.
-  const [branchNameOverride, setBranchNameOverride] = useState<string | null>(() => initialBranchName ?? null);
+  const [branchNameOverride, setBranchNameOverride] = useState<string | null>(
+    () => initialBranchName ?? draft?.branchNameOverride ?? null,
+  );
   const [shuffleNonce, setShuffleNonce] = useState<number>(0);
   const [isLoadingProjects, setIsLoadingProjects] = useState<boolean>(true);
   const [toast, setToast] = useState<ToastContent | null>(null);
@@ -193,6 +210,33 @@ export const NewWorkspaceForm = ({
   });
 
   const sourceBranch = useMemo(() => userSelectedBranch ?? repoInfo?.currentBranch, [userSelectedBranch, repoInfo]);
+
+  // Effects — stash the form's entries whenever it unmounts, whatever closed
+  // it (Escape, an overlay click, the X, the Settings CTAs), so the next open
+  // can restore them. The unmount cleanup would close over first-render state,
+  // so it reads through a snapshot ref refreshed on every commit; a successful
+  // create suppresses the stash so a completed form doesn't resurrect.
+  const draftSnapshotRef = useRef<NewWorkspaceDraft | null>(null);
+  const isDraftSuppressedRef = useRef<boolean>(false);
+  useEffect(() => {
+    draftSnapshotRef.current = {
+      projectId: selectedProjectId,
+      title: workspaceName,
+      prompt,
+      branchNameOverride,
+      mode,
+      sourceBranch: userSelectedBranch,
+      agentTypeValue,
+      piSelectionOverride,
+    };
+  });
+  useEffect(() => {
+    return (): void => {
+      if (!isDraftSuppressedRef.current && draftSnapshotRef.current !== null) {
+        setDraft(draftSnapshotRef.current);
+      }
+    };
+  }, [setDraft]);
 
   // Effects — load projects on mount. Fall back to the MRU project, then the
   // first project, only when there is no valid seeded selection.
@@ -373,6 +417,9 @@ export const NewWorkspaceForm = ({
       return;
     }
 
+    // The entries became a workspace: clear the session draft.
+    setDraft(undefined);
+
     // Fires on every success, keep-open or not. The callback may come from a
     // extension, so contain a throw rather than letting it break the form's own
     // post-create flow (field reset / dialog close).
@@ -399,6 +446,10 @@ export const NewWorkspaceForm = ({
       setShuffleNonce((prev) => prev + 1);
       nameInputRef.current?.focus();
     } else {
+      // The dialog is about to close on a completed form; keep the unmount
+      // from stashing it as a draft. (A keep-open create stays mounted and
+      // keeps stashing whatever the user types next.)
+      isDraftSuppressedRef.current = true;
       onCreated();
     }
   }, [
@@ -423,6 +474,7 @@ export const NewWorkspaceForm = ({
     initialBranchName,
     onWorkspaceCreated,
     onCreated,
+    setDraft,
   ]);
 
   // Effects — Cmd+Enter creates from anywhere in the form. An overlay open over

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -219,11 +219,17 @@ export const NewWorkspaceForm = ({
   const draftSnapshotRef = useRef<NewWorkspaceDraft | null>(null);
   const isDraftSuppressedRef = useRef<boolean>(false);
   useEffect(() => {
+    // Stash the user's OWN entries, not an untouched caller seed. A field that
+    // still equals the seed the open request supplied — most visibly the
+    // first-run auto-open's `/sculptor:help` prompt, which "belongs to the
+    // auto-open only" — is the caller's, not a draft; it stashes blank so it
+    // never leaks into the next plain open (sidebar / Cmd-T). Any edit makes
+    // the field the user's content, and it then rides the stash like the rest.
     draftSnapshotRef.current = {
       projectId: selectedProjectId,
-      title: workspaceName,
-      prompt,
-      branchNameOverride,
+      title: workspaceName === initialTitle ? "" : workspaceName,
+      prompt: prompt === initialPrompt ? "" : prompt,
+      branchNameOverride: branchNameOverride === (initialBranchName ?? null) ? null : branchNameOverride,
       mode,
       sourceBranch: userSelectedBranch,
       agentTypeValue,

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -1,16 +1,18 @@
-import { Button, Skeleton, Switch, Text, Tooltip } from "@radix-ui/themes";
+import { Button, Flex, Skeleton, Switch, Tooltip } from "@radix-ui/themes";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { ReactElement } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { EffortLevel } from "~/api";
+import type { EffortLevel, ModelOption } from "~/api";
 import {
   ElementIds,
   getActiveProjects,
   getMostRecentlyUsedProject,
   type LlmModel,
+  ModelCatalogState,
   WorkspaceInitializationStrategy,
 } from "~/api";
+import { hasNoUsableModel } from "~/common/modelConstants.ts";
 import { isDismissibleOverlayOpen } from "~/common/overlayUtils.ts";
 import {
   lastUsedAgentTypeAtom,
@@ -21,11 +23,14 @@ import { isPiAvailableAtom } from "~/common/state/atoms/dependenciesStatus.ts";
 import { projectsArrayAtom, updateProjectsAtom } from "~/common/state/atoms/projects.ts";
 import { defaultEffortLevelAtom, defaultModelAtom, isDefaultFastModeAtom } from "~/common/state/atoms/userConfig.ts";
 import { useCreateWorkspace } from "~/common/state/hooks/useCreateWorkspace.ts";
+import { useOpenSettings } from "~/common/state/hooks/useOpenSettings.ts";
+import { usePiModels } from "~/common/state/hooks/usePiModels.ts";
 import { useRepoInfo } from "~/common/state/hooks/useRepoInfo.ts";
 import { useTerminalAgentRegistrations } from "~/common/state/hooks/useTerminalAgentRegistrations.ts";
 import { AgentSettingsControls } from "~/components/AgentSettingsControls.tsx";
 import { BranchSelector } from "~/components/BranchSelector.tsx";
 import { KeyboardHint } from "~/components/KeyboardHint.tsx";
+import { ModelSelector } from "~/components/ModelSelector.tsx";
 import { AgentTypeSelect } from "~/components/newWorkspace/AgentTypeSelect.tsx";
 import { BranchNameField } from "~/components/newWorkspace/BranchNameField.tsx";
 import { useBranchNamePreview } from "~/components/newWorkspace/hooks/useBranchNamePreview.ts";
@@ -38,6 +43,7 @@ import { RepoSelector } from "~/components/RepoSelector.tsx";
 import { resolveStoredAgentType } from "~/components/sections/addPanelCore.ts";
 import { Toast, type ToastContent, ToastType } from "~/components/Toast.tsx";
 import { getMetaKey, isModifierPressed } from "~/electron/utils.ts";
+import { SettingsSection } from "~/pages/settings/sections.ts";
 
 import styles from "./NewWorkspaceForm.module.scss";
 
@@ -113,6 +119,10 @@ export const NewWorkspaceForm = ({
   const [agentEffort, setAgentEffort] = useState<EffortLevel>(defaultEffortLevel as EffortLevel);
   const [isAgentFastMode, setIsAgentFastMode] = useState<boolean>(isDefaultFastMode);
   const [isAgentPlanMode, setIsAgentPlanMode] = useState<boolean>(false);
+  // The user's explicit pick in the pi model picker, if any. The effective
+  // selection is derived from this plus the catalog (below) so it can never drift
+  // out of the catalog; an unset override means "use pi's default".
+  const [piSelectionOverride, setPiSelectionOverride] = useState<ModelOption | undefined>(undefined);
 
   // State and hooks — seed the local form state once, from the preset repo (if
   // any) then the MRU settings. Reading the seed lazily keeps it a mount-time
@@ -152,6 +162,12 @@ export const NewWorkspaceForm = ({
   const effectiveAgentType = resolveEffectiveAgentType(agentTypeValue, registrations).agentType;
   const { repoInfo, fetchRepoInfo, fetchCurrentBranch } = useRepoInfo(selectedProjectId);
   const { isCreating, createWorkspace } = useCreateWorkspace();
+  const openSettings = useOpenSettings();
+  // Fetch pi's host-side catalog only while pi is the selected agent type, so the
+  // probe's latency hides behind the user typing a prompt; the hook's window-focus
+  // refetch picks up a Settings login round-trip on return.
+  const isPiSelected = effectiveAgentType === "pi";
+  const piModels = usePiModels({ enabled: isPiSelected });
   const nameInputRef = useRef<HTMLInputElement>(null);
   const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
   const formRef = useRef<HTMLDivElement>(null);
@@ -246,6 +262,9 @@ export const NewWorkspaceForm = ({
   }, [prompt]);
 
   // Functions and callbacks
+  const handleGoToPiSettings = useCallback((): void => {
+    openSettings(SettingsSection.PI);
+  }, [openSettings]);
   const handleProjectChange = useCallback((nextProjectId: string): void => {
     setSelectedProjectId(nextProjectId);
     // Switching repos invalidates branch choices made against the old repo.
@@ -265,6 +284,32 @@ export const NewWorkspaceForm = ({
     setShuffleNonce((prev) => prev + 1);
   }, []);
 
+  const isPromptEmpty = prompt.trim() === "";
+  // The pi catalog as the ModelSelector consumes it: the fetched list, or
+  // NOT_FETCHED_YET while the host-side probe is still resolving (which drives the
+  // picker's loading state rather than a premature empty state).
+  const piCatalog: ReadonlyArray<ModelOption> | ModelCatalogState =
+    piModels.data !== undefined ? piModels.availableModels : ModelCatalogState.NOT_FETCHED_YET;
+  // Shared predicate with the composer: a fetched-but-empty catalog is the
+  // no-usable-model state (no authenticated pi providers).
+  const isPiCatalogEmpty = hasNoUsableModel(true, piCatalog);
+  // The effective pi selection, derived (not stored) so it can't drift from the
+  // catalog: the user's explicit pick while the catalog still offers it, otherwise
+  // pi's default (or the first available). An empty or still-resolving catalog has
+  // no selection.
+  const piSelection: ModelOption | undefined =
+    piModels.availableModels.length === 0
+      ? undefined
+      : (piModels.availableModels.find(
+          (m) => m.provider === piSelectionOverride?.provider && m.modelId === piSelectionOverride?.modelId,
+        ) ??
+        piModels.defaultModel ??
+        piModels.availableModels[0]);
+  // The spec's one submission rule: a pi prompt is submittable only against a
+  // resolved, non-empty catalog with a selection (`piSelection` is set exactly
+  // then); a promptless create never waits on the catalog.
+  const isPiPromptBlocked = isPiSelected && !isPromptEmpty && piSelection === undefined;
+
   const isSubmitDisabled =
     selectedProjectId === null ||
     isCreating ||
@@ -279,7 +324,8 @@ export const NewWorkspaceForm = ({
     // A name the validator has flagged — illegal ref or existing branch — hard
     // blocks Create; the backend re-checks at create time as the backstop.
     branchNameStatus === "exists" ||
-    branchNameStatus === "invalid";
+    branchNameStatus === "invalid" ||
+    isPiPromptBlocked;
 
   const handleSubmit = useCallback(async (): Promise<void> => {
     if (isSubmitDisabled || selectedProjectId === null) return;
@@ -294,6 +340,7 @@ export const NewWorkspaceForm = ({
       agentTypeValue,
       registrations,
       defaultModel: agentModel,
+      piBackendModel: piSelection,
       effort: agentEffort,
       fastMode: isAgentFastMode,
       enterPlanMode: isAgentPlanMode,
@@ -358,6 +405,7 @@ export const NewWorkspaceForm = ({
     agentTypeValue,
     registrations,
     agentModel,
+    piSelection,
     agentEffort,
     isAgentFastMode,
     isAgentPlanMode,
@@ -402,7 +450,6 @@ export const NewWorkspaceForm = ({
   const currentProject = projects.find((p) => p.objectId === selectedProjectId);
   const crumbName = currentProject?.name ?? "Select repo";
   const crumbInitial = (currentProject?.name?.trim()?.[0] ?? "?").toUpperCase();
-  const isPromptEmpty = prompt.trim() === "";
 
   // Skeleton the crumb only on a cold first open (no cached project resolved yet
   // while the initial project fetch is in flight); otherwise the real selector
@@ -511,10 +558,10 @@ export const NewWorkspaceForm = ({
 
           {/* Per-prompt agent settings. The row is always laid out so it reserves
               its space; it is hidden via `visibility` until the user has typed a
-              prompt so the modal doesn't jump. Only Claude consumes model / effort
-              / plan / fast at create, so it gets the full control cluster. pi
-              ignores all of them — it picks its model from its own in-task catalog
-              and enters plan mode from the chat — so it gets a hint instead.
+              prompt so the modal doesn't jump. Claude gets the full control cluster
+              (model / effort / plan / fast). pi gets its own backend-sourced model
+              picker, driven by the host-side catalog — the same selector the
+              composer shows, so a pi prompt names a validated model by construction.
               Terminal/registered agents configure nothing here. */}
           <div className={styles.agentSettings} data-visible={!isPromptEmpty} aria-hidden={isPromptEmpty}>
             {effectiveAgentType === "claude" ? (
@@ -529,9 +576,32 @@ export const NewWorkspaceForm = ({
                 onPlanModeToggle={(): void => setIsAgentPlanMode((v) => !v)}
               />
             ) : effectiveAgentType === "pi" ? (
-              <Text size="1" color="gray" data-testid={ElementIds.NEW_WORKSPACE_PI_SETTINGS_HINT}>
-                Select your model after the workspace starts
-              </Text>
+              <Flex align="center" gap="2" data-testid={ElementIds.NEW_WORKSPACE_PI_MODEL_PICKER}>
+                <ModelSelector
+                  model={agentModel}
+                  onModelChange={setAgentModel}
+                  backendModels={piCatalog}
+                  selectedModelId={piSelection?.modelId}
+                  onBackendModelChange={(option): void => setPiSelectionOverride(option)}
+                  sourcesBackendModels
+                />
+                {isPiCatalogEmpty ? (
+                  // No authenticated providers: the picker shows "No models
+                  // available"; this CTA routes to Settings → Pi to authenticate,
+                  // mirroring the composer's send-slot CTA. A pi prompt stays
+                  // blocked until a provider is connected.
+                  <Tooltip content="Authenticate a provider before you can send a prompt">
+                    <Button
+                      size="1"
+                      onClick={handleGoToPiSettings}
+                      data-testid={ElementIds.NEW_WORKSPACE_PI_EMPTY_STATE}
+                      aria-label="Go to harness configuration"
+                    >
+                      Go to harness configuration
+                    </Button>
+                  </Tooltip>
+                ) : null}
+              </Flex>
             ) : null}
           </div>
         </div>

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -305,9 +305,9 @@ export const NewWorkspaceForm = ({
         ) ??
         piModels.defaultModel ??
         piModels.availableModels[0]);
-  // The spec's one submission rule: a pi prompt is submittable only against a
-  // resolved, non-empty catalog with a selection (`piSelection` is set exactly
-  // then); a promptless create never waits on the catalog.
+  // One submission rule: a pi prompt is submittable only against a resolved,
+  // non-empty catalog with a selection (`piSelection` is set exactly then);
+  // a promptless create never waits on the catalog.
   const isPiPromptBlocked = isPiSelected && !isPromptEmpty && piSelection === undefined;
 
   const isSubmitDisabled =

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -489,7 +489,12 @@ export const NewWorkspaceForm = ({
             />
           )}
 
-          <AgentTypeSelect value={agentTypeValue} onChange={setAgentTypeValue} className={styles.toolbarPill} />
+          <AgentTypeSelect
+            value={agentTypeValue}
+            onChange={setAgentTypeValue}
+            onRouteToPiSettings={onDismiss}
+            className={styles.toolbarPill}
+          />
 
           <ModeSelect value={mode} onChange={handleModeChange} className={styles.toolbarPill} />
 

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceForm.tsx
@@ -81,6 +81,12 @@ type NewWorkspaceFormProps = {
   onWorkspaceCreated?: (workspaceId: string) => void;
   /** Called after a successful create when "keep open" is off. */
   onCreated: () => void;
+  /**
+   * Called when the form needs its host dialog closed without a create — the
+   * pi empty-state CTA navigates to Settings → Pi, which lands underneath the
+   * dialog, so the navigation only becomes visible once the host dismisses.
+   */
+  onDismiss: () => void;
 };
 
 /**
@@ -98,6 +104,7 @@ export const NewWorkspaceForm = ({
   initialBranchName,
   onWorkspaceCreated,
   onCreated,
+  onDismiss,
 }: NewWorkspaceFormProps): ReactElement => {
   // State and hooks — atoms
   const projects = useAtomValue(projectsArrayAtom);
@@ -264,7 +271,8 @@ export const NewWorkspaceForm = ({
   // Functions and callbacks
   const handleGoToPiSettings = useCallback((): void => {
     openSettings(SettingsSection.PI);
-  }, [openSettings]);
+    onDismiss();
+  }, [openSettings, onDismiss]);
   const handleProjectChange = useCallback((nextProjectId: string): void => {
     setSelectedProjectId(nextProjectId);
     // Switching repos invalidates branch choices made against the old repo.

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.test.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen } from "@testing-library/react";
+import { act, cleanup, screen } from "@testing-library/react";
 import { createStore } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -63,6 +63,19 @@ describe("NewWorkspaceModal", () => {
         onWorkspaceCreated,
       }),
     );
+  });
+
+  it("closes the dialog when the form asks to be dismissed", () => {
+    // The form's pi empty-state CTA navigates to Settings, which lands
+    // underneath this dialog — its dismissal request must actually close it.
+    const store = createStore();
+    store.set(newWorkspaceModalAtom, { open: true });
+    renderWithProviders(<NewWorkspaceModal />, { store });
+
+    const props = formProps.mock.calls[0][0] as { onDismiss: () => void };
+    act(() => props.onDismiss());
+    expect(store.get(newWorkspaceModalAtom).open).toBe(false);
+    expect(screen.queryByTestId(ElementIds.NEW_WORKSPACE_DIALOG)).toBeNull();
   });
 
   it("renders every open as a modal dialog (with overlay)", () => {

--- a/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
+++ b/sculptor/frontend/src/components/newWorkspace/NewWorkspaceModal.tsx
@@ -33,7 +33,10 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
     [setModalState],
   );
 
-  const handleCreated = useCallback((): void => {
+  // One close for both form-initiated exits: a completed create (keep-open
+  // off) and a dismissal request (the pi empty-state CTA navigating to
+  // Settings, which lands underneath this dialog).
+  const handleClose = useCallback((): void => {
     setModalState({ open: false });
   }, [setModalState]);
 
@@ -60,7 +63,8 @@ export const NewWorkspaceModal = (): ReactElement | undefined => {
         initialPrompt={modalState.initialPrompt}
         initialBranchName={modalState.initialBranchName}
         onWorkspaceCreated={onWorkspaceCreated}
-        onCreated={handleCreated}
+        onCreated={handleClose}
+        onDismiss={handleClose}
       />
     </PaletteDialog>
   );

--- a/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
+++ b/sculptor/frontend/src/components/newWorkspace/newWorkspaceAtoms.ts
@@ -2,7 +2,7 @@ import type { Atom, PrimitiveAtom, WritableAtom } from "jotai";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 
-import type { WorkspaceInitializationStrategy } from "~/api";
+import type { ModelOption, WorkspaceInitializationStrategy } from "~/api";
 import type { StoredAgentType } from "~/common/state/atoms/agentTabs.ts";
 import { hasEverHadWorkspacesAtom, workspacesArrayAtom } from "~/common/state/atoms/workspaces.ts";
 
@@ -31,6 +31,29 @@ export type NewWorkspaceModalState = {
 export const newWorkspaceModalAtom: PrimitiveAtom<NewWorkspaceModalState> = atom<NewWorkspaceModalState>({
   open: false,
 });
+
+/**
+ * The form's in-progress entries, stashed whenever the form unmounts —
+ * Escape, an overlay click, the X, and the Settings-routing CTAs all close
+ * the dialog the same way — and seeding the next open, where the open
+ * request's explicit seeds still win. A successful create clears it, so a
+ * completed form never resurrects. Deliberately not persisted: a draft lives
+ * for the session, keeping reloads fresh and prompt text off disk.
+ */
+export type NewWorkspaceDraft = {
+  projectId: string | null;
+  title: string;
+  prompt: string;
+  branchNameOverride: string | null;
+  mode: WorkspaceInitializationStrategy;
+  sourceBranch: string | undefined;
+  agentTypeValue: StoredAgentType;
+  piSelectionOverride: ModelOption | undefined;
+};
+
+export const newWorkspaceDraftAtom: PrimitiveAtom<NewWorkspaceDraft | undefined> = atom<NewWorkspaceDraft | undefined>(
+  undefined,
+);
 
 /**
  * The "keep open" switch: when on, Create keeps the dialog open for rapid

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -1391,13 +1391,9 @@ class PiAgent(DefaultAgentWrapper):
             try:
                 self._drive_turn(lambda prompt_id: self._build_prompt_payload(prompt_id, message))
             except PiCrashError as error:
-                # A turn-level pi failure on a user turn (unauthenticated
-                # provider, unusable model — e.g. credentials revoked between
-                # create and start) is a failed request, not an agent teardown:
-                # re-raise on the contained AgentClientError rail so
-                # `_handle_user_message` emits the per-turn error block (whose
-                # auth-shaped message carries the login CTA) and the agent stays
-                # alive for a re-send once the user authenticates — the policy
+                # Re-raise on the contained AgentClientError rail (see
+                # PiTurnError): `_handle_user_message` then emits the per-turn
+                # error block and the agent stays alive — the policy
                 # `_run_wake_turn` already applies to reaction turns.
                 raise PiTurnError(error.args[0], exit_code=error.exit_code, metadata=error.metadata) from error
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper.py
@@ -45,6 +45,7 @@ import time
 from collections.abc import Callable
 from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from queue import Empty
 from queue import Queue
@@ -55,8 +56,6 @@ from typing import Mapping
 from typing import assert_never
 
 from loguru import logger
-from packaging.version import InvalidVersion
-from packaging.version import Version
 from pydantic import PrivateAttr
 from pydantic import ValidationError
 
@@ -73,6 +72,15 @@ from sculptor.agents.pi_agent.backchannel import is_plan_approval
 from sculptor.agents.pi_agent.background import BackgroundTaskCompletion
 from sculptor.agents.pi_agent.background import parse_background_completion
 from sculptor.agents.pi_agent.background import parse_background_start
+from sculptor.agents.pi_agent.catalog_probe import MODEL_FETCH_TIMEOUT_SECONDS
+from sculptor.agents.pi_agent.catalog_probe import PI_PROBE_SESSION_DIR_NAME
+from sculptor.agents.pi_agent.catalog_probe import STDOUT_QUEUE_POLL_SECONDS
+from sculptor.agents.pi_agent.catalog_probe import consume_until_command_response
+from sculptor.agents.pi_agent.catalog_probe import curate_models
+from sculptor.agents.pi_agent.catalog_probe import model_option_from_pi
+from sculptor.agents.pi_agent.catalog_probe import pi_version_in_range
+from sculptor.agents.pi_agent.catalog_probe import probe_catalog
+from sculptor.agents.pi_agent.catalog_probe import send_rpc_line
 from sculptor.agents.pi_agent.harness import PiHarness
 from sculptor.agents.pi_agent.output_processor import AgentMessage
 from sculptor.agents.pi_agent.output_processor import ExtensionUiRequest
@@ -120,6 +128,7 @@ from sculptor.agents.pi_agent.tool_rendering import extract_text_from_tool_paylo
 from sculptor.agents.pi_agent.tool_rendering import map_pi_tool_call
 from sculptor.common.plugin import get_plugin_dirs
 from sculptor.foundation.common import generate_id
+from sculptor.foundation.processes.local_process import RunningProcess
 from sculptor.foundation.secrets_utils import Secret
 from sculptor.foundation.thread_utils import ObservableThread
 from sculptor.interfaces.agents.agent import AskUserQuestionAgentMessage
@@ -151,7 +160,9 @@ from sculptor.interfaces.agents.errors import PiBinaryNotFoundError
 from sculptor.interfaces.agents.errors import PiContextResetError
 from sculptor.interfaces.agents.errors import PiCrashError
 from sculptor.interfaces.agents.errors import PiSetModelError
+from sculptor.interfaces.agents.errors import PiTurnError
 from sculptor.interfaces.agents.errors import PiVersionMismatchError
+from sculptor.interfaces.environments.agent_execution_environment import AgentExecutionEnvironment
 from sculptor.interfaces.environments.agent_execution_environment import Dependency
 from sculptor.primitives.ids import AgentMessageID
 from sculptor.primitives.ids import AssistantMessageID
@@ -196,12 +207,6 @@ FILE_CHANGE_TOOL_NAMES: frozenset[str] = frozenset({"edit", "write", "bash"})
 # persisted in PI_SESSION_ID_STATE_FILE so a restart reuses it.
 PI_SESSION_DIR_NAME: str = "pi_session"
 PI_SESSION_ID_STATE_FILE: str = "pi_session_id"
-
-# The throwaway session dir the pre-message catalog probe launches pi against
-# (see fetch_available_models_probe). Distinct from PI_SESSION_DIR_NAME so the
-# probe's short-lived session never collides with the real conversation session
-# the agent later resumes.
-PI_PROBE_SESSION_DIR_NAME: str = "pi_probe_session"
 
 # Control messages that legitimately reach the end of `_push_message` without pi
 # handling them: the base class handles these after the False return (see
@@ -248,20 +253,12 @@ The user's request follows:
 # (ChatInput.tsx `wsTimeout`) so a wedged `new_session` fails rather than hanging the UI.
 _CLEAR_CONTEXT_TIMEOUT_SECONDS: float = 10.0
 
-# How long each blocking read of pi's stdout queue waits before the drain loop
-# re-checks shutdown / process-exit; small so an exit is noticed promptly.
-_STDOUT_QUEUE_POLL_SECONDS: float = 0.1
-
 # Input-queue wait between turns. While async tasks are pending, poll briefly so
 # their out-of-band completions surface promptly; when idle, wait longer to
 # avoid busy-polling (a new user message wakes the queue immediately either way,
 # and the longer wait bounds shutdown latency).
 _TASK_POLL_SECONDS: float = 0.1
 _IDLE_WAIT_SECONDS: float = 1.0
-
-# How long the start-time model fetch waits for pi's get_available_models /
-# get_state responses before giving up (see _fetch_models_into_state).
-_MODEL_FETCH_TIMEOUT_SECONDS: float = 10.0
 
 # Transient-provider-error retry policy. A turn that ends with a known-transient
 # provider failure (overloaded / rate-limit / 5xx / timeout — see
@@ -273,114 +270,6 @@ _MODEL_FETCH_TIMEOUT_SECONDS: float = 10.0
 _PI_TRANSIENT_MAX_RETRIES: int = 4
 _PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS: float = 1.0
 _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS: float = 30.0
-
-# Obsolete model ids pi's get_available_models returns that the switcher must not
-# offer — the whole pre-4 `claude-3-*` family (the live Anthropic catalog still
-# lists these). Curation drops any id in this set (_curate_models).
-_PI_MODEL_BLACKLIST: frozenset[str] = frozenset(
-    {
-        "claude-3-5-haiku-20241022",
-        "claude-3-5-haiku-latest",
-        "claude-3-5-sonnet-20240620",
-        "claude-3-5-sonnet-20241022",
-        "claude-3-5-sonnet-latest",
-        "claude-3-7-sonnet-20250219",
-        "claude-3-7-sonnet-latest",
-        "claude-3-haiku-20240307",
-        "claude-3-opus-20240229",
-        "claude-3-opus-latest",
-        "claude-3-sonnet-20240229",
-    }
-)
-
-# A "dated pin" model id ends in an 8-digit date (e.g. claude-opus-4-1-20250805).
-# pi lists these alongside the friendly alias for the same model (claude-opus-4-1),
-# so curation drops the dated duplicate and keeps the alias.
-_DATED_PIN_SUFFIX_RE = re.compile(r"-\d{8}$")
-
-# Captures the trailing major.minor version of a pi model id (e.g. the (4, 8) in
-# claude-opus-4-8, the (4, 0) in claude-opus-4-0) for the newest-first sort.
-_MODEL_VERSION_RE = re.compile(r"-(\d+)-(\d+)$")
-
-
-def _model_sort_key(model: ModelOption) -> tuple[int, int, str]:
-    """Newest-first sort key: descending (major, minor), then id for stability.
-
-    Parses the trailing `-<major>-<minor>` of the model id (e.g. claude-opus-4-8
-    → (4, 8)); ids without that shape sort last. The id tiebreaker keeps the order
-    deterministic across same-version families.
-    """
-    match = _MODEL_VERSION_RE.search(model.model_id)
-    if match is None:
-        return (1, 0, model.model_id)
-    major, minor = int(match.group(1)), int(match.group(2))
-    return (-major, -minor, model.model_id)
-
-
-def _curate_models(
-    models: list[ModelOption],
-    current_model: ModelOption | None,
-    authenticated_providers: set[str] | None = None,
-) -> list[ModelOption]:
-    """Trim pi's raw catalog to the models the switcher should offer, newest-first.
-
-    Drops the obsolete `_PI_MODEL_BLACKLIST` ids and dated-pin duplicates
-    (`_DATED_PIN_SUFFIX_RE`), then sorts newest-first (`_model_sort_key`). The
-    current model is always kept even if a rule would drop it, so the switcher
-    never shows an empty selection. Duplicate ids are de-duplicated, first-wins.
-
-    When `authenticated_providers` is provided, options whose `provider` is not in
-    that set are also dropped — pi gates its catalog on credential presence, not
-    validity, so a stray ambient key would otherwise leak that provider's models
-    into the picker. `None` (the default) disables the filter. The current model is
-    exempt from every rule, including this one.
-    """
-    kept: list[ModelOption] = []
-    seen_ids: set[str] = set()
-    current_id = current_model.model_id if current_model is not None else None
-    for model in models:
-        if model.model_id in seen_ids:
-            continue
-        is_current = model.model_id == current_id
-        if not is_current and model.model_id in _PI_MODEL_BLACKLIST:
-            continue
-        if not is_current and _DATED_PIN_SUFFIX_RE.search(model.model_id):
-            continue
-        if not is_current and authenticated_providers is not None and model.provider not in authenticated_providers:
-            continue
-        seen_ids.add(model.model_id)
-        kept.append(model)
-    # The current model must be offered even if pi did not list it in the catalog.
-    if current_model is not None and current_id not in seen_ids:
-        kept.append(current_model)
-    return sorted(kept, key=_model_sort_key)
-
-
-def _model_option_from_pi(raw: Mapping[str, Any]) -> ModelOption | None:
-    """Map one pi Model dict (`{id, name, provider, …}`) to a `ModelOption`.
-
-    Returns None when the required `id` is missing/empty. `provider` defaults to
-    "anthropic" (Sculptor launches pi against the Anthropic catalog) and the
-    display name falls back to the id when pi omits `name`.
-    """
-    model_id = raw.get("id")
-    if not isinstance(model_id, str) or not model_id:
-        return None
-    provider = raw.get("provider")
-    name = raw.get("name")
-    return ModelOption(
-        provider=provider if isinstance(provider, str) and provider else "anthropic",
-        model_id=model_id,
-        display_name=name if isinstance(name, str) and name else model_id,
-    )
-
-
-def _pi_version_in_range(version: str) -> bool:
-    try:
-        v = Version(version)
-    except InvalidVersion:
-        return False
-    return Version(PI_VERSION_RANGE.min_version) <= v <= Version(PI_VERSION_RANGE.max_version)
 
 
 @dataclass
@@ -566,6 +455,19 @@ class _ReactionWakeMessage:
     text: str
 
 
+def _spawn_probe_in_environment(
+    command: Sequence[str],
+    environment: AgentExecutionEnvironment,
+    secrets: Mapping[str, str | Secret],
+) -> RunningProcess:
+    """Spawn the catalog probe's pi through an agent execution environment (stdin open)."""
+    return environment.run_process_in_background(
+        command,
+        secrets=secrets,
+        open_stdin=True,
+    )
+
+
 class PiAgent(DefaultAgentWrapper):
     # Narrows the inherited `harness: Harness` field — the registry owns
     # construction, so no agent↔harness import cycle exists.
@@ -686,7 +588,7 @@ class PiAgent(DefaultAgentWrapper):
             raise PiBinaryNotFoundError()
 
         detected_version = self._check_pi_version(binary)
-        if not _pi_version_in_range(detected_version):
+        if not pi_version_in_range(detected_version):
             raise PiVersionMismatchError(
                 detected_version=detected_version,
                 pinned_version=PI_VERSION_RANGE.recommended_version,
@@ -1050,20 +952,15 @@ class PiAgent(DefaultAgentWrapper):
         process = self._process
         if process is None:
             return
-        line = json.dumps(payload, separators=(",", ":")) + "\n"
         # The prompt pump, answer delivery, and wait()'s abort can all write
         # stdin from different threads; serialize so lines never interleave.
         with self._send_lock:
-            try:
-                process.write_stdin(line)
-            except Exception as e:  # noqa: BLE001
-                logger.debug("PiAgent write_stdin failed: {}", e)
+            send_rpc_line(process, payload)
 
     def _consume_until_command_response(self, command: str, command_id: str, timeout: float) -> RpcResponse | None:
         """Drain pi's stdout until the `response` for (command, command_id) arrives.
 
-        Correlates by id (RPC §5.1), skipping any session events pi emits
-        meanwhile; returns None on timeout / process exit. Used for the
+        Delegates to the shared consume loop (`catalog_probe`). Used for the
         between-turns control commands this harness issues directly (`get_state`,
         `new_session`). It reads the process queue, so it is ONLY safe when it is
         the SOLE reader of that queue: before the message-processing thread starts
@@ -1074,30 +971,7 @@ class PiAgent(DefaultAgentWrapper):
         process = self._process
         if process is None:
             return None
-        out_queue = process.get_queue()
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if process.is_finished() and out_queue.empty():
-                return None
-            try:
-                line, is_stdout = out_queue.get(timeout=_STDOUT_QUEUE_POLL_SECONDS)
-            except Empty:
-                continue
-            if not is_stdout:
-                continue
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                event = json.loads(stripped)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(event, dict):
-                continue
-            parsed = parse_rpc_message(event)
-            if isinstance(parsed, RpcResponse) and parsed.command == command and parsed.id == command_id:
-                return parsed
-        return None
+        return consume_until_command_response(process, command, command_id, timeout)
 
     def _request_state_blocking(self, timeout: float = 10.0) -> dict[str, Any] | None:
         """Send `get_state` and return pi's reported `RpcSessionState` data (RPC §5.1).
@@ -1147,9 +1021,7 @@ class PiAgent(DefaultAgentWrapper):
         else:
             logger.info("PiAgent resumed pi session {} (messageCount={})", expected_session_id, message_count)
 
-    def _request_available_models_blocking(
-        self, timeout: float = _MODEL_FETCH_TIMEOUT_SECONDS
-    ) -> list[dict[str, Any]]:
+    def _request_available_models_blocking(self, timeout: float = MODEL_FETCH_TIMEOUT_SECONDS) -> list[dict[str, Any]]:
         """Send `get_available_models` and return pi's raw `data.models` list.
 
         Returns `[]` on timeout / process exit / a malformed payload. Shares the
@@ -1168,7 +1040,7 @@ class PiAgent(DefaultAgentWrapper):
         return [m for m in models if isinstance(m, dict)]
 
     def _request_set_model_blocking(
-        self, provider: str, model_id: str, timeout: float = _MODEL_FETCH_TIMEOUT_SECONDS
+        self, provider: str, model_id: str, timeout: float = MODEL_FETCH_TIMEOUT_SECONDS
     ) -> ModelOption | None:
         """Send `set_model` and return pi's new current model, or None on failure.
 
@@ -1184,7 +1056,7 @@ class PiAgent(DefaultAgentWrapper):
         response = self._consume_until_command_response("set_model", command_id, timeout)
         if response is None or not response.success:
             return None
-        new_model = _model_option_from_pi(response.data) if isinstance(response.data, dict) else None
+        new_model = model_option_from_pi(response.data) if isinstance(response.data, dict) else None
         return new_model or ModelOption(provider=provider, model_id=model_id, display_name=model_id)
 
     def _reselect_unauthenticated_current_model(
@@ -1253,7 +1125,7 @@ class PiAgent(DefaultAgentWrapper):
         ):
             return pi_default
         adopted = self._request_set_model_blocking(
-            preselected.provider, preselected.model_id, _MODEL_FETCH_TIMEOUT_SECONDS
+            preselected.provider, preselected.model_id, MODEL_FETCH_TIMEOUT_SECONDS
         )
         if adopted is None:
             logger.info(
@@ -1267,7 +1139,7 @@ class PiAgent(DefaultAgentWrapper):
 
         Issues `get_available_models` and `get_state` (sole reader of the process
         queue, before the message thread starts), maps the raw Model dicts to
-        `ModelOption`s, curates them (`_curate_models`), and emits a
+        `ModelOption`s, curates them (`curate_models`), and emits a
         `ModelsAvailableAgentMessage` the run-agent handler maps onto
         `AgentTaskStateV2.available_models` / `current_model`. An empty catalog (no
         authenticated providers) is emitted as `[]`, driving the pi switcher's
@@ -1276,22 +1148,22 @@ class PiAgent(DefaultAgentWrapper):
         raw_models = self._request_available_models_blocking()
         state = self._request_state_blocking()
         current_raw = state.get("model") if isinstance(state, dict) else None
-        current_model = _model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
+        current_model = model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
         options: list[ModelOption] = []
         for raw in raw_models:
-            option = _model_option_from_pi(raw)
+            option = model_option_from_pi(raw)
             if option is not None:
                 options.append(option)
         authenticated = compute_authenticated_provider_ids()
         current_model = self._adopt_preselected_model(current_model, options, authenticated)
-        curated = _curate_models(options, current_model, authenticated)
+        curated = curate_models(options, current_model, authenticated)
         # Don't strand the agent on a model whose provider was just deauthorized
         # (e.g. the user disconnected it): switch to an authenticated model and
         # re-curate so the now-unusable model drops out of the switcher. Safe here
         # because the fetch above already proved pi responsive.
         if current_model is not None and current_model.provider not in authenticated:
             current_model = self._reselect_unauthenticated_current_model(current_model, curated, authenticated)
-            curated = _curate_models(options, current_model, authenticated)
+            curated = curate_models(options, current_model, authenticated)
         # Cache the catalog so a later set_model can re-emit it with the new current
         # model. An empty catalog (no authenticated providers) is emitted too, so the
         # pi switcher reaches its "no usable model" empty state instead of falling back
@@ -1317,13 +1189,11 @@ class PiAgent(DefaultAgentWrapper):
 
         Lets the run-agent handler populate the switcher for a fresh pi agent
         BEFORE the first message, when `start()` (and its
-        `_fetch_models_into_state`) has not run yet. Launches a minimal `pi
-        --mode rpc` process against a throwaway probe session
-        (`PI_PROBE_SESSION_DIR_NAME`, a distinct `--session-id`) with no
-        extensions / skills / system prompt — `get_available_models` and
-        `get_state` need none — issues those two RPCs as the sole reader of the
-        process queue, then shuts the probe down before returning the curated
-        `list[ModelOption]` + current `ModelOption | None`.
+        `_fetch_models_into_state`) has not run yet. Delegates to the shared
+        `probe_catalog` core (the same code behind the host-side pre-workspace
+        probe, so the two surfaces cannot disagree), spawning pi through this
+        agent's execution environment against a throwaway probe session
+        (`PI_PROBE_SESSION_DIR_NAME`).
 
         `secrets` are the backend-env + PATH the caller would pass `start()` (so
         the probe resolves the same `pi` and reaches the same provider); the
@@ -1334,7 +1204,7 @@ class PiAgent(DefaultAgentWrapper):
         version mismatch, timeout, no response) it logs and returns
         `([], None)`, never raising — the switcher then falls back to the
         frontend's built-in list, exactly as before this probe existed. Does NOT
-        touch the agent lifecycle: it neither sets `self._process` for the
+        touch the agent lifecycle: it never sets `self._process` for the
         message loop nor mints/persists the real session id, so the normal
         `start()` path is unaffected.
         """
@@ -1343,7 +1213,7 @@ class PiAgent(DefaultAgentWrapper):
             logger.info("PiAgent model probe skipped: pi binary not found; switcher will fall back to defaults")
             return [], None
         detected_version = self._check_pi_version_for_probe(binary)
-        if detected_version is None or not _pi_version_in_range(detected_version):
+        if detected_version is None or not pi_version_in_range(detected_version):
             logger.info(
                 "PiAgent model probe skipped: pi version {} out of range; switcher will fall back to defaults",
                 detected_version,
@@ -1352,68 +1222,8 @@ class PiAgent(DefaultAgentWrapper):
 
         pi_secrets = self._collect_api_key_secrets()
         merged_secrets: dict[str, str | Secret] = {**secrets, **pi_secrets}
-        probe_session_dir = self.environment.get_state_path() / PI_PROBE_SESSION_DIR_NAME
-        command = [
-            binary,
-            "--mode",
-            "rpc",
-            "--session-dir",
-            str(probe_session_dir),
-            "--session-id",
-            f"probe-{generate_id()}",
-            "--no-extensions",
-        ]
-        probe_process = None
-        try:
-            probe_process = self.environment.run_process_in_background(
-                command,
-                secrets=merged_secrets,
-                open_stdin=True,
-            )
-            # Point the blocking RPC helpers at the probe process for the duration
-            # of the fetch only; the message loop never runs here, so there is no
-            # concurrent reader of this queue.
-            self._process = probe_process
-            raw_models = self._request_available_models_blocking()
-            state = self._request_state_blocking()
-        except Exception as e:  # noqa: BLE001
-            logger.info("PiAgent model probe failed ({}); switcher will fall back to defaults", e)
-            self._shutdown_probe_process(probe_process)
-            self._process = None
-            return [], None
-
-        self._shutdown_probe_process(probe_process)
-        self._process = None
-
-        current_raw = state.get("model") if isinstance(state, dict) else None
-        current_model = _model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
-        options: list[ModelOption] = []
-        for raw in raw_models:
-            option = _model_option_from_pi(raw)
-            if option is not None:
-                options.append(option)
-        authenticated = compute_authenticated_provider_ids()
-        # Drop a selected model whose provider is no longer authenticated when nothing
-        # authenticated remains to fall back to: the switcher must reach its empty
-        # "no usable model" state, not offer a single model that cannot run. (When an
-        # authenticated model does remain, the read-only probe leaves the switch to the
-        # start-time reselect in `_fetch_models_into_state`, which can `set_model`.)
-        if (
-            current_model is not None
-            and current_model.provider not in authenticated
-            and not any(option.provider in authenticated for option in options)
-        ):
-            current_model = None
-        curated = _curate_models(options, current_model, authenticated)
-        if not curated and current_model is None:
-            logger.info("PiAgent model probe found no usable models; switcher shows the empty state")
-            return [], None
-        logger.info(
-            "PiAgent model probe fetched {} model(s); current model={}",
-            len(curated),
-            current_model.model_id if current_model is not None else None,
-        )
-        return curated, current_model
+        spawn = partial(_spawn_probe_in_environment, environment=self.environment, secrets=merged_secrets)
+        return probe_catalog(spawn, binary, self.environment.get_state_path() / PI_PROBE_SESSION_DIR_NAME)
 
     def _check_pi_version_for_probe(self, binary: str) -> str | None:
         """`_check_pi_version` for the probe: return None instead of raising.
@@ -1426,24 +1236,6 @@ class PiAgent(DefaultAgentWrapper):
             return self._check_pi_version(binary)
         except PiVersionMismatchError:
             return None
-
-    def _shutdown_probe_process(self, process: Any) -> None:
-        """Close stdin then terminate the catalog probe's pi process.
-
-        Pi exits on stdin EOF (Sculptor closes stdin at shutdown); terminate is
-        the backstop if it lingers. Best-effort — the probe is throwaway, so any
-        teardown error is logged and swallowed rather than failing the fetch.
-        """
-        if process is None:
-            return
-        try:
-            process.close_stdin()
-        except Exception as e:  # noqa: BLE001
-            logger.debug("PiAgent model probe close_stdin failed: {}", e)
-        try:
-            process.terminate()
-        except Exception as e:  # noqa: BLE001
-            logger.debug("PiAgent model probe terminate failed: {}", e)
 
     def _request_interrupt(self) -> None:
         """Halt the in-flight pi turn via pi's `abort` command (supports_interruption).
@@ -1596,7 +1388,18 @@ class PiAgent(DefaultAgentWrapper):
         self._update_plan_mode_from_message(message)
         self._ensure_diff_baseline()
         with self._handle_user_message(message):
-            self._drive_turn(lambda prompt_id: self._build_prompt_payload(prompt_id, message))
+            try:
+                self._drive_turn(lambda prompt_id: self._build_prompt_payload(prompt_id, message))
+            except PiCrashError as error:
+                # A turn-level pi failure on a user turn (unauthenticated
+                # provider, unusable model — e.g. credentials revoked between
+                # create and start) is a failed request, not an agent teardown:
+                # re-raise on the contained AgentClientError rail so
+                # `_handle_user_message` emits the per-turn error block (whose
+                # auth-shaped message carries the login CTA) and the agent stays
+                # alive for a re-send once the user authenticates — the policy
+                # `_run_wake_turn` already applies to reaction turns.
+                raise PiTurnError(error.args[0], exit_code=error.exit_code, metadata=error.metadata) from error
 
     def _run_wake_turn(self, wake: _ReactionWakeMessage) -> None:
         """Run a completion's Sculptor-initiated reaction as its own request cycle.
@@ -1725,7 +1528,7 @@ class PiAgent(DefaultAgentWrapper):
             remaining = deadline - time.monotonic()
             if remaining <= 0.0:
                 return
-            if self._shutdown_event.wait(timeout=min(remaining, _STDOUT_QUEUE_POLL_SECONDS)):
+            if self._shutdown_event.wait(timeout=min(remaining, STDOUT_QUEUE_POLL_SECONDS)):
                 return
 
     def _update_plan_mode_from_message(self, message: ChatInputUserMessage) -> None:
@@ -1874,7 +1677,7 @@ class PiAgent(DefaultAgentWrapper):
                 {"type": "set_model", "id": command_id, "provider": message.provider, "modelId": message.model_id}
             )
             response = self._consume_until_command_response(
-                "set_model", command_id, timeout=_MODEL_FETCH_TIMEOUT_SECONDS
+                "set_model", command_id, timeout=MODEL_FETCH_TIMEOUT_SECONDS
             )
             if response is None:
                 raise PiSetModelError(
@@ -1889,7 +1692,7 @@ class PiAgent(DefaultAgentWrapper):
                 )
             # Prefer pi's returned Model (authoritative id/display name); fall back
             # to the requested identity if pi omits it.
-            new_model = _model_option_from_pi(response.data) if isinstance(response.data, dict) else None
+            new_model = model_option_from_pi(response.data) if isinstance(response.data, dict) else None
             if new_model is None:
                 new_model = ModelOption(
                     provider=message.provider, model_id=message.model_id, display_name=message.model_id
@@ -1922,7 +1725,7 @@ class PiAgent(DefaultAgentWrapper):
             return
         state = self._request_state_blocking()
         current_raw = state.get("model") if isinstance(state, dict) else None
-        current_model = _model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
+        current_model = model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
         if current_model is None:
             return
         self._output_messages.put(
@@ -1968,7 +1771,7 @@ class PiAgent(DefaultAgentWrapper):
                 if process.is_finished() and out_queue.empty():
                     return
                 try:
-                    line, is_stdout = out_queue.get(timeout=_STDOUT_QUEUE_POLL_SECONDS)
+                    line, is_stdout = out_queue.get(timeout=STDOUT_QUEUE_POLL_SECONDS)
                 except Empty:
                     continue
                 if not is_stdout:

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -30,12 +30,12 @@ from sculptor.agents.pi_agent.agent_wrapper import PiAgent
 from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_BASE_DELAY_SECONDS
 from sculptor.agents.pi_agent.agent_wrapper import _PI_TRANSIENT_RETRY_MAX_DELAY_SECONDS
 from sculptor.agents.pi_agent.agent_wrapper import _TurnState
-from sculptor.agents.pi_agent.agent_wrapper import _curate_models
 from sculptor.agents.pi_agent.agent_wrapper import _format_background_completion
 from sculptor.agents.pi_agent.agent_wrapper import _format_subagent_completion
-from sculptor.agents.pi_agent.agent_wrapper import _model_option_from_pi
 from sculptor.agents.pi_agent.agent_wrapper import _render_synthesized_skill
 from sculptor.agents.pi_agent.agent_wrapper import _rewrite_skill_invocation
+from sculptor.agents.pi_agent.agent_wrapper import curate_models
+from sculptor.agents.pi_agent.agent_wrapper import model_option_from_pi
 from sculptor.agents.pi_agent.backchannel import DISMISSED_ANSWER_VALUE
 from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_DIALOG_TITLE
 from sculptor.agents.pi_agent.backchannel import PLAN_APPROVAL_HEADER
@@ -645,7 +645,7 @@ _CURATED_PI_MODEL_IDS: list[str] = [
 
 
 def _options_from_raw(raw: list[dict[str, Any]]) -> list[ModelOption]:
-    options = [_model_option_from_pi(m) for m in raw]
+    options = [model_option_from_pi(m) for m in raw]
     return [option for option in options if option is not None]
 
 
@@ -936,6 +936,39 @@ class TestTurnFailures:
         )
         with pytest.raises(PiCrashError):
             agent._consume_until_turn_end(prompt_id=_PROMPT_ID)
+
+
+class TestPromptTurnContainment:
+    """A doomed user turn fails softly (error block) instead of killing the agent."""
+
+    def test_auth_failure_on_prompt_turn_reports_failure_without_crashing(self) -> None:
+        """A non-transient provider failure (unauthenticated / unusable model) on a
+        USER turn surfaces the per-turn error block — a RequestFailure carrying the
+        humanized auth message the frontend keys its login CTA on — and the agent
+        stays alive, the same containment `_run_wake_turn` applies. Credentials can
+        be revoked between create and start, so a doomed first prompt must be a
+        recoverable error, not an agent teardown."""
+        agent = _make_agent()
+        auth_error = json.dumps({"type": "authentication_error", "message": "No API key found for provider"})
+        agent._process = _make_process(
+            [
+                _event({"type": "agent_start"}),
+                _event({"type": "message_end", "message": _assistant_error_msg(auth_error)}),
+            ]
+        )
+
+        # Must NOT raise: the crash is contained at the prompt-turn boundary.
+        agent._run_prompt_turn(ChatInputUserMessage(text="do the thing"))
+
+        emitted = _drain(agent._output_messages)
+        failures = [m for m in emitted if isinstance(m, RequestFailureAgentMessage)]
+        assert len(failures) == 1
+        # The humanized auth message survives, so the error block's login CTA
+        # (keyed on "require authentication") still renders.
+        assert "require authentication" in str(failures[0].error.args[0])
+        assert not any(isinstance(m, RequestSuccessAgentMessage) for m in emitted)
+        # The agent did not crash: no fatal exception was captured.
+        assert agent._exception is None
 
 
 class TestTransientRetry:
@@ -3163,7 +3196,7 @@ class TestModelCuration:
 
     def test_curate_models_drops_blacklist_and_dated_and_sorts_newest_first(self) -> None:
         """Curation drops obsolete claude-3-* + dated-pin duplicates, newest-first."""
-        curated = _curate_models(_options_from_raw(_RAW_PI_MODELS), current_model=None)
+        curated = curate_models(_options_from_raw(_RAW_PI_MODELS), current_model=None)
         assert [option.model_id for option in curated] == _CURATED_PI_MODEL_IDS
         # Display names ride through from pi's `name`, and provider is preserved.
         opus_4_8 = next(option for option in curated if option.model_id == "claude-opus-4-8")
@@ -3173,7 +3206,7 @@ class TestModelCuration:
     def test_curate_models_keeps_current_model_even_when_a_rule_would_drop_it(self) -> None:
         """The current model is never dropped — the switcher must not show an empty selection."""
         current = ModelOption(provider="anthropic", model_id="claude-3-opus-20240229", display_name="Claude Opus 3")
-        curated = _curate_models(_options_from_raw(_RAW_PI_MODELS), current_model=current)
+        curated = curate_models(_options_from_raw(_RAW_PI_MODELS), current_model=current)
         assert current in curated
         # Everything else still curated; only the blacklisted current survives the blacklist.
         assert "claude-3-5-haiku-20241022" not in {option.model_id for option in curated}
@@ -3181,38 +3214,38 @@ class TestModelCuration:
     def test_curate_models_keeps_current_model_absent_from_catalog(self) -> None:
         """A current model pi did not list is appended so it can still be shown selected."""
         current = ModelOption(provider="anthropic", model_id="claude-opus-9-9", display_name="Claude Opus 9.9")
-        curated = _curate_models(_options_from_raw(_RAW_PI_MODELS), current_model=current)
+        curated = curate_models(_options_from_raw(_RAW_PI_MODELS), current_model=current)
         assert current in curated
         # Newest major.minor wins, so the fictional 9.9 sorts to the front.
         assert curated[0].model_id == "claude-opus-9-9"
 
     def test_curate_models_filters_to_single_authenticated_provider(self) -> None:
         """Only options whose provider is in the authenticated set survive."""
-        curated = _curate_models(_MULTI_PROVIDER_OPTIONS, current_model=None, authenticated_providers={"anthropic"})
+        curated = curate_models(_MULTI_PROVIDER_OPTIONS, current_model=None, authenticated_providers={"anthropic"})
         assert {option.provider for option in curated} == {"anthropic"}
         assert [option.model_id for option in curated] == ["claude-opus-4-8"]
 
     def test_curate_models_filters_to_multiple_authenticated_providers(self) -> None:
-        curated = _curate_models(
+        curated = curate_models(
             _MULTI_PROVIDER_OPTIONS, current_model=None, authenticated_providers={"anthropic", "openai"}
         )
         assert {option.provider for option in curated} == {"anthropic", "openai"}
 
     def test_curate_models_empty_authenticated_set_yields_empty(self) -> None:
         """An empty authenticated set drops everything (this drives the empty-state CTA)."""
-        curated = _curate_models(_MULTI_PROVIDER_OPTIONS, current_model=None, authenticated_providers=set())
+        curated = curate_models(_MULTI_PROVIDER_OPTIONS, current_model=None, authenticated_providers=set())
         assert curated == []
 
     def test_curate_models_retains_current_model_even_when_provider_unauthenticated(self) -> None:
         """The current model is always offered, even if its provider isn't authenticated."""
         current = ModelOption(provider="openai", model_id="gpt-5", display_name="GPT-5")
-        curated = _curate_models(_MULTI_PROVIDER_OPTIONS, current_model=current, authenticated_providers={"anthropic"})
+        curated = curate_models(_MULTI_PROVIDER_OPTIONS, current_model=current, authenticated_providers={"anthropic"})
         assert current in curated
         assert "gemini-3" not in {option.model_id for option in curated}
 
     def test_curate_models_filter_preserves_blacklist_and_sort(self) -> None:
         """The authenticated filter layers on top of the existing blacklist/sort rules."""
-        curated = _curate_models(
+        curated = curate_models(
             _options_from_raw(_RAW_PI_MODELS), current_model=None, authenticated_providers={"anthropic"}
         )
         # _RAW_PI_MODELS are all anthropic, so the filter is a no-op here and the curated
@@ -3221,10 +3254,10 @@ class TestModelCuration:
 
     def test_model_option_from_pi_defaults_provider_and_name(self) -> None:
         # Missing provider defaults to anthropic; missing name falls back to the id.
-        option = _model_option_from_pi({"id": "claude-opus-4-8"})
+        option = model_option_from_pi({"id": "claude-opus-4-8"})
         assert option == ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="claude-opus-4-8")
         # A row with no usable id is dropped.
-        assert _model_option_from_pi({"name": "no id"}) is None
+        assert model_option_from_pi({"name": "no id"}) is None
 
 
 class TestModelCatalogFetch:
@@ -3439,11 +3472,12 @@ class TestModelProbe:
         agent = _make_agent(env)
         with (
             patch(
-                "sculptor.agents.pi_agent.agent_wrapper.generate_id",
+                "sculptor.agents.pi_agent.catalog_probe.generate_id",
                 side_effect=["probe-sess", "cmd-models", "cmd-state"],
             ),
             patch(
-                "sculptor.agents.pi_agent.agent_wrapper.compute_authenticated_provider_ids", return_value={"anthropic"}
+                "sculptor.agents.pi_agent.catalog_probe.compute_authenticated_provider_ids",
+                return_value={"anthropic"},
             ),
         ):
             available_models, current_model = agent.fetch_available_models_probe(secrets={})
@@ -3468,7 +3502,7 @@ class TestModelProbe:
         env = _make_probe_env(probe_process)
         agent = _make_agent(env)
         with patch(
-            "sculptor.agents.pi_agent.agent_wrapper.generate_id",
+            "sculptor.agents.pi_agent.catalog_probe.generate_id",
             side_effect=["probe-sess", "cmd-models", "cmd-state"],
         ):
             agent.fetch_available_models_probe(secrets={})
@@ -3513,7 +3547,7 @@ class TestModelProbe:
         env = _make_probe_env(probe_process)
         agent = _make_agent(env)
         with patch(
-            "sculptor.agents.pi_agent.agent_wrapper.generate_id",
+            "sculptor.agents.pi_agent.catalog_probe.generate_id",
             side_effect=["probe-sess", "cmd-models", "cmd-state"],
         ):
             assert agent.fetch_available_models_probe(secrets={}) == ([], None)
@@ -3532,10 +3566,10 @@ class TestModelProbe:
         agent = _make_agent(env)
         with (
             patch(
-                "sculptor.agents.pi_agent.agent_wrapper.generate_id",
+                "sculptor.agents.pi_agent.catalog_probe.generate_id",
                 side_effect=["probe-sess", "cmd-models", "cmd-state"],
             ),
-            patch("sculptor.agents.pi_agent.agent_wrapper.compute_authenticated_provider_ids", return_value=set()),
+            patch("sculptor.agents.pi_agent.catalog_probe.compute_authenticated_provider_ids", return_value=set()),
         ):
             assert agent.fetch_available_models_probe(secrets={}) == ([], None)
 

--- a/sculptor/sculptor/agents/pi_agent/catalog_probe.py
+++ b/sculptor/sculptor/agents/pi_agent/catalog_probe.py
@@ -1,0 +1,370 @@
+"""pi catalog discovery: a short-lived ``pi --mode rpc`` probe that fetches + curates the model list.
+
+Two callers share this module so their catalogs cannot disagree:
+
+- the in-workspace pre-message probe (``PiAgent.fetch_available_models_probe``),
+  which spawns pi through the agent's execution environment, and
+- the host-side pre-workspace probe (``probe_catalog_on_host``), which spawns pi
+  directly on the backend host to feed pre-create surfaces such as the New
+  Workspace modal's pi model picker.
+
+The probe launches a minimal pi (no extensions / skills / system prompt)
+against a throwaway session, issues only the ``get_available_models`` and
+``get_state`` RPCs, then shuts the process down. Curation and the
+authenticated-provider filter live here too, next to their sole consumers.
+"""
+
+import json
+import os
+import re
+import time
+from collections.abc import Callable
+from collections.abc import Mapping
+from collections.abc import Sequence
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+from loguru import logger
+from packaging.version import InvalidVersion
+from packaging.version import Version
+
+from sculptor.agents.pi_agent.authenticated_providers import compute_authenticated_provider_ids
+from sculptor.agents.pi_agent.output_processor import RpcResponse
+from sculptor.agents.pi_agent.output_processor import parse_rpc_message
+from sculptor.foundation.common import generate_id
+from sculptor.foundation.processes.local_process import RunningProcess
+from sculptor.foundation.processes.local_process import run_background
+from sculptor.foundation.processes.local_process import run_blocking
+from sculptor.services.dependency_management_service import PI_VERSION_RANGE
+from sculptor.services.dependency_management_service import parse_pi_version
+from sculptor.state.messages import ModelOption
+from sculptor.utils.build import get_sculptor_folder
+
+# The throwaway session dir the catalog probe launches pi against. Distinct from
+# PI_SESSION_DIR_NAME so the probe's short-lived session never collides with the
+# real conversation session the agent later resumes.
+PI_PROBE_SESSION_DIR_NAME: str = "pi_probe_session"
+
+# How long each blocking read of pi's stdout queue waits before the drain loop
+# re-checks shutdown / process-exit; small so an exit is noticed promptly.
+STDOUT_QUEUE_POLL_SECONDS: float = 0.1
+
+# How long a model fetch waits for pi's get_available_models / get_state
+# responses before giving up.
+MODEL_FETCH_TIMEOUT_SECONDS: float = 10.0
+
+# Obsolete model ids pi's get_available_models returns that the switcher must not
+# offer — the whole pre-4 `claude-3-*` family (the live Anthropic catalog still
+# lists these). Curation drops any id in this set (curate_models).
+_PI_MODEL_BLACKLIST: frozenset[str] = frozenset(
+    {
+        "claude-3-5-haiku-20241022",
+        "claude-3-5-haiku-latest",
+        "claude-3-5-sonnet-20240620",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-5-sonnet-latest",
+        "claude-3-7-sonnet-20250219",
+        "claude-3-7-sonnet-latest",
+        "claude-3-haiku-20240307",
+        "claude-3-opus-20240229",
+        "claude-3-opus-latest",
+        "claude-3-sonnet-20240229",
+    }
+)
+
+# A "dated pin" model id ends in an 8-digit date (e.g. claude-opus-4-1-20250805).
+# pi lists these alongside the friendly alias for the same model (claude-opus-4-1),
+# so curation drops the dated duplicate and keeps the alias.
+_DATED_PIN_SUFFIX_RE = re.compile(r"-\d{8}$")
+
+# Captures the trailing major.minor version of a pi model id (e.g. the (4, 8) in
+# claude-opus-4-8, the (4, 0) in claude-opus-4-0) for the newest-first sort.
+_MODEL_VERSION_RE = re.compile(r"-(\d+)-(\d+)$")
+
+
+def _model_sort_key(model: ModelOption) -> tuple[int, int, str]:
+    """Newest-first sort key: descending (major, minor), then id for stability.
+
+    Parses the trailing `-<major>-<minor>` of the model id (e.g. claude-opus-4-8
+    → (4, 8)); ids without that shape sort last. The id tiebreaker keeps the order
+    deterministic across same-version families.
+    """
+    match = _MODEL_VERSION_RE.search(model.model_id)
+    if match is None:
+        return (1, 0, model.model_id)
+    major, minor = int(match.group(1)), int(match.group(2))
+    return (-major, -minor, model.model_id)
+
+
+def curate_models(
+    models: list[ModelOption],
+    current_model: ModelOption | None,
+    authenticated_providers: set[str] | None = None,
+) -> list[ModelOption]:
+    """Trim pi's raw catalog to the models the switcher should offer, newest-first.
+
+    Drops the obsolete `_PI_MODEL_BLACKLIST` ids and dated-pin duplicates
+    (`_DATED_PIN_SUFFIX_RE`), then sorts newest-first (`_model_sort_key`). The
+    current model is always kept even if a rule would drop it, so the switcher
+    never shows an empty selection. Duplicate ids are de-duplicated, first-wins.
+
+    When `authenticated_providers` is provided, options whose `provider` is not in
+    that set are also dropped — pi gates its catalog on credential presence, not
+    validity, so a stray ambient key would otherwise leak that provider's models
+    into the picker. `None` (the default) disables the filter. The current model is
+    exempt from every rule, including this one.
+    """
+    kept: list[ModelOption] = []
+    seen_ids: set[str] = set()
+    current_id = current_model.model_id if current_model is not None else None
+    for model in models:
+        if model.model_id in seen_ids:
+            continue
+        is_current = model.model_id == current_id
+        if not is_current and model.model_id in _PI_MODEL_BLACKLIST:
+            continue
+        if not is_current and _DATED_PIN_SUFFIX_RE.search(model.model_id):
+            continue
+        if not is_current and authenticated_providers is not None and model.provider not in authenticated_providers:
+            continue
+        seen_ids.add(model.model_id)
+        kept.append(model)
+    # The current model must be offered even if pi did not list it in the catalog.
+    if current_model is not None and current_id not in seen_ids:
+        kept.append(current_model)
+    return sorted(kept, key=_model_sort_key)
+
+
+def model_option_from_pi(raw: Mapping[str, Any]) -> ModelOption | None:
+    """Map one pi Model dict (`{id, name, provider, …}`) to a `ModelOption`.
+
+    Returns None when the required `id` is missing/empty. `provider` defaults to
+    "anthropic" (Sculptor launches pi against the Anthropic catalog) and the
+    display name falls back to the id when pi omits `name`.
+    """
+    model_id = raw.get("id")
+    if not isinstance(model_id, str) or not model_id:
+        return None
+    provider = raw.get("provider")
+    name = raw.get("name")
+    return ModelOption(
+        provider=provider if isinstance(provider, str) and provider else "anthropic",
+        model_id=model_id,
+        display_name=name if isinstance(name, str) and name else model_id,
+    )
+
+
+def pi_version_in_range(version: str) -> bool:
+    try:
+        v = Version(version)
+    except InvalidVersion:
+        return False
+    return Version(PI_VERSION_RANGE.min_version) <= v <= Version(PI_VERSION_RANGE.max_version)
+
+
+def send_rpc_line(process: RunningProcess, payload: Mapping[str, Any]) -> None:
+    """Write one JSON-RPC line to pi's stdin, best-effort."""
+    line = json.dumps(payload, separators=(",", ":")) + "\n"
+    try:
+        process.write_stdin(line)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("pi rpc write_stdin failed: {}", e)
+
+
+def consume_until_command_response(
+    process: RunningProcess, command: str, command_id: str, timeout: float
+) -> RpcResponse | None:
+    """Drain pi's stdout until the `response` for (command, command_id) arrives.
+
+    Correlates by id (RPC §5.1), skipping any session events pi emits meanwhile;
+    returns None on timeout / process exit. It reads the process queue, so it is
+    ONLY safe when the caller is the SOLE reader of that queue: a probe process,
+    or an agent's process before its message-processing thread starts / between
+    turns. Never call it while a turn is streaming — the turn pump would race it
+    for the same queue.
+    """
+    out_queue = process.get_queue()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.is_finished() and out_queue.empty():
+            return None
+        try:
+            line, is_stdout = out_queue.get(timeout=STDOUT_QUEUE_POLL_SECONDS)
+        except Empty:
+            continue
+        if not is_stdout:
+            continue
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        parsed = parse_rpc_message(event)
+        if isinstance(parsed, RpcResponse) and parsed.command == command and parsed.id == command_id:
+            return parsed
+    return None
+
+
+def request_available_models(
+    process: RunningProcess, timeout: float = MODEL_FETCH_TIMEOUT_SECONDS
+) -> list[dict[str, Any]]:
+    """Send `get_available_models` and return pi's raw `data.models` list.
+
+    Returns `[]` on timeout / process exit / a malformed payload. Shares the
+    sole-reader safety constraint of `consume_until_command_response`.
+    """
+    request_id = generate_id()
+    send_rpc_line(process, {"type": "get_available_models", "id": request_id})
+    response = consume_until_command_response(process, "get_available_models", request_id, timeout)
+    if response is None or not isinstance(response.data, dict):
+        return []
+    models = response.data.get("models")
+    if not isinstance(models, list):
+        return []
+    return [m for m in models if isinstance(m, dict)]
+
+
+def request_state(process: RunningProcess, timeout: float = 10.0) -> dict[str, Any] | None:
+    """Send `get_state` and return pi's reported `RpcSessionState` data (RPC §5.1).
+
+    Returns None on timeout / process exit / no matching response. Shares the
+    sole-reader safety constraint of `consume_until_command_response`.
+    """
+    request_id = generate_id()
+    send_rpc_line(process, {"type": "get_state", "id": request_id})
+    response = consume_until_command_response(process, "get_state", request_id, timeout)
+    if response is None or not isinstance(response.data, dict):
+        return None
+    return response.data
+
+
+def shutdown_probe_process(process: RunningProcess | None) -> None:
+    """Close stdin then terminate the catalog probe's pi process.
+
+    Pi exits on stdin EOF (Sculptor closes stdin at shutdown); terminate is
+    the backstop if it lingers. Best-effort — the probe is throwaway, so any
+    teardown error is logged and swallowed rather than failing the fetch.
+    """
+    if process is None:
+        return
+    try:
+        process.close_stdin()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("pi catalog probe close_stdin failed: {}", e)
+    try:
+        process.terminate()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("pi catalog probe terminate failed: {}", e)
+
+
+def probe_catalog(
+    spawn: Callable[[Sequence[str]], RunningProcess],
+    binary: str,
+    session_dir: Path,
+) -> tuple[list[ModelOption], ModelOption | None]:
+    """Fetch + curate pi's catalog via a short-lived probe process.
+
+    Launches a minimal `pi --mode rpc` through `spawn` against a throwaway probe
+    session (a distinct `--session-id` under `session_dir`) with no extensions /
+    skills / system prompt — `get_available_models` and `get_state` need none —
+    issues those two RPCs as the sole reader of the process queue, then shuts the
+    probe down before returning the curated `list[ModelOption]` + current
+    `ModelOption | None`.
+
+    Best-effort: on any failure (spawn error, timeout, no response) it logs and
+    returns `([], None)`, never raising.
+    """
+    command = [
+        binary,
+        "--mode",
+        "rpc",
+        "--session-dir",
+        str(session_dir),
+        "--session-id",
+        f"probe-{generate_id()}",
+        "--no-extensions",
+    ]
+    probe_process = None
+    try:
+        probe_process = spawn(command)
+        raw_models = request_available_models(probe_process)
+        state = request_state(probe_process)
+    except Exception as e:  # noqa: BLE001
+        logger.info("pi catalog probe failed ({}); returning an empty catalog", e)
+        shutdown_probe_process(probe_process)
+        return [], None
+
+    shutdown_probe_process(probe_process)
+
+    current_raw = state.get("model") if isinstance(state, dict) else None
+    current_model = model_option_from_pi(current_raw) if isinstance(current_raw, dict) else None
+    options: list[ModelOption] = []
+    for raw in raw_models:
+        option = model_option_from_pi(raw)
+        if option is not None:
+            options.append(option)
+    authenticated = compute_authenticated_provider_ids()
+    # Drop a selected model whose provider is no longer authenticated when nothing
+    # authenticated remains to fall back to: the catalog must reach its empty
+    # "no usable model" state, not offer a single model that cannot run. (When an
+    # authenticated model does remain, the read-only probe leaves the switch to the
+    # start-time reselect in `_fetch_models_into_state`, which can `set_model`.)
+    if (
+        current_model is not None
+        and current_model.provider not in authenticated
+        and not any(option.provider in authenticated for option in options)
+    ):
+        current_model = None
+    curated = curate_models(options, current_model, authenticated)
+    if not curated and current_model is None:
+        logger.info("pi catalog probe found no usable models; callers show the empty state")
+        return [], None
+    logger.info(
+        "pi catalog probe fetched {} model(s); current model={}",
+        len(curated),
+        current_model.model_id if current_model is not None else None,
+    )
+    return curated, current_model
+
+
+def _detect_pi_version_on_host(binary: str) -> str | None:
+    """Run `pi --version` on the backend host and parse the version, best-effort."""
+    try:
+        result = run_blocking([binary, "--version"], timeout=5.0, is_checked=False)
+    except Exception as e:  # noqa: BLE001
+        logger.info("pi host catalog probe could not run --version ({})", e)
+        return None
+    # WHY: real pi emits --version to stderr, not stdout; feed both channels.
+    return parse_pi_version(f"{result.stdout}\n{result.stderr}")
+
+
+def _spawn_probe_on_host(command: Sequence[str]) -> RunningProcess:
+    """Spawn the probe pi directly on the backend host, with the backend's env."""
+    return run_background(command, env=dict(os.environ), open_stdin=True)
+
+
+def probe_catalog_on_host(binary: str) -> tuple[list[ModelOption], ModelOption | None]:
+    """Fetch + curate pi's catalog directly on the backend host, pre-workspace.
+
+    The host-side twin of `PiAgent.fetch_available_models_probe`: no
+    `AgentExecutionEnvironment` exists yet, so pi is spawned with the backend
+    process env (which is where the api-key env vars live) against a throwaway
+    session dir under Sculptor's own folder. Execution environments are local —
+    same machine, same `$HOME`, same `auth.json` — so this observes the same
+    catalog an in-workspace probe would. Best-effort like the core: any failure
+    yields `([], None)`.
+    """
+    detected_version = _detect_pi_version_on_host(binary)
+    if detected_version is None or not pi_version_in_range(detected_version):
+        logger.info(
+            "pi host catalog probe skipped: pi version {} out of range; returning an empty catalog",
+            detected_version,
+        )
+        return [], None
+    session_dir = get_sculptor_folder() / PI_PROBE_SESSION_DIR_NAME
+    return probe_catalog(_spawn_probe_on_host, binary, session_dir)

--- a/sculptor/sculptor/agents/pi_agent/catalog_probe.py
+++ b/sculptor/sculptor/agents/pi_agent/catalog_probe.py
@@ -11,7 +11,8 @@ Two callers share this module so their catalogs cannot disagree:
 The probe launches a minimal pi (no extensions / skills / system prompt)
 against a throwaway session, issues only the ``get_available_models`` and
 ``get_state`` RPCs, then shuts the process down. Curation and the
-authenticated-provider filter live here too, next to their sole consumers.
+authenticated-provider filter live here too, shared by the probes and the
+agent wrapper's start-time fetch.
 """
 
 import json
@@ -358,6 +359,14 @@ def probe_catalog_on_host(binary: str) -> tuple[list[ModelOption], ModelOption |
     same machine, same `$HOME`, same `auth.json` — so this observes the same
     catalog an in-workspace probe would. Best-effort like the core: any failure
     yields `([], None)`.
+
+    One divergence from the in-task probe: the core keeps an UNAUTHENTICATED
+    current model when an authenticated fallback exists, because a running
+    agent's start-time reselect can `set_model` away from it. No reselect
+    exists before a workspace does — offering that model pre-create would only
+    arm the create-time provider-authentication rejection — so the host
+    boundary strips the concession: the catalog is authenticated-only and the
+    default re-points to the newest authenticated model.
     """
     detected_version = _detect_pi_version_on_host(binary)
     if detected_version is None or not pi_version_in_range(detected_version):
@@ -367,4 +376,9 @@ def probe_catalog_on_host(binary: str) -> tuple[list[ModelOption], ModelOption |
         )
         return [], None
     session_dir = get_sculptor_folder() / PI_PROBE_SESSION_DIR_NAME
-    return probe_catalog(_spawn_probe_on_host, binary, session_dir)
+    available_models, default_model = probe_catalog(_spawn_probe_on_host, binary, session_dir)
+    authenticated = compute_authenticated_provider_ids()
+    available_models = [option for option in available_models if option.provider in authenticated]
+    if default_model is not None and default_model.provider not in authenticated:
+        default_model = available_models[0] if available_models else None
+    return available_models, default_model

--- a/sculptor/sculptor/agents/pi_agent/catalog_probe_test.py
+++ b/sculptor/sculptor/agents/pi_agent/catalog_probe_test.py
@@ -186,3 +186,47 @@ class TestProbeCatalogOnHost:
         # The backend process env rides along so pi resolves providers the same
         # way an in-workspace probe would.
         assert "PATH" in kwargs["env"]
+
+    def test_strips_unauthenticated_current_model_kept_for_in_task_reselect(self, tmp_path: Path) -> None:
+        """An unauthenticated session default never reaches a pre-create surface.
+
+        The core probe deliberately KEEPS an unauthenticated current model when an
+        authenticated fallback exists — in-task, the start-time reselect can
+        `set_model` away from it. No reselect exists before a workspace does, so
+        offering that model in the modal/CLI would only arm the create-time 422.
+        The host boundary strips the concession: the catalog is authenticated-only
+        and the default re-points to the newest authenticated model.
+        """
+        raw = [
+            {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"},
+            {"id": "gpt-5", "name": "GPT-5", "provider": "openai"},
+        ]
+        # pi's session default is the anthropic model, but only openai is authenticated.
+        process = _make_process(
+            [
+                _models_response(raw),
+                _state_response_with_model(
+                    {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+                ),
+            ]
+        )
+        with (
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe._detect_pi_version_on_host",
+                return_value=PI_VERSION_RANGE.recommended_version,
+            ),
+            patch("sculptor.agents.pi_agent.catalog_probe.run_background", return_value=process),
+            patch("sculptor.agents.pi_agent.catalog_probe.get_sculptor_folder", return_value=tmp_path),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.generate_id",
+                side_effect=["probe-sess", "cmd-models", "cmd-state"],
+            ),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.compute_authenticated_provider_ids",
+                return_value={"openai"},
+            ),
+        ):
+            available_models, default_model = probe_catalog_on_host("/bin/pi")
+
+        assert [option.model_id for option in available_models] == ["gpt-5"]
+        assert default_model is not None and default_model.model_id == "gpt-5"

--- a/sculptor/sculptor/agents/pi_agent/catalog_probe_test.py
+++ b/sculptor/sculptor/agents/pi_agent/catalog_probe_test.py
@@ -1,0 +1,188 @@
+"""Tests for the shared pi catalog probe: the spawn-agnostic core and the host-side entry."""
+
+import json
+from pathlib import Path
+from queue import Queue
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from sculptor.agents.pi_agent.catalog_probe import PI_PROBE_SESSION_DIR_NAME
+from sculptor.agents.pi_agent.catalog_probe import probe_catalog
+from sculptor.agents.pi_agent.catalog_probe import probe_catalog_on_host
+from sculptor.services.dependency_management_service import PI_VERSION_RANGE
+
+_RAW_MODELS: list[dict[str, Any]] = [
+    {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"},
+    {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5", "provider": "anthropic"},
+    {"id": "gpt-5", "name": "GPT-5", "provider": "openai"},
+]
+
+
+def _event(payload: dict[str, Any]) -> str:
+    return json.dumps(payload)
+
+
+def _models_response(raw_models: list[dict[str, Any]]) -> str:
+    return _event(
+        {
+            "type": "response",
+            "command": "get_available_models",
+            "success": True,
+            "id": "cmd-models",
+            "data": {"models": raw_models},
+        }
+    )
+
+
+def _state_response_with_model(model: dict[str, Any] | None) -> str:
+    return _event(
+        {
+            "type": "response",
+            "command": "get_state",
+            "success": True,
+            "id": "cmd-state",
+            "data": {"sessionId": "s", "messageCount": 1, "model": model},
+        }
+    )
+
+
+def _make_process(lines: list[str]) -> MagicMock:
+    """Stub `RunningProcess`: replays canned stdout lines then reports finished."""
+    queue: Queue[tuple[str, bool]] = Queue()
+    for line in lines:
+        queue.put((line, True))
+
+    process = MagicMock()
+    process.get_queue.return_value = queue
+    # is_finished() is polled inside the consume loop; report True only once
+    # the queue has been drained.
+    process.is_finished.side_effect = [False] * len(lines) + [True] * 50
+    return process
+
+
+class TestProbeCatalog:
+    """The spawn-agnostic probe core."""
+
+    def test_returns_curated_catalog_and_current_model(self) -> None:
+        """The probe fetches models + state through the two RPCs, applies the
+        authenticated filter, and shuts its process down."""
+        process = _make_process(
+            [
+                _models_response(_RAW_MODELS),
+                _state_response_with_model(
+                    {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+                ),
+            ]
+        )
+        spawn = MagicMock(return_value=process)
+        with (
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.generate_id",
+                side_effect=["probe-sess", "cmd-models", "cmd-state"],
+            ),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.compute_authenticated_provider_ids",
+                return_value={"anthropic"},
+            ),
+        ):
+            available_models, current_model = probe_catalog(spawn, "/bin/pi", Path("/fake/probe"))
+
+        # openai is unauthenticated so gpt-5 is filtered; newest-first sort.
+        assert [option.model_id for option in available_models] == ["claude-opus-4-8", "claude-sonnet-4-5"]
+        assert current_model is not None and current_model.model_id == "claude-opus-4-8"
+        command = list(spawn.call_args.args[0])
+        assert command[:3] == ["/bin/pi", "--mode", "rpc"]
+        assert command[command.index("--session-dir") + 1] == str(Path("/fake/probe"))
+        assert command[command.index("--session-id") + 1] == "probe-probe-sess"
+        assert "--no-extensions" in command
+        process.close_stdin.assert_called_once()
+        process.terminate.assert_called_once()
+
+    def test_spawn_failure_returns_empty_catalog(self) -> None:
+        """A spawn failure is best-effort: an empty catalog, never an exception."""
+        spawn = MagicMock(side_effect=OSError("no such binary"))
+        assert probe_catalog(spawn, "/bin/pi", Path("/fake/probe")) == ([], None)
+
+    def test_drops_unauthenticated_current_model_without_fallback(self) -> None:
+        """A selected model whose provider lost authentication is dropped when nothing
+        authenticated remains, so the catalog reaches its designed empty state."""
+        raw = [{"id": "openai/gpt-4o", "name": "GPT-4o", "provider": "openrouter"}]
+        process = _make_process(
+            [
+                _models_response(raw),
+                _state_response_with_model({"id": "openai/gpt-4o", "name": "GPT-4o", "provider": "openrouter"}),
+            ]
+        )
+        spawn = MagicMock(return_value=process)
+        with (
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.generate_id",
+                side_effect=["probe-sess", "cmd-models", "cmd-state"],
+            ),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.compute_authenticated_provider_ids",
+                return_value=set(),
+            ),
+        ):
+            assert probe_catalog(spawn, "/bin/pi", Path("/fake/probe")) == ([], None)
+
+
+class TestProbeCatalogOnHost:
+    """The host-side entry: version gate + host spawn, no AgentExecutionEnvironment."""
+
+    def test_version_mismatch_returns_empty_without_spawning(self) -> None:
+        with (
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe._detect_pi_version_on_host",
+                return_value="0.1.0",
+            ),
+            patch("sculptor.agents.pi_agent.catalog_probe.run_background") as run_background_mock,
+        ):
+            assert probe_catalog_on_host("/bin/pi") == ([], None)
+        run_background_mock.assert_not_called()
+
+    def test_spawns_probe_on_host_with_backend_env(self, tmp_path: Path) -> None:
+        """The host probe runs pi with the backend process env, stdin open, against a
+        throwaway session dir under Sculptor's own folder."""
+        process = _make_process(
+            [
+                _models_response(_RAW_MODELS),
+                _state_response_with_model(
+                    {"id": "claude-opus-4-8", "name": "Claude Opus 4.8", "provider": "anthropic"}
+                ),
+            ]
+        )
+        with (
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe._detect_pi_version_on_host",
+                return_value=PI_VERSION_RANGE.recommended_version,
+            ),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.run_background",
+                return_value=process,
+            ) as run_background_mock,
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.get_sculptor_folder",
+                return_value=tmp_path,
+            ),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.generate_id",
+                side_effect=["probe-sess", "cmd-models", "cmd-state"],
+            ),
+            patch(
+                "sculptor.agents.pi_agent.catalog_probe.compute_authenticated_provider_ids",
+                return_value={"anthropic"},
+            ),
+        ):
+            available_models, current_model = probe_catalog_on_host("/bin/pi")
+
+        assert [option.model_id for option in available_models] == ["claude-opus-4-8", "claude-sonnet-4-5"]
+        assert current_model is not None and current_model.model_id == "claude-opus-4-8"
+        command = list(run_background_mock.call_args.args[0])
+        assert command[command.index("--session-dir") + 1] == str(tmp_path / PI_PROBE_SESSION_DIR_NAME)
+        kwargs = run_background_mock.call_args.kwargs
+        assert kwargs["open_stdin"] is True
+        # The backend process env rides along so pi resolves providers the same
+        # way an in-workspace probe would.
+        assert "PATH" in kwargs["env"]

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -37,10 +37,14 @@ class ElementIDs(StrEnum):
     NEW_WORKSPACE_CONTEXT_PILL = "NEW_WORKSPACE_CONTEXT_PILL"
     NEW_WORKSPACE_KEEP_OPEN_SWITCH = "NEW_WORKSPACE_KEEP_OPEN_SWITCH"
     NEW_WORKSPACE_CREATE_BUTTON = "NEW_WORKSPACE_CREATE_BUTTON"
-    # Shown in place of the per-prompt agent-settings controls when the first
-    # agent is pi: model / effort / plan / fast do not apply to a pi create
-    # (pi picks its model from its own in-task catalog), so a hint replaces them.
-    NEW_WORKSPACE_PI_SETTINGS_HINT = "NEW_WORKSPACE_PI_SETTINGS_HINT"
+    # The pi first-agent model picker, shown in place of Claude's per-prompt
+    # controls: pi carries a backend-sourced catalog, so the modal offers the same
+    # model selector the composer has, fed by the host-side catalog probe.
+    NEW_WORKSPACE_PI_MODEL_PICKER = "NEW_WORKSPACE_PI_MODEL_PICKER"
+    # The pi no-usable-model surface (no authenticated providers): the picker's
+    # "No models available" state plus the CTA routing to Settings -> Pi. A pi
+    # prompt cannot be submitted against it; a promptless create still can.
+    NEW_WORKSPACE_PI_EMPTY_STATE = "NEW_WORKSPACE_PI_EMPTY_STATE"
     WORKSPACE_SELECTOR = "WORKSPACE_SELECTOR"
     WORKSPACE_OPTION_NAME = "WORKSPACE_OPTION_NAME"
     HOME_PAGE_SYSTEM_PROMPT_OPEN_BUTTON = "HOME_PAGE_SYSTEM_PROMPT_OPEN_BUTTON"

--- a/sculptor/sculptor/interfaces/agents/errors.py
+++ b/sculptor/sculptor/interfaces/agents/errors.py
@@ -90,6 +90,17 @@ class PiSetModelError(AgentClientError):
     """
 
 
+class PiTurnError(AgentClientError):
+    """Raised when a pi USER turn fails (provider auth failure, unusable model, pi dying mid-turn).
+
+    An ``AgentClientError`` rather than a crash: the turn's failure is reported
+    as a failed request — the per-turn error block, whose auth-shaped message
+    carries the login CTA — while the agent keeps running so the user can
+    authenticate or switch models and re-send. ``_run_prompt_turn`` converts the
+    turn pump's ``PiCrashError`` onto this contained rail.
+    """
+
+
 class PiCrashError(AgentCrashed):
     """
     This error is raised when pi reports a structured error mid-turn or its subprocess exits unexpectedly.

--- a/sculptor/sculptor/interfaces/agents/errors.py
+++ b/sculptor/sculptor/interfaces/agents/errors.py
@@ -96,8 +96,7 @@ class PiTurnError(AgentClientError):
     An ``AgentClientError`` rather than a crash: the turn's failure is reported
     as a failed request — the per-turn error block, whose auth-shaped message
     carries the login CTA — while the agent keeps running so the user can
-    authenticate or switch models and re-send. ``_run_prompt_turn`` converts the
-    turn pump's ``PiCrashError`` onto this contained rail.
+    authenticate or switch models and re-send.
     """
 
 

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1.py
@@ -17,6 +17,7 @@ from loguru import logger
 from sculptor.agents.harness_registry import create_agent_for_run
 from sculptor.agents.harness_registry import get_harness_for_config
 from sculptor.agents.pi_agent.agent_wrapper import PiAgent
+from sculptor.agents.pi_agent.authenticated_providers import compute_authenticated_provider_ids
 from sculptor.config.settings import SculptorSettings
 from sculptor.database.models import AgentTaskInputsV2
 from sculptor.database.models import AgentTaskStateV2
@@ -856,6 +857,15 @@ def _eager_fetch_pi_models_into_state(
         return task_state
     secrets = _build_agent_secrets(settings=settings, task=task, task_state=task_state, project=project)
     available_models, current_model = agent_wrapper.fetch_available_models_probe(secrets)
+    # A create-time selection (the modal's validated backend model) is already on
+    # task state; the read-only probe reports pi's own session default, which must
+    # not clobber it. Keep the seeded selection while its provider is still
+    # authenticated — the wrapper's start-time adoption reconciles pi to it. A
+    # seeded selection whose provider lost authentication falls back to the
+    # probe's result (the start-time reselect owns dropping or switching it).
+    seeded_model = task_state.current_model
+    if seeded_model is not None and seeded_model.provider in compute_authenticated_provider_ids():
+        current_model = seeded_model
     # Persist even the empty result: it records that the probe COMPLETED, moving the
     # catalog off NOT_FETCHED_YET to a fetched-but-empty [] (authenticated with no
     # providers — or a best-effort probe failure, which today falls back the same

--- a/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
+++ b/sculptor/sculptor/tasks/handlers/run_agent/v1_test.py
@@ -1374,6 +1374,104 @@ def test_eager_pi_probe_records_fetched_empty_when_no_models(
     assert _read_persisted_task_state(local_task, services).available_models == []
 
 
+_SEEDED_OPUS = ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8")
+_PI_DEFAULT_SONNET = ModelOption(provider="anthropic", model_id="claude-sonnet-4-5", display_name="Claude Sonnet 4.5")
+
+
+class _DefaultModelProbePiAgent:
+    """Stands in for a PiAgent whose probe reports pi's own session default."""
+
+    def fetch_available_models_probe(self, secrets: object) -> tuple[list[ModelOption], ModelOption]:
+        return [_SEEDED_OPUS, _PI_DEFAULT_SONNET], _PI_DEFAULT_SONNET
+
+
+def test_eager_pi_probe_preserves_seeded_current_model(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: AgentExecutionEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A create-time backend-model selection survives the pre-message probe.
+
+    The probe reports pi's own session default, but a modal-created task is born
+    with a validated `current_model`; persisting the probe's default over it
+    would silently discard the user's choice before start-time adoption runs.
+    """
+    task_data = local_task.input_data
+    assert isinstance(task_data, AgentTaskInputsV2)
+    seeded = AgentTaskStateV2(workspace_id=WorkspaceID(), current_model=_SEEDED_OPUS)
+    _set_task_state(local_task, seeded, services)
+
+    harness_stub = MagicMock()
+    harness_stub.capabilities.return_value.supports_model_selection = True
+    with (
+        patch("sculptor.tasks.handlers.run_agent.v1.get_harness_for_config", return_value=harness_stub),
+        patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=_DefaultModelProbePiAgent()),
+        patch("sculptor.tasks.handlers.run_agent.v1._build_agent_secrets", return_value={}),
+        patch("sculptor.tasks.handlers.run_agent.v1.PiAgent", _DefaultModelProbePiAgent),
+        patch(
+            "sculptor.tasks.handlers.run_agent.v1.compute_authenticated_provider_ids",
+            return_value={"anthropic"},
+        ),
+    ):
+        evolved = _eager_fetch_pi_models_into_state(
+            task=local_task,
+            task_data=task_data,
+            task_state=seeded,
+            environment=environment,
+            project=project,
+            settings=test_settings,
+            services=services,
+            in_testing=True,
+        )
+
+    assert evolved.current_model == _SEEDED_OPUS
+    assert _read_persisted_task_state(local_task, services).current_model == _SEEDED_OPUS
+
+
+def test_eager_pi_probe_drops_seeded_current_model_when_provider_lost_auth(
+    local_task: Task,
+    services: ServiceCollectionForTask,
+    project: Project,
+    environment: AgentExecutionEnvironment,
+    test_settings: SculptorSettings,
+) -> None:
+    """A seeded selection whose provider lost authentication between create and
+    env-ready is not retained — the probe's own result stands (the start-time
+    reselect owns dropping or switching properly)."""
+    task_data = local_task.input_data
+    assert isinstance(task_data, AgentTaskInputsV2)
+    seeded = AgentTaskStateV2(workspace_id=WorkspaceID(), current_model=_SEEDED_OPUS)
+    _set_task_state(local_task, seeded, services)
+
+    harness_stub = MagicMock()
+    harness_stub.capabilities.return_value.supports_model_selection = True
+    with (
+        patch("sculptor.tasks.handlers.run_agent.v1.get_harness_for_config", return_value=harness_stub),
+        patch("sculptor.tasks.handlers.run_agent.v1._get_agent_wrapper", return_value=_EmptyProbePiAgent()),
+        patch("sculptor.tasks.handlers.run_agent.v1._build_agent_secrets", return_value={}),
+        patch("sculptor.tasks.handlers.run_agent.v1.PiAgent", _EmptyProbePiAgent),
+        patch(
+            "sculptor.tasks.handlers.run_agent.v1.compute_authenticated_provider_ids",
+            return_value=set(),
+        ),
+    ):
+        evolved = _eager_fetch_pi_models_into_state(
+            task=local_task,
+            task_data=task_data,
+            task_state=seeded,
+            environment=environment,
+            project=project,
+            settings=test_settings,
+            services=services,
+            in_testing=True,
+        )
+
+    assert evolved.current_model is None
+    assert evolved.available_models == []
+
+
 def test_queued_followup_is_dispatched_after_resumed_turn_completes(
     local_task: Task,
     services: ServiceCollectionForTask,

--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -423,8 +423,9 @@ def start_task_and_wait_for_ready(
     Opens the new-workspace modal via ``open_new_workspace_form``, fills in the
     workspace name, clicks create, then waits for the agent chat page to appear.
 
-    The new-workspace form has no model selector, so the model is switched on the
-    chat panel once the workspace is ready.
+    This helper creates promptless and switches the model on the chat panel once
+    the workspace is ready, rather than driving the form's own per-prompt model
+    controls.
 
     When *prompt* is provided, this helper leaves the creation form's own prompt
     field empty and sends *prompt* through the chat input after the workspace is

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -2308,7 +2308,20 @@ def create_workspace_agent(
                 settings=settings,
             )
 
-        # No prompt — create agent in waiting state
+        # No prompt — create agent in waiting state. There is no turn to run a
+        # backend-model selection under (post-start selection owns that case),
+        # so reject one rather than silently dropping it.
+        if agent_request.backend_model is not None:
+            raise HTTPException(
+                status_code=422,
+                detail=[
+                    {
+                        "loc": ["body", "backend_model"],
+                        "msg": "backend_model requires a prompt — a promptless create selects pi's model after start",
+                        "type": "value_error",
+                    }
+                ],
+            )
         _prevent_action_if_out_of_free_space(services)
 
         workspace_tasks = _get_tasks_for_workspace(workspace, transaction)

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -56,8 +56,10 @@ from sculptor.agents.attachments import resolve_attachment_source
 from sculptor.agents.default.claude_code_sdk.btw_process_manager import NoBtwSessionAvailable
 from sculptor.agents.harness_registry import get_harness_for_config
 from sculptor.agents.pi_agent.authenticated_providers import PiAuthJsonError
+from sculptor.agents.pi_agent.authenticated_providers import compute_authenticated_provider_ids
 from sculptor.agents.pi_agent.authenticated_providers import get_provider_auth_statuses
 from sculptor.agents.pi_agent.authenticated_providers import write_auth_json_entry
+from sculptor.agents.pi_agent.catalog_probe import probe_catalog_on_host
 from sculptor.agents.pi_agent.provider_catalog import ProviderGroup
 from sculptor.agents.pi_agent.provider_catalog import get_provider_entry
 from sculptor.common.plugin import get_plugin_dirs
@@ -167,6 +169,7 @@ from sculptor.startup_checks import check_is_user_email_field_valid
 from sculptor.startup_checks import check_sculptor_directory_writable
 from sculptor.state.messages import ChatInputUserMessage
 from sculptor.state.messages import LLMModel
+from sculptor.state.messages import ModelOption
 from sculptor.tasks.handlers.run_terminal_agent.terminal_session import create_agent_terminal
 from sculptor.tasks.handlers.run_terminal_agent.terminal_session import make_agent_terminal_id
 from sculptor.telemetry import telemetry
@@ -236,6 +239,7 @@ from sculptor.web.data_types import PasteKeyRequest
 from sculptor.web.data_types import PiLoginRequest
 from sculptor.web.data_types import PiLoginResponse
 from sculptor.web.data_types import PiLoginStatusResponse
+from sculptor.web.data_types import PiModelsResponse
 from sculptor.web.data_types import PreviewBranchNameResponse
 from sculptor.web.data_types import ProjectEnvVarNames
 from sculptor.web.data_types import ProjectInitializationRequest
@@ -555,6 +559,70 @@ def set_session_token_cookie(
     )
 
 
+def _validate_prompt_model_selection(
+    agent_type: AgentTypeName,
+    model: LLMModel | None,
+    backend_model: ModelOption | None,
+) -> None:
+    """Enforce the create-time model contract for a prompt-ful create.
+
+    A create names its model on exactly one harness's terms: `model` for
+    Claude's static list, `backend_model` for a backend-sourced catalog (pi).
+    A pi prompt requires a `backend_model` whose provider is authenticated at
+    create time — an instant host-side read sharing
+    `compute_authenticated_provider_ids` with the catalog probe — so a queued
+    first prompt can never name a model that cannot run.
+    """
+    if model is not None and backend_model is not None:
+        raise HTTPException(
+            status_code=422,
+            detail=[
+                {
+                    "loc": ["body", "backend_model"],
+                    "msg": "model and backend_model are mutually exclusive",
+                    "type": "value_error",
+                }
+            ],
+        )
+    if agent_type == AgentTypeName.PI:
+        if backend_model is None:
+            raise HTTPException(
+                status_code=422,
+                detail=[
+                    {
+                        "loc": ["body", "backend_model"],
+                        "msg": "A pi prompt requires a backend_model selected from pi's catalog",
+                        "type": "value_error.missing",
+                    }
+                ],
+            )
+        if backend_model.provider not in compute_authenticated_provider_ids():
+            raise HTTPException(
+                status_code=422,
+                detail=[
+                    {
+                        "loc": ["body", "backend_model"],
+                        "msg": (
+                            f"pi provider '{backend_model.provider}' is not authenticated — "
+                            + "connect it under Settings → Pi → Providers and retry"
+                        ),
+                        "type": "value_error",
+                    }
+                ],
+            )
+    elif model is None:
+        raise HTTPException(
+            status_code=422,
+            detail=[
+                {
+                    "loc": ["body", "model"],
+                    "msg": "Model is required when providing a prompt",
+                    "type": "value_error.missing",
+                }
+            ],
+        )
+
+
 @router.post("/api/v1/projects/{project_id}/tasks")
 def start_task(
     project_id: ProjectID,
@@ -637,6 +705,7 @@ def start_task(
             if task_request.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
                 raise HTTPException(status_code=422, detail="terminal agents do not take an initial prompt")
             resolved_agent_type, _ = _resolve_requested_agent_type(task_request.agent_type, None, has_prompt=True)
+            _validate_prompt_model_selection(resolved_agent_type, model, task_request.backend_model)
             agent_config = _agent_config_for_request(resolved_agent_type, None)
             if task_request.agent_type is not None:
                 _record_most_recently_used_agent_type(resolved_agent_type, None)
@@ -653,10 +722,13 @@ def start_task(
 
         max_seconds = None
 
-        # Create initial task state with workspace_id
+        # Create initial task state with workspace_id. A validated backend-model
+        # selection (pi) is the task's current model from birth, so the wrapper's
+        # start-time adoption runs the queued prompt under it.
         initial_task_state = AgentTaskStateV2(
             title=task_name,
             workspace_id=workspace.object_id,
+            current_model=task_request.backend_model,
         )
 
         task = Task(
@@ -2211,24 +2283,14 @@ def create_workspace_agent(
         if agent_request.prompt:
             if agent_request.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
                 raise HTTPException(status_code=422, detail="terminal agents do not take an initial prompt")
-            # Delegate to existing start_task logic
-            model = agent_request.model
-            if model is None:
-                raise HTTPException(
-                    status_code=422,
-                    detail=[
-                        {
-                            "loc": ["body", "model"],
-                            "msg": "Model is required when providing a prompt",
-                            "type": "value_error.missing",
-                        }
-                    ],
-                )
-
+            # Delegate to existing start_task logic, which validates the
+            # model/backend_model pair against the resolved harness
+            # (`_validate_prompt_model_selection`).
             task_request = StartTaskRequest(
                 prompt=agent_request.prompt,
                 interface=agent_request.interface,
-                model=model,
+                model=agent_request.model,
+                backend_model=agent_request.backend_model,
                 files=agent_request.files,
                 name=agent_request.name,
                 workspace_id=validated_workspace_id,
@@ -4526,6 +4588,26 @@ def get_pi_authenticated_providers(
             for status in get_provider_auth_statuses()
         )
     )
+
+
+@router.get("/api/v1/pi/models")
+def get_pi_models(
+    request: Request,
+    user_session: UserSession = Depends(get_user_session),
+) -> PiModelsResponse:
+    """Return pi's curated, authenticated-only model catalog, probed on the host.
+
+    Global (no workspace/agent): pre-create surfaces — the New Workspace modal's
+    pi model picker — read this before any execution environment exists. The
+    probe is best-effort like its in-task twin, so a missing binary, version
+    mismatch, or unauthenticated user yields an empty catalog, never an error.
+    """
+    services = get_services_from_request_or_websocket(request)
+    binary = services.dependency_management_service.resolve_binary_path(Dependency.PI)
+    if binary is None:
+        return PiModelsResponse(available_models=(), default_model=None)
+    available_models, default_model = probe_catalog_on_host(binary)
+    return PiModelsResponse(available_models=tuple(available_models), default_model=default_model)
 
 
 @router.post("/api/v1/pi/login")

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -8,6 +8,7 @@ NOTE: Endpoints are not currently tested for cross-user authorization (preventin
 
 from pathlib import Path
 from typing import Generator
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -1201,17 +1202,20 @@ def test_start_task_resolves_agent_type(
     client: TestClient, test_services: CompleteServiceCollection, test_project: Project
 ) -> None:
     """Prompt-ful creation honors a chat agent_type and rejects terminal types."""
-    response = client.post(
-        f"/api/v1/projects/{test_project.object_id}/tasks",
-        json=model_dump(
-            StartTaskRequest(
-                prompt="hello pi",
-                model=LLMModel.CLAUDE_4_SONNET,
-                agent_type=AgentTypeName.PI,
+    with patch("sculptor.web.app.compute_authenticated_provider_ids", return_value={"anthropic"}):
+        response = client.post(
+            f"/api/v1/projects/{test_project.object_id}/tasks",
+            json=model_dump(
+                StartTaskRequest(
+                    prompt="hello pi",
+                    backend_model=ModelOption(
+                        provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8"
+                    ),
+                    agent_type=AgentTypeName.PI,
+                ),
+                is_camel_case=True,
             ),
-            is_camel_case=True,
-        ),
-    )
+        )
     assert response.status_code == 200, response.text
     task_id = TaskID(response.json()["id"])
     user_session = authenticate_anonymous(test_services, RequestID())

--- a/sculptor/sculptor/web/app_create_model_contract_test.py
+++ b/sculptor/sculptor/web/app_create_model_contract_test.py
@@ -1,0 +1,128 @@
+"""Tests for the create-time model contract on prompt-ful creates.
+
+A create names its model on exactly one harness's terms: `model` for Claude's
+static list, `backend_model` for a backend-sourced catalog (pi). A pi prompt
+requires a `backend_model` whose provider is authenticated at create time, and
+the accepted selection is seeded as the task's `current_model`.
+"""
+
+from unittest.mock import patch
+
+import httpx
+from fastapi.testclient import TestClient
+
+from sculptor.database.models import AgentTaskInputsV2
+from sculptor.database.models import AgentTaskStateV2
+from sculptor.database.models import Project
+from sculptor.database.models import TaskID
+from sculptor.foundation.pydantic_serialization import model_dump
+from sculptor.primitives.ids import RequestID
+from sculptor.service_collections.service_collection import CompleteServiceCollection
+from sculptor.state.messages import LLMModel
+from sculptor.state.messages import ModelOption
+from sculptor.web.auth import authenticate_anonymous
+from sculptor.web.data_types import AgentTypeName
+from sculptor.web.data_types import StartTaskRequest
+
+_OPUS = ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8")
+
+
+def _post_task(client: TestClient, project: Project, request: StartTaskRequest) -> httpx.Response:
+    return client.post(
+        f"/api/v1/projects/{project.object_id}/tasks",
+        json=model_dump(request, is_camel_case=True),
+    )
+
+
+def test_pi_prompt_with_authenticated_backend_model_seeds_current_model(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    with patch("sculptor.web.app.compute_authenticated_provider_ids", return_value={"anthropic"}):
+        response = _post_task(
+            client,
+            test_project,
+            StartTaskRequest(prompt="hello pi", backend_model=_OPUS, agent_type=AgentTypeName.PI),
+        )
+    assert response.status_code == 200, response.text
+
+    task_id = TaskID(response.json()["id"])
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        task = test_services.task_service.get_task(task_id, transaction)
+    assert task is not None
+    assert isinstance(task.current_state, AgentTaskStateV2)
+    # The validated selection is the task's current model from birth, so the
+    # wrapper's start-time adoption runs the queued prompt under it.
+    assert task.current_state.current_model == _OPUS
+    assert isinstance(task.input_data, AgentTaskInputsV2)
+    assert task.input_data.default_model is None
+
+
+def test_pi_prompt_without_backend_model_is_rejected(client: TestClient, test_project: Project) -> None:
+    response = _post_task(
+        client,
+        test_project,
+        StartTaskRequest(prompt="hello pi", agent_type=AgentTypeName.PI),
+    )
+    assert response.status_code == 422
+    assert "backend_model" in response.text
+
+
+def test_pi_prompt_with_unauthenticated_provider_is_rejected(client: TestClient, test_project: Project) -> None:
+    with patch("sculptor.web.app.compute_authenticated_provider_ids", return_value=set()):
+        response = _post_task(
+            client,
+            test_project,
+            StartTaskRequest(prompt="hello pi", backend_model=_OPUS, agent_type=AgentTypeName.PI),
+        )
+    assert response.status_code == 422
+    assert "not authenticated" in response.text
+
+
+def test_model_and_backend_model_together_are_rejected(client: TestClient, test_project: Project) -> None:
+    with patch("sculptor.web.app.compute_authenticated_provider_ids", return_value={"anthropic"}):
+        response = _post_task(
+            client,
+            test_project,
+            StartTaskRequest(
+                prompt="hello",
+                model=LLMModel.CLAUDE_4_SONNET,
+                backend_model=_OPUS,
+                agent_type=AgentTypeName.PI,
+            ),
+        )
+    assert response.status_code == 422
+    assert "mutually exclusive" in response.text
+
+
+def test_claude_prompt_without_model_is_rejected(client: TestClient, test_project: Project) -> None:
+    response = _post_task(
+        client,
+        test_project,
+        StartTaskRequest(prompt="hello claude", agent_type=AgentTypeName.CLAUDE),
+    )
+    assert response.status_code == 422
+    assert "Model is required when providing a prompt" in response.text
+
+
+def test_claude_prompt_with_model_is_unchanged(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    response = _post_task(
+        client,
+        test_project,
+        StartTaskRequest(prompt="hello claude", model=LLMModel.CLAUDE_4_SONNET, agent_type=AgentTypeName.CLAUDE),
+    )
+    assert response.status_code == 200, response.text
+
+    task_id = TaskID(response.json()["id"])
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        task = test_services.task_service.get_task(task_id, transaction)
+    assert task is not None
+    assert isinstance(task.current_state, AgentTaskStateV2)
+    # Claude's model rides `default_model`/`model_name`, never the backend
+    # catalog's `current_model`.
+    assert task.current_state.current_model is None
+    assert isinstance(task.input_data, AgentTaskInputsV2)
+    assert task.input_data.default_model == LLMModel.CLAUDE_4_SONNET

--- a/sculptor/sculptor/web/app_create_model_contract_test.py
+++ b/sculptor/sculptor/web/app_create_model_contract_test.py
@@ -1,9 +1,11 @@
-"""Tests for the create-time model contract on prompt-ful creates.
+"""Tests for the create-time model contract.
 
 A create names its model on exactly one harness's terms: `model` for Claude's
 static list, `backend_model` for a backend-sourced catalog (pi). A pi prompt
 requires a `backend_model` whose provider is authenticated at create time, and
-the accepted selection is seeded as the task's `current_model`.
+the accepted selection is seeded as the task's `current_model`. A promptless
+create must not carry a `backend_model` at all — post-start selection owns
+that case.
 """
 
 from unittest.mock import patch
@@ -15,13 +17,17 @@ from sculptor.database.models import AgentTaskInputsV2
 from sculptor.database.models import AgentTaskStateV2
 from sculptor.database.models import Project
 from sculptor.database.models import TaskID
+from sculptor.database.models import Workspace
+from sculptor.database.workspace_enums import WorkspaceInitializationStrategy
 from sculptor.foundation.pydantic_serialization import model_dump
 from sculptor.primitives.ids import RequestID
 from sculptor.service_collections.service_collection import CompleteServiceCollection
+from sculptor.services.data_model_service.data_types import DataModelTransaction
 from sculptor.state.messages import LLMModel
 from sculptor.state.messages import ModelOption
 from sculptor.web.auth import authenticate_anonymous
 from sculptor.web.data_types import AgentTypeName
+from sculptor.web.data_types import CreateAgentRequest
 from sculptor.web.data_types import StartTaskRequest
 
 _OPUS = ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8")
@@ -31,6 +37,21 @@ def _post_task(client: TestClient, project: Project, request: StartTaskRequest) 
     return client.post(
         f"/api/v1/projects/{project.object_id}/tasks",
         json=model_dump(request, is_camel_case=True),
+    )
+
+
+def _create_workspace(
+    transaction: DataModelTransaction,
+    services: CompleteServiceCollection,
+    project: Project,
+) -> Workspace:
+    return services.workspace_service.create_workspace(
+        project=project,
+        initialization_strategy=WorkspaceInitializationStrategy.IN_PLACE,
+        source_branch=None,
+        requested_branch_name=None,
+        description="test workspace",
+        transaction=transaction,
     )
 
 
@@ -93,6 +114,27 @@ def test_model_and_backend_model_together_are_rejected(client: TestClient, test_
         )
     assert response.status_code == 422
     assert "mutually exclusive" in response.text
+
+
+def test_promptless_backend_model_is_rejected(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    """A promptless create has no turn to run the selection under — post-start
+    selection owns that case — so a backend_model riding one is rejected
+    rather than silently dropped."""
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        workspace = _create_workspace(transaction, test_services, test_project)
+
+    response = client.post(
+        f"/api/v1/workspaces/{workspace.object_id}/agents",
+        json=model_dump(
+            CreateAgentRequest(agent_type=AgentTypeName.PI, backend_model=_OPUS),
+            is_camel_case=True,
+        ),
+    )
+    assert response.status_code == 422
+    assert "backend_model requires a prompt" in response.text
 
 
 def test_claude_prompt_without_model_is_rejected(client: TestClient, test_project: Project) -> None:

--- a/sculptor/sculptor/web/app_pi_models_test.py
+++ b/sculptor/sculptor/web/app_pi_models_test.py
@@ -1,0 +1,53 @@
+"""Tests for GET /api/v1/pi/models: the host-side pre-workspace pi catalog probe."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sculptor.services.dependency_management_service import DependencyManagementService
+from sculptor.state.messages import ModelOption
+
+_OPUS = ModelOption(provider="anthropic", model_id="claude-opus-4-8", display_name="Claude Opus 4.8")
+_SONNET = ModelOption(provider="anthropic", model_id="claude-sonnet-4-5", display_name="Claude Sonnet 4.5")
+
+
+def test_pi_models_returns_probed_catalog(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(DependencyManagementService, "resolve_binary_path", lambda self, tool: "/bin/pi")
+    probe_mock = MagicMock(return_value=([_OPUS, _SONNET], _OPUS))
+    monkeypatch.setattr("sculptor.web.app.probe_catalog_on_host", probe_mock)
+
+    response = client.get("/api/v1/pi/models")
+    assert response.status_code == 200
+
+    body = response.json()
+    assert [model["modelId"] for model in body["availableModels"]] == ["claude-opus-4-8", "claude-sonnet-4-5"]
+    assert body["defaultModel"]["modelId"] == "claude-opus-4-8"
+    assert body["defaultModel"]["provider"] == "anthropic"
+    probe_mock.assert_called_once_with("/bin/pi")
+
+
+def test_pi_models_returns_empty_catalog_when_binary_missing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(DependencyManagementService, "resolve_binary_path", lambda self, tool: None)
+    probe_mock = MagicMock()
+    monkeypatch.setattr("sculptor.web.app.probe_catalog_on_host", probe_mock)
+
+    response = client.get("/api/v1/pi/models")
+    assert response.status_code == 200
+    assert response.json() == {"availableModels": [], "defaultModel": None}
+    probe_mock.assert_not_called()
+
+
+def test_pi_models_returns_empty_catalog_when_probe_finds_nothing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unauthenticated user (or a best-effort probe failure) yields the designed
+    empty catalog — a 200, never an error — driving the shared empty state."""
+    monkeypatch.setattr(DependencyManagementService, "resolve_binary_path", lambda self, tool: "/bin/pi")
+    monkeypatch.setattr("sculptor.web.app.probe_catalog_on_host", MagicMock(return_value=([], None)))
+
+    response = client.get("/api/v1/pi/models")
+    assert response.status_code == 200
+    assert response.json() == {"availableModels": [], "defaultModel": None}

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -30,6 +30,7 @@ from sculptor.state.chat_state import AskUserQuestionData
 from sculptor.state.messages import EffortLevel
 from sculptor.state.messages import LLMModel
 from sculptor.state.messages import Message
+from sculptor.state.messages import ModelOption
 
 
 class TaskInterface(StrEnum):
@@ -126,7 +127,12 @@ class RequestModel(SerializableModel):
 class StartTaskRequest(RequestModel):
     prompt: str
     interface: str = TaskInterface.TERMINAL.value
-    model: LLMModel
+    # A create names its model on exactly one harness's terms: `model` for
+    # Claude's static list, `backend_model` for a backend-sourced catalog (pi).
+    # The two are mutually exclusive; the prompt-ful create validates the pair
+    # per resolved harness (`_validate_prompt_model_selection`).
+    model: LLMModel | None = None
+    backend_model: ModelOption | None = None
     files: list[str] = Field(default_factory=list)
     initialization_strategy: WorkspaceInitializationStrategy = WorkspaceInitializationStrategy.IN_PLACE
     name: str | None = None
@@ -173,7 +179,12 @@ class CreateAgentRequest(RequestModel):
     """Create agent request — prompt is optional for the '+' button flow."""
 
     prompt: str | None = None
+    # Mutually exclusive with `backend_model`: a create names its model on
+    # exactly one harness's terms — `model` for Claude's static list,
+    # `backend_model` (the chosen `ModelOption`) for a backend-sourced catalog
+    # (pi). A pi prompt requires `backend_model`.
     model: LLMModel | None = None
+    backend_model: ModelOption | None = None
     interface: str = TaskInterface.TERMINAL.value
     files: list[str] = Field(default_factory=list)
     name: str | None = None
@@ -295,6 +306,19 @@ class AuthenticatedProvidersResponse(SerializableModel):
     """The full pi provider catalog crossed with current authentication status."""
 
     providers: tuple[AuthenticatedProviderEntry, ...]
+
+
+class PiModelsResponse(SerializableModel):
+    """The host-side pi catalog for pre-workspace surfaces (the New Workspace modal's picker).
+
+    Mirrors the task-state catalog fields: `available_models` is the curated,
+    authenticated-only list and `default_model` is pi's own current model when
+    usable. Empty/None means "no usable model" (or a best-effort probe failure),
+    driving the same empty state the composer shows.
+    """
+
+    available_models: tuple[ModelOption, ...]
+    default_model: ModelOption | None
 
 
 class PiLoginRequest(RequestModel):

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -181,7 +181,8 @@ class CreateAgentRequest(RequestModel):
     # Mutually exclusive with `backend_model`: a create names its model on
     # exactly one harness's terms — `model` for Claude's static list,
     # `backend_model` (the chosen `ModelOption`) for a backend-sourced catalog
-    # (pi). A pi prompt requires `backend_model`.
+    # (pi). A pi prompt requires `backend_model`; a promptless create must not
+    # carry one (post-start selection owns that case).
     model: LLMModel | None = None
     backend_model: ModelOption | None = None
     interface: str = TaskInterface.TERMINAL.value

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -127,10 +127,9 @@ class RequestModel(SerializableModel):
 class StartTaskRequest(RequestModel):
     prompt: str
     interface: str = TaskInterface.TERMINAL.value
-    # A create names its model on exactly one harness's terms: `model` for
-    # Claude's static list, `backend_model` for a backend-sourced catalog (pi).
-    # The two are mutually exclusive; the prompt-ful create validates the pair
-    # per resolved harness (`_validate_prompt_model_selection`).
+    # Mutually exclusive, one per harness's terms — the same pair as
+    # CreateAgentRequest, validated per resolved harness
+    # (`_validate_prompt_model_selection`).
     model: LLMModel | None = None
     backend_model: ModelOption | None = None
     files: list[str] = Field(default_factory=list)

--- a/tools/sculpt/sculpt/commands/_harness_helpers.py
+++ b/tools/sculpt/sculpt/commands/_harness_helpers.py
@@ -9,7 +9,9 @@ commands stay in lockstep.
 import httpx
 
 from sculpt.client import Client
+from sculpt.client.api.default import get_pi_models
 from sculpt.client.api.default import list_terminal_agent_registrations
+from sculpt.client.models.model_option import ModelOption
 from sculpt.client.models.terminal_agent_registration import TerminalAgentRegistration
 from sculpt.formatting import cli_error
 from sculpt.formatting import handle_connection_error
@@ -51,3 +53,27 @@ def resolve_harness_selection(harness: str | None, client: Client, json_output: 
         valid = ", ".join(available_harness_names(registrations))
         cli_error(f"Invalid harness '{harness}'. Valid options: {valid}", json_output=json_output)
     return selection
+
+
+def resolve_pi_backend_model(client: Client, json_output: bool) -> ModelOption:
+    """Pick the backend model a pi prompt runs under, from pi's own catalog.
+
+    A pi prompt must name a model from pi's curated, authenticated-only catalog
+    (GET /api/v1/pi/models) — the Claude ``--model`` names do not apply to pi.
+    Uses pi's own default when usable, else the newest available model; errors
+    when the catalog is empty (no authenticated provider / unusable pi).
+    """
+    try:
+        catalog = get_pi_models.sync(client=client)
+    except httpx.ConnectError:
+        handle_connection_error(json_output)
+    if catalog is None:
+        cli_error("Failed to fetch pi models", detail="No response from server", json_output=json_output)
+    if catalog.default_model is not None:
+        return catalog.default_model
+    if catalog.available_models:
+        return catalog.available_models[0]
+    cli_error(
+        "pi has no usable model — authenticate a provider (Sculptor Settings → Pi → Providers), then retry",
+        json_output=json_output,
+    )

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -128,8 +128,12 @@ def _format_snapshot_datetime(iso_str: str) -> str:
 def create(
     workspace: str | None = typer.Option(None, "--workspace", "-w", help="Workspace ID (or set SCULPT_WORKSPACE_ID)"),
     prompt: str | None = typer.Option(None, "--prompt", "-p", help="The task prompt"),
-    model: str = typer.Option(
-        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)"
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)",
+        show_default="opus",
     ),
     name: str | None = typer.Option(None, "--name", help="Agent name"),
     harness: str | None = typer.Option(
@@ -147,13 +151,13 @@ def create(
     """Create a new agent in a workspace."""
     base_url = base_url or get_default_base_url()
 
-    if not prompt and model != "opus":
+    if not prompt and model is not None:
         cli_error("--model has no effect without --prompt", json_output=json_output)
 
     client = get_authenticated_client(base_url, json_output)
     workspace_id = resolve_workspace(workspace, client, json_output)
 
-    model_lower = model.lower()
+    model_lower = "opus" if model is None else model.lower()
     if model_lower not in MODEL_MAPPING:
         valid = ", ".join(MODEL_MAPPING.keys())
         cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
@@ -166,7 +170,7 @@ def create(
 
     backend_model = None
     if prompt and selection is not None and selection.agent_type == AgentTypeName.PI:
-        if model_lower != "opus":
+        if model is not None:
             cli_error(
                 "--model does not apply to the Pi harness — pi picks from its own catalog",
                 json_output=json_output,

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -42,6 +42,7 @@ from sculpt.commands._follow_helpers import on_reconnect_separator
 from sculpt.commands._follow_helpers import on_reconnect_text
 from sculpt.commands._follow_helpers import on_status_json
 from sculpt.commands._harness_helpers import resolve_harness_selection
+from sculpt.commands._harness_helpers import resolve_pi_backend_model
 from sculpt.commands.data_types import AgentCreateOutput
 from sculpt.commands.data_types import AgentDeleteOutput
 from sculpt.commands.data_types import AgentInterruptOutput
@@ -163,9 +164,21 @@ def create(
     if prompt and selection is not None and selection.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
         cli_error("Terminal agents do not take an initial prompt (--prompt)", json_output=json_output)
 
+    # pi names its model from its own authenticated catalog, so a pi prompt
+    # carries a backend_model instead of a Claude --model name.
+    backend_model = None
+    if prompt and selection is not None and selection.agent_type == AgentTypeName.PI:
+        if model_lower != "opus":
+            cli_error(
+                "--model does not apply to the Pi harness — pi picks from its own catalog",
+                json_output=json_output,
+            )
+        backend_model = resolve_pi_backend_model(client, json_output)
+
     request = CreateAgentRequest(
         prompt=prompt,
-        model=llm_model if prompt else None,
+        model=llm_model if prompt and backend_model is None else None,
+        backend_model=backend_model if backend_model is not None else UNSET,
         interface="API",
         name=name,
         sent_via="sculpt",

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -164,8 +164,6 @@ def create(
     if prompt and selection is not None and selection.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
         cli_error("Terminal agents do not take an initial prompt (--prompt)", json_output=json_output)
 
-    # pi names its model from its own authenticated catalog, so a pi prompt
-    # carries a backend_model instead of a Claude --model name.
     backend_model = None
     if prompt and selection is not None and selection.agent_type == AgentTypeName.PI:
         if model_lower != "opus":

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -13,6 +13,7 @@ from sculpt.client.models.http_validation_error import HTTPValidationError
 from sculpt.client.types import UNSET
 from sculpt.commands._follow_helpers import follow_and_stream_messages
 from sculpt.commands._harness_helpers import resolve_harness_selection
+from sculpt.commands._harness_helpers import resolve_pi_backend_model
 from sculpt.commands._workspace_helpers import STRATEGY_MAPPING
 from sculpt.commands._workspace_helpers import resolve_requested_branch_name
 from sculpt.commands._workspace_helpers import resolve_strategy
@@ -91,6 +92,17 @@ def run_cmd(
             json_output=json_output,
         )
 
+    # pi names its model from its own authenticated catalog, so a pi prompt
+    # carries a backend_model instead of a Claude --model name.
+    backend_model = None
+    if selection is not None and selection.agent_type == AgentTypeName.PI:
+        if model_lower != "opus":
+            cli_error(
+                "--model does not apply to the Pi harness — pi picks from its own catalog",
+                json_output=json_output,
+            )
+        backend_model = resolve_pi_backend_model(client, json_output)
+
     project_id = resolve_project(repo, client, json_output)
 
     strategy_enum = resolve_strategy(strategy, json_output=json_output)
@@ -132,7 +144,8 @@ def run_cmd(
     # "+" button uses).
     agent_request = CreateAgentRequest(
         prompt=prompt,
-        model=llm_model,
+        model=llm_model if backend_model is None else UNSET,
+        backend_model=backend_model if backend_model is not None else UNSET,
         interface="API",
         files=file or [],
         name=name,

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -92,8 +92,6 @@ def run_cmd(
             json_output=json_output,
         )
 
-    # pi names its model from its own authenticated catalog, so a pi prompt
-    # carries a backend_model instead of a Claude --model name.
     backend_model = None
     if selection is not None and selection.agent_type == AgentTypeName.PI:
         if model_lower != "opus":

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -34,8 +34,12 @@ def run_cmd(
             + " or matched against the current working directory."
         ),
     ),
-    model: str = typer.Option(
-        "opus", "--model", "-m", help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)"
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)",
+        show_default="opus",
     ),
     strategy: str = typer.Option(
         "worktree",
@@ -72,7 +76,7 @@ def run_cmd(
     """Create a workspace and agent in one step."""
     base_url = base_url or get_default_base_url()
 
-    model_lower = model.lower()
+    model_lower = "opus" if model is None else model.lower()
     if model_lower not in MODEL_MAPPING:
         valid = ", ".join(MODEL_MAPPING.keys())
         cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
@@ -94,7 +98,7 @@ def run_cmd(
 
     backend_model = None
     if selection is not None and selection.agent_type == AgentTypeName.PI:
-        if model_lower != "opus":
+        if model is not None:
             cli_error(
                 "--model does not apply to the Pi harness — pi picks from its own catalog",
                 json_output=json_output,

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -207,6 +207,14 @@ class TestAgentCreate:
 
         assert result.exit_code == 1
 
+    def test_create_explicit_model_without_prompt_is_rejected(self, runner: CliRunner) -> None:
+        """--model configures the initial prompt's run, so a promptless create
+        rejects it — even when it names the flag's default."""
+        result = runner.invoke(app, ["agent", "create", "-w", "ws_test123", "-m", "opus"])
+
+        assert result.exit_code == 1
+        assert "has no effect without --prompt" in result.output + (result.stderr or "")
+
     @respx.mock
     def test_create_connection_error(self, runner: CliRunner) -> None:
         _mock_session()
@@ -234,6 +242,21 @@ class TestAgentCreateHarness:
         assert result.exit_code == 0
         body = json.loads(route.calls.last.request.content)
         assert body["agentType"] == "pi"
+
+    @respx.mock
+    def test_create_with_harness_pi_rejects_explicit_default_model_flag(self, runner: CliRunner) -> None:
+        """--model is rejected for a pi prompt even when it names the flag's
+        default — an explicit choice is never silently ignored."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+
+        result = runner.invoke(
+            app,
+            ["agent", "create", "-w", "ws_test123", "-p", "Do something", "--harness", "Pi", "--model", "opus"],
+        )
+
+        assert result.exit_code == 1
+        assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
 
     @respx.mock
     def test_create_with_harness_terminal_sends_terminal_agent_type(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_run.py
+++ b/tools/sculpt/tests/unit/test_run.py
@@ -403,12 +403,24 @@ _CLAUDE_CLI_REGISTRATION = {
 }
 
 
+_PI_MODEL_DICT = {"provider": "anthropic", "modelId": "claude-opus-4-8", "displayName": "Claude Opus 4.8"}
+
+
+def _mock_pi_models(available: list[dict[str, Any]], default: dict[str, Any] | None) -> None:
+    respx.get("http://localhost:5050/api/v1/pi/models").mock(
+        return_value=Response(200, json={"availableModels": available, "defaultModel": default})
+    )
+
+
 class TestRunHarness:
     @respx.mock
-    def test_run_with_harness_pi_sends_pi_agent_type(self, runner: CliRunner) -> None:
+    def test_run_with_harness_pi_sends_backend_model(self, runner: CliRunner) -> None:
+        """A pi prompt carries a backend_model from pi's own catalog — never a
+        placeholder Claude model."""
         _mock_session()
         _mock_initialize_project()
         _mock_preview_branch_name()
+        _mock_pi_models([_PI_MODEL_DICT], _PI_MODEL_DICT)
         respx.post("http://localhost:5050/api/v1/workspaces").mock(
             return_value=Response(200, json=_workspace_response_dict())
         )
@@ -421,6 +433,34 @@ class TestRunHarness:
         assert result.exit_code == 0, result.output + (result.stderr or "")
         body = json.loads(agent_route.calls.last.request.content)
         assert body["agentType"] == "pi"
+        assert body["backendModel"]["modelId"] == "claude-opus-4-8"
+        assert body["backendModel"]["provider"] == "anthropic"
+        assert "model" not in body
+
+    @respx.mock
+    def test_run_with_harness_pi_errors_when_no_usable_model(self, runner: CliRunner) -> None:
+        """An empty pi catalog (no authenticated provider) fails up front with the
+        authenticate pointer — before any workspace is created."""
+        _mock_session()
+        _mock_initialize_project()
+        _mock_pi_models([], None)
+
+        result = runner.invoke(app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi"])
+
+        assert result.exit_code != 0
+        assert "authenticate a provider" in result.output + (result.stderr or "")
+
+    @respx.mock
+    def test_run_with_harness_pi_rejects_claude_model_flag(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_initialize_project()
+
+        result = runner.invoke(
+            app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi", "--model", "sonnet"]
+        )
+
+        assert result.exit_code != 0
+        assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
 
     @respx.mock
     def test_run_without_harness_omits_agent_type(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_run.py
+++ b/tools/sculpt/tests/unit/test_run.py
@@ -463,6 +463,20 @@ class TestRunHarness:
         assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
 
     @respx.mock
+    def test_run_with_harness_pi_rejects_explicit_default_model_flag(self, runner: CliRunner) -> None:
+        """--model is rejected for pi even when it names the flag's default —
+        an explicit choice is never silently ignored."""
+        _mock_session()
+        _mock_initialize_project()
+
+        result = runner.invoke(
+            app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi", "--model", "opus"]
+        )
+
+        assert result.exit_code != 0
+        assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
+
+    @respx.mock
     def test_run_without_harness_omits_agent_type(self, runner: CliRunner) -> None:
         _mock_session()
         _mock_initialize_project()


### PR DESCRIPTION
## Why

Creating a workspace with a **pi** agent and an initial prompt could crash the agent before the user could do anything (SCU-1813): the modal offered no pi model picker ("Select your model after the workspace starts"), the backend required a model alongside any prompt so the frontend sent a placeholder Claude model that pi discards, and the queued prompt ran at startup against a model that could not run. For an unauthenticated user, the auth failure escaped the prompt-turn path and tore the whole agent down (`PiCrashError` + `ConcurrencyExceptionGroup`).

pi's catalog was knowable all along: discovery is a headless `pi --mode rpc` probe plus an `auth.json`/env read, and execution environments are local — a host-side probe observes the same catalog an in-workspace probe would (the Settings login flow already runs pi host-side). This PR makes model selection possible **before** the workspace exists, so the queued first prompt is valid by construction.

## What

- **`catalog_probe.py`** — the probe core extracted from the agent wrapper, shared by the in-task probe and the new host-side `probe_catalog_on_host` so the two surfaces cannot disagree. The host path strips the in-task keep-unauthenticated-current concession (no start-time reselect exists pre-create).
- **`GET /api/v1/pi/models`** — the host-probed, authenticated-only catalog for pre-create surfaces.
- **Create contract** — pi prompts carry `backend_model` (the chosen `ModelOption`), validated against the authenticated provider set (actionable 422s); mutually exclusive with Claude's `model`; the placeholder is gone. The accepted selection seeds the task's `current_model` at birth and start-time adoption runs the prompt under it; the eager pre-message probe preserves a seeded selection instead of clobbering it with pi's session default.
- **New Workspace modal** — a real pi model picker (shared `ModelSelector`, shared `hasNoUsableModel` predicate, login CTA routing to Settings → Pi). One rule gates every submit path: *a pi prompt is submittable only against a resolved, non-empty catalog with a selection; a promptless create never waits on the catalog.*
- **sculpt CLI** — pi prompts fetch the catalog and send `backend_model`; an empty catalog fails up front with the authenticate pointer; `--model` with pi is rejected instead of silently ignored.
- **Containment backstop** — a doomed prompt turn (e.g. credentials revoked between create and start) surfaces the per-turn error block via `PiTurnError` (an `AgentClientError`) with the login CTA, and the agent stays alive.

Spec: `agent_docs/pi-modal-model-picker/spec.md`.


<img width="2800" height="1800" alt="image" src="https://github.com/user-attachments/assets/a99f2e9c-7a47-4945-8aa4-676c4eeb5108" />

<img width="2800" height="1800" alt="image" src="https://github.com/user-attachments/assets/351f3ddc-30b0-4d27-91e3-022484b6f4ac" />

<img width="2800" height="1800" alt="image" src="https://github.com/user-attachments/assets/65f27281-cefb-44dc-9774-50ef55f36c50" />


## Testing

- `just check` and `just test-unit` green (backend, frontend, foundation, sculpt).
- Integration: `test_pi_model_picker_empty_state.py` and `test_pi_turn_error.py` pass.
- New coverage: probe core + host-boundary tests, endpoint tests, the create-contract 422 matrix, eager-probe selection preservation, prompt-turn containment, modal admission-rule tests, sculpt pi-path tests.
- Manual QA (headless browser): unauthenticated pi + prompt shows "No models available" + "Go to harness configuration" and Create refuses; after authenticating, the picker populates preselecting pi's default; create runs the prompt under the selection; with an invalid key the turn lands on a single contained `PiTurnError` block with login/retry CTAs and a live composer — no agent crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
