### PR TITLE
Sync the Android PWA status bar color with the app theme

### DIFF
--- a/sculptor/frontend/src/common/theme/statusBarThemeColor.test.ts
+++ b/sculptor/frontend/src/common/theme/statusBarThemeColor.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { syncStatusBarThemeColor } from "./statusBarThemeColor.ts";
+
+const getMeta = (): HTMLMetaElement | null => {
+  return document.head.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+};
+
+// jsdom does not resolve CSS custom properties, so the --gray-2 read is
+// stubbed at the getComputedStyle boundary.
+const stubComputedGray2 = (value: string): void => {
+  vi.spyOn(window, "getComputedStyle").mockReturnValue({
+    getPropertyValue: (property: string): string => (property === "--gray-2" ? value : ""),
+  } as unknown as CSSStyleDeclaration);
+};
+
+describe("syncStatusBarThemeColor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getMeta()?.remove();
+  });
+
+  it("creates the meta tag with the computed --gray-2 color", () => {
+    stubComputedGray2(" #212225 ");
+
+    syncStatusBarThemeColor(document.createElement("div"), false);
+
+    expect(getMeta()?.content).toBe("#212225");
+  });
+
+  it("updates an existing meta tag instead of adding another", () => {
+    const existing = document.createElement("meta");
+    existing.name = "theme-color";
+    existing.content = "#f2f0e7";
+    document.head.appendChild(existing);
+    stubComputedGray2("#212225");
+
+    syncStatusBarThemeColor(document.createElement("div"), false);
+
+    expect(document.head.querySelectorAll('meta[name="theme-color"]')).toHaveLength(1);
+    expect(existing.content).toBe("#212225");
+  });
+
+  it("leaves the document untouched when --gray-2 does not resolve", () => {
+    stubComputedGray2("");
+
+    syncStatusBarThemeColor(document.createElement("div"), false);
+
+    expect(getMeta()).toBeNull();
+  });
+
+  it("pins the dev-preview color regardless of the theme", () => {
+    stubComputedGray2("#212225");
+
+    syncStatusBarThemeColor(document.createElement("div"), true);
+
+    expect(getMeta()?.content).toBe("#f76b15");
+  });
+});

--- a/sculptor/frontend/src/common/theme/statusBarThemeColor.ts
+++ b/sculptor/frontend/src/common/theme/statusBarThemeColor.ts
@@ -1,0 +1,35 @@
+/**
+ * Keeps the document's `<meta name="theme-color">` in sync with the app's
+ * top surface color. On Android, Chrome paints the standalone-PWA status
+ * bar with this value (and picks light/dark status icons from its
+ * luminance), so without it the bar stays the static manifest
+ * `theme_color` — a light cream — even when the app renders dark.
+ *
+ * The color is read from the live `--gray-2` CSS variable (the surface
+ * the sidebar, app shell, and workspace header share at the top of the
+ * viewport) rather than hard-coded per appearance, so theme builder gray
+ * overrides are reflected too.
+ *
+ * Dev builds instead pin a fixed orange, so an installed PWA pointed at a
+ * Vite dev preview is instantly distinguishable from prod by its status
+ * bar. Everywhere theme-color has no effect (Electron, desktop browsers)
+ * the meta tag is inert.
+ */
+
+/** Radix orange-9 — the dev-preview status bar indicator. */
+const DEV_PREVIEW_COLOR = "#f76b15";
+
+export const syncStatusBarThemeColor = (themeRoot: HTMLElement, isDevPreview: boolean = import.meta.env.DEV): void => {
+  const color = isDevPreview ? DEV_PREVIEW_COLOR : getComputedStyle(themeRoot).getPropertyValue("--gray-2").trim();
+  if (color === "") {
+    return;
+  }
+
+  let meta = document.head.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (meta === null) {
+    meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.appendChild(meta);
+  }
+  meta.content = color;
+};

--- a/sculptor/frontend/src/components/ThemeProvider.tsx
+++ b/sculptor/frontend/src/components/ThemeProvider.tsx
@@ -7,6 +7,7 @@ import { COLOR_SETTING_KEYS, DEFAULT_HEX_OVERRIDES } from "~/common/state/atoms/
 import { useThemeBuilderSettings } from "~/common/state/hooks/useThemeBuilder.ts";
 import { generateColorScale, isValidHex } from "~/common/theme/generateColorScale.ts";
 import { getColorScale, resolveGrayColor } from "~/common/theme/radixColorHexMap.ts";
+import { syncStatusBarThemeColor } from "~/common/theme/statusBarThemeColor.ts";
 import { useResolvedTheme } from "~/common/Utils.ts";
 
 /**
@@ -183,6 +184,16 @@ export const ImbueTheme = ({ children }: PropsWithChildren): ReactElement => {
     });
   }, [appearance]);
 
+  const themeRootRef = useRef<HTMLDivElement>(null);
+
+  // Declared after the effect above so the root theme class is already
+  // corrected when the status bar color is computed from the live CSS vars.
+  useLayoutEffect(() => {
+    if (themeRootRef.current !== null) {
+      syncStatusBarThemeColor(themeRootRef.current);
+    }
+  }, [appearance, settings]);
+
   return (
     <RadixTheme
       accentColor={settings.accentColor}
@@ -193,7 +204,11 @@ export const ImbueTheme = ({ children }: PropsWithChildren): ReactElement => {
       scaling={settings.scaling}
       style={fontStyles}
     >
-      <div style={overrideStyles}>{children}</div>
+      {/* Hex overrides land on this div (not the Radix root), so it is
+          also where the status bar color must be read from. */}
+      <div ref={themeRootRef} style={overrideStyles}>
+        {children}
+      </div>
     </RadixTheme>
   );
 };


### PR DESCRIPTION
## Why

The PWA manifest's `theme_color` is a static light cream picked to match the install splash, and on Android that's what Chrome paints the standalone status bar with — so the bar stays cream even when the app renders in dark mode.

## What

- `ImbueTheme` now upserts a document-level `<meta name="theme-color">` whenever the effective appearance or theme-builder settings change. Chrome prefers that meta over the manifest and re-reads it on change, so the status bar follows the app theme, including mid-session switches.
- The color is read at runtime from the computed `--gray-2` variable (the surface the sidebar, app shell, and workspace header share at the top of the viewport), off the div that carries theme-builder hex overrides — so custom gray overrides tint the bar too.
- Dev builds (`import.meta.env.DEV`, i.e. anything served by the Vite dev server) pin the meta to a fixed orange instead, making an installed PWA that's pointed at a dev preview instantly distinguishable from prod by its status bar. Since the meta is per-document, switching between prod and a preview flips the color automatically in both directions.
- The manifest `theme_color`/`background_color` stay as-is: they still drive the install splash, which shows before any JS runs.

The meta tag is inert everywhere `theme-color` isn't honored (Electron, desktop browsers), so no gating is needed.

## Testing

- New unit tests for the meta sync (create, update-in-place, no-op when the variable doesn't resolve, dev-pin).
- Full frontend suite and `tsc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)