### PR TITLE
[SCU-1820] Fix spurious turn footer when unqueuing a message mid-turn

### DIFF
--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -656,36 +656,43 @@ def convert_agent_messages_to_task_update(
             pending_turn_metrics = msg.turn_metrics
 
         elif isinstance(msg, RequestSuccessAgentMessage):
-            # When the turn was interrupted before any content was streamed, there may
-            # be no in-progress message yet. Create an empty one so the frontend can
-            # render the "Stopped" footer — but only when this RequestSuccess is for
-            # the active request (so _finalize_request will move the synthesized
-            # message into completed_chat_messages on the same pass). Synthesizing
-            # for a stale request_id (e.g. the lifecycle RequestSuccess of an
-            # InterruptProcessUserMessage emitted after the active request was
-            # already finalized) leaves the message dangling as in_progress and
-            # freezes the StatusPill in a "thinking" state.
-            #
-            # Also skip synthesis when there's a queued user message waiting to
-            # replace this turn — that's the always-interrupt-and-send / keyboard-
-            # shortcut-interrupt flow where the user is moving on, not stopping.
-            # Surfacing an empty "Interrupted by user" marker for the replaced
-            # turn would leave a dangling assistant message between the two user
-            # turns.
+            # Only run end-of-turn logic when this RequestSuccess belongs to the
+            # active content turn. Lifecycle requests (e.g. RemoveQueuedMessage)
+            # emit their OWN RequestStarted/RequestSuccess pair; running the side
+            # effects below for one of those while a real turn is still open would
+            # corrupt it: attaching the turn's still-pending metrics stamps a
+            # spurious turn footer (token counts) onto the in-progress message,
+            # clearing pending_background_task_ids drops the "waiting for
+            # background task" state, and resetting streaming mid-stream breaks
+            # partial assembly. All of it must wait for the turn's real
+            # RequestSuccess. Mirrors the can_finalize gate in the RequestStopped
+            # branch below.
             can_finalize = current_request_id is not None and current_request_id == msg.request_id
             has_pending_replacement = bool(queued_chat_messages)
-            if in_progress_chat_message is None and msg.interrupted and can_finalize and not has_pending_replacement:
-                in_progress_chat_message = _create_empty_assistant_message(
-                    chat_message_id=msg.message_id,
-                    approximate_creation_time=msg.approximate_creation_time,
-                )
-            if msg.interrupted:
-                in_progress_chat_message = _mark_stopped(in_progress_chat_message)
-                # Clear any pending AUQs — the agent was interrupted so the questions
-                # are no longer valid and the chat input should reappear.
-                pending_user_questions.clear()
-            in_progress_chat_message = _attach_turn_metrics(in_progress_chat_message, pending_turn_metrics)
-            pending_turn_metrics = None
+            if can_finalize:
+                # When the turn was interrupted before any content was streamed, there may
+                # be no in-progress message yet. Create an empty one so the frontend can
+                # render the "Stopped" footer — _finalize_request will move the synthesized
+                # message into completed_chat_messages on the same pass.
+                #
+                # Skip synthesis when there's a queued user message waiting to
+                # replace this turn — that's the always-interrupt-and-send / keyboard-
+                # shortcut-interrupt flow where the user is moving on, not stopping.
+                # Surfacing an empty "Interrupted by user" marker for the replaced
+                # turn would leave a dangling assistant message between the two user
+                # turns.
+                if in_progress_chat_message is None and msg.interrupted and not has_pending_replacement:
+                    in_progress_chat_message = _create_empty_assistant_message(
+                        chat_message_id=msg.message_id,
+                        approximate_creation_time=msg.approximate_creation_time,
+                    )
+                if msg.interrupted:
+                    in_progress_chat_message = _mark_stopped(in_progress_chat_message)
+                    # Clear any pending AUQs — the agent was interrupted so the questions
+                    # are no longer valid and the chat input should reappear.
+                    pending_user_questions.clear()
+                in_progress_chat_message = _attach_turn_metrics(in_progress_chat_message, pending_turn_metrics)
+                pending_turn_metrics = None
             in_progress_chat_message, current_request_id = _finalize_request(
                 current_request_id,
                 msg.request_id,
@@ -693,8 +700,9 @@ def convert_agent_messages_to_task_update(
                 completed_message_by_id,
                 completed_chat_messages,
             )
-            streaming.reset()
-            pending_background_task_ids.clear()
+            if can_finalize:
+                streaming.reset()
+                pending_background_task_ids.clear()
 
         elif isinstance(msg, RequestFailureAgentMessage):
             in_progress_chat_message = _add_error_to_message(in_progress_chat_message, msg)

--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -668,7 +668,6 @@ def convert_agent_messages_to_task_update(
             # RequestSuccess. Mirrors the can_finalize gate in the RequestStopped
             # branch below.
             can_finalize = current_request_id is not None and current_request_id == msg.request_id
-            has_pending_replacement = bool(queued_chat_messages)
             if can_finalize:
                 # When the turn was interrupted before any content was streamed, there may
                 # be no in-progress message yet. Create an empty one so the frontend can
@@ -681,6 +680,7 @@ def convert_agent_messages_to_task_update(
                 # Surfacing an empty "Interrupted by user" marker for the replaced
                 # turn would leave a dangling assistant message between the two user
                 # turns.
+                has_pending_replacement = bool(queued_chat_messages)
                 if in_progress_chat_message is None and msg.interrupted and not has_pending_replacement:
                     in_progress_chat_message = _create_empty_assistant_message(
                         chat_message_id=msg.message_id,
@@ -705,10 +705,18 @@ def convert_agent_messages_to_task_update(
                 pending_background_task_ids.clear()
 
         elif isinstance(msg, RequestFailureAgentMessage):
-            in_progress_chat_message = _add_error_to_message(in_progress_chat_message, msg)
-            # Clear any pending AUQs — the agent failed so the questions
-            # are no longer valid and the chat input should reappear.
-            pending_user_questions.clear()
+            # Only surface the failure on the active turn. Lifecycle requests
+            # (e.g. RemoveQueuedMessage) emit their own RequestStarted/Failure
+            # pair when their handler raises; running these side effects for one
+            # of those while a real turn is still open would stamp its error
+            # block onto the in-progress message and reset the live turn's
+            # streaming / background-wait state. See the RequestSuccess branch.
+            can_finalize = current_request_id is not None and current_request_id == msg.request_id
+            if can_finalize:
+                in_progress_chat_message = _add_error_to_message(in_progress_chat_message, msg)
+                # Clear any pending AUQs — the agent failed so the questions
+                # are no longer valid and the chat input should reappear.
+                pending_user_questions.clear()
             in_progress_chat_message, current_request_id = _finalize_request(
                 current_request_id,
                 msg.request_id,
@@ -716,8 +724,9 @@ def convert_agent_messages_to_task_update(
                 completed_message_by_id,
                 completed_chat_messages,
             )
-            streaming.reset()
-            pending_background_task_ids.clear()
+            if can_finalize:
+                streaming.reset()
+                pending_background_task_ids.clear()
 
         elif isinstance(msg, RequestStoppedAgentMessage):
             # Only synthesize a stopped message when this stop is for the
@@ -758,10 +767,15 @@ def convert_agent_messages_to_task_update(
                 completed_message_by_id,
                 completed_chat_messages,
             )
-            streaming.reset()
-            pending_background_task_ids.clear()
+            if can_finalize:
+                streaming.reset()
+                pending_background_task_ids.clear()
 
         elif isinstance(msg, RequestSkippedAgentMessage):
+            # A skipped request that isn't the active turn (e.g. the agent skips
+            # an already-removed queued message) must not reset the live turn's
+            # streaming / background-wait state. See the RequestSuccess branch.
+            can_finalize = current_request_id is not None and current_request_id == msg.request_id
             in_progress_chat_message, current_request_id = _finalize_request(
                 current_request_id,
                 msg.request_id,
@@ -769,8 +783,9 @@ def convert_agent_messages_to_task_update(
                 completed_message_by_id,
                 completed_chat_messages,
             )
-            streaming.reset()
-            pending_background_task_ids.clear()
+            if can_finalize:
+                streaming.reset()
+                pending_background_task_ids.clear()
 
         elif isinstance(msg, ERROR_MESSAGE_TYPES):
             # Add error block to assistant message

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -3659,6 +3659,120 @@ def test_turn_metrics_attached_when_stopped() -> None:
     assert completed_assistant[0].stopped is True
 
 
+def test_unqueue_during_background_wait_does_not_stamp_turn_footer() -> None:
+    """Unqueuing a message while the turn is still running (waiting on a
+    background task) must not stamp that turn's pending metrics onto its
+    in-progress message.
+
+    Repro: while the agent waits for a background task, its foreground turn has
+    already emitted ``TurnMetricsAgentMessage`` (so metrics are *pending*) but the
+    request stays open — ``RequestSuccess`` for the real turn has not arrived yet.
+    Queue a message and then unqueue it in that window: the RemoveQueuedMessage
+    lifecycle emits its OWN ``RequestStarted``/``RequestSuccess`` pair. That
+    lifecycle ``RequestSuccess`` does NOT belong to the active turn, so it must
+    not run end-of-turn side effects. Previously it did — unconditionally
+    attaching the pending metrics (a spurious turn footer with token counts that
+    persisted until the turn actually finished and survived a reload) and
+    clearing the background-task wait state. Mirrors the ``can_finalize`` gate in
+    the RequestStopped branch.
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+
+    # Turn A streams its foreground response and launches a background task.
+    user_message = ChatInputUserMessage(text="do a bg thing", model_name=LLMModel.CLAUDE_4_SONNET)
+    state = convert_agent_messages_to_task_update(
+        [user_message],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+
+    assistant_message_id = AssistantMessageID("assistant-bg-wait")
+    metrics = _make_turn_metrics()
+    state = convert_agent_messages_to_task_update(
+        [
+            RequestStartedAgentMessage(request_id=user_message.message_id),
+            ResponseBlockAgentMessage(
+                role="assistant",
+                assistant_message_id=assistant_message_id,
+                message_id=AgentMessageID(),
+                content=(TextBlock(text="Launching background work"),),
+            ),
+            BackgroundTaskStartedAgentMessage(
+                background_task_id="bg-task-1",
+                tool_use_id=ToolUseID("toolu-bg"),
+                description="Find Python files",
+            ),
+            # Foreground turn-end: metrics are emitted but the request stays open
+            # because the background task is still in flight (no RequestSuccess yet).
+            TurnMetricsAgentMessage(turn_metrics=metrics),
+        ],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    # Sanity: the turn is still running (metrics only pending, not attached), and
+    # the background-task wait is in effect.
+    assert state.in_progress_chat_message is not None
+    assert state.in_progress_chat_message.turn_metrics is None
+    assert state.in_progress_user_message_id == user_message.message_id
+    assert set(state.pending_background_task_ids) == {"bg-task-1"}
+
+    # User queues a message, then unqueues it via the RemoveQueuedMessage
+    # lifecycle (its own RequestStarted/RequestSuccess pair).
+    queued_message = ChatInputUserMessage(text="test", model_name=LLMModel.CLAUDE_4_SONNET)
+    state = convert_agent_messages_to_task_update(
+        [queued_message],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    assert len(state.queued_chat_messages) == 1
+
+    remove_request_id = AgentMessageID()
+    state = convert_agent_messages_to_task_update(
+        [
+            RequestStartedAgentMessage(request_id=remove_request_id),
+            RemoveQueuedMessageAgentMessage(removed_message_id=queued_message.message_id),
+            RequestSuccessAgentMessage(request_id=remove_request_id, interrupted=False),
+        ],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+
+    # The turn is still running — the lifecycle RequestSuccess must NOT have
+    # finalized it or stamped the pending metrics onto the in-progress message.
+    assert state.in_progress_chat_message is not None, "the active turn must not be finalized by the remove lifecycle"
+    assert state.in_progress_chat_message.turn_metrics is None, (
+        "pending turn metrics must not be attached to the still-running turn (spurious turn footer)"
+    )
+    assert state.in_progress_chat_message.stopped is False
+    assert state.in_progress_user_message_id == user_message.message_id
+    assert len(state.queued_chat_messages) == 0
+    # The background-task wait must survive — the lifecycle success must not clear it.
+    assert set(state.pending_background_task_ids) == {"bg-task-1"}
+
+    # When the real turn finally finishes, the (preserved) metrics attach then —
+    # so the footer still shows on the completed message at the correct time.
+    state = convert_agent_messages_to_task_update(
+        [RequestSuccessAgentMessage(request_id=user_message.message_id)],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    assert state.in_progress_chat_message is None
+    completed_assistant = [m for m in state.chat_messages if m.role == ChatMessageRole.ASSISTANT]
+    assert len(completed_assistant) == 1
+    assert completed_assistant[0].turn_metrics == metrics
+
+
 # ========== Background Task Notification Tests ==========
 
 

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -3773,6 +3773,118 @@ def test_unqueue_during_background_wait_does_not_stamp_turn_footer() -> None:
     assert completed_assistant[0].turn_metrics == metrics
 
 
+def _setup_turn_running_with_background_wait() -> tuple[
+    TaskID, dict[AgentMessageID, ChatMessage], ChatInputUserMessage, TurnMetrics, TaskUpdate
+]:
+    """Set up a turn that is streaming a foreground response and waiting on a
+    background task: its metrics are emitted but still pending because the
+    request has not received its RequestSuccess yet."""
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+
+    user_message = ChatInputUserMessage(text="do a bg thing", model_name=LLMModel.CLAUDE_4_SONNET)
+    state = convert_agent_messages_to_task_update(
+        [user_message],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+
+    metrics = _make_turn_metrics()
+    state = convert_agent_messages_to_task_update(
+        [
+            RequestStartedAgentMessage(request_id=user_message.message_id),
+            ResponseBlockAgentMessage(
+                role="assistant",
+                assistant_message_id=AssistantMessageID("assistant-bg-sibling"),
+                message_id=AgentMessageID(),
+                content=(TextBlock(text="Launching background work"),),
+            ),
+            BackgroundTaskStartedAgentMessage(
+                background_task_id="bg-task-1",
+                tool_use_id=ToolUseID("toolu-bg"),
+                description="Find Python files",
+            ),
+            TurnMetricsAgentMessage(turn_metrics=metrics),
+        ],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    assert state.in_progress_chat_message is not None
+    assert state.in_progress_chat_message.turn_metrics is None
+    assert state.in_progress_user_message_id == user_message.message_id
+    assert set(state.pending_background_task_ids) == {"bg-task-1"}
+    return task_id, completed_by_id, user_message, metrics, state
+
+
+def test_skip_of_removed_message_during_background_wait_does_not_corrupt_active_turn() -> None:
+    """When the agent skips an already-removed queued message mid-turn, the
+    RequestSkipped is for that skipped message — not the active turn — so it
+    must not reset the running turn's streaming / background-wait state."""
+    task_id, completed_by_id, user_message, metrics, state = _setup_turn_running_with_background_wait()
+
+    # A message was queued and removed; the agent reaches it and skips it. The
+    # RequestStarted does not promote (it is no longer queued) and must not
+    # clobber the active request; RequestSkipped carries the skipped id.
+    skipped_id = AgentMessageID()
+    state = convert_agent_messages_to_task_update(
+        [
+            RequestStartedAgentMessage(request_id=skipped_id),
+            RequestSkippedAgentMessage(request_id=skipped_id),
+        ],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+
+    assert state.in_progress_chat_message is not None
+    assert state.in_progress_chat_message.turn_metrics is None
+    assert state.in_progress_user_message_id == user_message.message_id
+    assert set(state.pending_background_task_ids) == {"bg-task-1"}
+
+    # The real turn still finalizes correctly, attaching its metrics.
+    state = convert_agent_messages_to_task_update(
+        [RequestSuccessAgentMessage(request_id=user_message.message_id)],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+    completed_assistant = [m for m in state.chat_messages if m.role == ChatMessageRole.ASSISTANT]
+    assert len(completed_assistant) == 1
+    assert completed_assistant[0].turn_metrics == metrics
+
+
+def test_failure_of_lifecycle_request_during_background_wait_does_not_corrupt_active_turn() -> None:
+    """A RequestFailure for a non-active (lifecycle) request must not stamp an
+    error block onto the running turn's message or reset its state."""
+    task_id, completed_by_id, user_message, metrics, state = _setup_turn_running_with_background_wait()
+
+    # A lifecycle request (e.g. a failed RemoveQueuedMessage handler) fails with
+    # its own request_id while the real turn is still open.
+    lifecycle_id = AgentMessageID()
+    state = convert_agent_messages_to_task_update(
+        [RequestFailureAgentMessage(request_id=lifecycle_id, error=_make_serialized_exception("write failed"))],
+        task_id=task_id,
+        harness=CLAUDE_CODE_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+
+    in_progress = state.in_progress_chat_message
+    assert in_progress is not None
+    assert not any(isinstance(block, ErrorBlock) for block in in_progress.content), (
+        "a lifecycle failure must not stamp an error block onto the active turn"
+    )
+    assert in_progress.turn_metrics is None
+    assert state.in_progress_user_message_id == user_message.message_id
+    assert set(state.pending_background_task_ids) == {"bg-task-1"}
+
+
 # ========== Background Task Notification Tests ==========
 
 


### PR DESCRIPTION
## Summary

Unqueuing a queued message while an agent turn is still running could make a **turn-end footer (token count / context) appear on the still-running message** and clear the "waiting for background task" state. It persisted until the turn actually finished and **survived a hard reload**.

It reproduces most easily when the agent is **waiting for a background task**: queue a message, then unqueue it — the footer with token count/context appears immediately.

Fixes SCU-1820.

## Root cause

In `sculptor/sculptor/web/message_conversion.py`, the `RequestSuccess` branch ran its end-of-turn side effects (`_attach_turn_metrics`, `_mark_stopped`, `streaming.reset()`, `pending_background_task_ids.clear()`) **without checking that the success belonged to the active turn**.

Unqueuing fires a `RemoveQueuedMessage` lifecycle that emits its **own** `RequestStarted`/`RequestSuccess` pair. During a background-task wait the real turn's `TurnMetricsAgentMessage` is already emitted but still **pending** (the request stays open for the background `task_notification`). The lifecycle success therefore stamped the pending metrics onto the in-progress message (the footer), cleared the background-wait state, and reset streaming mid-stream. All of it re-derives from the persisted message log, so it survived a reload.

## Fix

Gate those side effects behind `can_finalize` (`current_request_id == msg.request_id`) — the same guard the sibling `RequestStopped` branch already used — so only the active turn's own `RequestSuccess` ends the turn.

A code-review pass surfaced that the sibling terminal branches (`RequestFailure`, `RequestStopped`, `RequestSkipped`) had the *same* ungated hazard, reachable through the same remove flow (a failing lifecycle handler emits `RequestFailure`/`RequestStopped`; the agent reaching an already-removed message emits `RequestSkipped`). The gate is now applied uniformly across all four terminal branches to close that hole and remove the asymmetry.

## Tests

- `test_unqueue_during_background_wait_does_not_stamp_turn_footer` — reproduces the exact bg-wait → queue → unqueue sequence; asserts the still-running turn keeps no footer, the background-wait state survives, and the metrics correctly attach at the *real* turn end.
- `test_skip_of_removed_message_during_background_wait_does_not_corrupt_active_turn` and `test_failure_of_lifecycle_request_during_background_wait_does_not_corrupt_active_turn` — cover the sibling branches.

All three fail without the corresponding fix and pass with it (verified by reverting the source hunk). Full backend suite green; `just format` / `just check` clean.

## Why a unit test, not an e2e

The trigger — a `TurnMetricsAgentMessage` sitting *pending* while the request stays open during a background wait — depends on real-Claude timing. FakeClaude never emits it during a background wait (the output processor only flushes stashed metrics on loop-exit or a context-usage response, neither of which the paused FakeClaude produces), so a converter unit test reproduces the message sequence deterministically instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
