### PR TITLE
[SCU-1810] Fix sculpt client crash on string-detail 422 responses

### DIFF
--- a/sculptor/sculptor/scripts/generate_json_schema.py
+++ b/sculptor/sculptor/scripts/generate_json_schema.py
@@ -5,15 +5,37 @@ Generate an OpenAPI schema describing the pydantic types involved in all sculpto
 
 import json
 from pathlib import Path
+from typing import Any
 
 import typer
 
 from sculptor.web.app import APP
 
 
+def _widen_http_validation_error_detail(json_schema: dict[str, Any]) -> None:
+    """Allow a plain-string `detail` on the 422 error schema, not just a list.
+
+    FastAPI documents every 422 response with `HTTPValidationError`, whose
+    `detail` is a list of structured request-validation errors. But a
+    hand-raised `HTTPException(422, detail="...")` serializes `detail` as a
+    plain string, which does not match that schema. Widening `detail` to
+    `string | list[ValidationError]` makes the generated client parse both
+    shapes and surface the message instead of crashing on the string.
+    """
+    schema = json_schema.get("components", {}).get("schemas", {}).get("HTTPValidationError")
+    if schema is None:
+        return
+    detail = schema["properties"]["detail"]
+    schema["properties"]["detail"] = {
+        "anyOf": [detail, {"type": "string"}],
+        "title": detail.get("title", "Detail"),
+    }
+
+
 def main(output_path: Path = typer.Argument(Path("sculptor_schema.json"))) -> None:
     typer.echo("Generating JSON schema for sculptor web API...")
     json_schema = APP.openapi()
+    _widen_http_validation_error_detail(json_schema)
     with output_path.open("w", encoding="utf-8") as f:
         json.dump(json_schema, f, indent=2)
     typer.echo(f"JSON schema written to {output_path.resolve()}")

--- a/sculptor/sculptor/scripts/generate_json_schema.py
+++ b/sculptor/sculptor/scripts/generate_json_schema.py
@@ -13,21 +13,23 @@ from sculptor.web.app import APP
 
 
 def _widen_http_validation_error_detail(json_schema: dict[str, Any]) -> None:
-    """Allow a plain-string `detail` on the 422 error schema, not just a list.
+    """Allow a non-list `detail` on the 422 error schema, not just a list.
 
     FastAPI documents every 422 response with `HTTPValidationError`, whose
     `detail` is a list of structured request-validation errors. But a
-    hand-raised `HTTPException(422, detail="...")` serializes `detail` as a
-    plain string, which does not match that schema. Widening `detail` to
-    `string | list[ValidationError]` makes the generated client parse both
-    shapes and surface the message instead of crashing on the string.
+    hand-raised `HTTPException` can pass any JSON value: endpoints here raise
+    `detail="..."` (a plain string) and `detail={...}` (an object), neither of
+    which matches that schema. Widening `detail` to
+    `list[ValidationError] | string | object` makes the generated client parse
+    all three shapes and surface the value instead of crashing on the string
+    (it iterates a bare string per-character) or on the object.
     """
     schema = json_schema.get("components", {}).get("schemas", {}).get("HTTPValidationError")
     if schema is None:
         return
     detail = schema["properties"]["detail"]
     schema["properties"]["detail"] = {
-        "anyOf": [detail, {"type": "string"}],
+        "anyOf": [detail, {"type": "string"}, {"type": "object"}],
         "title": detail.get("title", "Detail"),
     }
 

--- a/tools/sculpt/tests/unit/test_http_validation_error.py
+++ b/tools/sculpt/tests/unit/test_http_validation_error.py
@@ -1,10 +1,10 @@
 """Unit tests for parsing 422 response bodies in the generated sculpt client.
 
-FastAPI serves two differently-shaped 422 bodies: request-validation failures
-carry a list of structured errors under `detail`, while a hand-raised
-`HTTPException(422, detail="...")` carries a plain string. The generated
-`HTTPValidationError.from_dict` must tolerate both so a plain-string detail
-surfaces its message instead of crashing.
+FastAPI serves 422 bodies with `detail` in more than one shape: request
+validation failures carry a list of structured errors, while a hand-raised
+`HTTPException(422, detail=...)` carries whatever was passed — a plain string,
+or a structured object. The generated `HTTPValidationError.from_dict` must
+tolerate any of these so a non-list detail surfaces instead of crashing.
 """
 
 from sculpt.client.models.http_validation_error import HTTPValidationError
@@ -29,3 +29,11 @@ def test_from_dict_parses_list_detail() -> None:
     assert len(result.detail) == 1
     assert isinstance(result.detail[0], ValidationError)
     assert result.detail[0].msg == "field required"
+
+
+def test_from_dict_tolerates_object_detail() -> None:
+    detail = {"code": "agent_plugin_loading_disabled", "message": "Agent plugin loading is disabled."}
+
+    result = HTTPValidationError.from_dict({"detail": detail})
+
+    assert result.detail == detail

--- a/tools/sculpt/tests/unit/test_http_validation_error.py
+++ b/tools/sculpt/tests/unit/test_http_validation_error.py
@@ -1,0 +1,31 @@
+"""Unit tests for parsing 422 response bodies in the generated sculpt client.
+
+FastAPI serves two differently-shaped 422 bodies: request-validation failures
+carry a list of structured errors under `detail`, while a hand-raised
+`HTTPException(422, detail="...")` carries a plain string. The generated
+`HTTPValidationError.from_dict` must tolerate both so a plain-string detail
+surfaces its message instead of crashing.
+"""
+
+from sculpt.client.models.http_validation_error import HTTPValidationError
+from sculpt.client.models.validation_error import ValidationError
+
+
+def test_from_dict_tolerates_string_detail() -> None:
+    message = "Testing model is only available when integration testing is enabled"
+
+    result = HTTPValidationError.from_dict({"detail": message})
+
+    assert result.detail == message
+    assert message in str(result)
+
+
+def test_from_dict_parses_list_detail() -> None:
+    result = HTTPValidationError.from_dict(
+        {"detail": [{"loc": ["body", "model"], "msg": "field required", "type": "value_error.missing"}]}
+    )
+
+    assert isinstance(result.detail, list)
+    assert len(result.detail) == 1
+    assert isinstance(result.detail[0], ValidationError)
+    assert result.detail[0].msg == "field required"

--- a/tools/sculpt/tests/unit/test_http_validation_error.py
+++ b/tools/sculpt/tests/unit/test_http_validation_error.py
@@ -32,8 +32,8 @@ def test_from_dict_parses_list_detail() -> None:
 
 
 def test_from_dict_tolerates_object_detail() -> None:
-    detail = {"code": "agent_plugin_loading_disabled", "message": "Agent plugin loading is disabled."}
+    # Some endpoints raise `HTTPException(422, detail={...})`, so a `detail`
+    # object must surface its content rather than crash the client.
+    result = HTTPValidationError.from_dict({"detail": {"error": "no setup command configured"}})
 
-    result = HTTPValidationError.from_dict({"detail": detail})
-
-    assert result.detail == detail
+    assert "no setup command configured" in str(result)


### PR DESCRIPTION
## Summary

The generated `sculpt` CLI client crashed with an opaque `ValueError` when the backend returned a 422 whose `detail` is a plain string, instead of surfacing the real error message. This widens the OpenAPI error schema so the generated client tolerates a string (or object) `detail`.

Linear: [SCU-1810](https://linear.app/imbue/issue/SCU-1810/sculpt-cli-client-crashes-parsing-string-detail-422-responses)

## Original bug

FastAPI serves 422 error bodies in two shapes:

- request-validation failures: `{"detail": [ {ValidationError}, ... ]}` (a list)
- a hand-raised `HTTPException(422, detail="...")`: `{"detail": "<message string>"}` (a plain string)

The OpenAPI schema documented only the list shape, so the generated client's `HTTPValidationError.from_dict` iterated the `detail` **string** character by character and called `ValidationError.from_dict("T")`, which does `dict("T")` and raises:

```
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

Any `sculpt` command that hit a plain-string 422 aborted with that opaque error instead of the backend's message (e.g. "Testing model is only available when integration testing is enabled").

## Reproduction

Run a `sculpt` command that triggers a string-detail 422 — e.g. create an agent with a testing-only model while integration testing is disabled. Minimal repro against the generated client:

```python
from sculpt.client.models.http_validation_error import HTTPValidationError
HTTPValidationError.from_dict({"detail": "Testing model is only available when integration testing is enabled"})
# -> ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

## Hypothesis / root cause

The mismatch is in the OpenAPI schema, not hand-written client code. FastAPI documents every 422 with `HTTPValidationError.detail: array[ValidationError]`, but `HTTPException(422, detail="...")` serializes a string, so the generated `from_dict` iterates a string per-character. Because the client is regenerated from the schema (`just generate-sculpt-client`), a hand-edit to the generated code would be overwritten — the fix has to live in the schema.

## Fix

`sculptor/sculptor/scripts/generate_json_schema.py` now post-processes the generated OpenAPI schema to widen `HTTPValidationError.detail` from `array[ValidationError]` to `anyOf: [array[ValidationError], string]`. `openapi-python-client` then emits a `_parse_detail` that tries the list shape and falls back to returning the raw value, so a string (or object) `detail` is surfaced instead of crashing. The same schema feeds both the sculpt CLI client and the frontend TypeScript client, so both regenerate consistently and the repo typecheck/lint stays green.

## Proof the fix works

Non-UI bug (CLI / generated client), so verified with a unit test rather than screenshots. The regression test and the fix are in the same commit (`f7837421`); the test fails on the pre-fix client and passes after regeneration.

**Before** (pre-fix generated client):

```
FAILED tools/sculpt/tests/unit/test_http_validation_error.py::test_from_dict_tolerates_string_detail
E   ValueError: dictionary update sequence element #0 has length 1; 2 is required
1 failed, 1 passed
```

**After** (client regenerated from the widened schema):

```
tools/sculpt/tests/unit/test_http_validation_error.py::test_from_dict_tolerates_string_detail PASSED
tools/sculpt/tests/unit/test_http_validation_error.py::test_from_dict_parses_list_detail PASSED
tools/sculpt/tests/unit/test_http_validation_error.py::test_from_dict_tolerates_object_detail PASSED
3 passed
```

`just format`, `just check` (regenerates both clients; typecheck + lint + ratchets), and `just test-unit` (backend, frontend, foundation, sculpt) all pass.

## Deferred follow-ups

- [SCU-1809](https://linear.app/imbue/issue/SCU-1809/fakeclaude-testing-model-gate-reportedly-rejects-the-2nd-agent-mid) — the reported FakeClaude `TESTING__INTEGRATION_ENABLED` mid-session drift (the string-detail 422 above surfaces the same "Testing model…" error). Could not reproduce it on current `main`; the ticket documents the investigation and a proposed robust fix.

## Review notes

Reviewed via `/code-review-checklist`. One LOW finding — missing coverage for the object/dict `detail` shape, which the fix also handles — addressed in `fa853e14`. No outstanding review notes.

(Sent by Claude)
