### PR TITLE
Fix release notes linking only the arm64 Linux AppImage

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -530,14 +530,27 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#sculptor-v}"
           PIPELINE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          # Dedupe by filename (publish prints from multiple buckets); keep
-          # the last URL per name (the stable bucket is printed last).
+          # Dedupe per (arch, filename). Publish prints each file from multiple
+          # buckets (slim-rc and slim), and the x64/arm64 AppImages share one
+          # basename (Sculptor-<version>.AppImage), differing only by the /x64/
+          # vs /arm64/ path segment — so keying on basename alone would collapse
+          # the two arches into a single link (the last one, arm64, winning).
+          # Key on the arch segment too to keep both, while still collapsing the
+          # channel duplicates (stable is printed last, so last-wins keeps it).
+          # Label each asset with its arch so users pick the right download.
           # `|| true`: a dry-run publish prints no https URLs, so grep would exit
           # non-zero and abort the step under `set -o pipefail`. Tolerate an empty
           # match and create the release with whatever notes we have.
           ASSETS_MD="$(grep -E '^\s+https://' "${GITHUB_WORKSPACE}/publish_output.log" \
             | sed 's/^ *//' \
-            | awk '{n=split($0,a,"/"); name=a[n]; map[name]=$0} END {for (k in map) print "- [" k "](" map[k] ")"}' || true)"
+            | awk '{
+                n = split($0, a, "/"); name = a[n]; arch = ""
+                for (i = 1; i < n; i++) if (a[i] == "x64" || a[i] == "arm64") arch = a[i]
+                key = arch "\t" name; url[key] = $0
+                label[key] = (arch == "" ? name : name " (" arch ")")
+              }
+              END { for (k in url) print "- [" label[k] "](" url[k] ")" }' \
+            | sort || true)"
           NOTES=$(printf 'Sculptor %s — [pipeline](%s)\n\n## Assets\n%s\n' \
             "$VERSION" "$PIPELINE_URL" "$ASSETS_MD")
           PRERELEASE=""

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -530,14 +530,11 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#sculptor-v}"
           PIPELINE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          # Dedupe per (arch, filename). Publish prints each file from multiple
-          # buckets (slim-rc and slim), and the x64/arm64 AppImages share one
-          # basename (Sculptor-<version>.AppImage), differing only by the /x64/
-          # vs /arm64/ path segment — so keying on basename alone would collapse
-          # the two arches into a single link (the last one, arm64, winning).
-          # Key on the arch segment too to keep both, while still collapsing the
-          # channel duplicates (stable is printed last, so last-wins keeps it).
-          # Label each asset with its arch so users pick the right download.
+          # Dedupe per (arch, filename): publish prints each file from both the
+          # slim-rc and slim buckets, and the x64/arm64 AppImages share a
+          # basename, differing only by the /x64/ vs /arm64/ path segment, so
+          # keying on basename alone would drop one arch. Last-wins keeps the
+          # stable URL (stable is printed last).
           # `|| true`: a dry-run publish prints no https URLs, so grep would exit
           # non-zero and abort the step under `set -o pipefail`. Tolerate an empty
           # match and create the release with whatever notes we have.


### PR DESCRIPTION
### Linked issue

Tracked in Linear **SCU-1825** (no GitHub issue).

### What changed and why

The release workflow deduped GitHub Release asset links by filename. The x64 and
arm64 Linux AppImages share the same filename (`Sculptor-<version>.AppImage`) and
differ only by their `/x64/` vs `/arm64/` S3 path — so they collapsed into one
link and arm64 (published last) won. The stable release listed **only the arm64
AppImage**, so x86_64 users who grabbed "the Linux AppImage" got an ARM binary.
This keys the dedup on arch as well as filename, so both are listed and labelled
`(x64)`/`(arm64)`, while still collapsing the `slim-rc`/`slim` copies (stable is
printed last, so last-wins keeps the stable URL).

### How you verified it

Ran the `grep|sed|awk|sort` pipeline against a synthetic publish log: final
releases now list both `(x64)` and `(arm64)` at their stable URLs (previously
arm64 only); an RC-only publish lists both at `slim-rc`; a dry-run yields an
empty asset list with no `pipefail` abort. YAML validated with the same loader CI
uses.

### Screenshots / recording

N/A — release-notes / CI only.

### Checklist

- [x] I understand what this change does and can explain it
- [ ] I opened an issue first and a maintainer approved it with `lgtm`
- [ ] `just format`, `just check`, and `just test-unit` pass — **not run**: this worktree isn't bootstrapped (missing frontend deps / `pyyaml`); YAML validated and the pipeline simulated instead
- [x] This PR does one thing — no unrelated changes

Follow-ups, out of scope here (tracked in SCU-1825): the already-published
`0.42.0` release notes still link arm64-only and need a manual fix; and
`tryimbue.link/sculptor-for-linux` currently redirects to the RC channel, not
stable.

(Sent by Claude)
