### PR TITLE
[SCU-1294] Perf: post experimental comments on every run, collapsed to a one-line summary

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -241,23 +241,19 @@ jobs:
               --base perf-out/base.jsonl --head perf-out/head.jsonl \
               --base-sha "${{ steps.baseline.outputs.base_sha }}" \
               --format github --observational --intersect-head > perf-out/comment.md
-            # Full table always goes to the step summary.
-            cat perf-out/comment.md >> "$GITHUB_STEP_SUMMARY"
-            # Comment only when something is non-green (regression/improvement/
-            # new/removed). Grep the verdict line the renderer emits.
-            if grep -q "no perf change" perf-out/comment.md; then
-              echo "should_comment=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "should_comment=true" >> "$GITHUB_OUTPUT"
-            fi
           else
             # No baseline note yet: render the absolute head numbers so the PR's
             # perf profile is visible now (deltas begin once a main run seeds a
-            # note). Step summary only — nothing to diff, so no PR comment.
+            # note).
             python3 tools/perf/comment.py --head perf-out/head.jsonl \
-              --format github --observational >> "$GITHUB_STEP_SUMMARY"
-            echo "should_comment=false" >> "$GITHUB_OUTPUT"
+              --format github --observational > perf-out/comment.md
           fi
+          # Full body always goes to the step summary.
+          cat perf-out/comment.md >> "$GITHUB_STEP_SUMMARY"
+          # This lane is experimental/observational, so it comments on every run
+          # regardless of verdict — the body is collapsed to a verdict + one-line
+          # summary, so an unchanged run is a quiet one-liner, not noise.
+          echo "should_comment=true" >> "$GITHUB_OUTPUT"
 
       - name: Upsert PR comment
         if: github.event_name == 'pull_request' && steps.render.outputs.should_comment == 'true'

--- a/tools/perf/comment.py
+++ b/tools/perf/comment.py
@@ -132,11 +132,6 @@ class Report:
     def has_regression(self) -> bool:
         return any(r.status == "regressed" for r in self.rows)
 
-    @property
-    def is_all_green(self) -> bool:
-        c = self.counts()
-        return c["regressed"] == 0 and c["improved"] == 0 and c["new"] == 0 and c["removed"] == 0
-
 
 def _pct(base: float, head: float) -> float:
     if base == 0:
@@ -301,12 +296,22 @@ def render_markdown(report: Report, base_sha: str | None, observational: bool) -
     # verdict heading plus this one counts line (baseline sha folded in). This
     # lane comments on *every* run, so an unchanged run must stay a quiet
     # one-liner — the full table lives one click away inside <details>.
+    # Zero-suppress the counts: this line is the always-visible one-liner on
+    # every PR, so a clean run should read "✅ N unchanged", not lead with a red
+    # "❌ 0 regressed". Only non-zero buckets get a marker; unchanged always
+    # shows as the reassuring green tally.
     out.append("")
-    summary = f"❌ {counts['regressed']} regressed · ⚡ {counts['improved']} improved · ✅ {counts['unchanged']} unchanged"
+    parts = []
+    if counts["regressed"]:
+        parts.append(f"❌ {counts['regressed']} regressed")
+    if counts["improved"]:
+        parts.append(f"⚡ {counts['improved']} improved")
     if counts["new"]:
-        summary += f" · 🆕 {counts['new']} new"
+        parts.append(f"🆕 {counts['new']} new")
     if counts["removed"]:
-        summary += f" · 🗑️ {counts['removed']} removed"
+        parts.append(f"🗑️ {counts['removed']} removed")
+    parts.append(f"✅ {counts['unchanged']} unchanged")
+    summary = " · ".join(parts)
     if base_sha:
         summary += f" · baseline `{base_sha[:7]}`"
     out.append(summary)

--- a/tools/perf/comment.py
+++ b/tools/perf/comment.py
@@ -291,21 +291,28 @@ def _verdict(report: Report) -> str:
 
 
 def render_markdown(report: Report, base_sha: str | None, observational: bool) -> str:
-    c = report.counts()
+    counts = report.counts()
     out: list[str] = [MARKER, "", f"### {_verdict(report)}"]
     if observational:
         out.append("")
-        out.append("_Observational — thresholds under calibration; comment-only, not a gate._")
+        out.append("_Experimental — observational only; thresholds still calibrating, not a gate._")
+
+    # Everything above the collapsible block is the always-visible summary: the
+    # verdict heading plus this one counts line (baseline sha folded in). This
+    # lane comments on *every* run, so an unchanged run must stay a quiet
+    # one-liner — the full table lives one click away inside <details>.
     out.append("")
-    summary = f"❌ {c['regressed']} regressed · ⚡ {c['improved']} improved · ✅ {c['unchanged']} unchanged"
-    if c["new"]:
-        summary += f" · 🆕 {c['new']} new"
-    if c["removed"]:
-        summary += f" · 🗑️ {c['removed']} removed"
-    out.append(summary)
+    summary = f"❌ {counts['regressed']} regressed · ⚡ {counts['improved']} improved · ✅ {counts['unchanged']} unchanged"
+    if counts["new"]:
+        summary += f" · 🆕 {counts['new']} new"
+    if counts["removed"]:
+        summary += f" · 🗑️ {counts['removed']} removed"
     if base_sha:
-        out.append("")
-        out.append(f"Baseline: `{base_sha}` (merge-base with main).")
+        summary += f" · baseline `{base_sha[:7]}`"
+    out.append(summary)
+
+    # Duplicate-row warnings stay visible: they signal corrupt/retried data
+    # (not a perf delta) and are rare enough not to add routine noise.
     for k in ("base", "head"):
         dupes = report.base_dupes if k == "base" else report.head_dupes
         if dupes:
@@ -313,6 +320,14 @@ def render_markdown(report: Report, base_sha: str | None, observational: bool) -
             out.append(f"⚠️ duplicate {k} rows (retries appended twice?): " + ", ".join(f"`{s}/{v}`" for s, v in dupes))
 
     out.append("")
+    out.append(
+        f"<details><summary>Full measurements — {len(report.rows)} scenario(s)"
+        + " (fg req · commits · dom · bg req · duration)</summary>"
+    )
+    out.append("")
+    if base_sha:
+        out.append(f"Baseline: `{base_sha}` (merge-base with main).")
+        out.append("")
     out.append("| scenario / variant | fg req | commits | dom | bg req | duration |")
     out.append("|---|---|---|---|---|---|")
     for r in report.rows:
@@ -324,12 +339,14 @@ def render_markdown(report: Report, base_sha: str | None, observational: bool) -
             out.append(f"| {name} | 🗑️ removed (base only) | | | | |")
             continue
 
-        by = {c.metric: c for c in r.cells}
+        by = {cell.metric: cell for cell in r.cells}
         cols = " | ".join(_cell(by[m]) for m in ("fg_req", "commits", "dom", "bg_req", "dur"))
         out.append(f"| {name} | {cols} |")
 
     detailed = [r for r in report.rows if r.details]
     if detailed:
+        # Attribution nests one level deeper: it's secondary to the table and
+        # only present when something changed. GitHub renders nested <details>.
         out.append("")
         out.append("<details><summary>Attribution for changed scenarios</summary>")
         out.append("")
@@ -341,6 +358,8 @@ def render_markdown(report: Report, base_sha: str | None, observational: bool) -
             out.append("")
         out.append("</details>")
 
+    out.append("")
+    out.append("</details>")
     out.append("")
     return "\n".join(out)
 
@@ -363,12 +382,16 @@ def render_head_only_markdown(head_idx: dict, head_dupes: list[tuple[str, str]])
     out: list[str] = [MARKER, "", "### 📊 perf measurements (no baseline yet)"]
     out.append("")
     out.append(
-        "_No `refs/notes/perf` baseline for the merge-base yet — deltas begin"
-        + " once a main run records a note. Absolute numbers below._"
+        "_Experimental — no `refs/notes/perf` baseline for the merge-base yet;"
+        + " deltas begin once a main run records a note. Absolute numbers below._"
     )
+    out.append("")
+    out.append(f"✅ {len(head_idx)} scenario(s) measured · no baseline to diff")
     if head_dupes:
         out.append("")
         out.append("⚠️ duplicate rows (retries appended twice?): " + ", ".join(f"`{s}/{v}`" for s, v in head_dupes))
+    out.append("")
+    out.append(f"<details><summary>Full measurements — {len(head_idx)} scenario(s)</summary>")
     out.append("")
     out.append("| scenario / variant | fg req | commits | dom | bg req | duration |")
     out.append("|---|---|---|---|---|---|")
@@ -376,6 +399,8 @@ def render_head_only_markdown(head_idx: dict, head_dupes: list[tuple[str, str]])
         scenario, variant = k
         fg, commits, dom, bg, dur = _head_cells(head_idx[k])
         out.append(f"| {scenario} / {variant} | {fg} | {commits} | {dom} | {bg} | {dur} |")
+    out.append("")
+    out.append("</details>")
     out.append("")
     return "\n".join(out)
 

--- a/tools/perf/comment_test.py
+++ b/tools/perf/comment_test.py
@@ -109,6 +109,50 @@ def test_attribution_details_on_regression() -> None:
     assert "FileTree" in joined and "Toast" in joined
 
 
+def _report(base_rows, head_rows):
+    bidx, bd = comment._index(base_rows)
+    hidx, hd = comment._index(head_rows)
+    return comment.compare(bidx, hidx, (bd, hd))
+
+
+def test_collapsible_structure_wraps_table_and_attribution() -> None:
+    # The whole point of the collapsed comment: the always-visible portion is
+    # just the summary, and the table + nested attribution live inside a
+    # <details>. GitHub only renders a markdown table / nested <details> when
+    # blank lines bracket the <summary> and the table, so pin those too — a
+    # future edit dropping a blank line would render as literal HTML.
+    rep = _report(
+        [_row("s", "v", commits=16, comps={"Toast": 16})],
+        [_row("s", "v", commits=30, comps={"Toast": 30, "FileTree": 8})],
+    )
+    md = comment.render_markdown(rep, "46720f07d8ff", observational=True)
+    visible = md.split("<details>", 1)[0]
+    # Above the fold: the one-line summary, not the table.
+    assert "regressed" in visible
+    assert "| scenario / variant |" not in visible
+    # Blank line after </summary> and before the table header (GitHub needs it).
+    assert "</summary>\n\n" in md
+    assert "\n\n| scenario / variant |" in md
+    # Attribution nests one level deeper; both <details> open and close.
+    assert "Attribution for changed scenarios" in md
+    assert md.count("<details>") == 2
+    assert md.count("</details>") == 2
+
+
+def test_all_green_summary_is_a_quiet_one_liner() -> None:
+    # A clean run must not lead with a red "❌ 0 regressed"; it reads as a
+    # single "✅ N unchanged" line and keeps the (empty) table collapsed.
+    rep = _report([_row("s", "v", commits=20)], [_row("s", "v", commits=20)])
+    md = comment.render_markdown(rep, "46720f07d8ff", observational=True)
+    visible = md.split("<details>", 1)[0]
+    assert "✅ no perf change" in visible
+    assert "regressed" not in visible
+    assert "✅ 1 unchanged" in visible
+    # No attribution on a clean run, so a single (table) <details>, still collapsed.
+    assert "| scenario / variant |" not in visible
+    assert md.count("<details>") == 1
+
+
 def test_head_only_renders_absolute_numbers() -> None:
     # With no base rows, the CLI renders a head-only absolute table rather than
     # a diff — the bootstrapping view before a main baseline note exists.


### PR DESCRIPTION
## What

Now that a `refs/notes/perf` baseline exists on `main`, make the observational perf lane comment on **every** PR run — but keep it unobtrusive by collapsing the body to a verdict + one-line summary, with the full measurement table (and its attribution) one click away inside `<details>`.

Previously the lane commented only when a PR was non-green, and rendered the full table inline.

## Changes

- **`tools/perf/comment.py`**
  - The always-visible portion is now just the verdict heading + a one-line counts summary (baseline SHA folded in). The full table and the nested attribution block move inside a `<details>`.
  - The summary is **zero-suppressed**: only non-zero buckets get a marker, so a clean run reads `✅ N unchanged · baseline abc1234` rather than leading with a red `❌ 0 regressed`.
  - The head-only (pre-baseline) renderer gets the same collapsible treatment.
  - Duplicate-row warnings stay *visible* — they flag corrupt/retried data, not a perf delta.
  - Dropped the unused `Report.is_all_green`.
- **`.github/workflows/perf.yml`**
  - Dropped the "skip comment when green" gate. The lane upserts a comment on every run (diff or head-only bootstrap), always mirrored to the step summary. The marker-based find/PATCH upsert is unchanged, so existing comments update in place.
- **`tools/perf/comment_test.py`**
  - Added tests pinning the collapsed structure (table + nested `<details>` with the blank lines GitHub requires) and the quiet all-green one-liner.

## What it looks like

Clean run (collapsed):
```
### ✅ no perf change
_Experimental — observational only; thresholds still calibrating, not a gate._
✅ 9 unchanged · baseline `46720f0`
▶ Full measurements — 9 scenario(s) (fg req · commits · dom · bg req · duration)
```
A regression flips the verdict to `⚠️ perf regressions detected` and the summary to `❌ 1 regressed · ✅ 8 unchanged · …`, with the table + attribution inside the collapsible.

## Heavy scenarios

No separate work: label-based selection already runs them. A PR labeled `performance` runs the full matrix (incl. `perf_heavy`), and `--intersect-head` keeps those rows so they diff against the full-matrix baseline note.

## Validation

`just format`, `just check`, and the perf comment unit suite (12 tests) all green. Reviewed via `/code-review-checklist` (clean — no blockers); rendered markdown eyeballed for all-green, regression, and head-only cases.

(Sent by Claude)