### PR TITLE
Fix choppy chat smooth-streaming reveal on fast output

### DIFF
--- a/sculptor/frontend/src/common/state/atoms/smoothStreaming.test.ts
+++ b/sculptor/frontend/src/common/state/atoms/smoothStreaming.test.ts
@@ -1,0 +1,28 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import { isSmoothStreamingEnabledAtomFamily, isSmoothStreamingViewportVisibleAtomFamily } from "./smoothStreaming.ts";
+
+describe("smooth streaming viewport atoms", () => {
+  it("default to visible/enabled for a task with no observed state", () => {
+    const store = createStore();
+    expect(store.get(isSmoothStreamingViewportVisibleAtomFamily("task-1"))).toBe(true);
+    // User preference defaults to true (no userConfig set), so enabled follows visibility.
+    expect(store.get(isSmoothStreamingEnabledAtomFamily("task-1"))).toBe(true);
+  });
+
+  it("keeps per-task visibility independent (multi-panel gate does not leak)", () => {
+    const store = createStore();
+
+    // Task A scrolls off-screen; task B stays visible.
+    store.set(isSmoothStreamingViewportVisibleAtomFamily("task-a"), false);
+
+    expect(store.get(isSmoothStreamingViewportVisibleAtomFamily("task-a"))).toBe(false);
+    expect(store.get(isSmoothStreamingViewportVisibleAtomFamily("task-b"))).toBe(true);
+
+    // The derived enabled atom follows each task's own visibility, so the
+    // off-screen panel does not disable smooth streaming for the visible one.
+    expect(store.get(isSmoothStreamingEnabledAtomFamily("task-a"))).toBe(false);
+    expect(store.get(isSmoothStreamingEnabledAtomFamily("task-b"))).toBe(true);
+  });
+});

--- a/sculptor/frontend/src/common/state/atoms/smoothStreaming.ts
+++ b/sculptor/frontend/src/common/state/atoms/smoothStreaming.ts
@@ -1,19 +1,31 @@
 import { atom } from "jotai";
+import { atomFamily } from "jotai/utils";
 
 import { isSmoothStreamingUserPreferenceAtom } from "~/common/state/atoms/userConfig.ts";
 
 /**
- * Writable atom set by the IntersectionObserver in useSmoothStreamingViewportObserver.
- * `true` when the message tail is in-view, `false` when off-screen.
+ * Per-task viewport-visibility atom, set by the IntersectionObserver in
+ * useSmoothStreamingViewportObserver. `true` when that task's message tail is
+ * in-view, `false` when off-screen.
+ *
+ * Keyed by task id because several chat panels can be mounted and streaming at
+ * once (one per placed agent section). A single shared atom would let an
+ * off-screen or differently-laid-out panel flip the gate for the panel the
+ * user is actually watching, forcing it to abandon smooth animation and dump
+ * text — which reads as choppiness. Scoping per task keeps each panel's gate
+ * independent.
  */
-export const isSmoothStreamingViewportVisibleAtom = atom<boolean>(true);
+export const isSmoothStreamingViewportVisibleAtomFamily = atomFamily((_taskID: string) => atom<boolean>(true));
 
 /**
- * Derived atom: smooth streaming is active only when BOTH the user preference
- * is enabled AND the message tail is visible in the viewport.
+ * Derived per-task atom: smooth streaming is active for a task only when BOTH
+ * the user preference is enabled AND that task's message tail is visible in the
+ * viewport.
  */
-export const isSmoothStreamingEnabledAtom = atom<boolean>((get) => {
-  const isUserPreferenceEnabled = get(isSmoothStreamingUserPreferenceAtom);
-  const isViewportVisible = get(isSmoothStreamingViewportVisibleAtom);
-  return isUserPreferenceEnabled && isViewportVisible;
-});
+export const isSmoothStreamingEnabledAtomFamily = atomFamily((taskID: string) =>
+  atom<boolean>((get) => {
+    const isUserPreferenceEnabled = get(isSmoothStreamingUserPreferenceAtom);
+    const isViewportVisible = get(isSmoothStreamingViewportVisibleAtomFamily(taskID));
+    return isUserPreferenceEnabled && isViewportVisible;
+  }),
+);

--- a/sculptor/frontend/src/pages/workspace/components/useChatData.ts
+++ b/sculptor/frontend/src/pages/workspace/components/useChatData.ts
@@ -63,7 +63,7 @@ export const useChatData = ({ taskID, workspaceID, appendTextRef, insertSkillRef
   const taskModel = useTaskModel(taskID);
   const isAutoCompacting = useTaskIsAutoCompacting(taskID);
   const setChatActions = useSetAtom(chatActionsAtom);
-  const bottomSentinelRef = useSmoothStreamingViewportObserver();
+  const bottomSentinelRef = useSmoothStreamingViewportObserver(taskID);
   useSmoothStreamingOnTaskSwitch(taskID, bottomSentinelRef);
 
   // `chatActionsAtom` is a single slot shared by workspace-scoped consumers

--- a/sculptor/frontend/src/pages/workspace/hooks/useSmoothStreaming.ts
+++ b/sculptor/frontend/src/pages/workspace/hooks/useSmoothStreaming.ts
@@ -3,47 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ChatMessage } from "~/api";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
-import { isSmoothStreamingEnabledAtom } from "~/common/state/atoms/smoothStreaming.ts";
+import { isSmoothStreamingEnabledAtomFamily } from "~/common/state/atoms/smoothStreaming.ts";
 import { useTask } from "~/common/state/hooks/useTaskHelpers.ts";
 
+import { computeDrainStep, snapToWordBoundary, updateDeliveryIntervalEma } from "../utils/smoothStreamingDrain.ts";
 import { StreamingEngine } from "../utils/StreamingEngine.ts";
-
-/** Hard flush when the buffer exceeds this many characters (~1.5s at high-speed streaming). */
-const MAX_BUFFER_CHARS = 500;
-
-/** Cap elapsed time per rAF frame to prevent huge jumps after browser tab idles. */
-const MAX_ELAPSED_CAP_MS = 100;
-
-/**
- * Minimum drain window — never drain faster than this even if the backend
- * delivers very rapidly.
- */
-const MIN_DRAIN_WINDOW_MS = 150;
-
-/**
- * Maximum drain window — if the backend stalls we don't want to stretch
- * a tiny batch over an unreasonably long period.
- */
-const MAX_DRAIN_WINDOW_MS = 1200;
-
-/** Fallback drain window used before we have delivery-interval data. */
-const DEFAULT_DRAIN_WINDOW_MS = 400;
-
-/** Smoothing factor for the exponential moving average of delivery intervals. */
-const DELIVERY_INTERVAL_SMOOTHING = 0.3;
-
-/**
- * Ignore arrival gaps longer than this when computing the delivery-interval
- * EMA. Gaps this large indicate a backend stall (not normal cadence) and
- * would distort the moving average.
- */
-const MAX_ARRIVAL_GAP_MS = 3000;
-
-/** Characters of look-ahead when snapping a reveal offset to a word boundary. */
-const WORD_BOUNDARY_LOOKAHEAD_CHARS = 15;
-
-/** Characters treated as word boundaries for snapping (whitespace and punctuation). */
-const WORD_BOUNDARY_PATTERN = /[\s\n.,;:!?)}\]"']/;
 
 /**
  * The currently animated message paired with the task it belongs to, so the
@@ -55,44 +19,25 @@ type RenderedState = {
 };
 
 /**
- * Snap a target character offset forward to the nearest word boundary.
- * Returns the adjusted number of characters to reveal.
- */
-const snapToWordBoundary = (text: string, currentOffset: number, rawCharsToReveal: number): number => {
-  const targetOffset = currentOffset + rawCharsToReveal;
-  if (targetOffset >= text.length) {
-    return rawCharsToReveal;
-  }
-
-  // Already at a boundary.
-  if (WORD_BOUNDARY_PATTERN.test(text[targetOffset])) {
-    return rawCharsToReveal;
-  }
-
-  const lookAhead = Math.min(targetOffset + WORD_BOUNDARY_LOOKAHEAD_CHARS, text.length);
-  for (let i = targetOffset + 1; i < lookAhead; i += 1) {
-    if (WORD_BOUNDARY_PATTERN.test(text[i])) {
-      return i - currentOffset;
-    }
-  }
-
-  // No boundary found within lookahead — use the raw value.
-  return rawCharsToReveal;
-};
-
-/**
  * Orchestrates a StreamingEngine against live task snapshots with smooth
  * time-based text draining via requestAnimationFrame.
  *
  * When smooth streaming is enabled:
  *   - New text accumulates in the engine's buffer.
- *   - A rAF loop drains the buffer at an adaptive rate. The drain window
- *     is set to the exponential moving average of the arrival-to-arrival
- *     interval between consecutive backend batches, so text spreads
- *     evenly across the full inter-batch period — creating continuous,
- *     fluid output.
- *   - The rendered text head never lags behind the received text by more
- *     than MAX_BUFFER_CHARS (~1500 ms equivalent).
+ *   - A rAF loop drains the buffer at an adaptive rate. The base drain
+ *     window is the exponential moving average of the arrival-to-arrival
+ *     interval between consecutive backend batches, so text spreads evenly
+ *     across the full inter-batch period — creating continuous, fluid
+ *     output.
+ *   - Each frame reveals a small, clamped number of characters
+ *     (MAX_CHARS_PER_FRAME) so even a fast stream crawls smoothly instead
+ *     of stepping in large chunks.
+ *   - If the buffer builds up (fast generation), the effective drain window
+ *     is progressively compressed so the reveal accelerates to catch up
+ *     without ever dumping the whole buffer in one frame. A hard flush is
+ *     reserved for pathological runaway buffers only.
+ *   - The drain math lives in ../utils/smoothStreamingDrain.ts so the
+ *     cadence can be unit-tested in isolation.
  *
  * When disabled (user toggle OFF, viewport off-screen, or per-task flag):
  *   - Text is flushed immediately (identical to previous ASAP behavior).
@@ -105,7 +50,8 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
   const taskID = agentID ?? "";
   const task = useTask(taskID);
   const isSmoothStreamingEnabledForTask = task?.isSmoothStreamingSupported ?? false;
-  const isSmoothStreamingEnabled = useAtomValue(isSmoothStreamingEnabledAtom) && isSmoothStreamingEnabledForTask;
+  const isSmoothStreamingEnabled =
+    useAtomValue(isSmoothStreamingEnabledAtomFamily(taskID)) && isSmoothStreamingEnabledForTask;
 
   const engineRef = useRef<StreamingEngine | null>(null);
   const activeMessageIdRef = useRef<string | null>(null);
@@ -160,26 +106,21 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
         return;
       }
 
-      // Enforce the hard max-latency cap.
-      if (bufferSize > MAX_BUFFER_CHARS) {
+      const elapsed = timestamp - lastFrameTimeRef.current;
+      lastFrameTimeRef.current = timestamp;
+
+      const step = computeDrainStep(bufferSize, elapsed, deliveryIntervalEmaRef.current);
+
+      // Runaway safety valve: reveal everything at once and stop the loop.
+      // Reserved for pathological bursts, not the common fast-streaming path.
+      if (step.shouldFlush) {
         rafIdRef.current = null;
         setRenderedState({ message: engine.flush(), taskID });
         return;
       }
 
-      const elapsed = Math.min(timestamp - lastFrameTimeRef.current, MAX_ELAPSED_CAP_MS);
-      lastFrameTimeRef.current = timestamp;
-
-      // Use the delivery-interval EMA as the drain window so text spreads
-      // evenly between backend batches, creating continuous flow.
-      const drainWindowMs = Math.min(
-        MAX_DRAIN_WINDOW_MS,
-        Math.max(MIN_DRAIN_WINDOW_MS, deliveryIntervalEmaRef.current ?? DEFAULT_DRAIN_WINDOW_MS),
-      );
-      const charsPerMs = bufferSize / drainWindowMs;
-      let charsToReveal = Math.max(1, Math.ceil(charsPerMs * elapsed));
-
       // Snap to the nearest word boundary to avoid mid-word cuts.
+      let charsToReveal = step.charsToReveal;
       const snapshot = engine.peekSnapshot();
       const cursorState = engine.peekCursor();
       if (snapshot && cursorState.blockIndex !== null && cursorState.offset !== null) {
@@ -248,11 +189,7 @@ export const useChatSmoothStreaming = (chatMessage: ChatMessage | null): ChatMes
         const nowMs = performance.now();
         if (lastBatchArrivalTimeRef.current > 0) {
           const arrivalGap = nowMs - lastBatchArrivalTimeRef.current;
-          if (arrivalGap < MAX_ARRIVAL_GAP_MS) {
-            const prev = deliveryIntervalEmaRef.current;
-            deliveryIntervalEmaRef.current =
-              prev === null ? arrivalGap : prev + DELIVERY_INTERVAL_SMOOTHING * (arrivalGap - prev);
-          }
+          deliveryIntervalEmaRef.current = updateDeliveryIntervalEma(deliveryIntervalEmaRef.current, arrivalGap);
         }
         lastBatchArrivalTimeRef.current = nowMs;
       }

--- a/sculptor/frontend/src/pages/workspace/hooks/useSmoothStreamingViewportObserver.ts
+++ b/sculptor/frontend/src/pages/workspace/hooks/useSmoothStreamingViewportObserver.ts
@@ -2,18 +2,41 @@ import { useSetAtom } from "jotai";
 import type { MutableRefObject, RefObject } from "react";
 import { useEffect, useRef } from "react";
 
-import { isSmoothStreamingViewportVisibleAtom } from "~/common/state/atoms/smoothStreaming.ts";
+import { isSmoothStreamingViewportVisibleAtomFamily } from "~/common/state/atoms/smoothStreaming.ts";
 
 /**
- * Hook that observes the message viewport visibility.
- * When the bottom sentinel goes off-screen, it disables smooth streaming so new snapshots render instantly.
- * When the sentinel re-enters the viewport, smooth streaming is re-enabled.
+ * Walk up from `element` to the nearest scrollable ancestor, so the
+ * IntersectionObserver measures visibility relative to the chat panel's own
+ * scroll container rather than the whole browser viewport. In a multi-panel
+ * layout a panel is not full-window, so a viewport-relative observer would
+ * report the sentinel as off-screen even when it is visible within its panel.
+ * Returns `null` (viewport root) if no scrollable ancestor is found.
+ */
+const findScrollableAncestor = (element: HTMLElement): HTMLElement | null => {
+  let node: HTMLElement | null = element.parentElement;
+  while (node) {
+    const style = window.getComputedStyle(node);
+    const overflowY = style.overflowY;
+    if ((overflowY === "auto" || overflowY === "scroll") && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+};
+
+/**
+ * Hook that observes the message viewport visibility for a single task.
+ * When the bottom sentinel goes off-screen, it disables smooth streaming for
+ * that task so new snapshots render instantly. When the sentinel re-enters the
+ * viewport, smooth streaming is re-enabled.
  *
+ * @param taskID - The task whose visibility this sentinel represents.
  * @returns Ref to attach to the bottom sentinel element
  */
-export const useSmoothStreamingViewportObserver = (): MutableRefObject<HTMLDivElement | null> => {
+export const useSmoothStreamingViewportObserver = (taskID: string): MutableRefObject<HTMLDivElement | null> => {
   const sentinelRef = useRef<HTMLDivElement | null>(null);
-  const setIsViewportVisible = useSetAtom(isSmoothStreamingViewportVisibleAtom);
+  const setIsViewportVisible = useSetAtom(isSmoothStreamingViewportVisibleAtomFamily(taskID));
 
   useEffect(() => {
     const node = sentinelRef.current;
@@ -21,9 +44,12 @@ export const useSmoothStreamingViewportObserver = (): MutableRefObject<HTMLDivEl
       return;
     }
 
-    const observer = new IntersectionObserver(([entry]) => {
-      setIsViewportVisible(entry.isIntersecting);
-    });
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsViewportVisible(entry.isIntersecting);
+      },
+      { root: findScrollableAncestor(node) },
+    );
 
     observer.observe(node);
 
@@ -46,7 +72,7 @@ export const useSmoothStreamingViewportObserver = (): MutableRefObject<HTMLDivEl
  * @param sentinelRef - Ref to the bottom sentinel element
  */
 export const useSmoothStreamingOnTaskSwitch = (taskID: string, sentinelRef: RefObject<HTMLDivElement | null>): void => {
-  const setIsViewportVisible = useSetAtom(isSmoothStreamingViewportVisibleAtom);
+  const setIsViewportVisible = useSetAtom(isSmoothStreamingViewportVisibleAtomFamily(taskID));
 
   useEffect(() => {
     const node = sentinelRef.current;
@@ -54,18 +80,25 @@ export const useSmoothStreamingOnTaskSwitch = (taskID: string, sentinelRef: RefO
       return;
     }
 
-    // Check if the sentinel is currently in the viewport and set visibility accordingly
-    const isInView = isElementInViewport(node);
-    setIsViewportVisible(isInView);
+    // Check if the sentinel is currently visible within its scroll container
+    // (or the viewport, if it isn't in one) and set visibility accordingly.
+    setIsViewportVisible(isElementVisibleInScrollParent(node));
   }, [taskID, sentinelRef, setIsViewportVisible]);
 };
 
-const isElementInViewport = (element: HTMLElement): boolean => {
+/**
+ * Whether `element` is currently visible within its nearest scrollable
+ * ancestor (falling back to the browser viewport). Uses the scroll container's
+ * bounds rather than the whole window so a non-full-window chat panel reports
+ * correctly.
+ */
+const isElementVisibleInScrollParent = (element: HTMLElement): boolean => {
   const rect = element.getBoundingClientRect();
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
+  const scrollParent = findScrollableAncestor(element);
+  if (scrollParent) {
+    const parentRect = scrollParent.getBoundingClientRect();
+    return rect.bottom > parentRect.top && rect.top < parentRect.bottom;
+  }
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+  return rect.bottom > 0 && rect.top < viewportHeight;
 };

--- a/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.test.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CATCHUP_BUFFER_CHARS,
+  computeDrainStep,
+  DEFAULT_DRAIN_WINDOW_MS,
+  MAX_CHARS_PER_FRAME,
+  MAX_DRAIN_WINDOW_MS,
+  MIN_CATCHUP_WINDOW_MS,
+  MIN_DRAIN_WINDOW_MS,
+  resolveBaseDrainWindowMs,
+  resolveEffectiveDrainWindowMs,
+  RUNAWAY_BUFFER_CHARS,
+  snapToWordBoundary,
+  updateDeliveryIntervalEma,
+} from "./smoothStreamingDrain.ts";
+
+describe("resolveBaseDrainWindowMs", () => {
+  it("falls back to the default before any cadence is observed", () => {
+    expect(resolveBaseDrainWindowMs(null)).toBe(DEFAULT_DRAIN_WINDOW_MS);
+  });
+
+  it("clamps into the [MIN, MAX] band", () => {
+    expect(resolveBaseDrainWindowMs(10)).toBe(MIN_DRAIN_WINDOW_MS);
+    expect(resolveBaseDrainWindowMs(99999)).toBe(MAX_DRAIN_WINDOW_MS);
+    expect(resolveBaseDrainWindowMs(500)).toBe(500);
+  });
+});
+
+describe("resolveEffectiveDrainWindowMs", () => {
+  it("leaves the window unchanged below the catch-up threshold", () => {
+    expect(resolveEffectiveDrainWindowMs(400, 100)).toBe(400);
+    expect(resolveEffectiveDrainWindowMs(400, CATCHUP_BUFFER_CHARS)).toBe(400);
+  });
+
+  it("compresses the window monotonically as the buffer grows past the threshold", () => {
+    const base = 400;
+    const small = resolveEffectiveDrainWindowMs(base, CATCHUP_BUFFER_CHARS + 100);
+    const larger = resolveEffectiveDrainWindowMs(base, CATCHUP_BUFFER_CHARS + 500);
+    expect(small).toBeLessThan(base);
+    expect(larger).toBeLessThan(small);
+    expect(larger).toBeGreaterThanOrEqual(MIN_CATCHUP_WINDOW_MS);
+  });
+
+  it("bottoms out at the catch-up floor near the runaway threshold", () => {
+    const base = 400;
+    expect(resolveEffectiveDrainWindowMs(base, RUNAWAY_BUFFER_CHARS)).toBeCloseTo(MIN_CATCHUP_WINDOW_MS, 5);
+  });
+});
+
+describe("computeDrainStep", () => {
+  it("reveals nothing when the buffer is empty", () => {
+    expect(computeDrainStep(0, 16, null)).toEqual({ charsToReveal: 0, shouldFlush: false });
+  });
+
+  it("flushes on a runaway buffer", () => {
+    const buffer = RUNAWAY_BUFFER_CHARS + 500;
+    expect(computeDrainStep(buffer, 16, null)).toEqual({ charsToReveal: buffer, shouldFlush: true });
+  });
+
+  it("always makes at least one character of progress", () => {
+    // Tiny buffer, tiny elapsed — still reveals at least one char.
+    const step = computeDrainStep(3, 1, MAX_DRAIN_WINDOW_MS);
+    expect(step.shouldFlush).toBe(false);
+    expect(step.charsToReveal).toBeGreaterThanOrEqual(1);
+  });
+
+  it("never reveals more than the per-frame cap even for a fast large stream", () => {
+    // Large buffer + short window would ask for a big chunk; the cap prevents it.
+    const step = computeDrainStep(CATCHUP_BUFFER_CHARS, 16, MIN_DRAIN_WINDOW_MS);
+    expect(step.shouldFlush).toBe(false);
+    expect(step.charsToReveal).toBeLessThanOrEqual(MAX_CHARS_PER_FRAME);
+  });
+
+  it("caps the elapsed time so a long idle frame does not dump the buffer", () => {
+    // A multi-second elapsed (background-tab resume) should behave like the cap,
+    // not reveal thousands of chars.
+    const idle = computeDrainStep(200, 10_000, DEFAULT_DRAIN_WINDOW_MS);
+    expect(idle.shouldFlush).toBe(false);
+    expect(idle.charsToReveal).toBeLessThanOrEqual(MAX_CHARS_PER_FRAME);
+  });
+});
+
+describe("snapToWordBoundary", () => {
+  it("returns the raw value when the target is at or past the text end", () => {
+    const text = "hello";
+    expect(snapToWordBoundary(text, 0, 10)).toBe(10);
+  });
+
+  it("returns the raw value when the target already lands on a boundary", () => {
+    const text = "hello world";
+    // offset 0, reveal 5 -> targets index 5 which is a space.
+    expect(snapToWordBoundary(text, 0, 5)).toBe(5);
+  });
+
+  it("snaps forward to the next boundary when it is closer", () => {
+    const text = "hello world foo";
+    // offset 0 reveal 4 -> target index 4 ('o'), nearest boundary is the space
+    // at index 5 (distance 1 forward) vs none behind within range.
+    expect(snapToWordBoundary(text, 0, 4)).toBe(5);
+  });
+
+  it("snaps backward to the previous boundary when it is closer", () => {
+    const text = "ab cdefghij";
+    // offset 0, reveal 8 -> target index 8 (mid 'cdefghij'); the space at index 2
+    // is the previous boundary. Forward has no boundary within lookahead, so it
+    // rounds down to the space, making progress of 2 chars.
+    expect(snapToWordBoundary(text, 0, 8)).toBe(2);
+  });
+
+  it("never regresses past the current offset", () => {
+    const text = "abcdefghij";
+    // No boundaries at all -> raw value preserved.
+    expect(snapToWordBoundary(text, 3, 4)).toBe(4);
+  });
+});
+
+describe("updateDeliveryIntervalEma", () => {
+  it("initializes to the first observed gap", () => {
+    expect(updateDeliveryIntervalEma(null, 200)).toBe(200);
+  });
+
+  it("smooths toward newer gaps", () => {
+    const next = updateDeliveryIntervalEma(200, 400);
+    expect(next).toBeGreaterThan(200);
+    expect(next).toBeLessThan(400);
+  });
+
+  it("ignores stall-sized gaps and keeps the previous EMA", () => {
+    expect(updateDeliveryIntervalEma(200, 999_999)).toBe(200);
+    expect(updateDeliveryIntervalEma(null, 999_999)).toBeNull();
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.test.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.test.ts
@@ -13,6 +13,7 @@ import {
   RUNAWAY_BUFFER_CHARS,
   snapToWordBoundary,
   updateDeliveryIntervalEma,
+  WORD_BOUNDARY_LOOKAHEAD_CHARS,
 } from "./smoothStreamingDrain.ts";
 
 describe("resolveBaseDrainWindowMs", () => {
@@ -106,6 +107,22 @@ describe("snapToWordBoundary", () => {
     // is the previous boundary. Forward has no boundary within lookahead, so it
     // rounds down to the space, making progress of 2 chars.
     expect(snapToWordBoundary(text, 0, 8)).toBe(2);
+  });
+
+  it("scans forward over the full lookahead window (symmetric with backward)", () => {
+    // Put the only boundary exactly WORD_BOUNDARY_LOOKAHEAD_CHARS characters
+    // ahead of the target (the far edge of the intended window), with no
+    // boundary behind within range. The forward scan must include the full
+    // lookahead distance to find it; a scan that stopped one char short (the
+    // prior off-by-one, asymmetric with the backward scan) would miss it and
+    // fall back to the raw value.
+    const currentOffset = 0;
+    const targetOffset = 1;
+    const boundaryIndex = targetOffset + WORD_BOUNDARY_LOOKAHEAD_CHARS;
+    const chars = Array<string>(boundaryIndex + 2).fill("a");
+    chars[boundaryIndex] = " ";
+    const text = chars.join("");
+    expect(snapToWordBoundary(text, currentOffset, targetOffset)).toBe(boundaryIndex);
   });
 
   it("never regresses past the current offset", () => {

--- a/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure drain-rate math for the smooth-streaming rAF loop.
+ *
+ * These helpers decide how many characters to reveal on a given animation
+ * frame given the current buffer size, the observed delivery cadence, and how
+ * much time elapsed since the previous frame. They are kept free of React and
+ * DOM state so the cadence can be unit-tested directly (the hook that drives
+ * the loop is otherwise hard to pin down in a test).
+ */
+
+/**
+ * Cap elapsed time per rAF frame to prevent huge jumps after the browser tab
+ * idles (rAF pauses in background tabs, so the first frame back can report a
+ * multi-second delta).
+ */
+export const MAX_ELAPSED_CAP_MS = 100;
+
+/**
+ * Minimum drain window — never spread a batch over less than this even if the
+ * backend delivers very rapidly. Draining faster than this reads as an
+ * instant dump rather than a smooth reveal.
+ */
+export const MIN_DRAIN_WINDOW_MS = 150;
+
+/**
+ * Maximum drain window — if the backend stalls we don't want to stretch a tiny
+ * batch over an unreasonably long period.
+ */
+export const MAX_DRAIN_WINDOW_MS = 1200;
+
+/** Fallback drain window used before we have delivery-interval data. */
+export const DEFAULT_DRAIN_WINDOW_MS = 400;
+
+/**
+ * Soft catch-up threshold. Once the buffer exceeds this, we progressively
+ * shrink the effective drain window so the reveal speeds up and latency stays
+ * bounded — WITHOUT dumping the whole buffer in a single frame (which is what
+ * produced the visible "jump" choppiness). The further past this the buffer
+ * is, the harder we compress the window, down to MIN_CATCHUP_WINDOW_MS.
+ */
+export const CATCHUP_BUFFER_CHARS = 350;
+
+/**
+ * Floor for the compressed drain window during catch-up. Small enough to burn
+ * down a large backlog quickly, but still spread across several frames so the
+ * reveal stays continuous instead of snapping.
+ */
+export const MIN_CATCHUP_WINDOW_MS = 60;
+
+/**
+ * Runaway threshold. Only when the buffer is this large do we give up on
+ * animating and hard-flush the remainder in one step. This is a safety valve
+ * for pathological bursts (e.g. a huge paste-like block arriving at once), not
+ * the common fast-streaming path.
+ */
+export const RUNAWAY_BUFFER_CHARS = 2000;
+
+/**
+ * Cap on characters revealed in a single frame. Even when the buffer is large,
+ * clamping the per-frame step keeps a fast stream rendering as a fast *smooth*
+ * crawl rather than a few big steps. Excess stays in the buffer and is soaked
+ * up by the catch-up window compression above.
+ */
+export const MAX_CHARS_PER_FRAME = 12;
+
+/** Smoothing factor for the exponential moving average of delivery intervals. */
+export const DELIVERY_INTERVAL_SMOOTHING = 0.3;
+
+/**
+ * Ignore arrival gaps longer than this when computing the delivery-interval
+ * EMA. Gaps this large indicate a backend stall (not normal cadence) and would
+ * distort the moving average.
+ */
+export const MAX_ARRIVAL_GAP_MS = 3000;
+
+/** Characters of look-ahead when snapping a reveal offset to a word boundary. */
+export const WORD_BOUNDARY_LOOKAHEAD_CHARS = 8;
+
+/** Characters treated as word boundaries for snapping (whitespace and punctuation). */
+export const WORD_BOUNDARY_PATTERN = /[\s\n.,;:!?)}\]"']/;
+
+/**
+ * The outcome of evaluating one animation frame.
+ *
+ * - `charsToReveal`: how many characters to advance the cursor by this frame.
+ * - `shouldFlush`: when true, reveal everything immediately (runaway safety
+ *   valve); the loop should stop after flushing.
+ */
+export type DrainStep = {
+  readonly charsToReveal: number;
+  readonly shouldFlush: boolean;
+};
+
+/**
+ * Clamp the base (non-compressed) drain window derived from the delivery-
+ * interval EMA into the sane `[MIN, MAX]` band, falling back to the default
+ * before any cadence has been observed.
+ */
+export const resolveBaseDrainWindowMs = (deliveryIntervalEmaMs: number | null): number =>
+  Math.min(MAX_DRAIN_WINDOW_MS, Math.max(MIN_DRAIN_WINDOW_MS, deliveryIntervalEmaMs ?? DEFAULT_DRAIN_WINDOW_MS));
+
+/**
+ * Compress the drain window as the buffer grows past the catch-up threshold so
+ * the reveal accelerates to burn down a backlog, bottoming out at
+ * MIN_CATCHUP_WINDOW_MS. Below the threshold the base window is used unchanged.
+ */
+export const resolveEffectiveDrainWindowMs = (baseWindowMs: number, bufferSize: number): number => {
+  if (bufferSize <= CATCHUP_BUFFER_CHARS) {
+    return baseWindowMs;
+  }
+  // Linear ramp from `baseWindowMs` at CATCHUP_BUFFER_CHARS down to
+  // MIN_CATCHUP_WINDOW_MS at RUNAWAY_BUFFER_CHARS.
+  const span = RUNAWAY_BUFFER_CHARS - CATCHUP_BUFFER_CHARS;
+  const over = Math.min(bufferSize - CATCHUP_BUFFER_CHARS, span);
+  const progress = span > 0 ? over / span : 1;
+  const compressed = baseWindowMs - progress * (baseWindowMs - MIN_CATCHUP_WINDOW_MS);
+  return Math.max(MIN_CATCHUP_WINDOW_MS, compressed);
+};
+
+/**
+ * Decide how many characters to reveal this frame.
+ *
+ * Returns `shouldFlush` for a runaway buffer (reveal everything at once);
+ * otherwise computes a per-frame character count from the effective drain rate
+ * and clamps it to `[1, MAX_CHARS_PER_FRAME]` so fast streams crawl smoothly
+ * instead of stepping.
+ */
+export const computeDrainStep = (
+  bufferSize: number,
+  elapsedMs: number,
+  deliveryIntervalEmaMs: number | null,
+): DrainStep => {
+  if (bufferSize <= 0) {
+    return { charsToReveal: 0, shouldFlush: false };
+  }
+
+  if (bufferSize >= RUNAWAY_BUFFER_CHARS) {
+    return { charsToReveal: bufferSize, shouldFlush: true };
+  }
+
+  const baseWindowMs = resolveBaseDrainWindowMs(deliveryIntervalEmaMs);
+  const effectiveWindowMs = resolveEffectiveDrainWindowMs(baseWindowMs, bufferSize);
+  const cappedElapsedMs = Math.min(Math.max(elapsedMs, 0), MAX_ELAPSED_CAP_MS);
+
+  const charsPerMs = bufferSize / effectiveWindowMs;
+  const raw = Math.ceil(charsPerMs * cappedElapsedMs);
+  const clamped = Math.min(Math.max(1, raw), MAX_CHARS_PER_FRAME);
+
+  return { charsToReveal: clamped, shouldFlush: false };
+};
+
+/**
+ * Snap a target character offset to the *nearest* word boundary within a small
+ * look-ahead/look-behind window, so reveals land between words instead of
+ * mid-word.
+ *
+ * Unlike a forward-only snap, this may round the step DOWN to the previous
+ * boundary when that boundary is closer. Rounding only forward inflated every
+ * frame's step by up to a full partial word, which read as phrase-by-phrase
+ * popping; snapping to the nearest boundary (and never below 1 char of
+ * progress) keeps the crawl smooth.
+ */
+export const snapToWordBoundary = (text: string, currentOffset: number, rawCharsToReveal: number): number => {
+  const targetOffset = currentOffset + rawCharsToReveal;
+
+  // Nothing past the end to snap to.
+  if (targetOffset >= text.length) {
+    return rawCharsToReveal;
+  }
+
+  // Already at a boundary.
+  if (WORD_BOUNDARY_PATTERN.test(text[targetOffset])) {
+    return rawCharsToReveal;
+  }
+
+  // Look forward for the next boundary.
+  let forwardOffset: number | null = null;
+  const forwardLimit = Math.min(targetOffset + WORD_BOUNDARY_LOOKAHEAD_CHARS, text.length);
+  for (let i = targetOffset + 1; i < forwardLimit; i += 1) {
+    if (WORD_BOUNDARY_PATTERN.test(text[i])) {
+      forwardOffset = i;
+      break;
+    }
+  }
+
+  // Look backward for the previous boundary (but never regress past the cursor,
+  // and always make at least 1 char of progress).
+  let backwardOffset: number | null = null;
+  const backwardLimit = Math.max(currentOffset + 1, targetOffset - WORD_BOUNDARY_LOOKAHEAD_CHARS);
+  for (let i = targetOffset - 1; i >= backwardLimit; i -= 1) {
+    if (WORD_BOUNDARY_PATTERN.test(text[i])) {
+      backwardOffset = i;
+      break;
+    }
+  }
+
+  // Choose whichever boundary is closer to the raw target.
+  if (forwardOffset === null && backwardOffset === null) {
+    return rawCharsToReveal;
+  }
+
+  if (forwardOffset === null) {
+    return (backwardOffset as number) - currentOffset;
+  }
+
+  if (backwardOffset === null) {
+    return forwardOffset - currentOffset;
+  }
+  const forwardDistance = forwardOffset - targetOffset;
+  const backwardDistance = targetOffset - backwardOffset;
+  const chosen = forwardDistance <= backwardDistance ? forwardOffset : backwardOffset;
+  return chosen - currentOffset;
+};
+
+/**
+ * Update the exponential moving average of the arrival-to-arrival interval
+ * between backend batches. Returns the new EMA, ignoring gaps so large they
+ * indicate a stall rather than normal cadence (in which case the previous EMA
+ * is returned unchanged).
+ */
+export const updateDeliveryIntervalEma = (previousEmaMs: number | null, arrivalGapMs: number): number | null => {
+  if (arrivalGapMs >= MAX_ARRIVAL_GAP_MS) {
+    return previousEmaMs;
+  }
+
+  if (previousEmaMs === null) {
+    return arrivalGapMs;
+  }
+  return previousEmaMs + DELIVERY_INTERVAL_SMOOTHING * (arrivalGapMs - previousEmaMs);
+};

--- a/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.ts
@@ -168,18 +168,19 @@ export const snapToWordBoundary = (text: string, currentOffset: number, rawChars
     return rawCharsToReveal;
   }
 
-  // Look forward for the next boundary.
+  // Look forward for the next boundary, up to and including the full lookahead
+  // distance (last index is text.length - 1).
   let forwardOffset: number | null = null;
-  const forwardLimit = Math.min(targetOffset + WORD_BOUNDARY_LOOKAHEAD_CHARS, text.length);
-  for (let i = targetOffset + 1; i < forwardLimit; i += 1) {
+  const forwardLimit = Math.min(targetOffset + WORD_BOUNDARY_LOOKAHEAD_CHARS, text.length - 1);
+  for (let i = targetOffset + 1; i <= forwardLimit; i += 1) {
     if (WORD_BOUNDARY_PATTERN.test(text[i])) {
       forwardOffset = i;
       break;
     }
   }
 
-  // Look backward for the previous boundary (but never regress past the cursor,
-  // and always make at least 1 char of progress).
+  // Look backward for the previous boundary, over the same distance (but never
+  // regress past the cursor, and always make at least 1 char of progress).
   let backwardOffset: number | null = null;
   const backwardLimit = Math.max(currentOffset + 1, targetOffset - WORD_BOUNDARY_LOOKAHEAD_CHARS);
   for (let i = targetOffset - 1; i >= backwardLimit; i -= 1) {

--- a/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.ts
+++ b/sculptor/frontend/src/pages/workspace/utils/smoothStreamingDrain.ts
@@ -32,11 +32,11 @@ export const MAX_DRAIN_WINDOW_MS = 1200;
 export const DEFAULT_DRAIN_WINDOW_MS = 400;
 
 /**
- * Soft catch-up threshold. Once the buffer exceeds this, we progressively
- * shrink the effective drain window so the reveal speeds up and latency stays
- * bounded — WITHOUT dumping the whole buffer in a single frame (which is what
- * produced the visible "jump" choppiness). The further past this the buffer
- * is, the harder we compress the window, down to MIN_CATCHUP_WINDOW_MS.
+ * Soft catch-up threshold. Once the buffer exceeds this, the effective drain
+ * window progressively shrinks so the reveal speeds up and latency stays
+ * bounded without dumping the whole buffer in a single frame. The further past
+ * this the buffer is, the harder the window compresses, down to
+ * MIN_CATCHUP_WINDOW_MS.
  */
 export const CATCHUP_BUFFER_CHARS = 350;
 
@@ -152,13 +152,8 @@ export const computeDrainStep = (
 /**
  * Snap a target character offset to the *nearest* word boundary within a small
  * look-ahead/look-behind window, so reveals land between words instead of
- * mid-word.
- *
- * Unlike a forward-only snap, this may round the step DOWN to the previous
- * boundary when that boundary is closer. Rounding only forward inflated every
- * frame's step by up to a full partial word, which read as phrase-by-phrase
- * popping; snapping to the nearest boundary (and never below 1 char of
- * progress) keeps the crawl smooth.
+ * mid-word. May round the step down to the previous boundary when it is
+ * closer, but never below one character of progress.
  */
 export const snapToWordBoundary = (text: string, currentOffset: number, rawCharsToReveal: number): number => {
   const targetOffset = currentOffset + rawCharsToReveal;


### PR DESCRIPTION
Fixes [SCU-1824](https://linear.app/imbue/issue/SCU-1824/chat-smooth-streaming-reveal-is-choppy-on-fast-output).

## Original problem

Chat text streaming had started to feel choppy — the "smooth" reveal steps in visible chunks rather than a continuous crawl, and it gets worse as model output speeds up. Reported from real use on a single open chat.

## Root cause

The `requestAnimationFrame` drain loop in `useSmoothStreaming.ts` had three defects, all amplified by faster generation:

1. **Overflow dumped-and-died.** When the unrevealed buffer exceeded a hard cap, the loop flushed the entire buffer in one frame **and stopped**, staying dead until the next backend batch restarted it. Fast streams hit this constantly → periodic large jumps with dead time between them.
2. **Large per-frame reveals.** With a short delivery-interval drain window and large batches, `ceil(bufferSize / drainWindow * elapsed)` revealed many characters in a single 16 ms frame → visible stepping.
3. **Forward-only word snapping.** Word-boundary snapping only ever *extended* the per-frame step forward (up to a full partial word), inflating every frame → phrase-by-phrase popping.

## Related issue (found while investigating)

Smooth streaming is gated on whether the message tail is visible in the viewport, but that visibility lived in a **single global atom**. Now that multiple chat panels can be mounted and streaming at once (one per placed agent section), each panel's viewport observer wrote the same shared atom, so an off-screen or differently-laid-out panel could flip the gate off for the panel the user was actually watching — forcing it to abandon smooth animation and dump text.

## Fix

Part A — drain loop (`useSmoothStreaming.ts`, new `smoothStreamingDrain.ts`):
- Replace dump-and-die overflow with **progressive catch-up**: once the buffer passes a soft threshold, the effective drain window compresses so the reveal accelerates to burn down the backlog — without dumping. A true flush is reserved only for a pathological runaway buffer.
- **Cap per-frame reveal** (`MAX_CHARS_PER_FRAME`) so a fast stream renders as a fast *smooth* crawl instead of a few big steps.
- Snap to the **nearest** word boundary (may round down) instead of always extending forward.
- Extract the drain math into a pure, unit-tested helper module.

Part B — viewport gate (`smoothStreaming.ts`, `useSmoothStreamingViewportObserver.ts`):
- Scope viewport-visibility and the derived "enabled" atoms into **per-task atom families** so each panel gates only its own animation.
- Measure visibility against the panel's **own scroll container** (nearest scrollable ancestor) rather than the whole browser window, which was inaccurate for a non-full-window panel.

## Proof the fix works

This is a visual/timing change to an animation cadence, so the primary evidence is the new unit coverage that pins the previously-untested drain math, plus the full frontend suite:

- `smoothStreamingDrain.test.ts` — per-frame cap, catch-up window compression, runaway flush, idle-frame clamping, nearest-boundary snapping, delivery-interval EMA.
- `smoothStreaming.test.ts` — per-task viewport atoms are independent (multi-panel gate does not leak).

```
$ just check
Check PASSED   (typecheck, lint, ratchets, file hygiene)

$ just test-unit-frontend
Test Files  248 passed (248)
     Tests  3050 passed | 1 skipped (3051)
```

## Notes

- No behavior change when smooth streaming is disabled (user toggle off, off-screen, or unsupported task) — text still flushes immediately as before.
- Constants (`MAX_CHARS_PER_FRAME`, catch-up thresholds, `MIN_CATCHUP_WINDOW_MS`) are the tuning knobs if the reveal feel needs adjustment after live use.

(Sent by Claude)
