### PR TITLE
[SCU-1294] Perf: give the heavy workspace-switch blend enough setup headroom on offload

### DIFF
--- a/sculptor/sculptor/testing/playwright_utils.py
+++ b/sculptor/sculptor/testing/playwright_utils.py
@@ -417,6 +417,7 @@ def start_task_and_wait_for_ready(
     workspace_name: str | None = None,
     mode: str | None = None,
     agent_type: str | None = None,
+    finish_timeout_ms: int | None = None,
 ) -> PlaywrightTaskPage:
     """Create a workspace and agent through the new-workspace UI.
 
@@ -433,6 +434,11 @@ def start_task_and_wait_for_ready(
 
     When *prompt* is empty the agent is created in a waiting state and
     ``wait_for_agent_to_finish`` is ignored.
+
+    ``finish_timeout_ms`` overrides the timeout on the "agent finished
+    outputting" waits (``None`` keeps Playwright's default). Prompts that make
+    the agent do a lot of sequential work — e.g. writing many files — need more
+    headroom than the default, especially on contended CI sandboxes.
 
     Defaults to the Fake Claude model, which returns deterministic responses
     without LLM calls.  Tests that need a real agent should pass an explicit model name.
@@ -588,8 +594,10 @@ def start_task_and_wait_for_ready(
             # assistant message (e.g. auto_compact flows).  Without it, the
             # not_to_be_visible check below can pass trivially during the gap
             # between send-click and the activity indicator rendering.
-            expect(chat_panel.get_messages().nth(1), "agent reply to appear").to_be_attached()
-            expect(chat_panel.get_thinking_indicator(), "to finish outputting data").not_to_be_visible()
+            expect(chat_panel.get_messages().nth(1), "agent reply to appear").to_be_attached(timeout=finish_timeout_ms)
+            expect(chat_panel.get_thinking_indicator(), "to finish outputting data").not_to_be_visible(
+                timeout=finish_timeout_ms
+            )
 
     return task_page
 

--- a/sculptor/tests/perf/test_workspace_switch.py
+++ b/sculptor/tests/perf/test_workspace_switch.py
@@ -65,6 +65,13 @@ def blend_default(page: Page) -> None:
 _HEAVY_BLEND_FILES_PER_WS = 20
 _HEAVY_BLEND_LINES_PER_FILE = 100
 
+# Fake Claude writes the ~20 files one tool call at a time, so the "agent
+# finished" wait must clear all of them. On contended offload sandboxes that
+# sequence can exceed the helper's default 30s, so give the setup generous
+# headroom — this is blend time, outside any measurement window, so a loose
+# ceiling costs nothing but flake resistance.
+_HEAVY_BLEND_FINISH_TIMEOUT_MS = 120_000
+
 
 def _write_many_files_prompt(seed: str) -> str:
     """fake_claude:multi_step prompt that writes N files with content seeded
@@ -110,10 +117,20 @@ def blend_with_diff_and_files(page: Page) -> None:
 
     Leaves the page on workspace B with B's file open.
     """
-    start_task_and_wait_for_ready(page, prompt=_write_many_files_prompt("alpha"), workspace_name="Perf Heavy WS A")
+    start_task_and_wait_for_ready(
+        page,
+        prompt=_write_many_files_prompt("alpha"),
+        workspace_name="Perf Heavy WS A",
+        finish_timeout_ms=_HEAVY_BLEND_FINISH_TIMEOUT_MS,
+    )
     _open_files_panel_and_first_file(page, seed="alpha")
 
-    start_task_and_wait_for_ready(page, prompt=_write_many_files_prompt("beta"), workspace_name="Perf Heavy WS B")
+    start_task_and_wait_for_ready(
+        page,
+        prompt=_write_many_files_prompt("beta"),
+        workspace_name="Perf Heavy WS B",
+        finish_timeout_ms=_HEAVY_BLEND_FINISH_TIMEOUT_MS,
+    )
     _open_files_panel_and_first_file(page, seed="beta")
 
 


### PR DESCRIPTION
## What

The `with_diff_and_files` workspace-switch perf blend has Fake Claude write ~20 files one tool call at a time. The blend's readiness helper, `start_task_and_wait_for_ready`, waits for the agent to finish outputting with Playwright's **default 30s** timeout — which the sequential writes occasionally exceed on a contended offload sandbox. The setup then times out **before the measurement window even opens**, reding the (observational, non-gating) perf lane.

This was the flaky scenario the CI lane was designed to surface. The junit artifact the lane uploads named it exactly: `test_workspace_switch[with_diff_and_files-warm]`, failing at the blend's `not_to_be_visible()` "finished outputting" wait.

## Fix

- Add an optional `finish_timeout_ms` pass-through to `start_task_and_wait_for_ready`. Default `None` keeps Playwright's existing default, so **no other caller changes behavior**.
- The heavy blend now requests **120s**. This is setup time *outside* any measurement window, so a generous ceiling only buys flake resistance — it doesn't affect any recorded number.

## Scope check

Audited the other heavy blends: `blend_long_history` (agent_switch) and the long-chat builder accumulate history via small per-turn sends that already carry their own 90s waits. This `with_diff_and_files` blend, which sends the whole heavy prompt at creation, is the only site with the gap.

## Validation

`just format`, `just check` (ratchets / typecheck / lint), and `just test-unit` all green. Diff is 2 files, +29/−4.

(Sent by Claude)