### PR TITLE
Fix Pi agent inline image rendering in streaming (SCU-1830)

### DIFF
--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -1209,12 +1209,19 @@ def _handle_partial_response(
     # via the partial first, and the later final ResponseBlockAgentMessage skips it
     # as a duplicate — so without stamping on this path the live turn never gets a role.
     committed_tool_use_ids = {b.id for b in committed_content if isinstance(b, ToolUseBlock)}
-    deduplicated = tuple(
-        _stamp_interactive_role(b, harness)
-        for b in content
-        if not (isinstance(b, ToolUseBlock) and b.id in committed_tool_use_ids)
-    )
-    new_content = committed_content + deduplicated
+    # Expand TextBlocks through split_text_and_media() so <img>/<video> tags
+    # are extracted into FileBlocks during streaming — matching the behavior of
+    # _handle_response_blocks. Without this, Pi agent partials deliver raw <img>
+    # tags as text, which the frontend MarkdownBlock suppresses (SCU-1830).
+    expanded: list[ContentBlockTypes] = []
+    for b in content:
+        if isinstance(b, ToolUseBlock) and b.id in committed_tool_use_ids:
+            continue
+        if isinstance(b, TextBlock):
+            expanded.extend(split_text_and_media(b.text))
+        else:
+            expanded.append(_stamp_interactive_role(b, harness))
+    new_content = committed_content + tuple(expanded)
 
     return in_progress.model_copy(update={"content": new_content})
 

--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -1209,10 +1209,8 @@ def _handle_partial_response(
     # via the partial first, and the later final ResponseBlockAgentMessage skips it
     # as a duplicate — so without stamping on this path the live turn never gets a role.
     committed_tool_use_ids = {b.id for b in committed_content if isinstance(b, ToolUseBlock)}
-    # Expand TextBlocks through split_text_and_media() so <img>/<video> tags
-    # are extracted into FileBlocks during streaming — matching the behavior of
-    # _handle_response_blocks. Without this, Pi agent partials deliver raw <img>
-    # tags as text, which the frontend MarkdownBlock suppresses (SCU-1830).
+    # Extract <img>/<video> tags from TextBlocks into FileBlocks during streaming.
+    # The _handle_response_blocks path already does this for persisted messages.
     expanded: list[ContentBlockTypes] = []
     for b in content:
         if isinstance(b, ToolUseBlock) and b.id in committed_tool_use_ids:

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -6837,3 +6837,76 @@ def test_workflow_states_survive_request_success() -> None:
 
     assert "toolu-wf-1" in _workflow_states_of(state)
     assert state.pending_background_task_ids == frozenset()
+
+
+def test_pi_partial_response_extracts_img_tags_into_file_blocks() -> None:
+    """A Pi agent streaming partial whose TextBlock contains <img> tags must
+    produce FileBlocks in the chat content, not raw <img> text.
+
+    Regression test for SCU-1830: _handle_partial_response did not call
+    split_text_and_media() on TextBlocks, so the frontend MarkdownBlock
+    suppressed the <img> tag and no image appeared in chat.
+    """
+    task_id = TaskID()
+    completed_by_id: dict[AgentMessageID, ChatMessage] = {}
+    assistant_message_id = AssistantMessageID("assistant-pi-img")
+    chat_message_id = AgentMessageID()
+
+    user_message = ChatInputUserMessage(
+        text="Show me the screenshot",
+        model_name=LLMModel.CLAUDE_4_SONNET,
+    )
+    state = convert_agent_messages_to_task_update(
+        [user_message],
+        task_id=task_id,
+        harness=PI_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=None,
+    )
+
+    request_started = RequestStartedAgentMessage(request_id=user_message.message_id)
+
+    partial_with_img = PartialResponseBlockAgentMessage(
+        assistant_message_id=assistant_message_id,
+        message_id=AgentMessageID(),
+        first_response_message_id=chat_message_id,
+        content=(TextBlock(text="Here is a screenshot:\n\n<img src='/tmp/test.png' alt='test'>\n\nDone."),),
+    )
+
+    response_block = ResponseBlockAgentMessage(
+        role="assistant",
+        assistant_message_id=assistant_message_id,
+        message_id=chat_message_id,
+        content=(TextBlock(text="Here is a screenshot:\n\n<img src='/tmp/test.png' alt='test'>\n\nDone."),),
+    )
+
+    request_success = _make_request_success(request_id=user_message.message_id)
+
+    state = convert_agent_messages_to_task_update(
+        [
+            request_started,
+            partial_with_img,
+            response_block,
+            request_success,
+        ],
+        task_id=task_id,
+        harness=PI_HARNESS,
+        completed_message_by_id=completed_by_id,
+        current_state=state,
+    )
+
+    # After the full flow (partial → response → request_success), the completed
+    # message should have the <img> tag extracted into a FileBlock.
+    assert len(state.chat_messages) == 2  # user + assistant
+    assistant_reply = state.chat_messages[1]
+
+    file_blocks = [b for b in assistant_reply.content if isinstance(b, FileBlock)]
+    assert len(file_blocks) == 1, f"Expected one FileBlock, got content: {assistant_reply.content}"
+    assert file_blocks[0].source == "/tmp/test.png"
+
+    text_blocks = [b for b in assistant_reply.content if isinstance(b, TextBlock)]
+    text_content = "".join(b.text for b in text_blocks)
+    assert "Here is a screenshot" in text_content
+    assert "Done." in text_content
+    # The <img> tag should NOT be present as raw text
+    assert "<img" not in text_content


### PR DESCRIPTION
## Original bug

Pi agent inline image rendering fails in Sculptor chat ([SCU-1830](https://linear.app/imbue/issue/SCU-1830)). A Pi agent writes an `<img src=...>` tag in its streaming response text, but the image does not appear in the chat.

## Hypotheses considered

1. `_handle_partial_response` does not call `split_text_and_media()` on TextBlocks — **REPRODUCED**
2. `_handle_response_blocks` path is also broken — DISCARDED — `_handle_response_blocks` already calls `split_text_and_media()` (line 1083); the bug is only in the streaming partial path
3. Frontend MarkdownBlock suppression is the root cause — DISCARDED — the frontend correctly suppresses `<img>` tags; the fix belongs in the backend where tags should be extracted into FileBlocks before reaching the frontend

## Reproduced bug

### Pi agent streaming partial does not extract `<img>` tags into FileBlocks

**Repro steps**
1. Start a Sculptor task using a Pi agent
2. Have the Pi agent produce a response containing an `<img src='/path/to/image.png'>` tag
3. Observe the chat after the turn completes

**Expected vs actual**
- Expected: The `<img>` tag is extracted into a `FileBlock`, rendered as an inline image thumbnail (same as Claude agent behavior)
- Actual: The `<img>` tag remains as raw text in a `TextBlock`. The frontend `MarkdownBlock` suppresses raw `<img>` rendering, so no image appears.

**Root cause**

`_handle_partial_response` in `message_conversion.py` passed incoming `TextBlock`s through as-is (only stamping interactive role on tool blocks). Unlike `_handle_response_blocks`, it never called `split_text_and_media()` to extract `<img>`/`<video>` tags into `FileBlock`s. For Claude agents, this extraction happens in the `output_processor`'s `_finalize_block_from_accumulator` before partials reach `message_conversion`, so the bug was specific to the Pi agent path where partials arrive with raw text.

Additionally, when a `ResponseBlockAgentMessage` arrives while streaming is active, only `ToolResultBlock`s are processed (text/FileBlocks are skipped because they're expected to come from partials). This means the final response blocks never fix up the raw `<img>` tags either — so the image is permanently absent from the rendered content.

**Fix**

Apply `split_text_and_media(block.text)` inside `_handle_partial_response` for every `TextBlock` in the incoming content tuple. This matches the behavior already present in `_handle_response_blocks` for persisted messages and in the Claude SDK's `output_processor` for its streaming path.

**Test**
- Path: `sculptor/sculptor/web/message_conversion_test.py::test_pi_partial_response_extracts_img_tags_into_file_blocks`
- Kind: unit
- Failing-test commit: `6a73cd5e`
- Fix commit: `065fd808`

**Failing test output (before fix):**
```
file_blocks = [b for b in assistant_reply.content if isinstance(b, FileBlock)]
>       assert len(file_blocks) == 1, f"Expected one FileBlock, got content: {assistant_reply.content}"
E       AssertionError: Expected one FileBlock, got content: (TextBlock(..., text="Here is a screenshot:\n\n<img src='/tmp/test.png' alt='test'>\n\nDone."),)
```

**Passing test output (after fix):**
```
sculptor/sculptor/web/message_conversion_test.py::test_pi_partial_response_extracts_img_tags_into_file_blocks PASSED [100%]
```

## Review notes

_(no outstanding review notes)_
