### PR TITLE
Streamline pi provider authentication in Settings (SCU-1821)

### DIFF
--- a/sculptor/frontend/src/common/modelConstants.ts
+++ b/sculptor/frontend/src/common/modelConstants.ts
@@ -86,6 +86,8 @@ const providerDisplayNames: Record<string, string> = {
   deepseek: "DeepSeek",
   google: "Google",
   openai: "OpenAI",
+  "openai-codex": "ChatGPT Plus/Pro (Codex)",
+  "github-copilot": "GitHub Copilot",
   "amazon-bedrock": "Amazon Bedrock",
 };
 

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
@@ -1,0 +1,86 @@
+import { Theme } from "@radix-ui/themes";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PiLoginDialog } from "./PiLoginDialog.tsx";
+
+const { mockStartPiLogin, mockFinishPiLogin, mockGetPiLoginStatus } = vi.hoisted(() => ({
+  mockStartPiLogin: vi.fn(),
+  mockFinishPiLogin: vi.fn(),
+  mockGetPiLoginStatus: vi.fn(),
+}));
+
+vi.mock("~/api", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    startPiLogin: mockStartPiLogin,
+    finishPiLogin: mockFinishPiLogin,
+    getPiLoginStatus: mockGetPiLoginStatus,
+  };
+});
+
+// The real terminal opens a PTY WebSocket; the stub only exposes the Done control.
+vi.mock("./PiLoginTerminal.tsx", () => ({
+  PiLoginTerminal: ({ loginId, onDone }: { loginId: string; onDone: () => void }): ReactElement => (
+    <div data-testid="fake-login-terminal" data-login-id={loginId}>
+      <div data-testid="fake-login-done" onClick={onDone}>
+        Done
+      </div>
+    </div>
+  ),
+}));
+
+const renderDialog = (mode: "login" | "logout", onClose: () => void = vi.fn()): void => {
+  render(
+    <Theme>
+      <PiLoginDialog request={{ providerId: "openai", displayName: "OpenAI", mode }} onClose={onClose} />
+    </Theme>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PiLoginDialog", () => {
+  it("starts the login session immediately on mount, with no intro step", async () => {
+    mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-1" } });
+    mockGetPiLoginStatus.mockResolvedValue({ data: { completed: false } });
+
+    renderDialog("login");
+
+    const terminal = await screen.findByTestId("fake-login-terminal");
+    expect(terminal.getAttribute("data-login-id")).toBe("login-1");
+    expect(mockStartPiLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { mode: "login", providerId: "openai" } }),
+    );
+    expect(screen.queryByText("Open pi login")).toBeNull();
+  });
+
+  it("shows an error when the session cannot start", async () => {
+    mockStartPiLogin.mockRejectedValue(new Error("no pi"));
+
+    renderDialog("login");
+
+    expect(await screen.findByText(/Could not start the pi session/)).toBeTruthy();
+  });
+
+  it("tears the session down and closes on Done", async () => {
+    mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-2" } });
+    mockGetPiLoginStatus.mockResolvedValue({ data: { completed: false } });
+    mockFinishPiLogin.mockResolvedValue({ data: {} });
+    const onClose = vi.fn();
+
+    renderDialog("login", onClose);
+
+    fireEvent.click(await screen.findByTestId("fake-login-done"));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(mockFinishPiLogin).toHaveBeenCalledWith(expect.objectContaining({ path: { login_id: "login-2" } }));
+  });
+});

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
@@ -3,6 +3,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { ProviderGroup } from "~/api";
+
 import { PiLoginDialog } from "./PiLoginDialog.tsx";
 
 const { mockStartPiLogin, mockFinishPiLogin, mockGetPiLoginStatus } = vi.hoisted(() => ({
@@ -35,12 +37,15 @@ vi.mock("./PiLoginTerminal.tsx", () => ({
 const renderDialog = (
   mode: "login" | "logout",
   onClose: () => void = vi.fn(),
-  { supportsSubscription = false }: { supportsSubscription?: boolean } = {},
+  {
+    supportsSubscription = false,
+    group = ProviderGroup.SINGLE_KEY,
+  }: { supportsSubscription?: boolean; group?: ProviderGroup } = {},
 ): void => {
   render(
     <Theme>
       <PiLoginDialog
-        request={{ providerId: "openai", displayName: "OpenAI", mode, supportsSubscription }}
+        request={{ providerId: "openai", displayName: "OpenAI", mode, supportsSubscription, group }}
         onClose={onClose}
       />
     </Theme>,
@@ -85,6 +90,16 @@ describe("PiLoginDialog", () => {
 
     await screen.findByTestId("fake-login-terminal");
     expect(screen.getByText(/Choose how to sign in/)).toBeTruthy();
+  });
+
+  it("tells a subscription-only provider's user that pi opens the subscription sign-in", async () => {
+    mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-5" } });
+    mockGetPiLoginStatus.mockResolvedValue({ data: { completed: false } });
+
+    renderDialog("login", vi.fn(), { supportsSubscription: true, group: ProviderGroup.SUBSCRIPTION_ONLY });
+
+    await screen.findByTestId("fake-login-terminal");
+    expect(screen.getByText(/subscription sign-in/)).toBeTruthy();
   });
 
   it("shows an error when the session cannot start", async () => {

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
@@ -32,10 +32,17 @@ vi.mock("./PiLoginTerminal.tsx", () => ({
   ),
 }));
 
-const renderDialog = (mode: "login" | "logout", onClose: () => void = vi.fn()): void => {
+const renderDialog = (
+  mode: "login" | "logout",
+  onClose: () => void = vi.fn(),
+  { supportsSubscription = false }: { supportsSubscription?: boolean } = {},
+): void => {
   render(
     <Theme>
-      <PiLoginDialog request={{ providerId: "openai", displayName: "OpenAI", mode }} onClose={onClose} />
+      <PiLoginDialog
+        request={{ providerId: "openai", displayName: "OpenAI", mode, supportsSubscription }}
+        onClose={onClose}
+      />
     </Theme>,
   );
 };
@@ -58,6 +65,26 @@ describe("PiLoginDialog", () => {
       expect.objectContaining({ body: { mode: "login", providerId: "openai" } }),
     );
     expect(screen.queryByText("Open pi login")).toBeNull();
+  });
+
+  it("tells an API-key-only provider's user that pi opens at the key input", async () => {
+    mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-3" } });
+    mockGetPiLoginStatus.mockResolvedValue({ data: { completed: false } });
+
+    renderDialog("login");
+
+    await screen.findByTestId("fake-login-terminal");
+    expect(screen.getByText(/Enter your OpenAI API key/)).toBeTruthy();
+  });
+
+  it("tells a subscription-capable provider's user to choose a sign-in method", async () => {
+    mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-4" } });
+    mockGetPiLoginStatus.mockResolvedValue({ data: { completed: false } });
+
+    renderDialog("login", vi.fn(), { supportsSubscription: true });
+
+    await screen.findByTestId("fake-login-terminal");
+    expect(screen.getByText(/Choose how to sign in/)).toBeTruthy();
   });
 
   it("shows an error when the session cannot start", async () => {

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.test.tsx
@@ -1,5 +1,5 @@
 import { Theme } from "@radix-ui/themes";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -108,6 +108,57 @@ describe("PiLoginDialog", () => {
     renderDialog("login");
 
     expect(await screen.findByText(/Could not start the pi session/)).toBeTruthy();
+  });
+
+  it("reaps the live session when the dialog unmounts without an explicit teardown", async () => {
+    mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-6" } });
+    mockGetPiLoginStatus.mockResolvedValue({ data: { completed: false } });
+    mockFinishPiLogin.mockResolvedValue({ data: {} });
+
+    const { unmount } = render(
+      <Theme>
+        <PiLoginDialog
+          request={{
+            providerId: "openai",
+            displayName: "OpenAI",
+            mode: "login",
+            supportsSubscription: false,
+            group: ProviderGroup.SINGLE_KEY,
+          }}
+          onClose={vi.fn()}
+        />
+      </Theme>,
+    );
+    await screen.findByTestId("fake-login-terminal");
+    unmount();
+
+    await waitFor(() => {
+      expect(mockFinishPiLogin).toHaveBeenCalledWith(expect.objectContaining({ path: { login_id: "login-6" } }));
+    });
+  });
+
+  it("keeps the status poll single-flight while a request is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      mockStartPiLogin.mockResolvedValue({ data: { loginId: "login-7" } });
+      // A status request that never settles: further interval ticks must not stack.
+      mockGetPiLoginStatus.mockImplementation(() => new Promise(() => undefined));
+
+      renderDialog("login");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1300);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1300);
+      });
+
+      expect(mockGetPiLoginStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("tears the session down and closes on Done", async () => {

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
@@ -1,5 +1,5 @@
 import { Cross1Icon } from "@radix-ui/react-icons";
-import { Button, Dialog, Flex, IconButton, Spinner, Text } from "@radix-ui/themes";
+import { Dialog, Flex, IconButton, Spinner, Text } from "@radix-ui/themes";
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 
 import { ElementIds, finishPiLogin, getPiLoginStatus, startPiLogin } from "~/api";
@@ -19,8 +19,6 @@ export type PiLoginRequestView = {
   mode: "login" | "logout";
 };
 
-type DialogView = "intro" | "terminal";
-
 type PiLoginDialogProps = {
   request: PiLoginRequestView;
   /** Called after the session is torn down; the parent clears the request and refetches. */
@@ -28,49 +26,35 @@ type PiLoginDialogProps = {
 };
 
 /**
- * Centered modal hosting the interactive pi /login (or /logout) session. Login shows a
- * short intro whose single "Open pi login" action launches the terminal; logout starts
- * the /logout terminal immediately. While the terminal is live, Escape and
- * outside-clicks are suppressed (Escape is a keystroke pi consumes) — the user leaves
- * via Done, which tears the PTY down. pi writes ~/.pi/agent/auth.json itself.
+ * Centered modal hosting the interactive pi /login (or /logout) session, which starts
+ * as soon as the modal mounts. While the terminal is live, Escape and outside-clicks
+ * are suppressed (Escape is a keystroke pi consumes) — the user leaves via Done, which
+ * tears the PTY down. pi writes ~/.pi/agent/auth.json itself.
  */
 export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactElement => {
-  const [view, setView] = useState<DialogView>(request.mode === "logout" ? "terminal" : "intro");
   const [activeLoginId, setActiveLoginId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const startSession = useCallback(async (): Promise<void> => {
-    setErrorMessage(null);
-    try {
-      const response = await startPiLogin({
-        body: { mode: request.mode, providerId: request.providerId ?? undefined },
-        meta: { skipWsAck: true },
-      });
-      if (response.data) {
-        setActiveLoginId(response.data.loginId);
-        setView("terminal");
-      }
-    } catch {
-      setErrorMessage("Could not start the pi session. Check that pi is installed in Settings → Pi.");
-    }
-  }, [request]);
-
-  // pi /logout has no intro step — kick off its interactive terminal as soon as the modal
-  // mounts (the parent remounts the dialog per request, so this fires once per open).
+  // Kick off the interactive terminal as soon as the modal mounts (the parent remounts
+  // the dialog per request, so this fires once per open). A session that resolves after
+  // the effect is torn down (dialog closed, or a StrictMode remount) is never adopted,
+  // so reap its PTY instead of leaking it.
   useEffect(() => {
-    if (request.mode !== "logout") {
-      return;
-    }
-
     let isActive = true;
     void (async (): Promise<void> => {
       try {
         const response = await startPiLogin({
-          body: { mode: "logout", providerId: request.providerId ?? undefined },
+          body: { mode: request.mode, providerId: request.providerId ?? undefined },
           meta: { skipWsAck: true },
         });
-        if (isActive && response.data) {
+        if (!response.data) {
+          return;
+        }
+
+        if (isActive) {
           setActiveLoginId(response.data.loginId);
+        } else {
+          await finishPiLogin({ path: { login_id: response.data.loginId }, meta: { skipWsAck: true } });
         }
       } catch {
         if (isActive) {
@@ -101,7 +85,7 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
   // the credential change (provider added on login / removed on logout). On completion
   // the modal closes and the Providers area refetches — no manual Done.
   useEffect(() => {
-    if (view !== "terminal" || activeLoginId === null) {
+    if (activeLoginId === null) {
       return;
     }
     let isCancelled = false;
@@ -123,7 +107,7 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
       isCancelled = true;
       window.clearInterval(interval);
     };
-  }, [view, activeLoginId, teardown]);
+  }, [activeLoginId, teardown]);
 
   const isLogin = request.mode === "login";
   const title = isLogin ? `Authenticate ${request.displayName}` : `Disconnect ${request.displayName}`;
@@ -138,8 +122,8 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
       <Dialog.Content
         maxWidth="640px"
         data-testid={ElementIds.PI_LOGIN_DIALOG}
-        onEscapeKeyDown={(event) => view === "terminal" && event.preventDefault()}
-        onPointerDownOutside={(event) => view === "terminal" && event.preventDefault()}
+        onEscapeKeyDown={(event) => activeLoginId !== null && event.preventDefault()}
+        onPointerDownOutside={(event) => activeLoginId !== null && event.preventDefault()}
       >
         <Flex align="center" gap="3" mb="3">
           <Dialog.Title size="3" mb="0" style={{ flexGrow: 1 }}>
@@ -152,40 +136,22 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
           </Dialog.Close>
         </Flex>
 
-        {view === "intro" && (
-          <Flex direction="column" gap="3">
+        {errorMessage !== null ? (
+          <Text size="2" color="red">
+            {errorMessage}
+          </Text>
+        ) : activeLoginId !== null ? (
+          <Flex direction="column" gap="2" data-testid={ElementIds.PI_PROVIDER_ACTIONS}>
             <Text size="2" color="gray">
-              Continue your login with a pi interactive session.
+              {terminalGuidance}
             </Text>
-            <Button
-              variant="solid"
-              onClick={() => void startSession()}
-              data-testid={ElementIds.PI_PROVIDER_AUTHENTICATE_BUTTON}
-              style={{ alignSelf: "flex-start" }}
-            >
-              Open pi login
-            </Button>
-            {errorMessage !== null && (
-              <Text size="2" color="red">
-                {errorMessage}
-              </Text>
-            )}
+            <PiLoginTerminal loginId={activeLoginId} onDone={() => void teardown()} />
+          </Flex>
+        ) : (
+          <Flex align="center" justify="center" p="5">
+            <Spinner />
           </Flex>
         )}
-
-        {view === "terminal" &&
-          (activeLoginId !== null ? (
-            <Flex direction="column" gap="2" data-testid={ElementIds.PI_PROVIDER_ACTIONS}>
-              <Text size="2" color="gray">
-                {terminalGuidance}
-              </Text>
-              <PiLoginTerminal loginId={activeLoginId} onDone={() => void teardown()} />
-            </Flex>
-          ) : (
-            <Flex align="center" justify="center" p="5">
-              <Spinner />
-            </Flex>
-          ))}
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
@@ -12,11 +12,14 @@ const PI_LOGIN_STATUS_POLL_INTERVAL_MS = 1200;
 
 /** What the Providers area hands the modal: which provider and which direction.
  *  `providerId` is null for the empty-state "Authenticate a provider" CTA (pi's own
- *  TUI picks the provider). */
+ *  TUI picks the provider). `supportsSubscription` selects the login guidance: the
+ *  backend drives pi straight to the API key input unless the provider also offers
+ *  pi's subscription (OAuth) sign-in, where that choice stays with the user. */
 export type PiLoginRequestView = {
   providerId: string | null;
   displayName: string;
   mode: "login" | "logout";
+  supportsSubscription: boolean;
 };
 
 type PiLoginDialogProps = {
@@ -111,10 +114,14 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
 
   const isLogin = request.mode === "login";
   const title = isLogin ? `Authenticate ${request.displayName}` : `Disconnect ${request.displayName}`;
-  const terminalGuidance = isLogin
-    ? request.providerId === null
+  const loginGuidance =
+    request.providerId === null
       ? "Select a provider in the pi login screen below and complete sign-in. This window closes automatically when done."
-      : `Choose ${request.displayName} in the pi login screen below and complete sign-in. This window closes automatically when done.`
+      : request.supportsSubscription
+        ? `Choose how to sign in — subscription or API key — and complete the ${request.displayName} sign-in below. This window closes automatically when done.`
+        : `Enter your ${request.displayName} API key in the pi screen below. This window closes automatically when done.`;
+  const terminalGuidance = isLogin
+    ? loginGuidance
     : `Disconnecting ${request.displayName} from pi — this window closes automatically when done.`;
 
   return (

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
@@ -95,7 +95,14 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
       return;
     }
     let isCancelled = false;
+    let isInFlight = false;
     const interval = window.setInterval(() => {
+      // Single-flight: a status request outliving the interval must not stack
+      // duplicates behind it.
+      if (isInFlight) {
+        return;
+      }
+      isInFlight = true;
       void (async (): Promise<void> => {
         try {
           const response = await getPiLoginStatus({ path: { login_id: activeLoginId }, meta: { skipWsAck: true } });
@@ -106,6 +113,8 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
           }
         } catch {
           // Transient (e.g. the session is briefly not found) — keep polling until teardown.
+        } finally {
+          isInFlight = false;
         }
       })();
     }, PI_LOGIN_STATUS_POLL_INTERVAL_MS);
@@ -114,6 +123,26 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
       window.clearInterval(interval);
     };
   }, [activeLoginId, teardown]);
+
+  // The live session's last-resort reap: Done, the X button, and the status poll all
+  // tear down explicitly, but the dialog can also unmount from above (the parent view
+  // goes away) before the terminal's WebSocket-close backstop is armed. finishPiLogin
+  // is idempotent across all of these paths.
+  useEffect(() => {
+    if (activeLoginId === null) {
+      return;
+    }
+
+    return (): void => {
+      void (async (): Promise<void> => {
+        try {
+          await finishPiLogin({ path: { login_id: activeLoginId }, meta: { skipWsAck: true } });
+        } catch {
+          // Best-effort reap; the PTY is also reaped on WebSocket close.
+        }
+      })();
+    };
+  }, [activeLoginId]);
 
   const isLogin = request.mode === "login";
   const title = isLogin ? `Authenticate ${request.displayName}` : `Disconnect ${request.displayName}`;

--- a/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiLoginDialog.tsx
@@ -2,7 +2,7 @@ import { Cross1Icon } from "@radix-ui/react-icons";
 import { Dialog, Flex, IconButton, Spinner, Text } from "@radix-ui/themes";
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 
-import { ElementIds, finishPiLogin, getPiLoginStatus, startPiLogin } from "~/api";
+import { ElementIds, finishPiLogin, getPiLoginStatus, ProviderGroup, startPiLogin } from "~/api";
 
 import { PiLoginTerminal } from "./PiLoginTerminal.tsx";
 
@@ -12,13 +12,16 @@ const PI_LOGIN_STATUS_POLL_INTERVAL_MS = 1200;
 
 /** What the Providers area hands the modal: which provider and which direction.
  *  `providerId` is null for the empty-state "Authenticate a provider" CTA (pi's own
- *  TUI picks the provider). `supportsSubscription` selects the login guidance: the
- *  backend drives pi straight to the API key input unless the provider also offers
- *  pi's subscription (OAuth) sign-in, where that choice stays with the user. */
+ *  TUI picks the provider). `group` + `supportsSubscription` mirror the provider's
+ *  catalog entry and select the login guidance: the backend drives pi straight to
+ *  the provider's single credential step (API key input, or the subscription
+ *  sign-in for a subscription-only provider) and leaves the method choice to the
+ *  user only when the provider supports both. */
 export type PiLoginRequestView = {
   providerId: string | null;
   displayName: string;
   mode: "login" | "logout";
+  group: ProviderGroup | null;
   supportsSubscription: boolean;
 };
 
@@ -117,9 +120,11 @@ export const PiLoginDialog = ({ request, onClose }: PiLoginDialogProps): ReactEl
   const loginGuidance =
     request.providerId === null
       ? "Select a provider in the pi login screen below and complete sign-in. This window closes automatically when done."
-      : request.supportsSubscription
-        ? `Choose how to sign in — subscription or API key — and complete the ${request.displayName} sign-in below. This window closes automatically when done.`
-        : `Enter your ${request.displayName} API key in the pi screen below. This window closes automatically when done.`;
+      : request.group === ProviderGroup.SUBSCRIPTION_ONLY
+        ? `Complete the ${request.displayName} subscription sign-in below — pi opens your browser to authorize. This window closes automatically when done.`
+        : request.supportsSubscription
+          ? `Choose how to sign in — subscription or API key — and complete the ${request.displayName} sign-in below. This window closes automatically when done.`
+          : `Enter your ${request.displayName} API key in the pi screen below. This window closes automatically when done.`;
   const terminalGuidance = isLogin
     ? loginGuidance
     : `Disconnecting ${request.displayName} from pi — this window closes automatically when done.`;

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
@@ -29,6 +29,7 @@ const makeProvider = (overrides: Partial<AuthenticatedProviderEntry>): Authentic
   inAuthJson: false,
   envDetected: false,
   envVarNames: ["ANTHROPIC_API_KEY"],
+  supportsSubscription: false,
   ...overrides,
 });
 

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
@@ -1,11 +1,12 @@
 import { Theme } from "@radix-ui/themes";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthenticatedProviderEntry } from "~/api";
-import { ProviderGroup } from "~/api";
+import { ElementIds, ProviderGroup } from "~/api";
 
+import type { PiLoginRequestView } from "./PiLoginDialog.tsx";
 import { PiProvidersArea } from "./PiProvidersArea.tsx";
 import { groupProviders } from "./piProvidersGrouping.ts";
 
@@ -17,9 +18,18 @@ vi.mock("~/common/state/hooks/usePiAuthenticatedProviders", () => ({
   usePiAuthenticatedProviders: mockUsePiAuthenticatedProviders,
 }));
 
-// The login dialog embeds an xterm terminal; these tests never open it.
+// The real login dialog embeds an xterm terminal; the stub echoes the request it
+// receives so tests can assert what the area hands it.
 vi.mock("./PiLoginDialog.tsx", () => ({
-  PiLoginDialog: (): ReactElement | null => null,
+  PiLoginDialog: ({ request }: { request: PiLoginRequestView }): ReactElement => (
+    <div
+      data-testid="fake-login-dialog"
+      data-mode={request.mode}
+      data-provider-id={request.providerId ?? ""}
+      data-group={request.group ?? ""}
+      data-supports-subscription={String(request.supportsSubscription)}
+    />
+  ),
 }));
 
 const makeProvider = (overrides: Partial<AuthenticatedProviderEntry>): AuthenticatedProviderEntry => ({
@@ -56,6 +66,36 @@ describe("PiProvidersArea copy", () => {
     renderProvidersArea([makeProvider({ inAuthJson: true })]);
     expect(screen.getByText(/The list of connected providers is synced with/)).toBeTruthy();
     expect(screen.getByText("~/.pi/agent/auth.json")).toBeTruthy();
+  });
+
+  it("hands the dialog the clicked provider's auth shape on login", () => {
+    renderProvidersArea([
+      makeProvider({
+        providerId: "openai-codex",
+        displayName: "ChatGPT Plus/Pro (Codex)",
+        group: ProviderGroup.SUBSCRIPTION_ONLY,
+        supportsSubscription: true,
+        envVarNames: [],
+      }),
+    ]);
+    fireEvent.click(screen.getByTestId(`${ElementIds.PI_PROVIDER_ADD_CELL}-openai-codex`));
+
+    const dialog = screen.getByTestId("fake-login-dialog");
+    expect(dialog.getAttribute("data-mode")).toBe("login");
+    expect(dialog.getAttribute("data-provider-id")).toBe("openai-codex");
+    expect(dialog.getAttribute("data-group")).toBe("subscription_only");
+    expect(dialog.getAttribute("data-supports-subscription")).toBe("true");
+  });
+
+  it("hands the dialog the clicked provider's auth shape on disconnect", () => {
+    renderProvidersArea([makeProvider({ providerId: "anthropic", inAuthJson: true, supportsSubscription: true })]);
+    fireEvent.click(screen.getByTestId(`${ElementIds.PI_PROVIDER_DISCONNECT_BUTTON}-anthropic`));
+
+    const dialog = screen.getByTestId("fake-login-dialog");
+    expect(dialog.getAttribute("data-mode")).toBe("logout");
+    expect(dialog.getAttribute("data-provider-id")).toBe("anthropic");
+    expect(dialog.getAttribute("data-group")).toBe("single_key");
+    expect(dialog.getAttribute("data-supports-subscription")).toBe("true");
   });
 
   it("renders connected rows without a per-row credential-source line", () => {

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
@@ -101,6 +101,33 @@ describe("groupProviders", () => {
     expect(grouping.connected).toHaveLength(0);
   });
 
+  it("puts an unauthenticated subscription-only provider under Available", () => {
+    const grouping = groupProviders([
+      makeProvider({
+        providerId: "openai-codex",
+        group: ProviderGroup.SUBSCRIPTION_ONLY,
+        supportsSubscription: true,
+        envVarNames: [],
+      }),
+    ]);
+    expect(grouping.available.map((p) => p.providerId)).toEqual(["openai-codex"]);
+    expect(grouping.sessionOnly).toHaveLength(0);
+  });
+
+  it("puts an authenticated subscription-only provider under Connected", () => {
+    const grouping = groupProviders([
+      makeProvider({
+        providerId: "github-copilot",
+        group: ProviderGroup.SUBSCRIPTION_ONLY,
+        supportsSubscription: true,
+        envVarNames: [],
+        inAuthJson: true,
+      }),
+    ]);
+    expect(grouping.connected.map((p) => p.providerId)).toEqual(["github-copilot"]);
+    expect(grouping.sessionOnly).toHaveLength(0);
+  });
+
   it("sorts the Available group alphabetically by display name", () => {
     const grouping = groupProviders([
       makeProvider({ providerId: "openrouter", displayName: "OpenRouter" }),

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.test.tsx
@@ -1,9 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { Theme } from "@radix-ui/themes";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthenticatedProviderEntry } from "~/api";
 import { ProviderGroup } from "~/api";
 
+import { PiProvidersArea } from "./PiProvidersArea.tsx";
 import { groupProviders } from "./piProvidersGrouping.ts";
+
+const { mockUsePiAuthenticatedProviders } = vi.hoisted(() => ({
+  mockUsePiAuthenticatedProviders: vi.fn(),
+}));
+
+vi.mock("~/common/state/hooks/usePiAuthenticatedProviders", () => ({
+  usePiAuthenticatedProviders: mockUsePiAuthenticatedProviders,
+}));
+
+// The login dialog embeds an xterm terminal; these tests never open it.
+vi.mock("./PiLoginDialog.tsx", () => ({
+  PiLoginDialog: (): ReactElement | null => null,
+}));
 
 const makeProvider = (overrides: Partial<AuthenticatedProviderEntry>): AuthenticatedProviderEntry => ({
   providerId: "anthropic",
@@ -13,6 +30,48 @@ const makeProvider = (overrides: Partial<AuthenticatedProviderEntry>): Authentic
   envDetected: false,
   envVarNames: ["ANTHROPIC_API_KEY"],
   ...overrides,
+});
+
+const renderProvidersArea = (providers: ReadonlyArray<AuthenticatedProviderEntry>): void => {
+  mockUsePiAuthenticatedProviders.mockReturnValue({
+    providers,
+    isPending: false,
+    refetch: vi.fn(),
+  });
+  render(
+    <Theme>
+      <PiProvidersArea />
+    </Theme>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PiProvidersArea copy", () => {
+  it("describes the connected providers as synced with auth.json", () => {
+    renderProvidersArea([makeProvider({ inAuthJson: true })]);
+    expect(screen.getByText(/The list of connected providers is synced with/)).toBeTruthy();
+    expect(screen.getByText("~/.pi/agent/auth.json")).toBeTruthy();
+  });
+
+  it("renders connected rows without a per-row credential-source line", () => {
+    renderProvidersArea([
+      makeProvider({ providerId: "anthropic", displayName: "Anthropic", inAuthJson: true }),
+      makeProvider({
+        providerId: "groq",
+        displayName: "Groq",
+        envDetected: true,
+        envVarNames: ["GROQ_API_KEY"],
+      }),
+    ]);
+    expect(screen.queryByText(/Imported from/)).toBeNull();
+    expect(screen.queryByText(/Detected via environment variable/)).toBeNull();
+    // The env-only row keeps its explainer note — the only place that names the env var.
+    expect(screen.getByText(/clear that variable to disconnect/)).toBeTruthy();
+  });
 });
 
 describe("groupProviders", () => {

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
@@ -173,6 +173,7 @@ export const PiProvidersArea = (): ReactElement => {
       providerId: provider.providerId,
       displayName: displayNameFor(provider),
       mode: "login",
+      group: provider.group,
       supportsSubscription: provider.supportsSubscription,
     });
   }, []);
@@ -182,12 +183,19 @@ export const PiProvidersArea = (): ReactElement => {
       providerId: provider.providerId,
       displayName: displayNameFor(provider),
       mode: "logout",
+      group: provider.group,
       supportsSubscription: provider.supportsSubscription,
     });
   }, []);
 
   const openAgnosticLogin = useCallback((): void => {
-    setLoginRequest({ providerId: null, displayName: "a provider", mode: "login", supportsSubscription: false });
+    setLoginRequest({
+      providerId: null,
+      displayName: "a provider",
+      mode: "login",
+      group: null,
+      supportsSubscription: false,
+    });
   }, []);
 
   const handleDialogClose = useCallback((): void => {

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
@@ -1,5 +1,5 @@
 import { ExclamationTriangleIcon, LockClosedIcon, PlusIcon } from "@radix-ui/react-icons";
-import { Box, Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
+import { Box, Button, Callout, Code, Flex, Spinner, Text } from "@radix-ui/themes";
 import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from "react";
 
 import type { AuthenticatedProviderEntry } from "~/api";
@@ -52,9 +52,6 @@ const ConnectedCard = ({
   onDisconnect: (provider: AuthenticatedProviderEntry) => void;
 }): ReactElement => {
   const canDisconnect = provider.inAuthJson;
-  const sourceText = provider.inAuthJson
-    ? "Imported from ~/.pi/agent/auth.json"
-    : `Detected via environment variable ${provider.envVarNames[0] ?? "—"}`;
   return (
     <Box
       data-testid={`${ElementIds.PI_PROVIDER_CARD}-${provider.providerId}`}
@@ -67,12 +64,9 @@ const ConnectedCard = ({
     >
       <Flex align="center" gap="3">
         <ProviderMark provider={provider} size={32} />
-        <Flex direction="column" gap="1" flexGrow="1" minWidth="0">
-          <Text weight="medium">{displayNameFor(provider)}</Text>
-          <Text size="2" color="gray">
-            {sourceText}
-          </Text>
-        </Flex>
+        <Text weight="medium" style={{ flexGrow: 1, minWidth: 0 }}>
+          {displayNameFor(provider)}
+        </Text>
         <Flex align="center" gap="2" flexShrink="0">
           <BlandCircle size={8} className={styles.connectedDot} />
           <Text size="2" color="green">
@@ -206,8 +200,8 @@ export const PiProvidersArea = (): ReactElement => {
       <Flex direction="column" gap="1">
         <Text weight="medium">Providers</Text>
         <Text size="2" color="gray">
-          Authenticate the LLM providers that pi supports. Connected providers are imported from your existing pi
-          credentials.
+          Authenticate the LLM providers that pi supports. The list of connected providers is synced with{" "}
+          <Code>~/.pi/agent/auth.json</Code>.
         </Text>
       </Flex>
 

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
@@ -173,6 +173,7 @@ export const PiProvidersArea = (): ReactElement => {
       providerId: provider.providerId,
       displayName: displayNameFor(provider),
       mode: "login",
+      supportsSubscription: provider.supportsSubscription,
     });
   }, []);
 
@@ -181,11 +182,12 @@ export const PiProvidersArea = (): ReactElement => {
       providerId: provider.providerId,
       displayName: displayNameFor(provider),
       mode: "logout",
+      supportsSubscription: provider.supportsSubscription,
     });
   }, []);
 
   const openAgnosticLogin = useCallback((): void => {
-    setLoginRequest({ providerId: null, displayName: "a provider", mode: "login" });
+    setLoginRequest({ providerId: null, displayName: "a provider", mode: "login", supportsSubscription: false });
   }, []);
 
   const handleDialogClose = useCallback((): void => {

--- a/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
+++ b/sculptor/frontend/src/pages/settings/components/PiProvidersArea.tsx
@@ -15,6 +15,14 @@ import { groupProviders } from "./piProvidersGrouping.ts";
 const displayNameFor = (provider: AuthenticatedProviderEntry): string =>
   provider.displayName || getProviderDisplayName(provider.providerId);
 
+const loginRequestFor = (provider: AuthenticatedProviderEntry, mode: "login" | "logout"): PiLoginRequestView => ({
+  providerId: provider.providerId,
+  displayName: displayNameFor(provider),
+  mode,
+  group: provider.group,
+  supportsSubscription: provider.supportsSubscription,
+});
+
 const SectionEyebrow = ({ children }: { children: ReactNode }): ReactElement => (
   <Text size="1" weight="bold" color="gray" style={{ textTransform: "uppercase", letterSpacing: "0.06em" }}>
     {children}
@@ -169,23 +177,11 @@ export const PiProvidersArea = (): ReactElement => {
   const grouping = useMemo(() => groupProviders(providers), [providers]);
 
   const openLogin = useCallback((provider: AuthenticatedProviderEntry): void => {
-    setLoginRequest({
-      providerId: provider.providerId,
-      displayName: displayNameFor(provider),
-      mode: "login",
-      group: provider.group,
-      supportsSubscription: provider.supportsSubscription,
-    });
+    setLoginRequest(loginRequestFor(provider, "login"));
   }, []);
 
   const openLogout = useCallback((provider: AuthenticatedProviderEntry): void => {
-    setLoginRequest({
-      providerId: provider.providerId,
-      displayName: displayNameFor(provider),
-      mode: "logout",
-      group: provider.group,
-      supportsSubscription: provider.supportsSubscription,
-    });
+    setLoginRequest(loginRequestFor(provider, "logout"));
   }, []);
 
   const openAgnosticLogin = useCallback((): void => {

--- a/sculptor/frontend/src/pages/settings/components/piProvidersGrouping.ts
+++ b/sculptor/frontend/src/pages/settings/components/piProvidersGrouping.ts
@@ -14,7 +14,7 @@ const isAuthenticated = (provider: AuthenticatedProviderEntry): boolean => provi
  * Session-only), ordered alphabetically by display name within each section.
  * Session-only providers always land in their own group regardless of auth state
  * (their persistence is deferred); otherwise an authenticated provider is Connected
- * and an unauthenticated single-key provider is Available.
+ * and an unauthenticated one (single-key or subscription-only) is Available.
  */
 export const groupProviders = (providers: ReadonlyArray<AuthenticatedProviderEntry>): ProviderGrouping => {
   const connected: Array<AuthenticatedProviderEntry> = [];

--- a/sculptor/frontend/src/pages/settings/components/piProvidersGrouping.ts
+++ b/sculptor/frontend/src/pages/settings/components/piProvidersGrouping.ts
@@ -14,7 +14,7 @@ const isAuthenticated = (provider: AuthenticatedProviderEntry): boolean => provi
  * Session-only), ordered alphabetically by display name within each section.
  * Session-only providers always land in their own group regardless of auth state
  * (their persistence is deferred); otherwise an authenticated provider is Connected
- * and an unauthenticated one (single-key or subscription-only) is Available.
+ * and an unauthenticated one is Available.
  */
 export const groupProviders = (providers: ReadonlyArray<AuthenticatedProviderEntry>): ProviderGrouping => {
   const connected: Array<AuthenticatedProviderEntry> = [];

--- a/sculptor/sculptor/agents/pi_agent/authenticated_providers.py
+++ b/sculptor/sculptor/agents/pi_agent/authenticated_providers.py
@@ -21,6 +21,7 @@ class ProviderAuthStatus(FrozenModel):
     in_auth_json: bool
     env_detected: bool
     env_var_names: tuple[str, ...]
+    supports_subscription: bool
 
 
 def resolve_pi_auth_json_path() -> Path:
@@ -128,6 +129,7 @@ def get_provider_auth_statuses() -> tuple[ProviderAuthStatus, ...]:
             in_auth_json=entry.provider_id in auth_json_provider_ids,
             env_detected=entry.provider_id in env_detected_provider_ids,
             env_var_names=entry.env_var_names,
+            supports_subscription=entry.supports_subscription,
         )
         for entry in get_provider_catalog()
     )

--- a/sculptor/sculptor/agents/pi_agent/provider_catalog.py
+++ b/sculptor/sculptor/agents/pi_agent/provider_catalog.py
@@ -7,13 +7,16 @@ class ProviderGroup(StrEnum):
     """How a pi provider's credentials are supplied.
 
     SINGLE_KEY providers are fully supported in v1: a single API key persisted in
-    ``auth.json`` is enough to authenticate them. SESSION_ONLY providers draw extra
-    values (region, base URL, account/gateway id, AWS profile) from the environment
-    that are not expressible in ``auth.json`` alone, so v1 surfaces them as
-    env-detected only.
+    ``auth.json`` is enough to authenticate them. SUBSCRIPTION_ONLY providers have
+    no API-key or env-var form at all — pi's interactive subscription (OAuth) login
+    is their only authentication, persisted by pi in ``auth.json``. SESSION_ONLY
+    providers draw extra values (region, base URL, account/gateway id, AWS profile)
+    from the environment that are not expressible in ``auth.json`` alone, so v1
+    surfaces them as env-detected only.
     """
 
     SINGLE_KEY = "single_key"
+    SUBSCRIPTION_ONLY = "subscription_only"
     SESSION_ONLY = "session_only"
 
 
@@ -24,9 +27,9 @@ class ProviderCatalogEntry(FrozenModel):
     field pi reports in ``get_available_models`` (e.g. Gemini is ``google``).
     ``env_var_names`` lists every conventional env var that authenticates the
     provider; the first is the canonical/primary one. ``supports_subscription``
-    marks providers pi can also authenticate via its OAuth/subscription login;
-    every provider accepts an API key. pi's other built-in OAuth providers
-    (github-copilot, openai-codex) are not catalog entries.
+    marks providers pi can authenticate via its OAuth/subscription login — for a
+    SINGLE_KEY provider (anthropic) it is one of two methods, and for a
+    SUBSCRIPTION_ONLY provider it is the only one.
     """
 
     provider_id: str
@@ -175,6 +178,20 @@ _PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
         env_var_names=("XIAOMI_TOKEN_PLAN_SGP_API_KEY",),
         display_name="Xiaomi Token Plan (SGP)",
         group=ProviderGroup.SINGLE_KEY,
+    ),
+    ProviderCatalogEntry(
+        provider_id="openai-codex",
+        env_var_names=(),
+        display_name="ChatGPT Plus/Pro (Codex)",
+        group=ProviderGroup.SUBSCRIPTION_ONLY,
+        supports_subscription=True,
+    ),
+    ProviderCatalogEntry(
+        provider_id="github-copilot",
+        env_var_names=(),
+        display_name="GitHub Copilot",
+        group=ProviderGroup.SUBSCRIPTION_ONLY,
+        supports_subscription=True,
     ),
     ProviderCatalogEntry(
         provider_id="azure-openai-responses",

--- a/sculptor/sculptor/agents/pi_agent/provider_catalog.py
+++ b/sculptor/sculptor/agents/pi_agent/provider_catalog.py
@@ -28,8 +28,8 @@ class ProviderCatalogEntry(FrozenModel):
     ``env_var_names`` lists every conventional env var that authenticates the
     provider; the first is the canonical/primary one. ``supports_subscription``
     marks providers pi can authenticate via its OAuth/subscription login — for a
-    SINGLE_KEY provider (anthropic) it is one of two methods, and for a
-    SUBSCRIPTION_ONLY provider it is the only one.
+    SINGLE_KEY provider it is one of two methods, and for a SUBSCRIPTION_ONLY
+    provider it is the only one.
     """
 
     provider_id: str

--- a/sculptor/sculptor/agents/pi_agent/provider_catalog.py
+++ b/sculptor/sculptor/agents/pi_agent/provider_catalog.py
@@ -23,13 +23,17 @@ class ProviderCatalogEntry(FrozenModel):
     ``provider_id`` equals both the ``auth.json`` top-level key and the ``provider``
     field pi reports in ``get_available_models`` (e.g. Gemini is ``google``).
     ``env_var_names`` lists every conventional env var that authenticates the
-    provider; the first is the canonical/primary one.
+    provider; the first is the canonical/primary one. ``supports_subscription``
+    marks providers pi can also authenticate via its OAuth/subscription login;
+    every provider accepts an API key. pi's other built-in OAuth providers
+    (github-copilot, openai-codex) are not catalog entries.
     """
 
     provider_id: str
     env_var_names: tuple[str, ...]
     display_name: str
     group: ProviderGroup
+    supports_subscription: bool = False
 
 
 _PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
@@ -38,6 +42,7 @@ _PROVIDER_CATALOG: tuple[ProviderCatalogEntry, ...] = (
         env_var_names=("ANTHROPIC_API_KEY",),
         display_name="Anthropic",
         group=ProviderGroup.SINGLE_KEY,
+        supports_subscription=True,
     ),
     ProviderCatalogEntry(
         provider_id="openai",

--- a/sculptor/sculptor/constants.py
+++ b/sculptor/sculptor/constants.py
@@ -432,16 +432,11 @@ class ElementIDs(StrEnum):
     PI_PROVIDER_ADD_CELL = "pi-provider-add-cell"
     # Mount point for the in-modal Authenticate/Disconnect actions and the login terminal.
     PI_PROVIDER_ACTIONS = "pi-provider-actions"
-    PI_PROVIDER_AUTHENTICATE_BUTTON = "pi-provider-authenticate-button"
     PI_PROVIDER_DISCONNECT_BUTTON = "pi-provider-disconnect-button"
     # Centered modal that hosts the interactive pi /login (or /logout) session.
     PI_LOGIN_DIALOG = "pi-login-dialog"
     PI_LOGIN_TERMINAL = "pi-login-terminal"
     PI_LOGIN_DONE_BUTTON = "pi-login-done-button"
-    # Unused paste-key UI test IDs; drop with a `just generate-api` pass.
-    PI_PROVIDER_PASTE_KEY_SWITCH = "pi-provider-paste-key-switch"
-    PI_PASTE_KEY_INPUT = "pi-paste-key-input"
-    PI_PASTE_KEY_SAVE = "pi-paste-key-save"
     # Model-picker disabled "no models available" state when a harness (pi) has no
     # authenticated providers; the fix-it action lives on the composer send slot.
     PI_PICKER_EMPTY_STATE = "pi-picker-empty-state"

--- a/sculptor/sculptor/services/pi_login_service.py
+++ b/sculptor/sculptor/services/pi_login_service.py
@@ -12,10 +12,11 @@ newline). For /logout the chosen provider is known up front (the user clicked it
 Disconnect), so the service fuzzy-filters pi's "select provider" list to that provider
 and confirms, fully automatically. For /login with a chosen provider, pi's two
 selectors (authentication method, then provider) are driven so the user lands directly
-on that provider's credential step; the method choice is auto-answered with "Use an
-API key" unless the provider also supports pi's subscription (OAuth) login, in which
-case that one choice stays with the user. The provider-agnostic /login only opens the
-prompt — every choice is the user's.
+on that provider's credential step; the method choice is auto-answered when the
+provider has exactly one valid method (API key, or subscription for pi's
+subscription-only OAuth providers), and stays with the user for a provider that
+supports both. The provider-agnostic /login only opens the prompt — every choice is
+the user's.
 
 Completion is observed against auth.json itself (the credential store pi writes): a
 background poll watches for the chosen provider's key to disappear (/logout) or appear
@@ -35,6 +36,7 @@ from loguru import logger
 from pydantic import PrivateAttr
 
 from sculptor.agents.pi_agent.authenticated_providers import read_auth_json_provider_ids
+from sculptor.agents.pi_agent.provider_catalog import ProviderGroup
 from sculptor.agents.pi_agent.provider_catalog import get_provider_entry
 from sculptor.database.models import AgentTaskInputsV2
 from sculptor.foundation.common import generate_id
@@ -270,10 +272,12 @@ def _drive_login(accumulator: _OutputAccumulator, manager: LocalTerminalManager,
     """Drive /login so the user lands on the chosen provider's credential step.
 
     pi's /login renders an authentication-method selector ("Use a subscription" /
-    "Use an API key"), then a provider list for that method. An API-key-only provider
-    has exactly one valid method, so both selectors are auto-answered and the user
-    lands on the key input. A subscription-capable provider leaves the method choice
-    to the user, then auto-selects the provider in the list their choice renders.
+    "Use an API key"), then a provider list for that method. A provider with exactly
+    one valid method has both selectors auto-answered: subscription-only providers
+    confirm the selector's default "Use a subscription" row, API-key-only providers
+    arrow down to "Use an API key" first. A provider supporting both (anthropic)
+    leaves the method choice to the user, then auto-selects the provider in the list
+    their choice renders.
     """
     if provider_id is None:
         # Provider-agnostic (empty-state CTA): pi's own selectors take over.
@@ -284,7 +288,10 @@ def _drive_login(accumulator: _OutputAccumulator, manager: LocalTerminalManager,
         return
 
     entry = get_provider_entry(provider_id)
-    if entry is not None and entry.supports_subscription:
+    if entry is not None and entry.group is ProviderGroup.SUBSCRIPTION_ONLY:
+        manager.write(_PI_SUBMIT)
+        provider_selector_timeout = _PI_SELECTOR_TIMEOUT_SECONDS
+    elif entry is not None and entry.supports_subscription:
         provider_selector_timeout = _PI_METHOD_CHOICE_TIMEOUT_SECONDS
     else:
         manager.write(_PI_DOWN_ARROW)
@@ -296,7 +303,7 @@ def _drive_login(accumulator: _OutputAccumulator, manager: LocalTerminalManager,
         logger.info("pi /login provider selector never rendered; leaving the session for manual completion")
         return
     # Return on the filtered row opens the provider's credential step (API key input,
-    # or the OAuth dialog when the user chose the subscription method).
+    # or the OAuth dialog on the subscription path).
     _filter_and_confirm(manager, provider_id)
 
 

--- a/sculptor/sculptor/services/pi_login_service.py
+++ b/sculptor/sculptor/services/pi_login_service.py
@@ -123,8 +123,7 @@ _PI_LOGIN_PROVIDER_SELECTOR_MARKER = b"Select provider to configure"
 # a literal newline in the input box).
 _PI_SUBMIT = b"\r"
 
-# The Down key: moves pi's method selector off "Use a subscription" (the default row)
-# onto "Use an API key".
+# The Down key: moves the highlighted row in pi's selectors.
 _PI_DOWN_ARROW = b"\x1b[B"
 
 # How long to wait for pi's TUI to come up before typing a slash command. The real
@@ -275,9 +274,9 @@ def _drive_login(accumulator: _OutputAccumulator, manager: LocalTerminalManager,
     "Use an API key"), then a provider list for that method. A provider with exactly
     one valid method has both selectors auto-answered: subscription-only providers
     confirm the selector's default "Use a subscription" row, API-key-only providers
-    arrow down to "Use an API key" first. A provider supporting both (anthropic)
-    leaves the method choice to the user, then auto-selects the provider in the list
-    their choice renders.
+    arrow down to "Use an API key" first. A provider supporting both methods leaves
+    the method choice to the user, then auto-selects the provider in the list their
+    choice renders.
     """
     if provider_id is None:
         # Provider-agnostic (empty-state CTA): pi's own selectors take over.

--- a/sculptor/sculptor/services/pi_login_service.py
+++ b/sculptor/sculptor/services/pi_login_service.py
@@ -10,8 +10,12 @@ PTY hosts a real login shell, types the resolved pi binary path, then drives pi'
 flow with keystrokes (a carriage return submits — pi's raw-mode TUI ignores a bare
 newline). For /logout the chosen provider is known up front (the user clicked its
 Disconnect), so the service fuzzy-filters pi's "select provider" list to that provider
-and confirms, fully automatically. For /login the service only opens the prompt; the
-user picks the provider and enters credentials in the terminal.
+and confirms, fully automatically. For /login with a chosen provider, pi's two
+selectors (authentication method, then provider) are driven so the user lands directly
+on that provider's credential step; the method choice is auto-answered with "Use an
+API key" unless the provider also supports pi's subscription (OAuth) login, in which
+case that one choice stays with the user. The provider-agnostic /login only opens the
+prompt — every choice is the user's.
 
 Completion is observed against auth.json itself (the credential store pi writes): a
 background poll watches for the chosen provider's key to disappear (/logout) or appear
@@ -31,6 +35,7 @@ from loguru import logger
 from pydantic import PrivateAttr
 
 from sculptor.agents.pi_agent.authenticated_providers import read_auth_json_provider_ids
+from sculptor.agents.pi_agent.provider_catalog import get_provider_entry
 from sculptor.database.models import AgentTaskInputsV2
 from sculptor.foundation.common import generate_id
 from sculptor.interfaces.agents.agent import PiAgentConfig
@@ -107,16 +112,30 @@ _PI_READY_MARKERS: tuple[bytes, ...] = (b"ctrl+", b"\xe2\x80\xa2", b"interrupt")
 # pi's /logout provider list prints this header; matched before fuzzy-filtering.
 _PI_LOGOUT_SELECTOR_MARKER = b"Select provider to logout"
 
+# pi's /login flow renders two selectors in sequence: the authentication method
+# ("Use a subscription" / "Use an API key"), then the provider list for that method.
+_PI_LOGIN_METHOD_SELECTOR_MARKER = b"Select authentication method"
+_PI_LOGIN_PROVIDER_SELECTOR_MARKER = b"Select provider to configure"
+
 # A carriage return — the Return key — submits in pi's raw-mode TUI (a bare newline is
 # a literal newline in the input box).
 _PI_SUBMIT = b"\r"
+
+# The Down key: moves pi's method selector off "Use a subscription" (the default row)
+# onto "Use an API key".
+_PI_DOWN_ARROW = b"\x1b[B"
 
 # How long to wait for pi's TUI to come up before typing a slash command. The real
 # login pi runs against the user's providers and may fetch a catalog at startup.
 _PI_READY_TIMEOUT_SECONDS = 20.0
 
-# How long to wait for the /logout selector to render after submitting the slash.
+# How long to wait for a selector to render after submitting a slash command or an
+# auto-answered choice.
 _PI_SELECTOR_TIMEOUT_SECONDS = 8.0
+
+# How long to wait for the user to answer the subscription-vs-API-key selector for a
+# subscription-capable provider before giving up on auto-selecting the provider.
+_PI_METHOD_CHOICE_TIMEOUT_SECONDS = 600.0
 
 # Let pi's fuzzy filter settle on the typed provider id before confirming the choice.
 _PI_FILTER_SETTLE_SECONDS = 0.5
@@ -181,6 +200,32 @@ def _login_change_observed(mode: PiLoginMode, provider_id: str | None, baseline:
     return bool(current - baseline)
 
 
+def _submit_slash_until(
+    accumulator: _OutputAccumulator, manager: LocalTerminalManager, slash: bytes, marker: bytes
+) -> bool:
+    """Submit ``slash`` and wait for ``marker`` to render, retyping the slash once.
+
+    A keystroke typed before pi is interactive can be dropped, so the slash is retried
+    once, guarded on the marker's absence (a rendered selector is never typed into).
+    Returns False when the marker still hasn't rendered after the retry.
+    """
+    manager.write(slash + _PI_SUBMIT)
+    if accumulator.wait_for(lambda b: marker in b, _PI_SELECTOR_TIMEOUT_SECONDS):
+        return True
+    manager.write(slash + _PI_SUBMIT)
+    return accumulator.wait_for(lambda b: marker in b, _PI_SELECTOR_TIMEOUT_SECONDS)
+
+
+def _filter_and_confirm(manager: LocalTerminalManager, provider_id: str) -> None:
+    """Fuzzy-filter the rendered provider selector to ``provider_id`` and confirm it.
+
+    Typing the provider id narrows pi's list to its row, and Return selects it.
+    """
+    manager.write(provider_id.encode())
+    time.sleep(_PI_FILTER_SETTLE_SECONDS)
+    manager.write(_PI_SUBMIT)
+
+
 def _drive_pi_session(
     accumulator: _OutputAccumulator,
     manager: LocalTerminalManager,
@@ -191,37 +236,68 @@ def _drive_pi_session(
     """Launch pi in the PTY and drive its /login or /logout flow.
 
     Logout is fully automatic: submit /logout, wait for pi's provider list, fuzzy-filter
-    to the chosen provider id, and confirm. Login only opens the prompt — the user picks
-    the provider and supplies credentials in the terminal. The slash is retried once for
-    logout, since a keystroke typed before pi is interactive can be dropped.
+    to the chosen provider id, and confirm. Login with a chosen provider drives pi's
+    selectors so the user lands on that provider's credential step (see _drive_login).
+    The provider-agnostic login only opens the prompt — the user picks everything.
     """
     # Launch pi as a shell job (the shell is cooked-mode, so a newline submits).
     write_launch_command(manager, pi_binary_path)
 
-    # Best-effort: wait for pi's TUI before typing. The logout retry below is the real
-    # safety net for a too-early slash; login has no auto-steps to lose.
+    # Best-effort: wait for pi's TUI before typing. The slash retry in
+    # _submit_slash_until is the real safety net for a too-early keystroke.
     if not accumulator.wait_for(lambda b: any(m in b for m in _PI_READY_MARKERS), _PI_READY_TIMEOUT_SECONDS):
         logger.debug("pi TUI readiness marker not seen; driving the slash command anyway")
 
-    slash = b"/login" if mode == PiLoginMode.LOGIN else b"/logout"
-    manager.write(slash + _PI_SUBMIT)
+    if mode == PiLoginMode.LOGOUT:
+        _drive_logout(accumulator, manager, provider_id)
+    else:
+        _drive_login(accumulator, manager, provider_id)
 
-    if mode != PiLoginMode.LOGOUT or provider_id is None:
+
+def _drive_logout(accumulator: _OutputAccumulator, manager: LocalTerminalManager, provider_id: str | None) -> None:
+    """Drive /logout to the chosen provider's removal; fully automatic."""
+    if provider_id is None:
+        manager.write(b"/logout" + _PI_SUBMIT)
+        return
+    if not _submit_slash_until(accumulator, manager, b"/logout", _PI_LOGOUT_SELECTOR_MARKER):
+        logger.info("pi /logout selector never rendered; leaving the session for manual completion")
+        return
+    # Return on the filtered row removes the provider's stored key.
+    _filter_and_confirm(manager, provider_id)
+
+
+def _drive_login(accumulator: _OutputAccumulator, manager: LocalTerminalManager, provider_id: str | None) -> None:
+    """Drive /login so the user lands on the chosen provider's credential step.
+
+    pi's /login renders an authentication-method selector ("Use a subscription" /
+    "Use an API key"), then a provider list for that method. An API-key-only provider
+    has exactly one valid method, so both selectors are auto-answered and the user
+    lands on the key input. A subscription-capable provider leaves the method choice
+    to the user, then auto-selects the provider in the list their choice renders.
+    """
+    if provider_id is None:
+        # Provider-agnostic (empty-state CTA): pi's own selectors take over.
+        manager.write(b"/login" + _PI_SUBMIT)
+        return
+    if not _submit_slash_until(accumulator, manager, b"/login", _PI_LOGIN_METHOD_SELECTOR_MARKER):
+        logger.info("pi /login method selector never rendered; leaving the session for manual completion")
         return
 
-    if not accumulator.wait_for(lambda b: _PI_LOGOUT_SELECTOR_MARKER in b, _PI_SELECTOR_TIMEOUT_SECONDS):
-        # The first slash was likely dropped (typed before pi was ready) — submit once
-        # more. Guarded on the marker's absence, so a rendered selector is never typed into.
-        manager.write(slash + _PI_SUBMIT)
-        if not accumulator.wait_for(lambda b: _PI_LOGOUT_SELECTOR_MARKER in b, _PI_SELECTOR_TIMEOUT_SECONDS):
-            logger.warning("pi /logout selector never rendered; leaving the session for manual completion")
-            return
+    entry = get_provider_entry(provider_id)
+    if entry is not None and entry.supports_subscription:
+        provider_selector_timeout = _PI_METHOD_CHOICE_TIMEOUT_SECONDS
+    else:
+        manager.write(_PI_DOWN_ARROW)
+        time.sleep(_PI_FILTER_SETTLE_SECONDS)
+        manager.write(_PI_SUBMIT)
+        provider_selector_timeout = _PI_SELECTOR_TIMEOUT_SECONDS
 
-    # Fuzzy-filter pi's list to the chosen provider, then confirm: typing the provider id
-    # narrows to its row, and Return removes its stored key.
-    manager.write(provider_id.encode())
-    time.sleep(_PI_FILTER_SETTLE_SECONDS)
-    manager.write(_PI_SUBMIT)
+    if not accumulator.wait_for(lambda b: _PI_LOGIN_PROVIDER_SELECTOR_MARKER in b, provider_selector_timeout):
+        logger.info("pi /login provider selector never rendered; leaving the session for manual completion")
+        return
+    # Return on the filtered row opens the provider's credential step (API key input,
+    # or the OAuth dialog when the user chose the subscription method).
+    _filter_and_confirm(manager, provider_id)
 
 
 class PiLoginService(Service):
@@ -240,11 +316,11 @@ class PiLoginService(Service):
     def spawn(self, mode: PiLoginMode, pi_binary_path: str, provider_id: str | None = None) -> str:
         """Spawn a login PTY and drive pi's /login|/logout, polling auth.json for completion.
 
-        ``provider_id`` is the row to filter to in pi's /logout selector and the key to
-        watch for in auth.json; it is None only for the empty-state "authenticate a
-        provider" CTA, where pi's own selector picks. The PTY inherits the user's
-        environment (extra_env empty, no PI_CODING_AGENT_DIR, no api-key secrets) so pi
-        reads/writes the user's real ~/.pi/agent/auth.json.
+        ``provider_id`` is the row to select in pi's /login and /logout selectors and
+        the key to watch for in auth.json; it is None only for the empty-state
+        "authenticate a provider" CTA, where pi's own selectors pick. The PTY inherits
+        the user's environment (extra_env empty, no PI_CODING_AGENT_DIR, no api-key
+        secrets) so pi reads/writes the user's real ~/.pi/agent/auth.json.
         """
         login_id = generate_id()
         terminal_id = pi_login_terminal_id(login_id)

--- a/sculptor/sculptor/services/pi_login_service_test.py
+++ b/sculptor/sculptor/services/pi_login_service_test.py
@@ -270,6 +270,23 @@ def test_drive_pi_session_login_subscription_provider_lets_user_pick_method(
     assert terminal.writes == [b"/login\r", b"anthropic", b"\r"]
 
 
+def test_drive_pi_session_login_subscription_only_provider_drives_to_oauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def on_write(manager: _FakeTerminal, data: bytes) -> None:
+        if data == b"/login\r":
+            manager.emit(b"Select authentication method:")
+        elif data == b"\r":
+            manager.emit(b"Select provider to configure:")
+
+    terminal = _drive_with_fake_pi(monkeypatch, PiLoginMode.LOGIN, "openai-codex", on_write)
+
+    # openai-codex is subscription-only: its single valid method is the selector's
+    # default row ("Use a subscription"), so a bare Return confirms it, then the
+    # provider list is fuzzy-filtered to the provider and confirmed.
+    assert terminal.writes == [b"/login\r", b"\r", b"openai-codex", b"\r"]
+
+
 def test_drive_pi_session_login_gives_up_when_method_selector_never_renders(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/sculptor/sculptor/services/pi_login_service_test.py
+++ b/sculptor/sculptor/services/pi_login_service_test.py
@@ -7,6 +7,7 @@ sequence, the auth.json completion judgement, and the broadcast's pi-only target
 all with a stand-in terminal manager.
 """
 
+from typing import Callable
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -196,42 +197,89 @@ class _FakeTerminal:
         self._on_write(self, data)
 
 
-def test_drive_pi_session_logout_filters_and_confirms(monkeypatch: pytest.MonkeyPatch) -> None:
+def _drive_with_fake_pi(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: PiLoginMode,
+    provider_id: str | None,
+    on_write: Callable[[_FakeTerminal, bytes], None] = lambda manager, data: None,
+) -> _FakeTerminal:
+    """Run _drive_pi_session against a scripted _FakeTerminal and return it.
+
+    Launch readiness is scripted (write_launch_command emits a readiness marker) and
+    the fuzzy-filter settle is zeroed, so the driver advances without real waits.
+    """
     monkeypatch.setattr(pi_login_service_module, "_PI_FILTER_SETTLE_SECONDS", 0.0)
-    # write_launch_command starts pi; emit a readiness marker so the slash is sent.
     monkeypatch.setattr(
         pi_login_service_module,
         "write_launch_command",
         lambda manager, command, **kwargs: manager.emit(b"escape interrupt"),
     )
+    terminal = _FakeTerminal(on_write)
+    manager = cast(LocalTerminalManager, terminal)
+    _drive_pi_session(_OutputAccumulator(manager), manager, "/fake/pi", mode, provider_id)
+    return terminal
 
+
+def test_drive_pi_session_logout_filters_and_confirms(monkeypatch: pytest.MonkeyPatch) -> None:
     def on_write(manager: _FakeTerminal, data: bytes) -> None:
         if data == b"/logout\r":
             manager.emit(b"Select provider to logout:")
 
-    terminal = _FakeTerminal(on_write)
-    manager = cast(LocalTerminalManager, terminal)
-    accumulator = _OutputAccumulator(manager)
-    _drive_pi_session(accumulator, manager, "/fake/pi", PiLoginMode.LOGOUT, "openai")
+    terminal = _drive_with_fake_pi(monkeypatch, PiLoginMode.LOGOUT, "openai", on_write)
 
     # Submit the slash, fuzzy-filter to the chosen provider, then confirm with Return.
     assert terminal.writes == [b"/logout\r", b"openai", b"\r"]
 
 
-def test_drive_pi_session_login_only_opens_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        pi_login_service_module,
-        "write_launch_command",
-        lambda manager, command, **kwargs: manager.emit(b"escape interrupt"),
-    )
+def test_drive_pi_session_agnostic_login_only_opens_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    terminal = _drive_with_fake_pi(monkeypatch, PiLoginMode.LOGIN, None)
 
-    terminal = _FakeTerminal(lambda manager, data: None)
-    manager = cast(LocalTerminalManager, terminal)
-    accumulator = _OutputAccumulator(manager)
-    _drive_pi_session(accumulator, manager, "/fake/pi", PiLoginMode.LOGIN, "openai")
-
-    # Login leaves provider selection + credential entry to the user — only the slash.
+    # The empty-state CTA names no provider — pi's own selectors take over, so only
+    # the slash is driven.
     assert terminal.writes == [b"/login\r"]
+
+
+def test_drive_pi_session_login_api_key_provider_lands_on_key_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    def on_write(manager: _FakeTerminal, data: bytes) -> None:
+        if data == b"/login\r":
+            manager.emit(b"Select authentication method:")
+        elif data == b"\r":
+            manager.emit(b"Select provider to configure:")
+
+    terminal = _drive_with_fake_pi(monkeypatch, PiLoginMode.LOGIN, "openai", on_write)
+
+    # openai is API-key-only, so its single valid method is chosen automatically
+    # (Down + Return on pi's method selector), then the provider list is
+    # fuzzy-filtered to the provider and confirmed — landing on the key input.
+    assert terminal.writes == [b"/login\r", b"\x1b[B", b"\r", b"openai", b"\r"]
+
+
+def test_drive_pi_session_login_subscription_provider_lets_user_pick_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def on_write(manager: _FakeTerminal, data: bytes) -> None:
+        if data == b"/login\r":
+            manager.emit(b"Select authentication method:")
+            # As if the user picked a method in pi's TUI: the provider list renders.
+            manager.emit(b"Select provider to configure:")
+
+    terminal = _drive_with_fake_pi(monkeypatch, PiLoginMode.LOGIN, "anthropic", on_write)
+
+    # anthropic also supports subscription login, so the method choice stays with the
+    # user; once their choice renders the provider list, the provider is auto-selected.
+    assert terminal.writes == [b"/login\r", b"anthropic", b"\r"]
+
+
+def test_drive_pi_session_login_gives_up_when_method_selector_never_renders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pi_login_service_module, "_PI_SELECTOR_TIMEOUT_SECONDS", 0.05)
+
+    terminal = _drive_with_fake_pi(monkeypatch, PiLoginMode.LOGIN, "openai")
+
+    # The slash is retried once (an early keystroke can be dropped); with no selector
+    # ever rendering, the session is left for manual completion — nothing else typed.
+    assert terminal.writes == [b"/login\r", b"/login\r"]
 
 
 def test_poll_marks_completed_on_auth_json_change(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/sculptor/sculptor/testing/elements/settings_pi.py
+++ b/sculptor/sculptor/testing/elements/settings_pi.py
@@ -96,10 +96,6 @@ class PlaywrightPiSettingsElement(PlaywrightIntegrationTestElement):
         """
         return self._page.get_by_test_id(ElementIDs.PI_LOGIN_DIALOG)
 
-    def get_authenticate_button(self) -> Locator:
-        """Get the 'Open pi login' button inside the login modal."""
-        return self._page.get_by_test_id(ElementIDs.PI_PROVIDER_AUTHENTICATE_BUTTON)
-
     def get_disconnect_button(self, provider_id: str) -> Locator:
         """Get a connected card's Disconnect button (auth.json-backed providers only)."""
         return self.get_by_test_id(f"{ElementIDs.PI_PROVIDER_DISCONNECT_BUTTON}-{provider_id}")

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -4597,6 +4597,7 @@ def get_pi_authenticated_providers(
                 in_auth_json=status.in_auth_json,
                 env_detected=status.env_detected,
                 env_var_names=status.env_var_names,
+                supports_subscription=status.supports_subscription,
             )
             for status in get_provider_auth_statuses()
         )

--- a/sculptor/sculptor/web/app_pi_providers_test.py
+++ b/sculptor/sculptor/web/app_pi_providers_test.py
@@ -64,6 +64,9 @@ def test_authenticated_providers_cover_full_catalog_with_groups(
     by_id = {entry["providerId"]: entry for entry in providers}
     assert by_id["amazon-bedrock"]["group"] == "session_only"
     assert by_id["anthropic"]["group"] == "single_key"
+    # Only anthropic supports pi's subscription (OAuth) login among catalog providers.
+    assert by_id["anthropic"]["supportsSubscription"] is True
+    assert by_id["openai"]["supportsSubscription"] is False
 
 
 def test_paste_key_writes_entry_and_broadcasts(

--- a/sculptor/sculptor/web/app_pi_providers_test.py
+++ b/sculptor/sculptor/web/app_pi_providers_test.py
@@ -64,9 +64,16 @@ def test_authenticated_providers_cover_full_catalog_with_groups(
     by_id = {entry["providerId"]: entry for entry in providers}
     assert by_id["amazon-bedrock"]["group"] == "session_only"
     assert by_id["anthropic"]["group"] == "single_key"
-    # Only anthropic supports pi's subscription (OAuth) login among catalog providers.
+    # anthropic accepts both an API key and pi's subscription (OAuth) login; the
+    # platform-API openai provider is API-key only.
     assert by_id["anthropic"]["supportsSubscription"] is True
     assert by_id["openai"]["supportsSubscription"] is False
+    # pi's subscription-only OAuth providers are catalog entries with no key/env form.
+    assert by_id["openai-codex"]["group"] == "subscription_only"
+    assert by_id["openai-codex"]["supportsSubscription"] is True
+    assert by_id["openai-codex"]["envVarNames"] == []
+    assert by_id["github-copilot"]["group"] == "subscription_only"
+    assert by_id["github-copilot"]["supportsSubscription"] is True
 
 
 def test_paste_key_writes_entry_and_broadcasts(
@@ -94,6 +101,19 @@ def test_paste_key_rejects_session_only_provider(
     response = client.post(
         "/api/v1/pi/providers/paste-key",
         json={"providerId": "amazon-bedrock", "keyValue": "x"},
+    )
+    assert response.status_code == 400
+    assert not (tmp_path / "auth.json").exists()
+
+
+def test_paste_key_rejects_subscription_only_provider(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No API key exists for a subscription-only provider — only pi's OAuth login.
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path))
+    response = client.post(
+        "/api/v1/pi/providers/paste-key",
+        json={"providerId": "openai-codex", "keyValue": "x"},
     )
     assert response.status_code == 400
     assert not (tmp_path / "auth.json").exists()

--- a/sculptor/sculptor/web/data_types.py
+++ b/sculptor/sculptor/web/data_types.py
@@ -300,6 +300,7 @@ class AuthenticatedProviderEntry(SerializableModel):
     in_auth_json: bool
     env_detected: bool
     env_var_names: tuple[str, ...]
+    supports_subscription: bool
 
 
 class AuthenticatedProvidersResponse(SerializableModel):
@@ -324,8 +325,10 @@ class PiModelsResponse(SerializableModel):
 class PiLoginRequest(RequestModel):
     """Start an interactive pi login or logout PTY.
 
-    ``provider_id`` is on-screen guidance / refresh context only — pi's /login and
-    /logout take no provider argument (the user selects in pi's own TUI selector).
+    pi's /login and /logout take no provider argument, so ``provider_id`` is the row
+    the spawned session's keystroke driver selects in pi's own TUI selectors (and the
+    auth.json key whose change marks the session completed). None means pi's selectors
+    are left entirely to the user.
     """
 
     mode: Literal["login", "logout"]

--- a/sculptor/tests/integration/frontend/test_pi_login_terminal.py
+++ b/sculptor/tests/integration/frontend/test_pi_login_terminal.py
@@ -1,6 +1,6 @@
 """Integration coverage for the pi login terminal in the Settings -> Pi -> Providers modal.
 
-Opening pi login spawns an interactive pi PTY embedded in the login modal; Done tears
+Opening the login modal spawns an interactive pi PTY embedded in it; Done tears
 it down and closes the modal. The PTY hosts a real login shell regardless of the pi
 binary, so this verifies the terminal wiring end-to-end without a real /login. The
 credential round-trip (pi writing auth.json) is covered by the real_pi conformance
@@ -50,7 +50,7 @@ def test_pi_login_terminal_mounts_and_done_unmounts(
     sculptor_instance_factory_: SculptorInstanceFactory,
     tmp_path: Path,
 ) -> None:
-    """Opening pi login in the modal mounts the terminal; Done tears it down and closes it."""
+    """Opening the login modal mounts the terminal immediately; Done tears it down and closes it."""
     agent_dir = tmp_path / "pi-agent"
     agent_dir.mkdir()
     # Empty auth.json: openrouter is an unconfigured single-key provider -> Available.
@@ -63,14 +63,11 @@ def test_pi_login_terminal_mounts_and_done_unmounts(
         settings_page = navigate_to_settings_page(page=instance.page)
         pi_section = settings_page.click_on_pi()
 
-        # An unconfigured single-key provider opens the login modal from its Add cell.
+        # An unconfigured single-key provider opens the login modal from its Add cell;
+        # the interactive session starts immediately. The login terminal mounts and
+        # useTerminal connects the PTY WebSocket (the container survives the brief
+        # 4404 retry while the PTY registers).
         pi_section.get_add_provider_cell("openrouter").click()
-        authenticate_button = pi_section.get_authenticate_button()
-        expect(authenticate_button).to_be_visible()
-        authenticate_button.click()
-
-        # The login terminal mounts and useTerminal connects the PTY WebSocket
-        # (the container survives the brief 4404 retry while the PTY registers).
         expect(pi_section.get_login_terminal()).to_be_visible(timeout=30_000)
 
         pi_section.get_login_done_button().click()

--- a/sculptor/tests/integration/frontend/test_pi_providers_settings.py
+++ b/sculptor/tests/integration/frontend/test_pi_providers_settings.py
@@ -35,9 +35,9 @@ def test_pi_providers_settings_groups_and_detail(
     sculptor_instance_factory_: SculptorInstanceFactory,
     tmp_path: Path,
 ) -> None:
-    """anthropic (in auth.json) shows as a Connected card with the import annotation, an
-    unconfigured single-key provider as an Add-a-provider cell, and a multi-value
-    provider in the Session-only callout with the deferred-persistence explainer."""
+    """anthropic (in auth.json) shows as a Connected card, an unconfigured single-key
+    provider as an Add-a-provider cell, and a multi-value provider in the Session-only
+    callout with the deferred-persistence explainer."""
     agent_dir = tmp_path / "pi-agent"
     agent_dir.mkdir()
     (agent_dir / "auth.json").write_text(json.dumps({"anthropic": {"type": "api_key", "key": "x"}}), encoding="utf-8")
@@ -48,10 +48,10 @@ def test_pi_providers_settings_groups_and_detail(
         settings_page = navigate_to_settings_page(page=instance.page)
         pi_section = settings_page.click_on_pi()
 
-        # anthropic is in auth.json -> a Connected card that names its auth.json source.
+        # anthropic is in auth.json -> a Connected card with the live status label.
         connected = pi_section.get_providers_group_connected()
         expect(connected).to_contain_text("Anthropic")
-        expect(connected).to_contain_text("Imported from ~/.pi/agent/auth.json")
+        expect(connected).to_contain_text("Connected")
 
         # A single-key provider with no credential -> a cell in the Add-a-provider grid.
         expect(pi_section.get_providers_group_available()).to_contain_text("OpenRouter")

--- a/sculptor/tests/integration/frontend/test_pi_providers_settings.py
+++ b/sculptor/tests/integration/frontend/test_pi_providers_settings.py
@@ -48,10 +48,11 @@ def test_pi_providers_settings_groups_and_detail(
         settings_page = navigate_to_settings_page(page=instance.page)
         pi_section = settings_page.click_on_pi()
 
-        # anthropic is in auth.json -> a Connected card with the live status label.
-        connected = pi_section.get_providers_group_connected()
-        expect(connected).to_contain_text("Anthropic")
-        expect(connected).to_contain_text("Connected")
+        # anthropic is in auth.json -> its card sits in the Connected section and
+        # shows the live status label (the section header also says "Connected",
+        # so assert the label on the card itself).
+        expect(pi_section.get_providers_group_connected()).to_contain_text("Anthropic")
+        expect(pi_section.get_connected_card("anthropic")).to_contain_text("Connected")
 
         # A single-key provider with no credential -> a cell in the Add-a-provider grid.
         expect(pi_section.get_providers_group_available()).to_contain_text("OpenRouter")


### PR DESCRIPTION
Improves the pi provider authentication flow in Settings (SCU-1821).

## What changed

**Copy**
- The Providers sub-heading now states that the connected list is synced with `~/.pi/agent/auth.json` instead of vaguely referencing "existing pi credentials".
- The per-row credential-source line ("Imported from ~/.pi/agent/auth.json" / "Detected via environment variable X") is removed — it repeated the sub-heading or the env-var explainer note that env-only rows already show.

**Login flow**
- The Authenticate-provider modal no longer shows an intro step with an "Open pi login" button; the interactive pi session starts as soon as the modal mounts, matching what Disconnect already did. Sessions that resolve after the dialog closes are reaped instead of leaked.
- Clicking Authenticate for a specific provider now lands directly on that provider's credential step. Previously Sculptor only typed `/login` into pi, leaving the user at pi's two-step TUI (authentication method, then provider list). The login PTY driver now answers those selectors the way the logout driver already does:
  - API-key-only providers: the driver picks "Use an API key" and selects the provider — the user lands on the key input.
  - Providers supporting both methods (Anthropic): the subscription-vs-API-key choice stays with the user; the provider is auto-selected right after.
  - The empty-state "Authenticate a provider" CTA still leaves pi's selectors entirely to the user.

**Catalog**
- pi's subscription-only OAuth providers — ChatGPT Plus/Pro (`openai-codex`) and GitHub Copilot (`github-copilot`) — are now catalog entries under a new `subscription_only` group, so Settings can connect them and shows them as connected when pi has their credential. For them the driver auto-answers "Use a subscription" (the selector's default row). They have no API-key or env-var form, so the paste-key route keeps rejecting them by construction. The model picker gains proper group-header names for both provider ids.
- A `supports_subscription` flag on catalog entries (exposed through the providers endpoint) drives the method handling and the modal's guidance copy.

**Cleanups**
- Unused element-id constants dropped; a stale integration-test assertion on the removed source line repaired; drift-prone comment enumerations pruned; the login-modal request projection consolidated into a single placement with characterization tests.

## Testing

- Unit tests throughout (driver keystroke sequences against a scripted terminal, endpoint serialization, paste-key gating, grouping, dialog guidance); full `just format` / `just check` / `just test-unit` green on every commit.
- pi login/providers integration tests pass.
- The driver's keystroke sequences were verified live against the pinned pi binary in an isolated PTY (`PI_CODING_AGENT_DIR` pointed at a temp dir): the API-key path lands on the key input, and the subscription path lands on pi's OAuth provider list (stopped before the final confirm so no browser opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
