### PR TITLE
[SCU-1831] Fix sidebar peek, add-panel dead zone, and menu highlight flash

### DIFF
--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -148,9 +148,10 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
           // resolves the hovered element via closest("[data-workspace-tab]")).
           // Marked on the row container, not the name button, so moving the
           // pointer onto the sibling hover-action buttons (menu, delete) stays
-          // inside the tab region and doesn't dismiss the peek.
-          data-workspace-tab
-          data-tab-id={workspace.objectId}
+          // inside the tab region and doesn't dismiss the peek. Omitted while
+          // renaming so the peek doesn't pop out over the inline rename input.
+          data-workspace-tab={isRenaming ? undefined : ""}
+          data-tab-id={isRenaming ? undefined : workspace.objectId}
         >
           {isRenaming ? (
             <span className={styles.workspaceRowButton}>

--- a/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
+++ b/sculptor/frontend/src/components/nav/SidebarRepoGroup.tsx
@@ -144,6 +144,13 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
           ref={setNodeRef}
           className={rowClassName}
           style={{ transform: CSS.Translate.toString(transform), transition }}
+          // The whole row is one workspace-peek "tab" (WorkspacePeekOverlay
+          // resolves the hovered element via closest("[data-workspace-tab]")).
+          // Marked on the row container, not the name button, so moving the
+          // pointer onto the sibling hover-action buttons (menu, delete) stays
+          // inside the tab region and doesn't dismiss the peek.
+          data-workspace-tab
+          data-tab-id={workspace.objectId}
         >
           {isRenaming ? (
             <span className={styles.workspaceRowButton}>
@@ -186,8 +193,6 @@ const SidebarWorkspaceRow = memo(function SidebarWorkspaceRow({
               data-sidebar-dragging={isDragging ? "true" : undefined}
               data-sidebar-drop-target={isOver && !isDragging ? "true" : undefined}
               data-sidebar-drop-side={dropSide}
-              data-workspace-tab
-              data-tab-id={workspace.objectId}
             >
               <span className={styles.workspaceDot}>
                 <WorkspaceStatusDots status={status} />

--- a/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
+++ b/sculptor/frontend/src/components/sections/AddPanelDropdown.tsx
@@ -14,7 +14,7 @@
 
 import { DropdownMenu, Tooltip } from "@radix-ui/themes";
 import { useAtomValue } from "jotai";
-import type { PointerEvent as ReactPointerEvent, ReactElement } from "react";
+import type { PointerEvent as ReactPointerEvent, ReactElement, Ref } from "react";
 import { useRef } from "react";
 
 import { type AgentTypeName, ElementIds } from "~/api";
@@ -210,13 +210,17 @@ const AddPanelMenuItems = ({
 // AddPanelDropdown (click-to-open) and the section-header control
 // (SectionAddPanelControl, hover-to-open). Owns the focus-restore suppression so an
 // opened panel keeps the focus it grabs on mount. Optional pointer handlers let a
-// hover-driven host keep the menu open while the pointer is over it.
+// hover-driven host keep the menu open while the pointer is over it, and an
+// optional ref exposes the popover element so the host can measure it (for the
+// hover safe-area geometry).
 export const AddPanelMenuContent = ({
   subSection,
+  contentRef,
   onPointerEnter,
   onPointerLeave,
 }: {
   subSection: SubSectionId;
+  contentRef?: Ref<HTMLDivElement>;
   onPointerEnter?: (event: ReactPointerEvent) => void;
   onPointerLeave?: (event: ReactPointerEvent) => void;
 }): ReactElement => {
@@ -229,6 +233,7 @@ export const AddPanelMenuContent = ({
   const openedPanelRef = useRef(false);
   return (
     <DropdownMenu.Content
+      ref={contentRef}
       size="1"
       className={styles.content}
       data-testid={`${ElementIds.ADD_PANEL_DROPDOWN}-${subSection}`}

--- a/sculptor/frontend/src/components/sections/SectionAddPanelControl.tsx
+++ b/sculptor/frontend/src/components/sections/SectionAddPanelControl.tsx
@@ -159,6 +159,18 @@ export const SectionAddPanelControl = ({
     document.addEventListener("pointermove", onMove);
   };
 
+  // Close promptly, with no safe-area grace. Used when leaving the menu itself,
+  // where there is no trigger->popover gap to forgive; a move back into the
+  // trigger or into an open submenu cancels this via their pointer-enter handlers.
+  const scheduleShortClose = (): void => {
+    if (pinnedRef.current) {
+      return; // a pinned menu stays open until it is explicitly toggled off
+    }
+    stopGraceTracking();
+    clearCloseTimer();
+    closeTimer.current = setTimeout(closeMenu, MENU_CLOSE_DELAY_MS);
+  };
+
   const handleEnter = (): void => {
     keepOpen();
     setIsOpen(true); // instant
@@ -168,12 +180,27 @@ export const SectionAddPanelControl = ({
     }
   };
 
-  const handleLeave = (event: ReactPointerEvent): void => {
-    // Clear a stray suppress flag if a press dragged off the button without a click.
+  // Clear the transient trigger UI shared by both leave paths: the tooltip, and a
+  // stray suppress flag left if a press dragged off the button without a click.
+  const resetTriggerTransientState = (): void => {
     suppressToggleRef.current = false;
     clearTooltipTimer();
     setIsTooltipOpen(false);
+  };
+
+  // Leaving the "+" trigger: the pointer may be crossing the gap toward the menu,
+  // so hold the close off while it stays in the safe area (see beginClose).
+  const handleTriggerLeave = (event: ReactPointerEvent): void => {
+    resetTriggerTransientState();
     beginClose({ x: event.clientX, y: event.clientY });
+  };
+
+  // Leaving the menu content or a submenu: close promptly — the safe area only
+  // bridges the trigger->popover gap, so applying it here would just make the
+  // menu linger open after the pointer has left it.
+  const handleMenuLeave = (): void => {
+    resetTriggerTransientState();
+    scheduleShortClose();
   };
 
   // The trigger's primary action: quick-add in the center, pin-toggle elsewhere.
@@ -260,7 +287,7 @@ export const SectionAddPanelControl = ({
             aria-label={isCenter ? "Add agent or panel" : "Add panel"}
             data-testid={`${ElementIds.SECTION_ADD_PANEL_BUTTON}-${subSection}`}
             onPointerEnter={handleEnter}
-            onPointerLeave={handleLeave}
+            onPointerLeave={handleTriggerLeave}
             // Flag the pointer-down (capture phase, so the flag is set before Radix's
             // bubble-phase toggle fires onOpenChange) so handleOpenChange drops Radix's
             // pointer toggle. `activate` is the sole authority for a pointer click. Only a
@@ -281,7 +308,7 @@ export const SectionAddPanelControl = ({
         subSection={subSection}
         contentRef={contentRef}
         onPointerEnter={keepOpen}
-        onPointerLeave={handleLeave}
+        onPointerLeave={handleMenuLeave}
       />
     </DropdownMenu.Root>
   );

--- a/sculptor/frontend/src/components/sections/SectionAddPanelControl.tsx
+++ b/sculptor/frontend/src/components/sections/SectionAddPanelControl.tsx
@@ -24,14 +24,25 @@ import { useEffect, useRef, useState } from "react";
 import { ElementIds } from "~/api";
 
 import { AddPanelMenuContent } from "./AddPanelDropdown.tsx";
+import { buildSafeTriangle, isPointInTriangle, type Point } from "./hoverSafeArea.ts";
 import type { SubSectionId } from "./sectionTypes.ts";
 import { toSection } from "./sectionTypes.ts";
 import { useAddPanelActions } from "./useAddPanelActions.ts";
 
-// Grace period after the pointer leaves the "+"/menu before a transient (unpinned) menu
-// closes — long enough to cross the gap from the button to the menu without it snapping
-// shut, short enough that it doesn't linger.
+// Grace period after the pointer leaves the safe area heading AWAY from the menu
+// before a transient (unpinned) menu closes — short so it doesn't linger once the
+// pointer is clearly not coming to the menu.
 const MENU_CLOSE_DELAY_MS = 150;
+// Grace while the pointer is inside the hover safe area (see hoverSafeArea.ts) —
+// plausibly still travelling toward the menu across the gap/band between the "+"
+// and the popover. Refreshed on every move that stays inside, so an arbitrarily
+// SLOW crossing never times out; it only lapses once the pointer stops moving
+// (parks in the dead space), which then closes rather than sticking open.
+const SAFE_AREA_GRACE_MS = 800;
+// Horizontal padding added to each end of the safe area's base (the popover's near
+// edge) so a slightly wobbly approach that drifts just past the popover's width
+// still counts as heading toward it.
+const SAFE_AREA_BASE_PADDING_PX = 24;
 // The center quick-add tooltip is a slower hint than the instant menu, so it only
 // surfaces on a deliberate dwell rather than a cursor sweep across the header.
 const QUICK_ADD_TOOLTIP_DELAY_MS = 1000;
@@ -59,6 +70,14 @@ export const SectionAddPanelControl = ({
   const suppressToggleRef = useRef(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const tooltipTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // The open popover element, measured on pointer-leave to build the hover safe area.
+  const contentRef = useRef<HTMLDivElement>(null);
+  // The document pointermove listener that watches the safe area while a close is
+  // pending, plus whether the pointer is currently inside it. Inside moves refresh
+  // the (generous) close so a slow crossing never times out; the flag makes leaving
+  // the area arm the short close just once, so continued outward motion still closes.
+  const graceMoveRef = useRef<((event: PointerEvent) => void) | null>(null);
+  const graceInsideRef = useRef<boolean | null>(null);
 
   const clearCloseTimer = (): void => {
     if (closeTimer.current) {
@@ -74,16 +93,77 @@ export const SectionAddPanelControl = ({
     }
   };
 
-  const scheduleClose = (): void => {
+  const stopGraceTracking = (): void => {
+    if (graceMoveRef.current) {
+      document.removeEventListener("pointermove", graceMoveRef.current);
+      graceMoveRef.current = null;
+    }
+    graceInsideRef.current = null;
+  };
+
+  // The pointer is safely over the "+"/menu: cancel any pending close and tear down
+  // safe-area tracking. Wired to every enter that should keep the menu alive.
+  const keepOpen = (): void => {
+    clearCloseTimer();
+    stopGraceTracking();
+  };
+
+  const closeMenu = (): void => {
+    stopGraceTracking();
+    setIsOpen(false);
+  };
+
+  // Close the transient menu, but forgive the trip across the gap/band between the
+  // "+" and the popover: while the pointer stays inside the safe area (a triangle
+  // from where it left the trigger toward the popover's near edge) it is plausibly
+  // still heading for the menu, so the close is held off. Leaving the area is
+  // treated as moving away, and reaching the menu fires keepOpen via a pointer-enter.
+  const beginClose = (apex: Point): void => {
     if (pinnedRef.current) {
       return; // a pinned menu stays open until it is explicitly toggled off
     }
-    clearCloseTimer();
-    closeTimer.current = setTimeout(() => setIsOpen(false), MENU_CLOSE_DELAY_MS);
+    stopGraceTracking();
+
+    const armClose = (delay: number): void => {
+      clearCloseTimer();
+      closeTimer.current = setTimeout(closeMenu, delay);
+    };
+
+    const popover = contentRef.current?.getBoundingClientRect();
+    if (!popover) {
+      // No measurable popover (shouldn't happen while open) — plain timed close.
+      armClose(MENU_CLOSE_DELAY_MS);
+      return;
+    }
+
+    const safeArea = buildSafeTriangle(apex, popover, SAFE_AREA_BASE_PADDING_PX);
+    // Assume the pointer is heading for the menu the instant it leaves; the first
+    // move refines that.
+    graceInsideRef.current = true;
+    armClose(SAFE_AREA_GRACE_MS);
+
+    const onMove = (event: PointerEvent): void => {
+      const isInside = isPointInTriangle({ x: event.clientX, y: event.clientY }, safeArea);
+      if (isInside) {
+        // Still inside the wedge and moving → making progress toward the menu. Keep
+        // refreshing the generous close on every move so a SLOW crossing never times
+        // out; if the pointer instead stops moving, no more moves fire and the last
+        // timer lapses, closing it.
+        graceInsideRef.current = true;
+        armClose(SAFE_AREA_GRACE_MS);
+      } else if (graceInsideRef.current !== false) {
+        // Just crossed out of the wedge → treat as leaving: arm the short close once,
+        // and don't keep pushing it out while the pointer continues outward.
+        graceInsideRef.current = false;
+        armClose(MENU_CLOSE_DELAY_MS);
+      }
+    };
+    graceMoveRef.current = onMove;
+    document.addEventListener("pointermove", onMove);
   };
 
   const handleEnter = (): void => {
-    clearCloseTimer();
+    keepOpen();
     setIsOpen(true); // instant
     if (isCenter) {
       clearTooltipTimer();
@@ -91,12 +171,12 @@ export const SectionAddPanelControl = ({
     }
   };
 
-  const handleLeave = (): void => {
+  const handleLeave = (event: ReactPointerEvent): void => {
     // Clear a stray suppress flag if a press dragged off the button without a click.
     suppressToggleRef.current = false;
     clearTooltipTimer();
     setIsTooltipOpen(false);
-    scheduleClose();
+    beginClose({ x: event.clientX, y: event.clientY });
   };
 
   // The trigger's primary action: quick-add in the center, pin-toggle elsewhere.
@@ -104,7 +184,7 @@ export const SectionAddPanelControl = ({
     clearTooltipTimer();
     setIsTooltipOpen(false);
     if (isCenter) {
-      clearCloseTimer();
+      keepOpen();
       pinnedRef.current = false;
       setIsOpen(false);
       actions.createRecentAgent(subSection);
@@ -112,7 +192,7 @@ export const SectionAddPanelControl = ({
     }
     const isNextPinned = !pinnedRef.current;
     pinnedRef.current = isNextPinned;
-    clearCloseTimer();
+    keepOpen();
     setIsOpen(isNextPinned);
   };
 
@@ -141,11 +221,12 @@ export const SectionAddPanelControl = ({
     if (nextOpen) {
       // A Radix-driven open (e.g. keyboard, right after a hover-out) must cancel any close
       // the hover-out scheduled — otherwise that timer fires and closes the just-opened menu.
-      clearCloseTimer();
+      keepOpen();
     } else {
       pinnedRef.current = false;
       clearTooltipTimer();
       setIsTooltipOpen(false);
+      stopGraceTracking();
     }
     setIsOpen(nextOpen);
   };
@@ -160,6 +241,10 @@ export const SectionAddPanelControl = ({
 
       if (tooltipTimer.current) {
         clearTimeout(tooltipTimer.current);
+      }
+
+      if (graceMoveRef.current) {
+        document.removeEventListener("pointermove", graceMoveRef.current);
       }
     };
   }, []);
@@ -195,7 +280,12 @@ export const SectionAddPanelControl = ({
           </IconButton>
         </DropdownMenu.Trigger>
       </Tooltip>
-      <AddPanelMenuContent subSection={subSection} onPointerEnter={clearCloseTimer} onPointerLeave={handleLeave} />
+      <AddPanelMenuContent
+        subSection={subSection}
+        contentRef={contentRef}
+        onPointerEnter={keepOpen}
+        onPointerLeave={handleLeave}
+      />
     </DropdownMenu.Root>
   );
 };

--- a/sculptor/frontend/src/components/sections/SectionAddPanelControl.tsx
+++ b/sculptor/frontend/src/components/sections/SectionAddPanelControl.tsx
@@ -73,11 +73,9 @@ export const SectionAddPanelControl = ({
   // The open popover element, measured on pointer-leave to build the hover safe area.
   const contentRef = useRef<HTMLDivElement>(null);
   // The document pointermove listener that watches the safe area while a close is
-  // pending, plus whether the pointer is currently inside it. Inside moves refresh
-  // the (generous) close so a slow crossing never times out; the flag makes leaving
-  // the area arm the short close just once, so continued outward motion still closes.
+  // pending, held in a ref so it can be torn down from any code path. (Whether the
+  // pointer is currently inside the area is closure-local to each beginClose cycle.)
   const graceMoveRef = useRef<((event: PointerEvent) => void) | null>(null);
-  const graceInsideRef = useRef<boolean | null>(null);
 
   const clearCloseTimer = (): void => {
     if (closeTimer.current) {
@@ -98,7 +96,6 @@ export const SectionAddPanelControl = ({
       document.removeEventListener("pointermove", graceMoveRef.current);
       graceMoveRef.current = null;
     }
-    graceInsideRef.current = null;
   };
 
   // The pointer is safely over the "+"/menu: cancel any pending close and tear down
@@ -138,8 +135,8 @@ export const SectionAddPanelControl = ({
 
     const safeArea = buildSafeTriangle(apex, popover, SAFE_AREA_BASE_PADDING_PX);
     // Assume the pointer is heading for the menu the instant it leaves; the first
-    // move refines that.
-    graceInsideRef.current = true;
+    // move refines that. Tracked closure-locally for this one close cycle.
+    let isInsideArea = true;
     armClose(SAFE_AREA_GRACE_MS);
 
     const onMove = (event: PointerEvent): void => {
@@ -149,12 +146,12 @@ export const SectionAddPanelControl = ({
         // refreshing the generous close on every move so a SLOW crossing never times
         // out; if the pointer instead stops moving, no more moves fire and the last
         // timer lapses, closing it.
-        graceInsideRef.current = true;
+        isInsideArea = true;
         armClose(SAFE_AREA_GRACE_MS);
-      } else if (graceInsideRef.current !== false) {
+      } else if (isInsideArea) {
         // Just crossed out of the wedge → treat as leaving: arm the short close once,
         // and don't keep pushing it out while the pointer continues outward.
-        graceInsideRef.current = false;
+        isInsideArea = false;
         armClose(MENU_CLOSE_DELAY_MS);
       }
     };

--- a/sculptor/frontend/src/components/sections/hoverSafeArea.test.ts
+++ b/sculptor/frontend/src/components/sections/hoverSafeArea.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSafeTriangle, isPointInTriangle } from "./hoverSafeArea.ts";
+
+// Minimal DOMRect stub: buildSafeTriangle only reads left/right/top/bottom.
+const rect = (over: Partial<DOMRect>): DOMRect => ({
+  left: 0,
+  right: 0,
+  top: 0,
+  bottom: 0,
+  width: 0,
+  height: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => "",
+  ...over,
+});
+
+describe("buildSafeTriangle", () => {
+  it("bases the triangle on the popover's TOP edge when the popover is below the apex", () => {
+    const apex = { x: 100, y: 50 };
+    const popover = rect({ left: 100, right: 420, top: 60, bottom: 300 });
+
+    const [a, b, c] = buildSafeTriangle(apex, popover);
+
+    expect(a).toEqual(apex);
+    expect(b).toEqual({ x: 100, y: 60 });
+    expect(c).toEqual({ x: 420, y: 60 });
+  });
+
+  it("bases the triangle on the popover's BOTTOM edge when the popover is above the apex (collision flip)", () => {
+    const apex = { x: 100, y: 300 };
+    const popover = rect({ left: 100, right: 420, top: 40, bottom: 260 });
+
+    const [, b, c] = buildSafeTriangle(apex, popover);
+
+    expect(b).toEqual({ x: 100, y: 260 });
+    expect(c).toEqual({ x: 420, y: 260 });
+  });
+
+  it("widens the base outward by basePadding at each end (wobble tolerance)", () => {
+    const apex = { x: 100, y: 50 };
+    const popover = rect({ left: 100, right: 420, top: 60, bottom: 300 });
+
+    const [, b, c] = buildSafeTriangle(apex, popover, 20);
+
+    expect(b).toEqual({ x: 80, y: 60 });
+    expect(c).toEqual({ x: 440, y: 60 });
+  });
+});
+
+describe("isPointInTriangle", () => {
+  const triangle = buildSafeTriangle({ x: 0, y: 0 }, rect({ left: -10, right: 10, top: 10, bottom: 20 }));
+
+  it("counts the apex and base corners as inside (edges are inclusive)", () => {
+    expect(isPointInTriangle({ x: 0, y: 0 }, triangle)).toBe(true);
+    expect(isPointInTriangle({ x: -10, y: 10 }, triangle)).toBe(true);
+    expect(isPointInTriangle({ x: 10, y: 10 }, triangle)).toBe(true);
+  });
+
+  it("counts a point in the interior as inside", () => {
+    expect(isPointInTriangle({ x: 0, y: 5 }, triangle)).toBe(true);
+  });
+
+  it("counts a point outside the wedge as outside", () => {
+    // Level with the apex but off to the side: the triangle only opens downward.
+    expect(isPointInTriangle({ x: 8, y: 0 }, triangle)).toBe(false);
+    // Below the base edge, past the popover.
+    expect(isPointInTriangle({ x: 0, y: 25 }, triangle)).toBe(false);
+  });
+
+  describe("the reported bug scenario: tiny trigger, wide popover below it", () => {
+    // A `+` button whose bottom-left is ~(100, 60); the popover is left-aligned
+    // to it, 320px wide, and starts 4px below (Radix sideOffset). The pointer
+    // leaves the button at its bottom edge.
+    const apex = { x: 108, y: 60 };
+    const popover = rect({ left: 100, right: 420, top: 64, bottom: 300 });
+    const safeArea = buildSafeTriangle(apex, popover);
+
+    // The menu is held open when the pointer is either still crossing the gap
+    // (inside the safe triangle) OR already over the popover (where the content's
+    // own pointer-enter keeps it open). The triangle only has to bridge the gap;
+    // the popover covers the rest. This union is the "no dead zone" region.
+    const inPopover = (p: { x: number; y: number }): boolean =>
+      p.x >= popover.left && p.x <= popover.right && p.y >= popover.top && p.y <= popover.bottom;
+    const isHeldOpen = (p: { x: number; y: number }): boolean => isPointInTriangle(p, safeArea) || inPopover(p);
+
+    it("has no dead zone along a slow straight-down move (bug #1: the 4px gap)", () => {
+      // Every step from the button's edge down into the popover keeps it open.
+      for (let y = apex.y; y <= 200; y += 1) {
+        expect(isHeldOpen({ x: apex.x, y })).toBe(true);
+      }
+    });
+
+    it("has no dead zone along a lazy diagonal toward the popover's center (bug #2)", () => {
+      const center = { x: (popover.left + popover.right) / 2, y: (popover.top + popover.bottom) / 2 };
+      for (let t = 0; t <= 1; t += 0.02) {
+        const p = { x: apex.x + (center.x - apex.x) * t, y: apex.y + (center.y - apex.y) * t };
+        expect(isHeldOpen(p)).toBe(true);
+      }
+    });
+
+    it("closes on a purely-horizontal move along the header (away from the popover)", () => {
+      // Same y as the apex (above the popover's top edge), sliding right toward
+      // other header controls — the user is not heading for the popover, so this
+      // is neither in the triangle nor over the popover and the menu should close.
+      expect(isHeldOpen({ x: 200, y: 60 })).toBe(false);
+      expect(isHeldOpen({ x: 300, y: 62 })).toBe(false);
+    });
+  });
+});

--- a/sculptor/frontend/src/components/sections/hoverSafeArea.ts
+++ b/sculptor/frontend/src/components/sections/hoverSafeArea.ts
@@ -1,0 +1,50 @@
+// Geometry for a hover "safe area" (a.k.a. the mega-menu "safe triangle").
+//
+// When a popover opens on hover, the pointer must travel from the trigger to the
+// popover — and on the way it crosses empty space: the gap directly below the
+// trigger, and (when the popover is wider than the trigger) the band beside it.
+// A flat close-delay reads that empty space as "the pointer left the menu" and
+// dismisses the popover mid-approach, forcing the user to move in a precise
+// straight line.
+//
+// The safe area is the triangle whose apex is where the pointer left the trigger
+// and whose base is the popover's near edge. While the pointer stays inside it,
+// the pointer is plausibly still heading for the popover, so the close is held
+// off; once it leaves the triangle it is treated as moving away and the popover
+// closes. This lets the user cut a lazy diagonal toward the popover's center
+// without the popover snapping shut.
+
+export type Point = { x: number; y: number };
+
+// apex → the point where the pointer left the trigger; the other two are the
+// corners of the popover's near edge.
+export type SafeTriangle = readonly [Point, Point, Point];
+
+// Builds the safe triangle from the apex (the pointer's exit point) to the
+// popover's near horizontal edge — its top when the popover sits below the apex,
+// its bottom when it sits above (Radix flips the menu to the other side on
+// collision). The NEAR edge is used, not the far edge, so the triangle is the
+// smallest wedge that still fully spans the approach corridor.
+//
+// `basePadding` extends the base outward at each end so a slightly wobbly approach
+// that drifts just past the popover's width still reads as heading toward it.
+export const buildSafeTriangle = (apex: Point, popover: DOMRect, basePadding = 0): SafeTriangle => {
+  const nearEdgeY = apex.y <= popover.top ? popover.top : popover.bottom;
+  return [apex, { x: popover.left - basePadding, y: nearEdgeY }, { x: popover.right + basePadding, y: nearEdgeY }];
+};
+
+// Standard barycentric-sign point-in-triangle test, inclusive of the edges so a
+// pointer skimming the boundary still counts as "heading toward the popover".
+export const isPointInTriangle = (p: Point, triangle: SafeTriangle): boolean => {
+  const [a, b, c] = triangle;
+  const cross = (p1: Point, p2: Point, p3: Point): number =>
+    (p1.x - p3.x) * (p2.y - p3.y) - (p2.x - p3.x) * (p1.y - p3.y);
+  const d1 = cross(p, a, b);
+  const d2 = cross(p, b, c);
+  const d3 = cross(p, c, a);
+  const hasNeg = d1 < 0 || d2 < 0 || d3 < 0;
+  const hasPos = d1 > 0 || d2 > 0 || d3 > 0;
+  // Inside (or on an edge) iff the cross-products never disagree in sign; a zero
+  // means the point lies exactly on that edge, which still counts as inside.
+  return !(hasNeg && hasPos);
+};

--- a/sculptor/frontend/src/pages/workspace/components/WorkspacePeekOverlay.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspacePeekOverlay.test.tsx
@@ -42,25 +42,35 @@ const mockRect = (over: Partial<DOMRect>): DOMRect => ({
 });
 
 /**
- * Creates a workspace-tab row nested inside a sidebar container, mirroring the
- * real DOM shape (aside[data-testid=WORKSPACE_SIDEBAR] > button[data-workspace-tab]).
+ * Creates a workspace-peek "tab" row nested inside a sidebar container, mirroring
+ * the real DOM shape:
+ *   aside[data-testid=WORKSPACE_SIDEBAR] > div[data-workspace-tab] > (name button + action button)
+ * The peek attributes live on the row container (not the name button) so the
+ * whole row — including its sibling hover-action buttons — counts as one tab.
  * The row's right edge is intentionally inset from the sidebar's right edge.
  */
-const createSidebarTab = (workspaceId: string): HTMLElement => {
+const createSidebarTab = (workspaceId: string): { nameButton: HTMLElement; actionButton: HTMLElement } => {
   const sidebar = document.createElement("aside");
   sidebar.setAttribute("data-testid", "WORKSPACE_SIDEBAR");
   sidebar.getBoundingClientRect = (): DOMRect =>
     mockRect({ left: 0, right: SIDEBAR_RIGHT, top: SIDEBAR_TOP, bottom: 600, width: SIDEBAR_RIGHT, height: 600 });
 
-  const tab = document.createElement("button");
-  tab.setAttribute("data-workspace-tab", "");
-  tab.setAttribute("data-tab-id", workspaceId);
-  tab.getBoundingClientRect = (): DOMRect =>
+  const row = document.createElement("div");
+  row.setAttribute("data-workspace-tab", "");
+  row.setAttribute("data-tab-id", workspaceId);
+  row.getBoundingClientRect = (): DOMRect =>
     mockRect({ left: 20, right: ROW_RIGHT, top: ROW_TOP, bottom: ROW_TOP + 28, width: ROW_RIGHT - 20, height: 28 });
 
-  sidebar.appendChild(tab);
+  // The clickable name button and the hover-revealed action button (menu/delete)
+  // are siblings inside the row; neither carries the peek attributes itself.
+  const nameButton = document.createElement("button");
+  const actionButton = document.createElement("button");
+  row.appendChild(nameButton);
+  row.appendChild(actionButton);
+
+  sidebar.appendChild(row);
   document.body.appendChild(sidebar);
-  return tab;
+  return { nameButton, actionButton };
 };
 
 const hoverTab = (tab: HTMLElement): void => {
@@ -89,9 +99,9 @@ afterEach(() => {
 describe("WorkspacePeekOverlay", () => {
   it("opens instantly on hover", () => {
     render(<WorkspacePeekOverlay onNavigate={vi.fn()} />);
-    const tab = createSidebarTab("ws-1");
+    const { nameButton } = createSidebarTab("ws-1");
 
-    hoverTab(tab);
+    hoverTab(nameButton);
 
     // Not visible until the (0ms) open timer flushes on the next tick.
     expect(screen.queryByTestId("workspace-peek-overlay")).toBeNull();
@@ -103,29 +113,50 @@ describe("WorkspacePeekOverlay", () => {
 
   it("reopens instantly after closing", () => {
     render(<WorkspacePeekOverlay onNavigate={vi.fn()} />);
-    const tab = createSidebarTab("ws-1");
+    const { nameButton } = createSidebarTab("ws-1");
 
     // Open the popover
-    hoverTab(tab);
+    hoverTab(nameButton);
     act(() => vi.advanceTimersByTime(OPEN_DELAY_MS));
     expect(screen.getByTestId("workspace-peek-overlay")).toBeDefined();
 
     // Leave tab and let it close
-    leaveTab(tab);
+    leaveTab(nameButton);
     act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS));
     expect(screen.queryByTestId("workspace-peek-overlay")).toBeNull();
 
     // Re-enter — the peek has no open delay, so it appears instantly again.
-    hoverTab(tab);
+    hoverTab(nameButton);
     act(() => vi.advanceTimersByTime(OPEN_DELAY_MS));
+    expect(screen.getByTestId("workspace-peek-overlay")).toBeDefined();
+  });
+
+  it("stays open when moving from the name button onto a sibling hover-action button", () => {
+    render(<WorkspacePeekOverlay onNavigate={vi.fn()} />);
+    const { nameButton, actionButton } = createSidebarTab("ws-1");
+
+    hoverTab(nameButton);
+    act(() => vi.advanceTimersByTime(OPEN_DELAY_MS));
+    expect(screen.getByTestId("workspace-peek-overlay")).toBeDefined();
+
+    // Moving from the name button onto the row's menu/delete button is NOT
+    // leaving the tab: both live inside the same [data-workspace-tab] row, so
+    // the peek must stay open. (Regression: it used to close because the action
+    // buttons sat outside the tab element that carried the peek attributes.)
+    const event = new MouseEvent("mouseout", { bubbles: true });
+    Object.defineProperty(event, "target", { value: nameButton });
+    Object.defineProperty(event, "relatedTarget", { value: actionButton });
+    document.dispatchEvent(event);
+
+    act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS));
     expect(screen.getByTestId("workspace-peek-overlay")).toBeDefined();
   });
 
   it("anchors to the sidebar's right edge, not the (variable) row width", () => {
     render(<WorkspacePeekOverlay onNavigate={vi.fn()} />);
-    const tab = createSidebarTab("ws-1");
+    const { nameButton } = createSidebarTab("ws-1");
 
-    hoverTab(tab);
+    hoverTab(nameButton);
     act(() => vi.advanceTimersByTime(OPEN_DELAY_MS));
 
     const overlay = screen.getByTestId("workspace-peek-overlay");

--- a/sculptor/frontend/src/pages/workspace/components/WorkspacePeekOverlay.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspacePeekOverlay.test.tsx
@@ -141,8 +141,7 @@ describe("WorkspacePeekOverlay", () => {
 
     // Moving from the name button onto the row's menu/delete button is NOT
     // leaving the tab: both live inside the same [data-workspace-tab] row, so
-    // the peek must stay open. (Regression: it used to close because the action
-    // buttons sat outside the tab element that carried the peek attributes.)
+    // the peek must stay open.
     const event = new MouseEvent("mouseout", { bubbles: true });
     Object.defineProperty(event, "target", { value: nameButton });
     Object.defineProperty(event, "relatedTarget", { value: actionButton });

--- a/sculptor/frontend/src/styles/radix-overrides.css
+++ b/sculptor/frontend/src/styles/radix-overrides.css
@@ -44,9 +44,9 @@
    highlight is the bright solid --accent-9. Restyle EVERY highlight state to the
    same subtle --accent-3 (and keep :hover for the brief window before Radix sets
    [data-highlighted]) so the item never flashes between the two backgrounds as the
-   states toggle out of sync (e.g. the instant a submenu opens), and so keyboard
-   focus reads the same as mouse hover. Prefixed with .rt-BaseMenuContent so it
-   out-specifies Radix's own highlight rules without relying on stylesheet order. */
+   states toggle out of sync (e.g. the instant a submenu opens). Prefixed with
+   .rt-BaseMenuContent so it out-specifies Radix's own highlight rules without
+   relying on stylesheet order. */
 .rt-BaseMenuContent
   .rt-BaseMenuItem:where(:hover, [data-highlighted], [data-state="open"]):where(:not([data-disabled])) {
   background: var(--accent-3);
@@ -58,6 +58,17 @@
     :not([data-disabled])
   ) {
   color: var(--accent-a11);
+}
+
+/* With the highlight background now subtle for every state, keyboard navigation
+   would otherwise lose its cue (the cursor marks position for pointer users, but
+   keyboard-only users have only the highlight). Radix focuses the highlighted
+   item, so add a ring for keyboard focus specifically: :focus-visible matches
+   keyboard-driven focus but not pointer hover, so the mouse highlight stays flat
+   while arrow-key navigation gets a clear indicator. */
+.rt-BaseMenuContent .rt-BaseMenuItem:where(:focus-visible) {
+  outline: 2px solid var(--accent-8);
+  outline-offset: -2px;
 }
 
 .rt-Link:where(a:not([href])) {

--- a/sculptor/frontend/src/styles/radix-overrides.css
+++ b/sculptor/frontend/src/styles/radix-overrides.css
@@ -39,12 +39,24 @@
   cursor: not-allowed;
 }
 
-.rt-BaseMenuItem:where(:hover):where(:not([data-disabled])) {
+/* Radix drives the menu-item highlight through [data-highlighted] (pointer AND
+   keyboard) and, for a submenu's trigger, [data-state='open'] — its default
+   highlight is the bright solid --accent-9. Restyle EVERY highlight state to the
+   same subtle --accent-3 (and keep :hover for the brief window before Radix sets
+   [data-highlighted]) so the item never flashes between the two backgrounds as the
+   states toggle out of sync (e.g. the instant a submenu opens), and so keyboard
+   focus reads the same as mouse hover. Prefixed with .rt-BaseMenuContent so it
+   out-specifies Radix's own highlight rules without relying on stylesheet order. */
+.rt-BaseMenuContent
+  .rt-BaseMenuItem:where(:hover, [data-highlighted], [data-state="open"]):where(:not([data-disabled])) {
   background: var(--accent-3);
   color: inherit;
 }
 
-.rt-BaseMenuItem:where([data-accent-color]):hover:where(:not([data-disabled])) {
+.rt-BaseMenuContent
+  .rt-BaseMenuItem:where([data-accent-color]):where(:hover, [data-highlighted], [data-state="open"]):where(
+    :not([data-disabled])
+  ) {
   color: var(--accent-a11);
 }
 


### PR DESCRIPTION
## Summary

Three small hover-interaction fixes in the workspace sidebar and the section `+` add-panel dropdown. Each is a self-contained commit. Linked to [SCU-1831](https://linear.app/imbue/issue/SCU-1831/fix-hover-interaction-bugs-sidebar-peek-add-panel-dropdown-dead-zone).

These are motion/timing interaction bugs (a popover dismissing mid-move, a hover dead zone, a one-frame colour flash), so the meaningful verification is feeling them live rather than a static screenshot. Behavioural pieces are pinned by unit tests; the purely-visual highlight change is verified by eye.

## 1. Workspace peek dismissed by the row's action buttons

- **Symptom:** hovering a workspace row's trailing action buttons (the `⋯` menu and the trash/delete icon) dismissed the workspace peek popover.
- **Root cause:** the peek is shown/hidden by a document-level hover delegation keyed on `data-workspace-tab`. That marker lived only on the row's name button, so the sibling action buttons fell outside the peek's "tab" region — moving from the name onto them read as leaving the tab.
- **Fix:** mark the whole row container as the peek tab, so the name button and its hover-action buttons resolve to the same tab. Omitted while a row is being inline-renamed so the peek can't pop out over the rename input.
- **Test:** regression test in `WorkspacePeekOverlay.test.tsx` covering the move from the name button onto a sibling action button.

## 2. Add-panel `+` hover menu closing when you approach it

- **Symptom:** the section `+` menu (hover-to-open) closed when the pointer moved toward it diagonally or slowly — there was an L-shaped dead zone between the small trigger and the wider popover offset below it.
- **Root cause:** the menu kept itself open with a single flat close timer and no tolerance for the gap/band the pointer crosses on its way to the popover.
- **Fix:** a hover "safe area" — on pointer-leave, build a triangle from the exit point to the popover's near edge and hold the close off while the pointer stays inside it (i.e. is plausibly still heading for the menu). The grace is refreshed on every in-triangle move, so an arbitrarily slow crossing never times out; a pointer that stops in the dead space still closes. The base is padded slightly for wobble tolerance. The triangle geometry is a pure, unit-tested helper (`hoverSafeArea.ts`).
- **Test:** `hoverSafeArea.test.ts` sweeps the straight-down and diagonal-to-centre paths asserting no gap in the held-open region, and confirms a purely-horizontal slide along the header still closes.

## 3. Menu items flashing to a brighter highlight

- **Symptom:** dropdown/context-menu items flashed to a brighter highlight on hover, most visibly the instant a submenu opened.
- **Root cause:** Radix drives the highlight through `[data-highlighted]` (pointer **and** keyboard) and `[data-state=open]` (an open submenu's trigger), whose default is the bright solid accent. The override only restyled `:hover` to a subtle background, so those states leaked the bright default whenever they toggled out of sync with `:hover`.
- **Fix:** restyle every highlight state to the same subtle background, so there is no brighter background left to flash to. Because this also softens the keyboard highlight, a `:focus-visible` ring is added for keyboard navigation — it matches keyboard-driven focus but not pointer hover, so the mouse highlight stays flat while arrow-key navigation keeps a clear indicator.
- **Test:** none — purely visual (per the repo's testing policy, visual-only changes are verified by eye, not automated tests).

## Verification

- `just format`, `just check`, and `just test-unit` all pass locally.
- New/updated frontend unit tests pass (safe-area geometry + peek regression).
- Frontend-only; no backend, API, or schema changes.

## Review

Ran the repo's `/code-review-checklist` pass over the diff. No CRITICAL/HIGH findings. Addressed the actionable findings in follow-up commits: suppress the peek during rename, add the keyboard focus ring, simplify the hover-grace state to a closure local, and reword a test comment. _(No outstanding review notes.)_

(Sent by Claude)
