### PR TITLE
[SCU-1827] Fix workspace rename from the context menu not focusing the input

### DIFF
--- a/docs/development/review/sculptor.md
+++ b/docs/development/review/sculptor.md
@@ -407,8 +407,8 @@ The deterministic shape: the action only records intent (a ref or a pending atom
 **What to look for:**
 - A menu `onSelect` or palette `perform` that sets state which mounts an auto-focusing component (a rename-target atom, `setIsRenaming(true)`) instead of stashing intent for `onCloseAutoFocus`
 - `requestAnimationFrame` / `setTimeout` wrapped around `.focus()` to "run after the menu closes"
-- A new rename entry point that bypasses the existing handoff patterns (`pendingRenameRef` in `SectionHeader`, `palettePendingRenameAtom` in the command palette)
+- A new rename entry point that bypasses the existing handoff patterns (`pendingRenameRef` in `SectionHeader`, `palettePendingRenameAtom` in the command palette, `pendingWorkspaceRenameIdAtom` in the sidebar row menus)
 
-**Fix:** Record intent in `onSelect`/`perform`; in the overlay's `onCloseAutoFocus`, call `event.preventDefault()` and start the focus-sensitive UI. See `SectionHeader`'s panel-tab context menu and the command palette's `palettePendingRenameAtom` for the two reference implementations.
+**Fix:** Record intent in `onSelect`/`perform`; in the overlay's `onCloseAutoFocus`, call `event.preventDefault()` and start the focus-sensitive UI. See `SectionHeader`'s panel-tab context menu, the command palette's `palettePendingRenameAtom`, and the sidebar row menus' `pendingWorkspaceRenameIdAtom` for reference implementations.
 
-**Exceptions:** Follow-up UI that owns a focus scope (e.g. a menu item opening a Radix Dialog) needs no deferral — the dialog's focus trap wins the handoff on its own. Non-focus side effects (clipboard copies, navigation, atom writes that don't mount focused UI) are unaffected. Menus whose items never hand off focus may keep an unconditional `onCloseAutoFocus={(e) => e.preventDefault()}` (the workspace row menus do) when returning focus to the trigger is not useful.
+**Exceptions:** Follow-up UI that owns a focus scope (e.g. a menu item opening a Radix Dialog) needs no deferral — the dialog's focus trap wins the handoff on its own. Non-focus side effects (clipboard copies, navigation, atom writes that don't mount focused UI) are unaffected. Menus whose items never hand off focus may keep an unconditional `onCloseAutoFocus={(e) => e.preventDefault()}` when returning focus to the trigger is not useful.

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/atoms.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/atoms.ts
@@ -19,6 +19,21 @@ import type { SubSectionId } from "~/components/sections/sectionTypes.ts";
 export const renamingWorkspaceIdAtom = atom<string | null>(null);
 
 /**
+ * A rename handoff the sidebar row menus flush once their menu has closed. The
+ * sidebar `beginRename` stashes the target workspace id here instead of writing
+ * `renamingWorkspaceIdAtom` directly: writing it while the right-click context
+ * menu or the row's "..." dropdown is still open would mount — and focus — the
+ * inline rename input inside the menu's still-active focus scope, which yanks
+ * focus back and the resulting blur cancels the rename. Each menu's
+ * `onCloseAutoFocus` is the consumer: it suppresses the focus restore, clears
+ * this atom, and writes `renamingWorkspaceIdAtom`, so the input only ever mounts
+ * with nothing competing for focus. Mirrors `palettePendingRenameAtom` for the
+ * sidebar menu surfaces; see the `use_close_auto_focus_for_focus_handoff`
+ * review rule.
+ */
+export const pendingWorkspaceRenameIdAtom = atom<string | null>(null);
+
+/**
  * A rename handoff the palette flushes once its dialog has closed. The palette
  * runtimes' `beginRename` stash the target here instead of writing the rename
  * atoms directly: writing them while the palette is open would mount — and

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/menu.tsx
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/menu.tsx
@@ -1,4 +1,5 @@
 import { ContextMenu, DropdownMenu } from "@radix-ui/themes";
+import { useStore } from "jotai";
 import { Copy, FolderOpenIcon, GitBranch, Stethoscope } from "lucide-react";
 import type { ComponentType, ReactElement, ReactNode } from "react";
 import { Fragment } from "react";
@@ -7,6 +8,7 @@ import { ElementIds, type ExternalApp, type Workspace } from "../../../api";
 import { getOpenWithItems } from "../../../common/openInApp/items.tsx";
 import type { AccentColor } from "../../../common/state/atoms/themeBuilder";
 import { useWorkspaceBranch } from "../../../common/state/hooks/useWorkspaceBranch.ts";
+import { pendingWorkspaceRenameIdAtom, renamingWorkspaceIdAtom } from "./atoms.ts";
 import type { WorkspaceAction } from "./types.ts";
 
 /** Pixel size shared by every icon rendered in these context menus. */
@@ -221,6 +223,30 @@ const useWorkspaceMenuItems = (
   });
 };
 
+/**
+ * The close-time focus handoff shared by both workspace row menu surfaces.
+ * Radix restores focus to the trigger when a menu closes, which would blur —
+ * and cancel — an inline rename input mounted while the menu was still open. So
+ * the Rename action only records intent in `pendingWorkspaceRenameIdAtom`; this
+ * handler, run from the menu's `onCloseAutoFocus` after the focus scope is torn
+ * down, suppresses the restore and only then enters rename mode, so the input
+ * takes focus with nothing competing for it. The `preventDefault` is
+ * unconditional — these menus never want focus bounced back to the row after a
+ * copy/diagnostics action either. See the `use_close_auto_focus_for_focus_handoff`
+ * review rule.
+ */
+const useWorkspaceMenuCloseAutoFocus = (): ((event: Event) => void) => {
+  const store = useStore();
+  return (event: Event): void => {
+    event.preventDefault();
+    const pendingId = store.get(pendingWorkspaceRenameIdAtom);
+    if (pendingId !== null) {
+      store.set(pendingWorkspaceRenameIdAtom, null);
+      store.set(renamingWorkspaceIdAtom, pendingId);
+    }
+  };
+};
+
 export const WorkspaceContextMenuContent = ({
   actions,
   workspace,
@@ -243,8 +269,9 @@ export const WorkspaceContextMenuContent = ({
     destructiveColor,
     openInRuntime,
   });
+  const onCloseAutoFocus = useWorkspaceMenuCloseAutoFocus();
   return (
-    <ContextMenu.Content size="1" onCloseAutoFocus={(e): void => e.preventDefault()}>
+    <ContextMenu.Content size="1" onCloseAutoFocus={onCloseAutoFocus}>
       {items}
     </ContextMenu.Content>
   );
@@ -273,8 +300,9 @@ export const WorkspaceDropdownMenuContent = ({
     destructiveColor,
     openInRuntime,
   });
+  const onCloseAutoFocus = useWorkspaceMenuCloseAutoFocus();
   return (
-    <DropdownMenu.Content size="1" onCloseAutoFocus={(e): void => e.preventDefault()}>
+    <DropdownMenu.Content size="1" onCloseAutoFocus={onCloseAutoFocus}>
       {items}
     </DropdownMenu.Content>
   );

--- a/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
+++ b/sculptor/frontend/src/components/nav/WorkspaceSidebar.tsx
@@ -15,7 +15,7 @@ import { agentIdsByWorkspaceAtom, ensurePseudoTabAtom } from "~/common/state/ato
 import { useOptimisticWorkspaceDelete } from "~/common/state/hooks/useOptimisticWorkspaceDelete.ts";
 import { AddRepoDialog } from "~/components/add-repo/AddRepoDialog.tsx";
 import { useCommandPalette } from "~/components/CommandPalette";
-import { renamingWorkspaceIdAtom } from "~/components/CommandPalette/contextActions/atoms.ts";
+import { pendingWorkspaceRenameIdAtom } from "~/components/CommandPalette/contextActions/atoms.ts";
 import type { OpenInRuntime } from "~/components/CommandPalette/contextActions/menu.tsx";
 import type { WorkspaceActionRuntime } from "~/components/CommandPalette/contextActions/types.ts";
 import { useGitAndOpenInRuntime } from "~/components/CommandPalette/contextActions/useGitAndOpenInRuntime.ts";
@@ -74,7 +74,7 @@ export const WorkspaceSidebar = (): ReactElement | null => {
   // (notably after a hard refresh), without conflating it with a genuinely
   // empty list.
   const isLoading = useAtomValue(isSidebarLoadingAtom);
-  const setRenamingWorkspaceId = useSetAtom(renamingWorkspaceIdAtom);
+  const setPendingWorkspaceRename = useSetAtom(pendingWorkspaceRenameIdAtom);
   // The workspace→last-agent map is only consulted inside the click handler, so
   // read it lazily from the store rather than subscribing: the whole sidebar
   // would otherwise re-render (and churn the click callbacks) on every agent-id
@@ -111,11 +111,15 @@ export const WorkspaceSidebar = (): ReactElement | null => {
   // Functions and callbacks
   const workspaceActionRuntime = useMemo<WorkspaceActionRuntime>(
     () => ({
-      beginRename: (ws): void => setRenamingWorkspaceId(ws.objectId),
+      // Record the rename intent only; the sidebar menu's onCloseAutoFocus enters
+      // rename mode once the menu (and its focus scope) is gone, so the inline
+      // input takes focus with nothing competing for it. See
+      // pendingWorkspaceRenameIdAtom.
+      beginRename: (ws): void => setPendingWorkspaceRename(ws.objectId),
       beginDelete: (ws): void => setDeleteTarget(ws),
       ...gitAndOpenIn,
     }),
-    [setRenamingWorkspaceId, gitAndOpenIn],
+    [setPendingWorkspaceRename, gitAndOpenIn],
   );
 
   // Run the optimistic delete once the user confirms in the dialog.

--- a/sculptor/tests/integration/frontend/test_workspace_row_context_menu.py
+++ b/sculptor/tests/integration/frontend/test_workspace_row_context_menu.py
@@ -275,3 +275,53 @@ def test_workspace_row_dropdown_menu_rename_focuses_input(
     rename_input = sidebar.get_inline_rename_input()
     expect(rename_input).to_be_visible()
     expect(rename_input).to_be_focused()
+
+
+@user_story("to rename a workspace by double-click and by the menu in the same session")
+def test_workspace_row_double_click_and_menu_rename_coexist(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Double-click rename and menu rename share one rename mode and don't interfere.
+
+    Two rename entry points drive the same ``renamingWorkspaceIdAtom``: the row's
+    double-click (which sets it directly) and the menu / dropdown (which defers
+    through ``pendingWorkspaceRenameIdAtom`` and flushes on the menu's
+    ``onCloseAutoFocus``). This exercises both in one session and also covers the
+    dropdown's click-outside dismissal.
+
+    Steps:
+    1. Create a workspace
+    2. Double-click the row — the inline input opens and holds focus; cancel it
+    3. Open the "..." dropdown and rename — the input opens and holds focus
+    4. Click elsewhere — the dropdown-initiated rename dismisses and the name is kept
+    """
+    page = sculptor_instance_.page
+    sidebar = get_workspace_sidebar(page)
+
+    # Step 1: Create a workspace.
+    task_page = start_task_and_wait_for_ready(page, prompt="Test task", workspace_name="Coexist WS")
+
+    rows = sidebar.get_workspace_rows()
+    expect(rows).to_have_count(1)
+
+    # Step 2: Double-click starts a focused rename; Escape cancels it.
+    rows.first.dblclick()
+    rename_input = sidebar.get_inline_rename_input()
+    expect(rename_input).to_be_visible()
+    expect(rename_input).to_be_focused()
+    rename_input.press("Escape")
+    expect(rename_input).not_to_be_visible()
+
+    # Step 3: The dropdown rename still works right after — focused, not stolen.
+    sidebar.open_row_dropdown_menu(sidebar.get_workspace_rows().first)
+    rename_item = sidebar.get_context_menu_rename()
+    expect(rename_item).to_be_visible()
+    rename_item.click()
+    rename_input = sidebar.get_inline_rename_input()
+    expect(rename_input).to_be_visible()
+    expect(rename_input).to_be_focused()
+
+    # Step 4: Clicking elsewhere dismisses the dropdown-initiated rename.
+    task_page.get_chat_panel().get_chat_input().click()
+    expect(rename_input).not_to_be_visible()
+    expect(sidebar.get_workspace_rows().first).to_contain_text("Coexist WS")

--- a/sculptor/tests/integration/frontend/test_workspace_row_context_menu.py
+++ b/sculptor/tests/integration/frontend/test_workspace_row_context_menu.py
@@ -160,3 +160,118 @@ def test_workspace_row_context_menu_copy_name_branch_id(
     page.wait_for_function("() => window.__clipboardWritten !== null")
     workspace_id = read_intercepted_clipboard(page)
     assert workspace_id, "Expected a workspace id to be copied to clipboard"
+
+
+@user_story("to have the rename input focused when renaming a workspace via the context menu")
+def test_workspace_row_context_menu_rename_focuses_input(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Selecting Rename from the row context menu focuses the inline input.
+
+    The inline input commits/cancels on blur, so it must take focus the instant
+    it mounts — otherwise the user cannot type into it. This asserts focus
+    explicitly (as the panel-tab rename test does) rather than relying on a
+    later ``fill``, which force-focuses the element and would mask a focus loss.
+
+    Steps:
+    1. Create a workspace
+    2. Right-click the workspace row and click Rename
+    3. Verify the inline rename input holds focus
+    """
+    page = sculptor_instance_.page
+    sidebar = get_workspace_sidebar(page)
+
+    # Step 1: Create a workspace.
+    start_task_and_wait_for_ready(page, prompt="Test task", workspace_name="Focus Me")
+
+    # Step 2: Right-click the row and click Rename.
+    rows = sidebar.get_workspace_rows()
+    expect(rows).to_have_count(1)
+    sidebar.open_row_context_menu(rows.first)
+    rename_item = sidebar.get_context_menu_rename()
+    expect(rename_item).to_be_visible()
+    rename_item.click()
+
+    # Step 3: The inline rename input must appear AND hold focus.
+    rename_input = sidebar.get_inline_rename_input()
+    expect(rename_input).to_be_visible()
+    expect(rename_input).to_be_focused()
+
+
+@user_story("to dismiss an in-progress workspace rename by clicking elsewhere")
+def test_workspace_row_context_menu_rename_dismisses_on_click_outside(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Clicking outside an in-progress rename closes it and keeps the old name.
+
+    The input dismisses via ``onBlur``, which only fires if it actually held
+    focus; a rename that never took focus stays stuck open when the user clicks
+    away. Clicking the chat input moves focus out of the rename input without
+    unmounting the sidebar row, so ``not_to_be_visible`` reflects the rename
+    being dismissed rather than the row disappearing.
+
+    Steps:
+    1. Create a workspace
+    2. Right-click the row and click Rename (the input takes focus)
+    3. Click the chat input (somewhere else)
+    4. Verify the rename input is dismissed and the row keeps its original name
+    """
+    page = sculptor_instance_.page
+    sidebar = get_workspace_sidebar(page)
+
+    # Step 1: Create a workspace.
+    task_page = start_task_and_wait_for_ready(page, prompt="Test task", workspace_name="Leave Me Alone")
+
+    # Step 2: Right-click the row and click Rename.
+    rows = sidebar.get_workspace_rows()
+    expect(rows).to_have_count(1)
+    sidebar.open_row_context_menu(rows.first)
+    rename_item = sidebar.get_context_menu_rename()
+    expect(rename_item).to_be_visible()
+    rename_item.click()
+    rename_input = sidebar.get_inline_rename_input()
+    expect(rename_input).to_be_visible()
+    expect(rename_input).to_be_focused()
+
+    # Step 3: Click somewhere else — a neutral focusable target that moves focus
+    # out of the rename input (firing its blur) without unmounting the row.
+    task_page.get_chat_panel().get_chat_input().click()
+
+    # Step 4: The rename input dismisses and the row keeps its original name.
+    expect(rename_input).not_to_be_visible()
+    expect(sidebar.get_workspace_rows().first).to_contain_text("Leave Me Alone")
+
+
+@user_story("to have the rename input focused when renaming a workspace via the row dropdown")
+def test_workspace_row_dropdown_menu_rename_focuses_input(
+    sculptor_instance_: SculptorInstance,
+) -> None:
+    """Selecting Rename from the row's "..." dropdown focuses the inline input.
+
+    The dropdown renders the same workspace-action menu (and shares the same
+    close-time focus handoff) as the right-click context menu, so renaming from
+    it must focus the input the same way.
+
+    Steps:
+    1. Create a workspace
+    2. Open the row's "..." dropdown and click Rename
+    3. Verify the inline rename input holds focus
+    """
+    page = sculptor_instance_.page
+    sidebar = get_workspace_sidebar(page)
+
+    # Step 1: Create a workspace.
+    start_task_and_wait_for_ready(page, prompt="Test task", workspace_name="Dropdown Focus")
+
+    # Step 2: Open the "..." dropdown and click Rename.
+    rows = sidebar.get_workspace_rows()
+    expect(rows).to_have_count(1)
+    sidebar.open_row_dropdown_menu(rows.first)
+    rename_item = sidebar.get_context_menu_rename()
+    expect(rename_item).to_be_visible()
+    rename_item.click()
+
+    # Step 3: The inline rename input must appear AND hold focus.
+    rename_input = sidebar.get_inline_rename_input()
+    expect(rename_input).to_be_visible()
+    expect(rename_input).to_be_focused()


### PR DESCRIPTION
## What

Fixes a bug where renaming a workspace from its **sidebar row** — via the right-click context menu or the row's "..." dropdown — did not focus the inline rename input. Because the input never held focus you couldn't type, and clicking elsewhere didn't dismiss it (its `onBlur` never fired, so the rename stayed stuck open).

Fixes SCU-1827.

## Root cause

The sidebar's `beginRename` set `renamingWorkspaceIdAtom` immediately inside the menu item's `onSelect`, so the inline input mounted while the Radix menu was still closing. The menu's focus scope pulled focus back, and the freshly-mounted input's synchronous `.focus()` lost the race — leaving the input visible but unfocused.

This is the same close-time focus race SCU-1699 fixed for the panel-tab context menu and the command palette; the sidebar row menus were never converted to that deterministic handoff.

## Fix

Adopt the SCU-1699 pattern for the sidebar row menus:

- `beginRename` records intent in a new `pendingWorkspaceRenameIdAtom` instead of entering rename mode directly.
- Both row menu surfaces (`WorkspaceContextMenuContent` and the "..." `WorkspaceDropdownMenuContent`) flush that intent into `renamingWorkspaceIdAtom` from their `onCloseAutoFocus`, after the menu's focus scope has torn down — via a shared `useWorkspaceMenuCloseAutoFocus` hook. The input then mounts with nothing competing for focus.
- Corrects the `use_close_auto_focus_for_focus_handoff` review rule, which wrongly cited the workspace row menus as not handing off focus.

The recently-merged double-click rename (#355) sets `renamingWorkspaceIdAtom` directly (no overlay, no race); it coexists cleanly with this deferred menu path since both converge on the single active-rename atom.

## Tests

New Playwright integration tests in `test_workspace_row_context_menu.py`:

- rename via the context menu focuses the input — asserts `to_be_focused()`, which the prior `fill()`-based test masked (`fill` force-focuses the element)
- rename via the "..." dropdown focuses the input
- clicking elsewhere dismisses an in-progress rename
- double-click and menu rename coexist in one session (also covers the dropdown rename's click-outside dismissal)

All fail on the pre-fix code (`Locator expected to be focused`) and pass after.

## Verification

- `just check` (typecheck, lint, ratchets, file hygiene) — pass
- `just test-unit-frontend` — 3030 passed, 1 skipped
- New integration tests — pass

(Sent by Claude)
