### PR TITLE
[SCU-1822] Integration test coverage for the mobile UI

### DIFF
--- a/sculptor/frontend/src/pages/home/MobileHomeHeader.tsx
+++ b/sculptor/frontend/src/pages/home/MobileHomeHeader.tsx
@@ -2,6 +2,8 @@ import { IconButton } from "@radix-ui/themes";
 import { SquareMenu } from "lucide-react";
 import type { ReactElement } from "react";
 
+import { ElementIds } from "~/api";
+
 import styles from "./MobileHomeHeader.module.scss";
 
 type MobileHomeHeaderProps = {
@@ -17,7 +19,7 @@ type MobileHomeHeaderProps = {
  */
 export const MobileHomeHeader = ({ onOpenDrawer }: MobileHomeHeaderProps): ReactElement => {
   return (
-    <header className={`mobileTheme ${styles.header}`}>
+    <header className={`mobileTheme ${styles.header}`} data-testid={ElementIds.MOBILE_HOME_HEADER}>
       <IconButton
         variant="ghost"
         color="gray"

--- a/sculptor/frontend/src/pages/settings/MobileSettingsHeader.tsx
+++ b/sculptor/frontend/src/pages/settings/MobileSettingsHeader.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft } from "lucide-react";
 import type { ReactElement } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import { ElementIds } from "~/api";
 import { useImbueNavigate } from "~/common/NavigateUtils.ts";
 
 import styles from "./MobileSettingsHeader.module.scss";
@@ -31,7 +32,7 @@ export const MobileSettingsHeader = (): ReactElement => {
   };
 
   return (
-    <header className={`mobileTheme ${styles.header}`}>
+    <header className={`mobileTheme ${styles.header}`} data-testid={ElementIds.MOBILE_SETTINGS_HEADER}>
       <IconButton variant="ghost" color="gray" className={styles.iconButton} aria-label="Back" onClick={handleBack}>
         <ChevronLeft size={22} />
       </IconButton>

--- a/sculptor/frontend/src/pages/workspace/WorkspacePage.tsx
+++ b/sculptor/frontend/src/pages/workspace/WorkspacePage.tsx
@@ -21,9 +21,9 @@ import { WorkspaceLayoutShell } from "./WorkspaceLayoutShell.tsx";
 // The desktop shell, bootstrapped for the active workspace + agent: scope switch,
 // registry sync, and center-agent placement happen here so the center renders the
 // resolved agent's chat. `taskId` is undefined for a workspace with no agents,
-// which renders the shell with an empty center. The mobile branch
-// (MobileWorkspaceShell) is not built yet — useIsMobile is a no-op seam that
-// always takes this path.
+// which renders the shell with an empty center. Narrow browser viewports take the
+// mobile branch in WorkspacePage below (MobileWorkspaceShell) instead of this
+// desktop shell; this content only renders on desktop.
 const WorkspacePageContent = ({ workspaceId, taskId }: { workspaceId: string; taskId?: string }): ReactElement => {
   useWorkspaceShellBootstrap({ workspaceId, taskId });
 

--- a/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/ChatInput.tsx
@@ -863,7 +863,13 @@ export const ChatInput = ({
               {isMobile ? (
                 <DropdownMenu.Root>
                   <DropdownMenu.Trigger>
-                    <IconButton variant="ghost" size="3" aria-label="Message options" style={{ margin: 0 }}>
+                    <IconButton
+                      variant="ghost"
+                      size="3"
+                      aria-label="Message options"
+                      data-testid={ElementIds.MOBILE_CHAT_INPUT_OPTIONS}
+                      style={{ margin: 0 }}
+                    >
                       <SlidersHorizontal size={16} />
                     </IconButton>
                   </DropdownMenu.Trigger>
@@ -882,7 +888,7 @@ export const ChatInput = ({
                       {(isPlanFirst || isInPlanMode) && <Check size={14} className={styles.menuTrailing} />}
                     </DropdownMenu.Item>
                     <DropdownMenu.Sub>
-                      <DropdownMenu.SubTrigger>
+                      <DropdownMenu.SubTrigger data-testid={ElementIds.MOBILE_CHAT_INPUT_MODEL_SUBMENU}>
                         <Bot size={16} /> {getModelShortName(localModel)}
                       </DropdownMenu.SubTrigger>
                       <DropdownMenu.SubContent className="mobileTheme">
@@ -899,7 +905,7 @@ export const ChatInput = ({
                       </DropdownMenu.SubContent>
                     </DropdownMenu.Sub>
                     <DropdownMenu.Sub>
-                      <DropdownMenu.SubTrigger>
+                      <DropdownMenu.SubTrigger data-testid={ElementIds.MOBILE_CHAT_INPUT_EFFORT_SUBMENU}>
                         <Gauge size={16} /> {EFFORT_DISPLAY_NAMES[effort]}
                       </DropdownMenu.SubTrigger>
                       <DropdownMenu.SubContent className="mobileTheme">
@@ -916,7 +922,10 @@ export const ChatInput = ({
                       </DropdownMenu.SubContent>
                     </DropdownMenu.Sub>
                     {modelCapabilities.supportsFastMode && canUseFastMode && (
-                      <DropdownMenu.Item onSelect={() => setIsFastMode(!isFastMode)}>
+                      <DropdownMenu.Item
+                        onSelect={() => setIsFastMode(!isFastMode)}
+                        data-testid={ElementIds.MOBILE_CHAT_INPUT_FAST_MODE_ITEM}
+                      >
                         <Zap size={16} /> Fast mode
                         {isFastMode && <Check size={14} className={styles.menuTrailing} />}
                       </DropdownMenu.Item>
@@ -1002,7 +1011,7 @@ export const ChatInput = ({
           )}
         </div>
         {!isMobile && (
-          <Flex justify="between" mt="2" gap="3">
+          <Flex justify="between" mt="2" gap="3" data-testid={ElementIds.CHAT_INPUT_KEYBOARD_HINTS}>
             <Flex gap="3" align="center">
               {showPromptNavHint && <KeyboardHint keys="↑↓" label="navigate prompts" />}
             </Flex>

--- a/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/diffPanel/CombinedDiffView.tsx
@@ -328,7 +328,7 @@ export const CombinedDiffView = ({
   return (
     <div ref={contentRef} className={isActive ? styles.wrapper : styles.wrapperHidden}>
       {!hideToolbar && (
-        <div className={styles.toolbar}>
+        <div className={styles.toolbar} data-testid={ElementIds.COMBINED_DIFF_TOOLBAR}>
           <TooltipIconButton
             tooltipText="Previous file"
             size="1"

--- a/sculptor/frontend/src/pages/workspace/mobile/AgentSheet.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/AgentSheet.tsx
@@ -4,7 +4,7 @@ import { Check, Pencil, Plus, Trash2 } from "lucide-react";
 import type { ReactElement } from "react";
 import { useMemo, useState } from "react";
 
-import type { CodingAgentTaskView } from "~/api";
+import { type CodingAgentTaskView, ElementIds } from "~/api";
 import { formatRelativeTime } from "~/common/formatRelativeTime.ts";
 import { useImbueNavigate, useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
@@ -104,11 +104,15 @@ const AgentRow = ({
           <span className={styles.menuAnchor} aria-hidden="true" />
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="start" side="bottom" variant="soft" className="mobileTheme">
-          <DropdownMenu.Item onSelect={() => setIsRenaming(true)}>
+          <DropdownMenu.Item onSelect={() => setIsRenaming(true)} data-testid={ElementIds.MOBILE_ROW_RENAME_ACTION}>
             <Pencil size={16} /> Rename
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
-          <DropdownMenu.Item color="red" onSelect={() => onRequestDelete(agent)}>
+          <DropdownMenu.Item
+            color="red"
+            onSelect={() => onRequestDelete(agent)}
+            data-testid={ElementIds.MOBILE_ROW_DELETE_ACTION}
+          >
             <Trash2 size={16} /> Delete agent
           </DropdownMenu.Item>
         </DropdownMenu.Content>
@@ -118,6 +122,7 @@ const AgentRow = ({
         className={`${styles.row} ${isCurrent ? styles.current : ""}`}
         aria-current={isCurrent}
         onClick={handleClick}
+        data-testid={ElementIds.MOBILE_AGENT_SHEET_ROW}
         {...longPress}
       >
         {dot}
@@ -181,7 +186,11 @@ export const AgentSheet = ({ isOpen, onClose }: AgentSheetProps): ReactElement =
   };
 
   return (
-    <aside className={`${styles.sheet} ${isOpen ? styles.open : ""}`} aria-hidden={!isOpen}>
+    <aside
+      className={`${styles.sheet} ${isOpen ? styles.open : ""}`}
+      aria-hidden={!isOpen}
+      data-testid={ElementIds.MOBILE_AGENT_SHEET}
+    >
       <div className={styles.handle} />
       <div className={styles.title}>Agents in {workspaceName}</div>
 
@@ -209,6 +218,7 @@ export const AgentSheet = ({ isOpen, onClose }: AgentSheetProps): ReactElement =
           onClose();
           void createAgent();
         }}
+        data-testid={ElementIds.MOBILE_AGENT_SHEET_NEW_AGENT}
       >
         <span className={styles.newIcon}>
           <Plus size={18} />

--- a/sculptor/frontend/src/pages/workspace/mobile/AgentSwitcher.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/AgentSwitcher.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import type { PointerEvent as ReactPointerEvent, ReactElement } from "react";
 import { useCallback, useMemo, useRef } from "react";
 
+import { ElementIds } from "~/api";
 import { useImbueNavigate, useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 
@@ -102,6 +103,7 @@ export const AgentSwitcher = ({ onOpenSheet }: AgentSwitcherProps): ReactElement
         className={styles.pill}
         aria-haspopup="dialog"
         aria-label={`Current agent: ${name}. Tap to switch agents.`}
+        data-testid={ElementIds.MOBILE_AGENT_SWITCHER_PILL}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={(e) => endDrag(e.clientX)}

--- a/sculptor/frontend/src/pages/workspace/mobile/ChangesPill.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/ChangesPill.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, GitMerge, Layers, Plus } from "lucide-react";
 import type { ReactElement } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { PrStatusInfo } from "~/api";
+import { ElementIds, type PrStatusInfo } from "~/api";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { prStatusAtomFamily } from "~/common/state/atoms/prStatus.ts";
 import { useWorkspace } from "~/common/state/hooks/useWorkspace.ts";
@@ -179,10 +179,20 @@ export const ChangesPill = ({ onReviewAll }: ChangesPillProps): ReactElement | n
   };
 
   return (
-    <div ref={wrapRef} className={`${styles.wrap} ${isOpen ? styles.open : ""}`}>
+    <div
+      ref={wrapRef}
+      className={`${styles.wrap} ${isOpen ? styles.open : ""}`}
+      data-testid={ElementIds.MOBILE_CHANGES_PILL}
+    >
       <div className={styles.bar}>
         {renderPrControl()}
-        <button type="button" className={styles.changes} onClick={() => setIsOpen((v) => !v)} aria-expanded={isOpen}>
+        <button
+          type="button"
+          className={styles.changes}
+          onClick={() => setIsOpen((v) => !v)}
+          aria-expanded={isOpen}
+          data-testid={ElementIds.MOBILE_CHANGES_PILL_TOGGLE}
+        >
           <span className={styles.stat}>
             <span className={styles.add}>+{summary.added}</span> <span className={styles.del}>−{summary.removed}</span>
             {shouldDropFiles ? null : (
@@ -224,7 +234,12 @@ export const ChangesPill = ({ onReviewAll }: ChangesPillProps): ReactElement | n
           })}
         </div>
         <div className={styles.reviewFoot}>
-          <button type="button" className={styles.reviewButton} onClick={onReviewAll}>
+          <button
+            type="button"
+            className={styles.reviewButton}
+            onClick={onReviewAll}
+            data-testid={ElementIds.MOBILE_CHANGES_PILL_REVIEW_ALL}
+          >
             <Layers size={15} /> Review all changes
           </button>
         </div>

--- a/sculptor/frontend/src/pages/workspace/mobile/MobileWorkspaceHeader.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/MobileWorkspaceHeader.tsx
@@ -3,7 +3,7 @@ import { Ellipsis, Layers, Pencil, Plus, Settings, SquareMenu, Terminal } from "
 import type { ReactElement } from "react";
 import { useState } from "react";
 
-import { updateWorkspace } from "~/api";
+import { ElementIds, updateWorkspace } from "~/api";
 import { useImbueNavigate, useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { useWorkspace } from "~/common/state/hooks/useWorkspace.ts";
 
@@ -55,12 +55,13 @@ export const MobileWorkspaceHeader = ({
   };
 
   return (
-    <header className={styles.header}>
+    <header className={styles.header} data-testid={ElementIds.MOBILE_WORKSPACE_HEADER}>
       <IconButton
         variant="ghost"
         color="gray"
         className={styles.iconButton}
         aria-label="Open workspaces"
+        data-testid={ElementIds.MOBILE_HEADER_MENU_BUTTON}
         onClick={onOpenDrawer}
       >
         <SquareMenu size={22} />
@@ -74,27 +75,36 @@ export const MobileWorkspaceHeader = ({
 
       <DropdownMenu.Root>
         <DropdownMenu.Trigger>
-          <IconButton variant="ghost" color="gray" className={styles.iconButton} aria-label="Workspace actions">
+          <IconButton
+            variant="ghost"
+            color="gray"
+            className={styles.iconButton}
+            aria-label="Workspace actions"
+            data-testid={ElementIds.MOBILE_HEADER_ACTIONS_BUTTON}
+          >
             <Ellipsis size={22} />
           </IconButton>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="end" variant="soft" className="mobileTheme">
-          <DropdownMenu.Item onSelect={() => void createAgent()}>
+          <DropdownMenu.Item onSelect={() => void createAgent()} data-testid={ElementIds.MOBILE_HEADER_NEW_AGENT_ITEM}>
             <Plus size={16} /> Create new agent
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
-          <DropdownMenu.Item onSelect={onOpenReview}>
+          <DropdownMenu.Item onSelect={onOpenReview} data-testid={ElementIds.MOBILE_HEADER_REVIEW_ITEM}>
             <Layers size={16} /> Review all changes
             {filesChanged > 0 ? <span className={styles.menuMeta}>{filesChanged} files</span> : null}
           </DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={onOpenTerminal}>
+          <DropdownMenu.Item onSelect={onOpenTerminal} data-testid={ElementIds.MOBILE_HEADER_TERMINAL_ITEM}>
             <Terminal size={16} /> Open terminal
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
-          <DropdownMenu.Item onSelect={openRename}>
+          <DropdownMenu.Item onSelect={openRename} data-testid={ElementIds.MOBILE_HEADER_RENAME_ITEM}>
             <Pencil size={16} /> Rename workspace
           </DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => navigateToGlobalSettings()}>
+          <DropdownMenu.Item
+            onSelect={() => navigateToGlobalSettings()}
+            data-testid={ElementIds.MOBILE_HEADER_SETTINGS_ITEM}
+          >
             <Settings size={16} /> Workspace settings
           </DropdownMenu.Item>
         </DropdownMenu.Content>

--- a/sculptor/frontend/src/pages/workspace/mobile/MobileWorkspaceShell.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/MobileWorkspaceShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
+import { ElementIds } from "~/api";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 
 import { ChatPanelContent } from "../components/ChatPanelContent.tsx";
@@ -45,7 +46,7 @@ export const MobileWorkspaceShell = ({ taskID }: { taskID: string }): ReactEleme
   }, [taskID, workspaceID]);
 
   return (
-    <div className={`mobileTheme ${styles.shell}`}>
+    <div className={`mobileTheme ${styles.shell}`} data-testid={ElementIds.MOBILE_WORKSPACE_SHELL}>
       <MobileWorkspaceHeader
         onOpenDrawer={() => setIsDrawerOpen(true)}
         onOpenReview={() => setOverlay("review")}

--- a/sculptor/frontend/src/pages/workspace/mobile/WorkspaceDrawer.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/WorkspaceDrawer.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, Folder, FolderPlus, House, Pencil, Plus, Settings, Trash2 
 import type { ReactElement } from "react";
 import { useMemo, useState } from "react";
 
-import { updateWorkspace, type Workspace } from "~/api";
+import { ElementIds, updateWorkspace, type Workspace } from "~/api";
 import { useImbueLocation, useImbueNavigate } from "~/common/NavigateUtils.ts";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks.ts";
 import { userEmailAtom } from "~/common/state/atoms/userConfig.ts";
@@ -110,11 +110,15 @@ const DrawerWorkspaceRow = ({
           <span className={styles.menuAnchor} aria-hidden="true" />
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="start" side="bottom" variant="soft" className="mobileTheme">
-          <DropdownMenu.Item onSelect={() => setIsRenaming(true)}>
+          <DropdownMenu.Item onSelect={() => setIsRenaming(true)} data-testid={ElementIds.MOBILE_ROW_RENAME_ACTION}>
             <Pencil size={16} /> Rename
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
-          <DropdownMenu.Item color="red" onSelect={() => onRequestDelete(workspace)}>
+          <DropdownMenu.Item
+            color="red"
+            onSelect={() => onRequestDelete(workspace)}
+            data-testid={ElementIds.MOBILE_ROW_DELETE_ACTION}
+          >
             <Trash2 size={16} /> Delete workspace
           </DropdownMenu.Item>
         </DropdownMenu.Content>
@@ -124,6 +128,7 @@ const DrawerWorkspaceRow = ({
         className={`${styles.workspaceRow} ${isCurrent ? styles.current : ""}`}
         onClick={handleClick}
         aria-current={isCurrent}
+        data-testid={ElementIds.MOBILE_DRAWER_WORKSPACE_ROW}
         {...longPress}
       >
         {dot}
@@ -240,7 +245,11 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
   };
 
   return (
-    <aside className={`${styles.drawer} ${isOpen ? styles.open : ""}`} aria-hidden={!isOpen}>
+    <aside
+      className={`${styles.drawer} ${isOpen ? styles.open : ""}`}
+      aria-hidden={!isOpen}
+      data-testid={ElementIds.MOBILE_WORKSPACE_DRAWER}
+    >
       <div className={styles.header}>
         <span className={styles.wordmark}>Sculptor</span>
         <span className={styles.avatar}>{getInitials(userEmail)}</span>
@@ -254,6 +263,7 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
             onClose();
             navigateToHome();
           }}
+          data-testid={ElementIds.MOBILE_DRAWER_HOME_LINK}
         >
           <House size={20} /> Home
         </button>
@@ -264,6 +274,7 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
             onClose();
             navigateToGlobalSettings();
           }}
+          data-testid={ElementIds.MOBILE_DRAWER_SETTINGS_LINK}
         >
           <Settings size={20} /> Settings
         </button>
@@ -300,6 +311,7 @@ export const WorkspaceDrawer = ({ isOpen, onClose, currentWorkspaceID }: Workspa
           onClose();
           setNewWorkspaceModal({ open: true });
         }}
+        data-testid={ElementIds.MOBILE_DRAWER_NEW_WORKSPACE_BUTTON}
       >
         <Plus size={18} /> New workspace
       </button>

--- a/sculptor/frontend/src/pages/workspace/mobile/overlays/ReviewAllOverlay.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/overlays/ReviewAllOverlay.tsx
@@ -2,6 +2,7 @@ import { IconButton } from "@radix-ui/themes";
 import { ChevronLeft, Settings } from "lucide-react";
 import type { ReactElement } from "react";
 
+import { ElementIds } from "~/api";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 
 import { CombinedDiffView } from "../../components/diffPanel/CombinedDiffView.tsx";
@@ -19,13 +20,19 @@ export const ReviewAllOverlay = ({ onBack }: { onBack: () => void }): ReactEleme
   const summary = useMobileChangeSummary(workspaceID);
 
   return (
-    <div className={styles.overlay} role="dialog" aria-label="Review all changes">
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-label="Review all changes"
+      data-testid={ElementIds.MOBILE_REVIEW_ALL_OVERLAY}
+    >
       <header className={styles.header}>
         <IconButton
           variant="ghost"
           color="gray"
           className={styles.iconButton}
           aria-label="Back to chat"
+          data-testid={ElementIds.MOBILE_OVERLAY_BACK_BUTTON}
           onClick={onBack}
         >
           <ChevronLeft size={22} />

--- a/sculptor/frontend/src/pages/workspace/mobile/overlays/TerminalOverlay.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/overlays/TerminalOverlay.tsx
@@ -2,6 +2,7 @@ import { IconButton } from "@radix-ui/themes";
 import { ChevronLeft, Ellipsis } from "lucide-react";
 import type { ReactElement } from "react";
 
+import { ElementIds } from "~/api";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
 import { useProject } from "~/common/state/hooks/useProjects.ts";
 import { useWorkspace } from "~/common/state/hooks/useWorkspace.ts";
@@ -26,13 +27,19 @@ export const TerminalOverlay = ({ onBack }: { onBack: () => void }): ReactElemen
   const repoName = project?.name ?? "";
 
   return (
-    <div className={styles.overlay} role="dialog" aria-label="Terminal">
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-label="Terminal"
+      data-testid={ElementIds.MOBILE_TERMINAL_OVERLAY}
+    >
       <header className={styles.header}>
         <IconButton
           variant="ghost"
           color="gray"
           className={styles.iconButton}
           aria-label="Back to chat"
+          data-testid={ElementIds.MOBILE_OVERLAY_BACK_BUTTON}
           onClick={onBack}
         >
           <ChevronLeft size={22} />

--- a/sculptor/frontend/src/pages/workspace/panels/TerminalPanelView.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/TerminalPanelView.tsx
@@ -8,6 +8,7 @@
 import { useSetAtom } from "jotai";
 import { type ReactElement, useCallback, useEffect } from "react";
 
+import { ElementIds } from "~/api";
 import { reportTerminalConnectionStatusAtom } from "~/common/state/atoms/terminalTabs.ts";
 import { makeTerminalPanelId } from "~/components/sections/registry/dynamicPanels.tsx";
 import { terminalPanelMountedAtom } from "~/pages/workspace/atoms.ts";
@@ -55,7 +56,7 @@ export const TerminalPanelView = ({ workspaceId, index }: { workspaceId: string;
   }, [setTerminalPanelMounted]);
 
   return (
-    <div className={styles.terminalPanel}>
+    <div className={styles.terminalPanel} data-testid={ElementIds.TERMINAL_PANEL_VIEW}>
       <div ref={terminalContainerRef} className={styles.xtermWrapper} />
     </div>
   );

--- a/sculptor/pytest.ini
+++ b/sculptor/pytest.ini
@@ -18,6 +18,7 @@ markers =
     release: CI-pipeline opt-in — test runs against the packaged app in the release pipeline (no FakeClaude available)
     user_story: makes a note about the user story that is implemented by the test
     stub_dependency: stub an external dependency (e.g. git, claude) with a fake binary
+    mobile: exercises the mobile web UI (narrow-viewport shell). Runs in browser mode; groupable as its own suite/runner via `-m mobile` / `-m "not mobile"`.
     real_claude: tests that hit the real Claude API (excluded from CI)
     custom_sculptor_folder: provide a populator callable for the per-test sculptor folder (read by _extract_marker_arg in sculptor/testing/resources.py)
     real_pi: tests that hit a real pi binary + real upstream model (excluded from CI)

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -224,6 +224,9 @@ class ElementIDs(StrEnum):
     DIFF_SKELETON = "DIFF_SKELETON"
     DIFF_VIEWER_EMPTY = "DIFF_VIEWER_EMPTY"
     COMBINED_DIFF_FILE_SECTION = "COMBINED_DIFF_FILE_SECTION"
+    # The file-navigation / scope / commit toolbar row. Hidden (not rendered) when
+    # CombinedDiffView is given `hideToolbar` — as the mobile review-all overlay does.
+    COMBINED_DIFF_TOOLBAR = "COMBINED_DIFF_TOOLBAR"
     # Root of the Review All panel, which wraps the combined multi-file diff.
     REVIEW_ALL_PANEL = "REVIEW_ALL_PANEL"
     DIFF_VIEW_UNIFIED = "DIFF_VIEW_UNIFIED"
@@ -842,3 +845,56 @@ class ElementIDs(StrEnum):
     # an indefinite progress bar after a failed auto-update install.
     BACKEND_SHUTDOWN_SPINNER = "BACKEND_SHUTDOWN_SPINNER"
     BACKEND_SHUTDOWN_STALLED = "BACKEND_SHUTDOWN_STALLED"
+
+    # Mobile workspace shell (the single-column, chat-first Workspace view that
+    # replaces the desktop layout below 768px). These surfaces are mobile-only —
+    # none of the desktop sidebar/section/panel tags render under the mobile
+    # shell — so they carry their own hooks for the mobile integration suite.
+    MOBILE_WORKSPACE_SHELL = "MOBILE_WORKSPACE_SHELL"
+    MOBILE_WORKSPACE_HEADER = "MOBILE_WORKSPACE_HEADER"
+    MOBILE_HEADER_MENU_BUTTON = "MOBILE_HEADER_MENU_BUTTON"
+    MOBILE_HEADER_ACTIONS_BUTTON = "MOBILE_HEADER_ACTIONS_BUTTON"
+    MOBILE_HEADER_NEW_AGENT_ITEM = "MOBILE_HEADER_NEW_AGENT_ITEM"
+    MOBILE_HEADER_REVIEW_ITEM = "MOBILE_HEADER_REVIEW_ITEM"
+    MOBILE_HEADER_TERMINAL_ITEM = "MOBILE_HEADER_TERMINAL_ITEM"
+    MOBILE_HEADER_RENAME_ITEM = "MOBILE_HEADER_RENAME_ITEM"
+    MOBILE_HEADER_SETTINGS_ITEM = "MOBILE_HEADER_SETTINGS_ITEM"
+    # Left drawer: Home/Settings nav, repo-grouped workspace rows, and the pinned
+    # "New workspace" button that opens the shared new-workspace modal.
+    MOBILE_WORKSPACE_DRAWER = "MOBILE_WORKSPACE_DRAWER"
+    MOBILE_DRAWER_HOME_LINK = "MOBILE_DRAWER_HOME_LINK"
+    MOBILE_DRAWER_SETTINGS_LINK = "MOBILE_DRAWER_SETTINGS_LINK"
+    MOBILE_DRAWER_WORKSPACE_ROW = "MOBILE_DRAWER_WORKSPACE_ROW"
+    MOBILE_DRAWER_NEW_WORKSPACE_BUTTON = "MOBILE_DRAWER_NEW_WORKSPACE_BUTTON"
+    # The long-press context menu shared by drawer workspace rows and agent-sheet
+    # rows (only one menu is ever open at a time, so both reuse these two tags).
+    MOBILE_ROW_RENAME_ACTION = "MOBILE_ROW_RENAME_ACTION"
+    MOBILE_ROW_DELETE_ACTION = "MOBILE_ROW_DELETE_ACTION"
+    # Agent switcher pill (in the status row) and the agent bottom sheet.
+    MOBILE_AGENT_SWITCHER_PILL = "MOBILE_AGENT_SWITCHER_PILL"
+    MOBILE_AGENT_SHEET = "MOBILE_AGENT_SHEET"
+    MOBILE_AGENT_SHEET_ROW = "MOBILE_AGENT_SHEET_ROW"
+    MOBILE_AGENT_SHEET_NEW_AGENT = "MOBILE_AGENT_SHEET_NEW_AGENT"
+    # Changes pill (right of the status row) and the full-screen overlays it and
+    # the header ⋮ menu open over the chat.
+    MOBILE_CHANGES_PILL = "MOBILE_CHANGES_PILL"
+    MOBILE_CHANGES_PILL_TOGGLE = "MOBILE_CHANGES_PILL_TOGGLE"
+    MOBILE_CHANGES_PILL_REVIEW_ALL = "MOBILE_CHANGES_PILL_REVIEW_ALL"
+    MOBILE_REVIEW_ALL_OVERLAY = "MOBILE_REVIEW_ALL_OVERLAY"
+    MOBILE_TERMINAL_OVERLAY = "MOBILE_TERMINAL_OVERLAY"
+    MOBILE_OVERLAY_BACK_BUTTON = "MOBILE_OVERLAY_BACK_BUTTON"
+    # Mobile ChatInput: the secondary controls collapse into a single options
+    # menu; the model/effort submenus, fast-mode item, and (absent-on-mobile)
+    # keyboard-hint row carry hooks so the collapse can be asserted.
+    MOBILE_CHAT_INPUT_OPTIONS = "MOBILE_CHAT_INPUT_OPTIONS"
+    MOBILE_CHAT_INPUT_MODEL_SUBMENU = "MOBILE_CHAT_INPUT_MODEL_SUBMENU"
+    MOBILE_CHAT_INPUT_EFFORT_SUBMENU = "MOBILE_CHAT_INPUT_EFFORT_SUBMENU"
+    MOBILE_CHAT_INPUT_FAST_MODE_ITEM = "MOBILE_CHAT_INPUT_FAST_MODE_ITEM"
+    CHAT_INPUT_KEYBOARD_HINTS = "CHAT_INPUT_KEYBOARD_HINTS"
+    # Mobile Home / Settings headers (the drawer's Home/Settings nav lands here);
+    # these replace the global TopBar on those routes below 768px.
+    MOBILE_HOME_HEADER = "MOBILE_HOME_HEADER"
+    MOBILE_SETTINGS_HEADER = "MOBILE_SETTINGS_HEADER"
+    # The terminal panel's root (the shell-agnostic xterm wrapper). The mobile
+    # terminal overlay mounts this; a hook here lets a test assert it mounted.
+    TERMINAL_PANEL_VIEW = "TERMINAL_PANEL_VIEW"

--- a/sculptor/sculptor/testing/elements/mobile_workspace.py
+++ b/sculptor/sculptor/testing/elements/mobile_workspace.py
@@ -49,7 +49,7 @@ def expect_desktop_layout(page: Page) -> None:
     expect(page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_SHELL)).to_have_count(0)
 
 
-def enter_mobile_workspace(page: Page, viewport: dict[str, int] = MOBILE_VIEWPORT) -> "PlaywrightMobileWorkspaceShell":
+def enter_mobile_workspace(page: Page, viewport: dict[str, int] | None = None) -> "PlaywrightMobileWorkspaceShell":
     """Cross the 768px breakpoint into the mobile Workspace shell.
 
     Resizes to ``viewport`` (a phone width) and forces a full SPA reload so
@@ -60,7 +60,7 @@ def enter_mobile_workspace(page: Page, viewport: dict[str, int] = MOBILE_VIEWPOR
     the same agent. Call AFTER ``start_task_and_wait_for_ready`` (which creates the
     workspace/agent at the default desktop viewport).
     """
-    page.set_viewport_size(viewport)
+    page.set_viewport_size(viewport if viewport is not None else MOBILE_VIEWPORT)
     hash_parts = page.url.split("#", 1)
     target_hash = f"#{hash_parts[1]}" if len(hash_parts) > 1 else "#/"
     full_spa_reload(page, target_hash=target_hash)

--- a/sculptor/sculptor/testing/elements/mobile_workspace.py
+++ b/sculptor/sculptor/testing/elements/mobile_workspace.py
@@ -1,0 +1,355 @@
+"""Page Object Models for the mobile Workspace shell.
+
+The mobile shell (``pages/workspace/mobile/``) replaces the whole desktop layout
+below the 768px breakpoint — none of the desktop sidebar/section/panel POMs
+render under it — so these POMs are the mobile counterparts. A test crosses into
+the shell with :func:`enter_mobile_workspace` (resize to a phone viewport +
+full SPA reload so ``useLayoutMode`` initializes narrow at first paint), then
+drives the header, drawer, agent sheet, changes pill, and full-screen overlays
+through the getters here.
+
+Open/closed state for the sliding surfaces (drawer, agent sheet) is read from
+``aria-hidden`` rather than Playwright visibility: those surfaces stay mounted
+and are only translated off-screen when closed, so a translated element still
+reports a bounding box (and would read as "visible"). ``aria-hidden`` mirrors the
+component's ``isOpen`` exactly, so it is the reliable interactivity signal.
+"""
+
+from playwright.sync_api import Locator
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+
+from sculptor.constants import ElementIDs
+from sculptor.testing.elements.base import PlaywrightIntegrationTestElement
+from sculptor.testing.elements.chat_panel import PlaywrightChatPanelElement
+from sculptor.testing.playwright_utils import full_spa_reload
+
+# A phone viewport comfortably under the 768px breakpoint (iPhone-14-class).
+MOBILE_VIEWPORT = {"width": 390, "height": 844}
+# A deliberately SHORT phone viewport, for exercising surfaces that must stay
+# reachable when vertical space is scarce (e.g. the AskUserQuestion footer).
+SHORT_MOBILE_VIEWPORT = {"width": 390, "height": 560}
+
+
+def expect_mobile_layout(page: Page) -> None:
+    """Assert the app is in the mobile layout.
+
+    ``useLayoutMode`` mirrors its single mobile/desktop verdict onto
+    ``html.mobileUx`` (which all mobile CSS keys off), so the class is the
+    authoritative signal — and the mobile shell has swapped in for the desktop one.
+    """
+    expect(page.locator("html.mobileUx")).to_have_count(1)
+
+
+def expect_desktop_layout(page: Page) -> None:
+    """Assert the app stays on the desktop layout: no ``mobileUx`` class and the
+    mobile shell never mounted. Used to prove the Electron renderer never flips to
+    mobile no matter how narrow the window."""
+    expect(page.locator("html.mobileUx")).to_have_count(0)
+    expect(page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_SHELL)).to_have_count(0)
+
+
+def enter_mobile_workspace(page: Page, viewport: dict[str, int] = MOBILE_VIEWPORT) -> "PlaywrightMobileWorkspaceShell":
+    """Cross the 768px breakpoint into the mobile Workspace shell.
+
+    Resizes to ``viewport`` (a phone width) and forces a full SPA reload so
+    ``useLayoutMode`` re-initializes narrow at first paint — ``html.mobileUx`` set
+    and ``WorkspacePage`` mounting ``MobileWorkspaceShell`` from the first render,
+    rather than relying on the live media-query flip of an already-mounted desktop
+    tree. The current agent route (URL hash) is preserved, so the shell mounts for
+    the same agent. Call AFTER ``start_task_and_wait_for_ready`` (which creates the
+    workspace/agent at the default desktop viewport).
+    """
+    page.set_viewport_size(viewport)
+    hash_parts = page.url.split("#", 1)
+    target_hash = f"#{hash_parts[1]}" if len(hash_parts) > 1 else "#/"
+    full_spa_reload(page, target_hash=target_hash)
+    shell = PlaywrightMobileWorkspaceShell(page)
+    expect(shell.root()).to_be_visible()
+    return shell
+
+
+class PlaywrightMobileWorkspaceShell(PlaywrightIntegrationTestElement):
+    """The single-column, chat-first Workspace view for narrow viewports."""
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(locator=page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_SHELL), page=page)
+
+    def root(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_SHELL)
+
+    def get_header(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_HEADER)
+
+    def get_chat_panel(self) -> PlaywrightChatPanelElement:
+        """The reused desktop chat surface — the mobile shell mounts the same
+        ``ChatPanelContent`` + ``ChatInput``, so the existing chat POM applies."""
+        chat_panel = self._page.get_by_test_id(ElementIDs.CHAT_PANEL)
+        return PlaywrightChatPanelElement(locator=chat_panel, page=self._page)
+
+    # -- Status row --
+
+    def get_agent_switcher_pill(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_AGENT_SWITCHER_PILL)
+
+    def get_changes_pill(self) -> "PlaywrightMobileChangesPill":
+        return PlaywrightMobileChangesPill(self._page)
+
+    # -- Drawer (left) --
+
+    def open_drawer(self) -> "PlaywrightMobileDrawer":
+        self._page.get_by_test_id(ElementIDs.MOBILE_HEADER_MENU_BUTTON).click()
+        drawer = PlaywrightMobileDrawer(self._page)
+        drawer.expect_open()
+        return drawer
+
+    def get_drawer(self) -> "PlaywrightMobileDrawer":
+        return PlaywrightMobileDrawer(self._page)
+
+    # -- Agent sheet (bottom) --
+
+    def open_agent_sheet(self) -> "PlaywrightMobileAgentSheet":
+        self.get_agent_switcher_pill().click()
+        sheet = PlaywrightMobileAgentSheet(self._page)
+        sheet.expect_open()
+        return sheet
+
+    def get_agent_sheet(self) -> "PlaywrightMobileAgentSheet":
+        return PlaywrightMobileAgentSheet(self._page)
+
+    # -- Header ⋮ menu --
+
+    def open_header_menu(self) -> None:
+        self._page.get_by_test_id(ElementIDs.MOBILE_HEADER_ACTIONS_BUTTON).click()
+
+    def open_terminal_overlay(self) -> "PlaywrightMobileOverlay":
+        """Open the terminal overlay via the header ⋮ menu (its only entry point)."""
+        self.open_header_menu()
+        self._page.get_by_test_id(ElementIDs.MOBILE_HEADER_TERMINAL_ITEM).click()
+        overlay = PlaywrightMobileOverlay(self._page, ElementIDs.MOBILE_TERMINAL_OVERLAY)
+        expect(overlay.root()).to_be_visible()
+        return overlay
+
+    def open_review_overlay_via_header(self) -> "PlaywrightMobileOverlay":
+        self.open_header_menu()
+        self._page.get_by_test_id(ElementIDs.MOBILE_HEADER_REVIEW_ITEM).click()
+        overlay = PlaywrightMobileOverlay(self._page, ElementIDs.MOBILE_REVIEW_ALL_OVERLAY)
+        expect(overlay.root()).to_be_visible()
+        return overlay
+
+    def get_review_overlay(self) -> "PlaywrightMobileOverlay":
+        return PlaywrightMobileOverlay(self._page, ElementIDs.MOBILE_REVIEW_ALL_OVERLAY)
+
+    def get_terminal_overlay(self) -> "PlaywrightMobileOverlay":
+        return PlaywrightMobileOverlay(self._page, ElementIDs.MOBILE_TERMINAL_OVERLAY)
+
+    # -- Mobile ChatInput adaptations --
+
+    def get_chat_options_button(self) -> Locator:
+        """The ``SlidersHorizontal`` trigger the secondary controls collapse into."""
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHAT_INPUT_OPTIONS)
+
+    def open_chat_options(self) -> None:
+        self.get_chat_options_button().click()
+
+    # The options menu (Radix DropdownMenu) portals to <body>, so its items are
+    # resolved page-wide, not scoped to the shell.
+    def get_options_plan_mode(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.PLAN_MODE_TOGGLE)
+
+    def get_options_model_submenu(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHAT_INPUT_MODEL_SUBMENU)
+
+    def get_options_effort_submenu(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHAT_INPUT_EFFORT_SUBMENU)
+
+    def get_options_fast_mode(self) -> Locator:
+        """Fast mode is capability-gated — only present when the model supports it."""
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHAT_INPUT_FAST_MODE_ITEM)
+
+    def get_keyboard_hints(self) -> Locator:
+        """The desktop-only keyboard-hint row (absent on mobile)."""
+        return self._page.get_by_test_id(ElementIDs.CHAT_INPUT_KEYBOARD_HINTS)
+
+    def get_desktop_model_selector(self) -> Locator:
+        """The always-visible desktop model selector (absent on mobile)."""
+        return self._page.get_by_test_id(ElementIDs.MODEL_SELECTOR)
+
+
+def _long_press(row: Locator) -> None:
+    """Trigger a row's long-press context menu deterministically.
+
+    ``useLongPress`` opens the menu on either a 450ms touch-hold or a
+    ``contextmenu`` event (right-click). Dispatching ``contextmenu`` is the
+    deterministic path — synthetic touch-hold timing is flaky under Playwright.
+    """
+    row.dispatch_event("contextmenu")
+
+
+class PlaywrightMobileDrawer(PlaywrightIntegrationTestElement):
+    """The left drawer: Home/Settings nav, repo-grouped workspace rows, and the
+    pinned "New workspace" button."""
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(locator=page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_DRAWER), page=page)
+
+    def root(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_WORKSPACE_DRAWER)
+
+    def expect_open(self) -> None:
+        expect(self.root()).to_have_attribute("aria-hidden", "false")
+
+    def expect_closed(self) -> None:
+        expect(self.root()).to_have_attribute("aria-hidden", "true")
+
+    def get_home_link(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_DRAWER_HOME_LINK)
+
+    def get_settings_link(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_DRAWER_SETTINGS_LINK)
+
+    def get_workspace_rows(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_DRAWER_WORKSPACE_ROW)
+
+    def get_current_workspace_row(self) -> Locator:
+        return self.get_workspace_rows().and_(self._page.locator('[aria-current="true"]'))
+
+    def get_other_workspace_row(self) -> Locator:
+        """A workspace row other than the one currently being viewed."""
+        return self.get_workspace_rows().and_(self._page.locator('[aria-current="false"]')).first
+
+    def get_new_workspace_button(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_DRAWER_NEW_WORKSPACE_BUTTON)
+
+    def long_press_workspace_row(self, row: Locator) -> None:
+        _long_press(row)
+        expect(self.get_rename_action()).to_be_visible()
+
+    def get_rename_action(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_ROW_RENAME_ACTION)
+
+    def get_delete_action(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_ROW_DELETE_ACTION)
+
+
+class PlaywrightMobileAgentSheet(PlaywrightIntegrationTestElement):
+    """The bottom sheet listing the workspace's agents + a "New agent" row."""
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(locator=page.get_by_test_id(ElementIDs.MOBILE_AGENT_SHEET), page=page)
+
+    def root(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_AGENT_SHEET)
+
+    def expect_open(self) -> None:
+        expect(self.root()).to_have_attribute("aria-hidden", "false")
+
+    def expect_closed(self) -> None:
+        expect(self.root()).to_have_attribute("aria-hidden", "true")
+
+    def get_rows(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_AGENT_SHEET_ROW)
+
+    def get_current_row(self) -> Locator:
+        return self.get_rows().and_(self._page.locator('[aria-current="true"]'))
+
+    def get_other_row(self) -> Locator:
+        return self.get_rows().and_(self._page.locator('[aria-current="false"]')).first
+
+    def get_new_agent_button(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_AGENT_SHEET_NEW_AGENT)
+
+    def long_press_row(self, row: Locator) -> None:
+        _long_press(row)
+        expect(self.get_rename_action()).to_be_visible()
+
+    def get_rename_action(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_ROW_RENAME_ACTION)
+
+    def get_delete_action(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_ROW_DELETE_ACTION)
+
+
+class PlaywrightMobileChangesPill(PlaywrightIntegrationTestElement):
+    """The right pill of the status row; expands a file list with a
+    "Review all changes" affordance. Renders only when there are changes."""
+
+    def __init__(self, page: Page) -> None:
+        super().__init__(locator=page.get_by_test_id(ElementIDs.MOBILE_CHANGES_PILL), page=page)
+
+    def root(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHANGES_PILL)
+
+    def get_toggle(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHANGES_PILL_TOGGLE)
+
+    def get_review_all_button(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.MOBILE_CHANGES_PILL_REVIEW_ALL)
+
+    def open_review_all(self) -> "PlaywrightMobileOverlay":
+        self.get_toggle().click()
+        self.get_review_all_button().click()
+        overlay = PlaywrightMobileOverlay(self._page, ElementIDs.MOBILE_REVIEW_ALL_OVERLAY)
+        expect(overlay.root()).to_be_visible()
+        return overlay
+
+
+class PlaywrightMobileOverlay(PlaywrightIntegrationTestElement):
+    """A full-screen overlay over the chat (review-all or terminal). ``back``
+    closes it (in-shell state; not a router navigation)."""
+
+    def __init__(self, page: Page, overlay_test_id: str) -> None:
+        self._overlay_test_id = overlay_test_id
+        super().__init__(locator=page.get_by_test_id(overlay_test_id), page=page)
+
+    def root(self) -> Locator:
+        return self._page.get_by_test_id(self._overlay_test_id)
+
+    def get_back_button(self) -> Locator:
+        return self.root().get_by_test_id(ElementIDs.MOBILE_OVERLAY_BACK_BUTTON)
+
+    def back(self) -> None:
+        self.get_back_button().click()
+        expect(self.root()).to_have_count(0)
+
+    # -- Review-all overlay specifics (CombinedDiffView) --
+
+    def get_diff_file_sections(self) -> Locator:
+        return self._page.get_by_test_id(ElementIDs.COMBINED_DIFF_FILE_SECTION)
+
+    def get_diff_toolbar(self) -> Locator:
+        """The desktop diff toolbar — hidden (not rendered) in the mobile overlay."""
+        return self._page.get_by_test_id(ElementIDs.COMBINED_DIFF_TOOLBAR)
+
+    def get_commit_button(self) -> Locator:
+        """The pinned commit footer's button (shown for the uncommitted scope)."""
+        return self._page.get_by_test_id(ElementIDs.CHANGES_COMMIT_BUTTON)
+
+    # -- Terminal overlay specifics --
+
+    def get_terminal_panel(self) -> Locator:
+        """The reused ``TerminalPanelView`` mounted inside the terminal overlay."""
+        return self._page.get_by_test_id(ElementIDs.TERMINAL_PANEL_VIEW)
+
+
+# -- Module-level getters for surfaces the drawer nav lands on / shares --
+
+
+def get_mobile_home_header(page: Page) -> Locator:
+    """The mobile Home header (the drawer's Home nav lands here)."""
+    return page.get_by_test_id(ElementIDs.MOBILE_HOME_HEADER)
+
+
+def get_mobile_settings_header(page: Page) -> Locator:
+    """The mobile Settings header (the drawer's Settings nav lands here)."""
+    return page.get_by_test_id(ElementIDs.MOBILE_SETTINGS_HEADER)
+
+
+def get_inline_rename_input(page: Page) -> Locator:
+    """The inline rename ``<input>`` a drawer/agent row swaps to while renaming."""
+    return page.get_by_test_id(ElementIDs.INLINE_RENAME_INPUT)
+
+
+def get_delete_confirm_button(page: Page) -> Locator:
+    """The confirm button of the shared delete-confirmation dialog."""
+    return page.get_by_test_id(ElementIDs.DELETE_CONFIRMATION_CONFIRM)

--- a/sculptor/tests/integration/frontend/test_mobile_agents.py
+++ b/sculptor/tests/integration/frontend/test_mobile_agents.py
@@ -1,0 +1,83 @@
+"""Integration tests for the mobile AgentSwitcher pill + AgentSheet.
+
+The agent switcher pill (in the floating status row) opens a bottom sheet listing
+the workspace's agents, with a "New agent" row and long-press rename/delete on
+each row.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.mobile_workspace import enter_mobile_workspace
+from sculptor.testing.elements.mobile_workspace import get_delete_confirm_button
+from sculptor.testing.elements.mobile_workspace import get_inline_rename_input
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+pytestmark = pytest.mark.mobile
+
+
+@user_story("to add and switch between agents from the mobile agent sheet")
+def test_mobile_agent_sheet_new_and_switch(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    # The pill opens the sheet, which starts with just the one agent.
+    sheet = shell.open_agent_sheet()
+    expect(sheet.get_rows()).to_have_count(1)
+
+    # "New agent" creates a second agent and navigates to it.
+    sheet.get_new_agent_button().click()
+    sheet.expect_closed()
+    expect(shell.root()).to_be_visible()
+
+    # Reopening the sheet now lists both agents; switching to the other navigates.
+    sheet = shell.open_agent_sheet()
+    expect(sheet.get_rows()).to_have_count(2)
+    url_before = page.url
+    sheet.get_other_row().click()
+    sheet.expect_closed()
+    expect(shell.root()).to_be_visible()
+    expect(page).not_to_have_url(url_before)
+
+
+@user_story("to rename an agent from the mobile agent sheet")
+def test_mobile_agent_sheet_rename(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    sheet = shell.open_agent_sheet()
+    sheet.long_press_row(sheet.get_current_row())
+    sheet.get_rename_action().click()
+
+    rename_input = get_inline_rename_input(page)
+    expect(rename_input).to_be_visible()
+    rename_input.fill("Renamed Mobile Agent")
+    rename_input.press("Enter")
+
+    expect(rename_input).to_have_count(0)
+    expect(sheet.get_current_row()).to_contain_text("Renamed Mobile Agent")
+
+
+@user_story("to delete an agent from the mobile agent sheet")
+def test_mobile_agent_sheet_delete(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    # Add a second agent so we can delete the non-current one without navigating away.
+    sheet = shell.open_agent_sheet()
+    sheet.get_new_agent_button().click()
+    sheet.expect_closed()
+    expect(shell.root()).to_be_visible()
+
+    sheet = shell.open_agent_sheet()
+    expect(sheet.get_rows()).to_have_count(2)
+    sheet.long_press_row(sheet.get_other_row())
+    sheet.get_delete_action().click()
+    get_delete_confirm_button(page).click()
+
+    expect(sheet.get_rows()).to_have_count(1)

--- a/sculptor/tests/integration/frontend/test_mobile_ask_user_question.py
+++ b/sculptor/tests/integration/frontend/test_mobile_ask_user_question.py
@@ -1,0 +1,81 @@
+"""Integration test for AskUserQuestion on a short mobile viewport.
+
+On a short phone viewport the Q&A card caps its height and scrolls its options
+list internally while the footer (submit button) stays pinned and reachable, so
+the user can always complete the flow.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.ask_user_question import get_ask_user_question_panel
+from sculptor.testing.elements.ask_user_question import get_first_ask_user_question_tool_block
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.mobile_workspace import SHORT_MOBILE_VIEWPORT
+from sculptor.testing.elements.mobile_workspace import enter_mobile_workspace
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+pytestmark = pytest.mark.mobile
+
+
+@user_story("to answer a long list of options on a short phone screen with the submit still reachable")
+def test_mobile_ask_user_question_scrollable_options_reachable_submit(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(sculptor_page=page)
+    # A deliberately short viewport, so the many-option list must scroll inside the
+    # card while the footer stays pinned.
+    shell = enter_mobile_workspace(page, viewport=SHORT_MOBILE_VIEWPORT)
+    chat_panel = shell.get_chat_panel()
+
+    send_chat_message(
+        chat_panel=chat_panel,
+        message="""\
+fake_claude:ask_user_question `{
+  "questions": [
+    {
+      "question": "Which of these languages have you shipped production code in? Pick the one you reach for first.",
+      "header": "Language",
+      "options": [
+        {"label": "Python", "description": "A versatile general-purpose language with a huge ecosystem"},
+        {"label": "JavaScript", "description": "The language of the web, client and server"},
+        {"label": "TypeScript", "description": "Typed JavaScript for larger codebases"},
+        {"label": "Rust", "description": "Systems programming with memory safety and no GC"},
+        {"label": "Go", "description": "Simple, fast, great for cloud infrastructure"},
+        {"label": "Java", "description": "The long-standing enterprise workhorse"},
+        {"label": "C++", "description": "Systems programming with fine-grained control"},
+        {"label": "Ruby", "description": "Developer-friendly, expressive, great for web apps"}
+      ],
+      "multiSelect": false
+    }
+  ]
+}`""",
+    )
+
+    ask_panel = get_ask_user_question_panel(page)
+    expect(ask_panel).to_be_visible(timeout=30_000)
+
+    # All options are present, and the last one is reachable by scrolling the list
+    # inside the card (not the page).
+    options = ask_panel.get_options()
+    expect(options).to_have_count(8)
+    options.last.scroll_into_view_if_needed()
+    expect(options.last).to_be_visible()
+
+    # The submit button stays reachable: select an option and submit successfully.
+    submit_button = ask_panel.get_submit_button()
+    expect(submit_button).to_be_disabled()
+    options.first.click()
+    expect(submit_button).to_be_enabled()
+    submit_button.click()
+
+    expect(ask_panel).not_to_be_visible(timeout=30_000)
+    expect(chat_panel.get_thinking_indicator(), "agent to finish").not_to_be_visible()
+    # user message, assistant (AskUserQuestion), assistant follow-up after the answer.
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=3)
+
+    tool_block = get_first_ask_user_question_tool_block(page)
+    tool_block.expect_submitted_state()

--- a/sculptor/tests/integration/frontend/test_mobile_chat_input.py
+++ b/sculptor/tests/integration/frontend/test_mobile_chat_input.py
@@ -1,0 +1,67 @@
+"""Integration tests for the mobile ChatInput adaptations and message round-trip.
+
+On mobile the ChatInput collapses its secondary controls into a single options
+menu, drops the keyboard hints, and does not auto-focus (so the virtual keyboard
+doesn't pop on an agent switch). Sending a message still works and produces a
+FakeClaude reply.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.chat_panel import send_chat_message
+from sculptor.testing.elements.chat_panel import wait_for_completed_message_count
+from sculptor.testing.elements.mobile_workspace import enter_mobile_workspace
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+pytestmark = pytest.mark.mobile
+
+
+@user_story("to see a compact, keyboard-friendly chat toolbar on my phone")
+def test_mobile_chat_input_collapses_secondary_controls(sculptor_instance_: SculptorInstance) -> None:
+    """The mobile ChatInput collapses model/effort/plan/fast into one options menu,
+    drops the keyboard hints, and does not auto-focus the editor."""
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+    chat_panel = shell.get_chat_panel()
+
+    # No auto-focus on mobile: the editor stays unfocused until the user taps it.
+    chat_input = chat_panel.get_chat_input()
+    expect(chat_input).to_be_visible()
+    expect(chat_input).not_to_be_focused()
+    chat_input.click()
+    expect(chat_input).to_be_focused()
+
+    # No keyboard hints on mobile.
+    expect(shell.get_keyboard_hints()).to_have_count(0)
+
+    # The always-visible desktop controls (e.g. the model selector) are gone; a
+    # single options trigger takes their place.
+    expect(shell.get_desktop_model_selector()).to_have_count(0)
+    expect(shell.get_chat_options_button()).to_be_visible()
+
+    # The secondary controls live inside that options menu.
+    shell.open_chat_options()
+    expect(shell.get_options_plan_mode()).to_be_visible()
+    expect(shell.get_options_model_submenu()).to_be_visible()
+    expect(shell.get_options_effort_submenu()).to_be_visible()
+
+
+@user_story("to chat with the agent from the mobile shell")
+def test_mobile_send_message_and_receive_reply(sculptor_instance_: SculptorInstance) -> None:
+    """Sending a message in the mobile shell produces a FakeClaude reply."""
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+    chat_panel = shell.get_chat_panel()
+
+    send_chat_message(chat_panel=chat_panel, message="Hello from the mobile shell")
+
+    # User message + FakeClaude's default reply.
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+    expect(chat_panel.get_messages().last).to_contain_text("Task completed")

--- a/sculptor/tests/integration/frontend/test_mobile_drawer.py
+++ b/sculptor/tests/integration/frontend/test_mobile_drawer.py
@@ -1,0 +1,121 @@
+"""Integration tests for the mobile WorkspaceDrawer.
+
+The drawer is the mobile navigation surface (the desktop sidebar is suppressed
+below 768px): Home / Settings nav, repo-grouped workspace rows with long-press
+rename/delete, and a "New workspace" button that opens the shared modal.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.mobile_workspace import enter_mobile_workspace
+from sculptor.testing.elements.mobile_workspace import get_delete_confirm_button
+from sculptor.testing.elements.mobile_workspace import get_inline_rename_input
+from sculptor.testing.elements.mobile_workspace import get_mobile_home_header
+from sculptor.testing.elements.mobile_workspace import get_mobile_settings_header
+from sculptor.testing.elements.new_workspace_dialog import PlaywrightNewWorkspaceDialog
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+pytestmark = pytest.mark.mobile
+
+
+@user_story("to get to Home from a workspace on mobile")
+def test_mobile_drawer_navigates_to_home(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    drawer = shell.open_drawer()
+    drawer.get_home_link().click()
+
+    expect(get_mobile_home_header(page)).to_be_visible()
+
+
+@user_story("to get to Settings from a workspace on mobile")
+def test_mobile_drawer_navigates_to_settings(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    drawer = shell.open_drawer()
+    drawer.get_settings_link().click()
+
+    expect(get_mobile_settings_header(page)).to_be_visible()
+
+
+@user_story("to switch between workspaces from the mobile drawer")
+def test_mobile_drawer_switches_workspace(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    # Two workspaces so the drawer has one to switch away to; the second is current.
+    start_task_and_wait_for_ready(sculptor_page=page)
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    url_before = page.url
+    drawer = shell.open_drawer()
+    drawer.get_other_workspace_row().click()
+
+    # The drawer closes and the shell re-mounts for the other workspace's agent.
+    drawer.expect_closed()
+    expect(shell.root()).to_be_visible()
+    expect(page).not_to_have_url(url_before)
+
+
+@user_story("to create a new workspace from the mobile drawer")
+def test_mobile_drawer_new_workspace_opens_shared_modal(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    drawer = shell.open_drawer()
+    drawer.get_new_workspace_button().click()
+
+    # It opens the same NewWorkspaceModal every desktop entry point uses.
+    dialog = PlaywrightNewWorkspaceDialog(page)
+    expect(dialog.get_dialog()).to_be_visible()
+
+
+@user_story("to rename a workspace from the mobile drawer")
+def test_mobile_drawer_renames_workspace(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    drawer = shell.open_drawer()
+    # Rename the current workspace so the header (which shows the current
+    # workspace's name) reflects the change.
+    drawer.long_press_workspace_row(drawer.get_current_workspace_row())
+    drawer.get_rename_action().click()
+
+    rename_input = get_inline_rename_input(page)
+    expect(rename_input).to_be_visible()
+    rename_input.fill("Renamed Mobile Workspace")
+    rename_input.press("Enter")
+
+    expect(rename_input).to_have_count(0)
+    expect(shell.get_header()).to_contain_text("Renamed Mobile Workspace")
+
+
+@user_story("to delete a workspace from the mobile drawer")
+def test_mobile_drawer_deletes_workspace(sculptor_instance_: SculptorInstance) -> None:
+    page = sculptor_instance_.page
+    # Two workspaces; we delete the non-current one so the current view isn't stranded.
+    start_task_and_wait_for_ready(sculptor_page=page)
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    drawer = shell.open_drawer()
+    rows = drawer.get_workspace_rows()
+    # Each test starts from a clean instance (_pre_test clears all workspaces), so
+    # exactly the two workspaces created above are listed. Assert the absolute
+    # counts (auto-waiting) rather than a `.count()` snapshot, which can race the
+    # drawer's rows rendering.
+    expect(rows).to_have_count(2)
+
+    drawer.long_press_workspace_row(drawer.get_other_workspace_row())
+    drawer.get_delete_action().click()
+    get_delete_confirm_button(page).click()
+
+    expect(rows).to_have_count(1)

--- a/sculptor/tests/integration/frontend/test_mobile_overlays.py
+++ b/sculptor/tests/integration/frontend/test_mobile_overlays.py
@@ -1,0 +1,64 @@
+"""Integration tests for the mobile full-screen overlays: review-all and terminal.
+
+Both overlays float over the chat as in-shell state — "back" closes them and
+returns to the chat rather than navigating the router.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.mobile_workspace import enter_mobile_workspace
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+pytestmark = pytest.mark.mobile
+
+
+@user_story("to review all changes full-screen from my phone")
+def test_mobile_review_all_overlay(sculptor_instance_: SculptorInstance) -> None:
+    """The ChangesPill opens a full-screen review-all overlay: the combined diff
+    with its desktop toolbar hidden and the commit action pinned in a footer."""
+    page = sculptor_instance_.page
+
+    # Write a file so there are uncommitted changes for the pill to surface.
+    start_task_and_wait_for_ready(
+        sculptor_page=page,
+        prompt='fake_claude:write_file `{"file_path": "mobile_change.txt", "content": "hello from mobile\\n"}`',
+    )
+    shell = enter_mobile_workspace(page)
+
+    changes_pill = shell.get_changes_pill()
+    expect(changes_pill.root()).to_be_visible()
+
+    overlay = changes_pill.open_review_all()
+    expect(overlay.root()).to_be_visible()
+    # The combined diff renders the changed file...
+    expect(overlay.get_diff_file_sections().first).to_be_visible()
+    # ...with the desktop file-nav/scope toolbar hidden...
+    expect(overlay.get_diff_toolbar()).to_have_count(0)
+    # ...and the commit action pinned in the footer.
+    expect(overlay.get_commit_button()).to_be_visible()
+
+    # Back returns to the chat.
+    overlay.back()
+    expect(shell.get_chat_panel().get_chat_input()).to_be_visible()
+
+
+@user_story("to open a terminal full-screen from my phone")
+def test_mobile_terminal_overlay(sculptor_instance_: SculptorInstance) -> None:
+    """The header ⋮ menu opens a full-screen terminal overlay wrapping the real
+    terminal panel; back returns to the chat."""
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(sculptor_page=page)
+    shell = enter_mobile_workspace(page)
+
+    overlay = shell.open_terminal_overlay()
+    expect(overlay.root()).to_be_visible()
+    expect(overlay.get_terminal_panel()).to_be_visible()
+
+    # Back closes the overlay (it already asserts the overlay is gone) and returns
+    # to the chat.
+    overlay.back()
+    expect(shell.get_chat_panel().get_chat_input()).to_be_visible()

--- a/sculptor/tests/integration/frontend/test_mobile_shell.py
+++ b/sculptor/tests/integration/frontend/test_mobile_shell.py
@@ -1,0 +1,59 @@
+"""Integration tests for the mobile Workspace shell swapping in for the desktop layout.
+
+The mobile shell activates purely on viewport width: ``useLayoutMode`` reports
+mobile below 768px in a browser (never in Electron) and mirrors the verdict onto
+``<html class="mobileUx">``. These tests exercise both directions of that seam —
+a narrow browser gets the shell; a narrow Electron window does not.
+"""
+
+import pytest
+from playwright.sync_api import expect
+
+from sculptor.testing.elements.mobile_workspace import MOBILE_VIEWPORT
+from sculptor.testing.elements.mobile_workspace import enter_mobile_workspace
+from sculptor.testing.elements.mobile_workspace import expect_desktop_layout
+from sculptor.testing.elements.mobile_workspace import expect_mobile_layout
+from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
+from sculptor.testing.sculptor_instance import SculptorInstance
+from sculptor.testing.user_stories import user_story
+
+# Every test in this module drives the narrow-viewport mobile web UI.
+pytestmark = pytest.mark.mobile
+
+
+@user_story("to get a mobile-optimized workspace on a phone-sized screen")
+def test_mobile_shell_replaces_desktop_layout(sculptor_instance_: SculptorInstance) -> None:
+    """A narrow browser viewport swaps the desktop layout for the mobile shell."""
+    page = sculptor_instance_.page
+
+    # Create the workspace/agent at the default desktop viewport.
+    start_task_and_wait_for_ready(sculptor_page=page)
+    expect_desktop_layout(page)
+
+    # Narrowing below the 768px breakpoint replaces the whole desktop layout with
+    # the single-column mobile shell (header + chat + input).
+    shell = enter_mobile_workspace(page, viewport=MOBILE_VIEWPORT)
+    expect(shell.root()).to_be_visible()
+    expect(shell.get_header()).to_be_visible()
+    expect(shell.get_agent_switcher_pill()).to_be_visible()
+    expect_mobile_layout(page)
+
+
+@pytest.mark.electron
+@user_story("to keep the full desktop layout in the desktop app no matter how narrow the window")
+def test_narrow_electron_window_stays_desktop(sculptor_instance_: SculptorInstance) -> None:
+    """The Electron renderer never flips to the mobile shell, even when narrowed.
+
+    ``useLayoutMode`` short-circuits to desktop in the Electron renderer (decided
+    once at module load, and the media-query listener is never wired), so shrinking
+    the window below the mobile breakpoint must not swap in the mobile shell.
+    """
+    page = sculptor_instance_.page
+
+    start_task_and_wait_for_ready(sculptor_page=page)
+    expect_desktop_layout(page)
+
+    # Narrow the emulated window well below the 768px breakpoint — a browser would
+    # flip to mobile here; Electron must not.
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    expect_desktop_layout(page)


### PR DESCRIPTION
## Summary

Adds frontend **integration test coverage** for the experimental mobile UI landing in #326 (SCU-1618). **Stacked on #326** — it targets that branch, so the diff here is just the tests + their hooks; it flows to `main` once #326 lands.

The mobile shell activates purely on viewport width: `useLayoutMode` reports mobile below 768px in a browser (never in Electron) and mirrors the verdict onto `<html class="mobileUx">`. Tests enter the mobile UX by creating the workspace at the default viewport, then resizing to a phone viewport (390×844) and reloading so the shell mounts mobile from first paint — driven with FakeClaude for deterministic agent behavior.

## Coverage

- **Shell swap** — the mobile shell replaces the desktop layout at a narrow viewport; the **Electron inverse** (`@electron`) proves a narrowed desktop-app window stays on the desktop layout.
- **WorkspaceDrawer** — Home / Settings / workspace switch, long-press rename & delete, and "New workspace" opening the shared `NewWorkspaceModal`.
- **AgentSwitcher pill + AgentSheet** — switch agent, new agent, rename, delete.
- **Mobile ChatInput toolbar** — secondary controls collapsed into the options menu (plan / model / effort), no keyboard hints, no autofocus; plus a send/reply round-trip.
- **ChangesPill → review-all overlay** — combined diff with the desktop toolbar hidden and the commit action pinned in a footer; and the **terminal overlay** wrapping the real terminal panel.
- **AskUserQuestion** — scrollable options list with a reachable submit on a short viewport.

## How it's built

- The mobile-native surfaces carried **no test hooks**, so this adds `ElementIDs` + `data-testid` attributes to them (generated TS types regenerated), plus mobile Page Object Models and an `enter_mobile_workspace()` helper (`sculptor/sculptor/testing/elements/mobile_workspace.py`).
- Registers a **`mobile` pytest marker** (applied to all six files) so the suite is selectable as its own group via `-m mobile` — but it is **not** given a separate job; it's picked up by the existing browser integration run (and the `@electron` inverse by the existing Electron run). Opening this PR is partly to confirm that pickup on CI.
- Unit tests already cover the `useLayoutMode` Electron gate + class mirror and the short-viewport scroll threshold, so those aren't duplicated here.

## Testing

Locally: `format` / `check` (typecheck + lint + ratchets, no budget bumps) / `test-unit` all green; the browser mobile suite is **15 passed, 1 skipped** and the Electron inverse **passes**.

(Sent by Claude)