### PR TITLE
Bump managed pi to 0.80.10

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -117,6 +117,15 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      # Same early-signal philosophy for the pinned pi harness: annotate — never
+      # gate — when upstream pi has moved past PI_PINNED_VERSION (the pi-bump
+      # workflow opens the actual bump PR on its daily schedule).
+      - name: Warn when the pi pin is stale
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/check_pi_pin_freshness.py --emit-github-warning
+
       - name: Sync Python deps
         run: uv sync --frozen
 

--- a/.github/workflows/pi-bump.yml
+++ b/.github/workflows/pi-bump.yml
@@ -1,0 +1,111 @@
+# Keeps the managed pi pin fresh. Daily (and on manual dispatch), compare
+# PI_PINNED_VERSION against the latest earendil-works/pi release; when upstream
+# is ahead, run scripts/bump_pi_pin.py and open — or force-refresh — the single
+# rolling automation/pi-bump PR with the rewritten pins. The PR is the
+# notification; builds keep passing while the pin is stale (the checks workflow
+# separately annotates stale runs with a non-blocking warning).
+#
+# Trigger safety (see README.md): schedule and workflow_dispatch run main's own
+# code on a GitHub-hosted runner — no fork code, no self-hosted exposure — and
+# the token stays scoped to the two writes below. Actions-created PRs are
+# enabled repo-side (README.md rule 5).
+#
+# A PR opened with the workflow's GITHUB_TOKEN does not trigger pull_request
+# workflows (GitHub suppresses recursive runs), so the bump PR's CI starts only
+# once a maintainer closes and reopens it (one click) or pushes to its branch.
+# Swap the token for a GitHub App token if that friction ever outweighs the
+# extra credential.
+
+name: pi-bump
+
+on:
+  schedule:
+    # Daily. Off-hour minute: GitHub sheds scheduled load spiking at :00.
+    - cron: "23 14 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact pi version to pin (default: latest upstream release)"
+        required: false
+        type: string
+
+# Serialize runs so a manual dispatch cannot race the daily schedule for the
+# rolling branch; queue instead of cancelling so neither run's signal is lost.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The rewrite/verify tooling guards the real bump; prove it healthy before
+      # trusting it with file edits. The scripts are stdlib-only, so pytest is
+      # the sole dependency — no uv sync needed.
+      - name: Self-test the bump tooling
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest -q scripts/check_pi_pin_freshness_test.py scripts/bump_pi_pin_test.py
+
+      - name: Compare the pin with the latest release
+        id: freshness
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/check_pi_pin_freshness.py --github-output
+
+      - name: Apply the bump
+        if: inputs.version != '' || steps.freshness.outputs.stale == 'true'
+        env:
+          TARGET_VERSION: ${{ inputs.version || steps.freshness.outputs.latest }}
+        run: python3 scripts/bump_pi_pin.py "$TARGET_VERSION"
+
+      - name: Open or refresh the bump PR
+        if: inputs.version != '' || steps.freshness.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_VERSION: ${{ inputs.version || steps.freshness.outputs.latest }}
+          BRANCH: automation/pi-bump
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Pin already at $TARGET_VERSION; nothing to open."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          # Tracked files only: the bump rewrites known pins, never adds files.
+          git add -u
+          git commit -m "Bump managed pi to $TARGET_VERSION" \
+            -m "Automated by the pi-bump workflow; digests computed from the release tarballs and cross-checked against upstream SHA256SUMS."
+          # The branch is owned by this workflow and rebuilt from main every
+          # run, so an outdated open PR is force-refreshed, never stacked onto.
+          git push --force origin "$BRANCH"
+          TITLE="Bump managed pi to $TARGET_VERSION"
+          BODY="$(printf '%s\n' \
+            "Automated pin refresh: upstream pi released $TARGET_VERSION." \
+            "" \
+            "- \`scripts/bump_pi_pin.py\` rewrote \`PI_PINNED_VERSION\`, the baked per-platform sha256s, and every hardcoded copy in tests/docs." \
+            "- Digests are computed from the release tarballs and cross-checked against the release's published \`SHA256SUMS\`." \
+            "" \
+            "CI does not start automatically on workflow-opened PRs — close and reopen this PR (or push to its branch) to run checks." \
+            "" \
+            "Opened automatically by the pi-bump workflow.")"
+          EXISTING_PR="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --title "$TITLE" --body "$BODY"
+            echo "Refreshed PR #$EXISTING_PR"
+          else
+            gh pr create --base main --head "$BRANCH" --title "$TITLE" --body "$BODY"
+          fi

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -219,7 +219,7 @@ packaging Sculptor):
 - **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no
   minimum-version check** (searched; none found). The minimum supported git version is undefined
   (worktree support is the relevant capability). → OPEN-6 (§7).
-- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness pins **0.80.2**; platforms
+- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness pins **0.80.10**; platforms
   darwin-arm64, darwin-x64, linux-x64, with per-platform sha256 checksums
   (`sculptor/sculptor/services/managed_tools.py`). A version mismatch fails clearly (REQ-INT-022).
 - **REQ-COMPAT-023 (MUST, conditional).** The PR surface requires **`gh`** (GitHub CLI) present and

--- a/justfile
+++ b/justfile
@@ -1109,10 +1109,19 @@ install-pi:
 
 # Recompute pi's per-platform sha256 pin: download each supported-platform tarball,
 # hash it, and print the platforms={...} block to paste into PI_PIN
-# (sculptor/services/managed_tools.py). The one manual step at a pi version bump.
+# (sculptor/services/managed_tools.py). Print-only; `just bump-pi` applies a bump.
 [group("install")]
 compute-pi-pin version:
     uv run python "{{justfile_directory()}}/scripts/compute_pi_pin.py" "{{version}}"
+
+# Apply a pi version bump end-to-end: recompute the per-platform sha256 pins
+# (cross-checked against the release's published SHA256SUMS) and rewrite
+# PI_PINNED_VERSION plus every hardcoded copy in tests/docs/stories. The
+# pi-bump workflow runs this daily; run it by hand when the checks staleness
+# warning fires.
+[group("install")]
+bump-pi version:
+    uv run python "{{justfile_directory()}}/scripts/bump_pi_pin.py" "{{version}}"
 
 # Installs additional dependencies for testing
 [group("install")]

--- a/scripts/bump_pi_pin.py
+++ b/scripts/bump_pi_pin.py
@@ -192,7 +192,7 @@ def apply_edits_in_memory(repo_root: Path, edits: Sequence[PlannedEdit]) -> dict
         if occurrences != edit.count:
             raise BumpError(
                 f"{edit.path}: expected {edit.count} occurrence(s) of {edit.old!r}, found {occurrences}. "
-                "The pinned literals have drifted; update plan_edits in scripts/bump_pi_pin.py."
+                + "The pinned literals have drifted; update plan_edits in scripts/bump_pi_pin.py."
             )
         contents[edit.path] = contents[edit.path].replace(edit.old, edit.new)
     return contents
@@ -213,7 +213,7 @@ def assert_no_stale_residue(contents: Mapping[str, str], replaced_pairs: Sequenc
             if old_literal in content:
                 raise BumpError(
                     f"{path}: still contains {old_literal!r} after the bump; "
-                    "add the new copy to plan_edits in scripts/bump_pi_pin.py."
+                    + "add the new copy to plan_edits in scripts/bump_pi_pin.py."
                 )
 
 

--- a/scripts/bump_pi_pin.py
+++ b/scripts/bump_pi_pin.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Apply a pi version bump to every file that pins or hardcodes the version.
+
+``compute_pi_pin`` prints the sha block for a human to paste; this tool goes the
+rest of the way. It downloads and hashes the target release's tarballs (reusing
+``compute_pi_pin``), cross-checks the digests against the release's published
+``SHA256SUMS`` when one exists, and rewrites the pin plus every hardcoded copy:
+the version constant, the baked sha256s, the backend/frontend test literals, the
+Storybook fixture, and the requirements doc.
+
+Two tripwires keep a bump honest. Every rewrite asserts an exact occurrence
+count, so a pinned literal that moves or multiplies fails the bump instead of
+landing it half-applied. And after the rewrites, no touched file may still
+contain an old version/digest literal, so a hardcoded copy this tool does not
+know about yet surfaces as an error naming the file.
+
+Usage:
+    just bump-pi 0.81.0
+    python3 scripts/bump_pi_pin.py 0.81.0
+
+The ``pi-bump`` workflow runs this on its daily schedule (target version from
+``check_pi_pin_freshness``) and opens a PR with the result. Network is
+required. Stdlib-only, like its ``scripts/`` siblings.
+"""
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import check_pi_pin_freshness
+import compute_pi_pin
+
+_PI_VERSION_FILE = "sculptor/sculptor/services/pi_version.py"
+_MANAGED_TOOLS_FILE = "sculptor/sculptor/services/managed_tools.py"
+_MANAGED_TOOLS_TEST_FILE = "sculptor/sculptor/services/managed_tools_test.py"
+_AGENT_WRAPPER_TEST_FILE = "sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py"
+_USE_MANAGED_DEPENDENCY_TEST_FILE = "sculptor/frontend/src/common/useManagedDependency.test.tsx"
+_DEPENDENCIES_STORY_FILE = "sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx"
+_REQUIREMENTS_FILE = "docs/specs/requirements.md"
+
+_SHA256SUMS_ASSET = "SHA256SUMS"
+_REQUEST_TIMEOUT_SECONDS = 30
+
+
+class BumpError(RuntimeError):
+    """Raised when the bump cannot be applied safely."""
+
+
+@dataclass(frozen=True)
+class PlannedEdit:
+    """One exact-string rewrite in one file, with its required occurrence count."""
+
+    path: str
+    old: str
+    new: str
+    count: int
+
+
+def read_baked_shas(repo_root: Path) -> dict[str, str]:
+    """Read the current per-platform sha256 pins out of ``PI_PIN``."""
+    source = (repo_root / _MANAGED_TOOLS_FILE).read_text()
+    shas: dict[str, str] = {}
+    for platform_key in compute_pi_pin.SUPPORTED_PLATFORM_KEYS:
+        asset = compute_pi_pin.asset_name_for_platform(platform_key)
+        pattern = re.compile(
+            rf'"{re.escape(platform_key)}": PlatformPin\(\s*asset="{re.escape(asset)}",\s*sha256="([0-9a-f]{{64}})"'
+        )
+        match = pattern.search(source)
+        if match is None:
+            raise BumpError(f"Could not locate the {platform_key} pin in {_MANAGED_TOOLS_FILE}")
+        shas[platform_key] = match.group(1)
+    return shas
+
+
+def parse_sha256sums(text: str) -> dict[str, str]:
+    """Parse ``sha256sum``-style output lines into ``{asset_name: digest}``."""
+    digests: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            raise BumpError(f"Unexpected SHA256SUMS line: {line!r}")
+        digest, asset = parts
+        digests[asset] = digest
+    return digests
+
+
+def fetch_published_sha256sums(version: str) -> dict[str, str] | None:
+    """Fetch upstream's ``SHA256SUMS`` for a release, or None when it publishes none."""
+    url = compute_pi_pin.release_url(version, _SHA256SUMS_ASSET)
+    request = urllib.request.Request(url, headers={"User-Agent": "sculptor-pi-bump"})
+    try:
+        with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
+            text = response.read().decode()
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise BumpError(f"Could not download {url}: {error}") from error
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise BumpError(f"Could not download {url}: {error}") from error
+    return parse_sha256sums(text)
+
+
+def verify_computed_against_published(computed: Mapping[str, str], published: Mapping[str, str] | None) -> None:
+    """Fail when upstream's published digests disagree with what we downloaded.
+
+    A mismatch means the tarball we hashed is not the one upstream published —
+    do not bake it. The repo's own computed digests stay the source of truth
+    either way, so a release without ``SHA256SUMS`` just skips the cross-check.
+    """
+    if published is None:
+        print("No published SHA256SUMS for this release; skipping the cross-check.")
+        return
+    for platform_key, digest in computed.items():
+        asset = compute_pi_pin.asset_name_for_platform(platform_key)
+        upstream_digest = published.get(asset)
+        if upstream_digest is None:
+            raise BumpError(f"Upstream SHA256SUMS is missing {asset}")
+        if upstream_digest != digest:
+            raise BumpError(f"Digest mismatch for {asset}: computed {digest}, upstream publishes {upstream_digest}")
+
+
+def plan_edits(
+    old_version: str, new_version: str, old_shas: Mapping[str, str], new_shas: Mapping[str, str]
+) -> tuple[PlannedEdit, ...]:
+    """Every file that carries the pi version or its digests, as exact rewrites.
+
+    The counts are load-bearing: a mismatch means a pinned literal moved or
+    gained a copy, and the bump must stop so a human re-audits this table.
+    """
+    old_name = f"_PI_DARWIN_ARM64_SHA256_{old_version.replace('.', '_')}"
+    new_name = f"_PI_DARWIN_ARM64_SHA256_{new_version.replace('.', '_')}"
+    return (
+        PlannedEdit(
+            _PI_VERSION_FILE,
+            f'PI_PINNED_VERSION = "{old_version}"',
+            f'PI_PINNED_VERSION = "{new_version}"',
+            1,
+        ),
+        *(
+            PlannedEdit(
+                _MANAGED_TOOLS_FILE,
+                f'sha256="{old_shas[platform_key]}"',
+                f'sha256="{new_shas[platform_key]}"',
+                1,
+            )
+            for platform_key in compute_pi_pin.SUPPORTED_PLATFORM_KEYS
+        ),
+        PlannedEdit(_MANAGED_TOOLS_TEST_FILE, f"for pi {old_version};", f"for pi {new_version};", 1),
+        PlannedEdit(_MANAGED_TOOLS_TEST_FILE, old_name, new_name, 2),
+        PlannedEdit(
+            _MANAGED_TOOLS_TEST_FILE,
+            f'= "{old_shas["darwin-arm64"]}"',
+            f'= "{new_shas["darwin-arm64"]}"',
+            1,
+        ),
+        PlannedEdit(_AGENT_WRAPPER_TEST_FILE, f'"pi {old_version}\\n"', f'"pi {new_version}\\n"', 2),
+        PlannedEdit(
+            _AGENT_WRAPPER_TEST_FILE,
+            f'pinned_version == "{old_version}"',
+            f'pinned_version == "{new_version}"',
+            1,
+        ),
+        PlannedEdit(_USE_MANAGED_DEPENDENCY_TEST_FILE, f'version: "{old_version}",', f'version: "{new_version}",', 2),
+        PlannedEdit(
+            _DEPENDENCIES_STORY_FILE,
+            f'minVersion: "{old_version}", maxVersion: "{old_version}", recommendedVersion: "{old_version}"',
+            f'minVersion: "{new_version}", maxVersion: "{new_version}", recommendedVersion: "{new_version}"',
+            1,
+        ),
+        PlannedEdit(_REQUIREMENTS_FILE, f"pins **{old_version}**", f"pins **{new_version}**", 1),
+    )
+
+
+def apply_edits_in_memory(repo_root: Path, edits: Sequence[PlannedEdit]) -> dict[str, str]:
+    """Apply every edit to in-memory copies, verifying each occurrence count.
+
+    Nothing touches disk here, so a failing count leaves the checkout pristine.
+    """
+    contents: dict[str, str] = {}
+    for edit in edits:
+        if edit.path not in contents:
+            contents[edit.path] = (repo_root / edit.path).read_text()
+        occurrences = contents[edit.path].count(edit.old)
+        if occurrences != edit.count:
+            raise BumpError(
+                f"{edit.path}: expected {edit.count} occurrence(s) of {edit.old!r}, found {occurrences}. "
+                "The pinned literals have drifted; update plan_edits in scripts/bump_pi_pin.py."
+            )
+        contents[edit.path] = contents[edit.path].replace(edit.old, edit.new)
+    return contents
+
+
+def assert_no_stale_residue(contents: Mapping[str, str], replaced_pairs: Sequence[tuple[str, str]]) -> None:
+    """After the rewrites, no touched file may still carry an old literal.
+
+    Catches a hardcoded copy that ``plan_edits`` does not know about yet — the
+    counts only police the known copies. A pair whose old literal is a substring
+    of its replacement is skipped, since the new text legitimately contains it
+    (e.g. bumping 0.80.10 to 0.80.100).
+    """
+    for path, content in contents.items():
+        for old_literal, new_literal in replaced_pairs:
+            if old_literal in new_literal:
+                continue
+            if old_literal in content:
+                raise BumpError(
+                    f"{path}: still contains {old_literal!r} after the bump; "
+                    "add the new copy to plan_edits in scripts/bump_pi_pin.py."
+                )
+
+
+def write_contents(repo_root: Path, contents: Mapping[str, str]) -> None:
+    """Write the rewritten files back to the checkout."""
+    for path, content in contents.items():
+        (repo_root / path).write_text(content)
+
+
+def main(argv: Sequence[str]) -> int:
+    """Parse the target version, verify the digests, and rewrite the pinned copies."""
+    parser = argparse.ArgumentParser(description="Apply a pi version bump across the repo's pinned copies.")
+    parser.add_argument("version", help="pi version to pin, without a leading 'v' (e.g. 0.81.0)")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root to rewrite (defaults to this checkout)",
+    )
+    arguments = parser.parse_args(argv)
+    target_version = arguments.version
+    check_pi_pin_freshness.parse_version(target_version)
+
+    current_version = check_pi_pin_freshness.read_pinned_version(arguments.repo_root)
+    if current_version == target_version:
+        print(f"pi is already pinned to {target_version}; nothing to do.")
+        return 0
+    if check_pi_pin_freshness.is_stale(target_version, current_version):
+        print(f"Note: {target_version} is older than the current pin {current_version}; applying the downgrade.")
+
+    print(f"Bumping pi {current_version} -> {target_version}")
+    old_shas = read_baked_shas(arguments.repo_root)
+    new_shas = compute_pi_pin.compute_platform_shas(target_version)
+    verify_computed_against_published(new_shas, fetch_published_sha256sums(target_version))
+
+    contents = apply_edits_in_memory(arguments.repo_root, plan_edits(current_version, target_version, old_shas, new_shas))
+    replaced_pairs = [
+        (current_version, target_version),
+        (current_version.replace(".", "_"), target_version.replace(".", "_")),
+        *((old_shas[platform_key], new_shas[platform_key]) for platform_key in compute_pi_pin.SUPPORTED_PLATFORM_KEYS),
+    ]
+    assert_no_stale_residue(contents, replaced_pairs)
+    write_contents(arguments.repo_root, contents)
+    for path in sorted(contents):
+        print(f"rewrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/bump_pi_pin_test.py
+++ b/scripts/bump_pi_pin_test.py
@@ -36,9 +36,9 @@ def _make_mini_repo(repo_root: Path, version: str) -> None:
     _write(repo_root, bump_pi_pin._PI_VERSION_FILE, f'PI_PINNED_VERSION = "{version}"\n')
     platform_lines = "".join(
         f'        "{key}": PlatformPin(\n'
-        f'            asset="pi-{key}.tar.gz",\n'
-        f'            sha256="{_OLD_SHAS[key]}",\n'
-        f"        ),\n"
+        + f'            asset="pi-{key}.tar.gz",\n'
+        + f'            sha256="{_OLD_SHAS[key]}",\n'
+        + "        ),\n"
         for key in compute_pi_pin.SUPPORTED_PLATFORM_KEYS
     )
     _write(
@@ -50,16 +50,16 @@ def _make_mini_repo(repo_root: Path, version: str) -> None:
         repo_root,
         bump_pi_pin._MANAGED_TOOLS_TEST_FILE,
         f"# Verified darwin-arm64 sha256 for pi {version}; ``just bump-pi <version>`` refreshes it.\n"
-        f'_PI_DARWIN_ARM64_SHA256_{underscored} = "{_OLD_SHAS["darwin-arm64"]}"\n'
-        f"\n"
-        f"value = _PI_DARWIN_ARM64_SHA256_{underscored}\n",
+        + f'_PI_DARWIN_ARM64_SHA256_{underscored} = "{_OLD_SHAS["darwin-arm64"]}"\n'
+        + "\n"
+        + f"value = _PI_DARWIN_ARM64_SHA256_{underscored}\n",
     )
     _write(
         repo_root,
         bump_pi_pin._AGENT_WRAPPER_TEST_FILE,
         f'    version_result.stderr = "pi {version}\\n"\n'
-        f'    other_result.stderr = "pi {version}\\n"\n'
-        f'    assert exc_info.value.pinned_version == "{version}"\n',
+        + f'    other_result.stderr = "pi {version}\\n"\n'
+        + f'    assert exc_info.value.pinned_version == "{version}"\n',
     )
     _write(
         repo_root,

--- a/scripts/bump_pi_pin_test.py
+++ b/scripts/bump_pi_pin_test.py
@@ -1,0 +1,205 @@
+"""Smoke tests for the bump_pi_pin dev tool, colocated with the script.
+
+Not part of `just test-unit`; the pi-bump workflow runs them before trusting the
+tooling, and they run on demand with
+`uv run python -m pytest scripts/bump_pi_pin_test.py`. The end-to-end cases run
+against a miniature repo copy with the network stubbed out; hashing real release
+assets stays with the workflow itself.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import bump_pi_pin
+import compute_pi_pin
+
+_OLD_VERSION = "0.80.10"
+_NEW_VERSION = "0.81.0"
+_OLD_SHAS = {"darwin-arm64": "aa" * 32, "darwin-x64": "bb" * 32, "linux-x64": "cc" * 32}
+_NEW_SHAS = {"darwin-arm64": "dd" * 32, "darwin-x64": "ee" * 32, "linux-x64": "ff" * 32}
+
+
+def _write(repo_root: Path, relative_path: str, content: str) -> None:
+    path = repo_root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _read(repo_root: Path, relative_path: str) -> str:
+    return (repo_root / relative_path).read_text()
+
+
+def _make_mini_repo(repo_root: Path, version: str) -> None:
+    """Lay out every pinned copy exactly as it appears in the real files."""
+    underscored = version.replace(".", "_")
+    _write(repo_root, bump_pi_pin._PI_VERSION_FILE, f'PI_PINNED_VERSION = "{version}"\n')
+    platform_lines = "".join(
+        f'        "{key}": PlatformPin(\n'
+        f'            asset="pi-{key}.tar.gz",\n'
+        f'            sha256="{_OLD_SHAS[key]}",\n'
+        f"        ),\n"
+        for key in compute_pi_pin.SUPPORTED_PLATFORM_KEYS
+    )
+    _write(
+        repo_root,
+        bump_pi_pin._MANAGED_TOOLS_FILE,
+        "PI_PIN = PiPin(\n    version=PI_PINNED_VERSION,\n    platforms={\n" + platform_lines + "    },\n)\n",
+    )
+    _write(
+        repo_root,
+        bump_pi_pin._MANAGED_TOOLS_TEST_FILE,
+        f"# Verified darwin-arm64 sha256 for pi {version}; ``just bump-pi <version>`` refreshes it.\n"
+        f'_PI_DARWIN_ARM64_SHA256_{underscored} = "{_OLD_SHAS["darwin-arm64"]}"\n'
+        f"\n"
+        f"value = _PI_DARWIN_ARM64_SHA256_{underscored}\n",
+    )
+    _write(
+        repo_root,
+        bump_pi_pin._AGENT_WRAPPER_TEST_FILE,
+        f'    version_result.stderr = "pi {version}\\n"\n'
+        f'    other_result.stderr = "pi {version}\\n"\n'
+        f'    assert exc_info.value.pinned_version == "{version}"\n',
+    )
+    _write(
+        repo_root,
+        bump_pi_pin._USE_MANAGED_DEPENDENCY_TEST_FILE,
+        f'          version: "{version}",\n          version: "{version}",\n',
+    )
+    _write(
+        repo_root,
+        bump_pi_pin._DEPENDENCIES_STORY_FILE,
+        f'  versionRange: {{ minVersion: "{version}", maxVersion: "{version}", recommendedVersion: "{version}" }},\n',
+    )
+    _write(
+        repo_root,
+        bump_pi_pin._REQUIREMENTS_FILE,
+        f"- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness pins **{version}**; platforms\n",
+    )
+
+
+@pytest.fixture
+def mini_repo(tmp_path: Path) -> Path:
+    _make_mini_repo(tmp_path, _OLD_VERSION)
+    return tmp_path
+
+
+def _stub_network(monkeypatch: pytest.MonkeyPatch, new_shas: dict[str, str]) -> None:
+    monkeypatch.setattr(compute_pi_pin, "compute_platform_shas", lambda version: dict(new_shas))
+    monkeypatch.setattr(
+        bump_pi_pin,
+        "fetch_published_sha256sums",
+        lambda version: {f"pi-{key}.tar.gz": sha for key, sha in new_shas.items()},
+    )
+
+
+def test_main_rewrites_every_pinned_copy(mini_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_network(monkeypatch, _NEW_SHAS)
+
+    assert bump_pi_pin.main([_NEW_VERSION, "--repo-root", str(mini_repo)]) == 0
+
+    assert _read(mini_repo, bump_pi_pin._PI_VERSION_FILE) == f'PI_PINNED_VERSION = "{_NEW_VERSION}"\n'
+    managed_tools = _read(mini_repo, bump_pi_pin._MANAGED_TOOLS_FILE)
+    for sha in _NEW_SHAS.values():
+        assert sha in managed_tools
+    for sha in _OLD_SHAS.values():
+        assert sha not in managed_tools
+    managed_tools_test = _read(mini_repo, bump_pi_pin._MANAGED_TOOLS_TEST_FILE)
+    assert f"for pi {_NEW_VERSION};" in managed_tools_test
+    assert managed_tools_test.count("_PI_DARWIN_ARM64_SHA256_0_81_0") == 2
+    assert _NEW_SHAS["darwin-arm64"] in managed_tools_test
+    agent_wrapper_test = _read(mini_repo, bump_pi_pin._AGENT_WRAPPER_TEST_FILE)
+    assert agent_wrapper_test.count(f'"pi {_NEW_VERSION}\\n"') == 2
+    assert f'pinned_version == "{_NEW_VERSION}"' in agent_wrapper_test
+    assert _read(mini_repo, bump_pi_pin._USE_MANAGED_DEPENDENCY_TEST_FILE).count(f'version: "{_NEW_VERSION}",') == 2
+    assert _read(mini_repo, bump_pi_pin._DEPENDENCIES_STORY_FILE).count(f'"{_NEW_VERSION}"') == 3
+    assert f"pins **{_NEW_VERSION}**" in _read(mini_repo, bump_pi_pin._REQUIREMENTS_FILE)
+    assert _OLD_VERSION not in agent_wrapper_test
+
+
+def test_main_is_a_no_op_when_already_pinned(mini_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _must_not_download(version: str) -> dict[str, str]:
+        raise AssertionError("no network access expected for a no-op bump")
+
+    monkeypatch.setattr(compute_pi_pin, "compute_platform_shas", _must_not_download)
+    before = _read(mini_repo, bump_pi_pin._PI_VERSION_FILE)
+
+    assert bump_pi_pin.main([_OLD_VERSION, "--repo-root", str(mini_repo)]) == 0
+    assert _read(mini_repo, bump_pi_pin._PI_VERSION_FILE) == before
+
+
+def test_main_rejects_a_malformed_version(mini_repo: Path) -> None:
+    with pytest.raises(Exception, match="version format"):
+        bump_pi_pin.main(["not-a-version", "--repo-root", str(mini_repo)])
+
+
+def test_main_fails_loudly_when_a_pinned_literal_drifts(mini_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_network(monkeypatch, _NEW_SHAS)
+    _write(mini_repo, bump_pi_pin._USE_MANAGED_DEPENDENCY_TEST_FILE, f'          version: "{_OLD_VERSION}",\n')
+    before = _read(mini_repo, bump_pi_pin._PI_VERSION_FILE)
+
+    with pytest.raises(bump_pi_pin.BumpError, match="expected 2"):
+        bump_pi_pin.main([_NEW_VERSION, "--repo-root", str(mini_repo)])
+    assert _read(mini_repo, bump_pi_pin._PI_VERSION_FILE) == before
+
+
+def test_main_fails_when_a_touched_file_hides_an_unknown_copy(
+    mini_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_network(monkeypatch, _NEW_SHAS)
+    agent_wrapper_path = bump_pi_pin._AGENT_WRAPPER_TEST_FILE
+    _write(mini_repo, agent_wrapper_path, _read(mini_repo, agent_wrapper_path) + f'stray = "pi {_OLD_VERSION} lingers"\n')
+    before = _read(mini_repo, bump_pi_pin._PI_VERSION_FILE)
+
+    with pytest.raises(bump_pi_pin.BumpError, match="still contains"):
+        bump_pi_pin.main([_NEW_VERSION, "--repo-root", str(mini_repo)])
+    assert _read(mini_repo, bump_pi_pin._PI_VERSION_FILE) == before
+
+
+def test_main_allows_a_bump_where_the_old_version_prefixes_the_new(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_mini_repo(tmp_path, "0.80.10")
+    _stub_network(monkeypatch, _NEW_SHAS)
+
+    assert bump_pi_pin.main(["0.80.100", "--repo-root", str(tmp_path)]) == 0
+    assert _read(tmp_path, bump_pi_pin._PI_VERSION_FILE) == 'PI_PINNED_VERSION = "0.80.100"\n'
+
+
+def test_read_baked_shas_reads_all_three_platform_pins(mini_repo: Path) -> None:
+    assert bump_pi_pin.read_baked_shas(mini_repo) == _OLD_SHAS
+
+
+def test_parse_sha256sums_maps_assets_to_digests() -> None:
+    text = f"{_NEW_SHAS['darwin-arm64']}  pi-darwin-arm64.tar.gz\n\n{_NEW_SHAS['linux-x64']}  pi-linux-x64.tar.gz\n"
+    assert bump_pi_pin.parse_sha256sums(text) == {
+        "pi-darwin-arm64.tar.gz": _NEW_SHAS["darwin-arm64"],
+        "pi-linux-x64.tar.gz": _NEW_SHAS["linux-x64"],
+    }
+
+
+def test_parse_sha256sums_rejects_a_malformed_line() -> None:
+    with pytest.raises(bump_pi_pin.BumpError, match="Unexpected SHA256SUMS line"):
+        bump_pi_pin.parse_sha256sums("only-one-column\n")
+
+
+def test_verify_accepts_matching_published_digests() -> None:
+    published = {f"pi-{key}.tar.gz": sha for key, sha in _NEW_SHAS.items()}
+    bump_pi_pin.verify_computed_against_published(_NEW_SHAS, published)
+
+
+def test_verify_rejects_a_digest_mismatch() -> None:
+    published = {f"pi-{key}.tar.gz": sha for key, sha in _NEW_SHAS.items()}
+    published["pi-linux-x64.tar.gz"] = "00" * 32
+    with pytest.raises(bump_pi_pin.BumpError, match="Digest mismatch"):
+        bump_pi_pin.verify_computed_against_published(_NEW_SHAS, published)
+
+
+def test_verify_rejects_a_missing_asset() -> None:
+    published = {"pi-darwin-arm64.tar.gz": _NEW_SHAS["darwin-arm64"]}
+    with pytest.raises(bump_pi_pin.BumpError, match="missing"):
+        bump_pi_pin.verify_computed_against_published(_NEW_SHAS, published)
+
+
+def test_verify_skips_the_cross_check_when_upstream_publishes_no_sums() -> None:
+    bump_pi_pin.verify_computed_against_published(_NEW_SHAS, None)

--- a/scripts/check_pi_pin_freshness.py
+++ b/scripts/check_pi_pin_freshness.py
@@ -108,7 +108,7 @@ def _run_warning_mode(repo_root: Path) -> int:
     if stale:
         print(
             f"::warning title=pi pin is stale::pi {latest} is released; Sculptor pins {pinned}. "
-            f"The pi-bump workflow opens a bump PR daily, or run `just bump-pi {latest}`."
+            + f"The pi-bump workflow opens a bump PR daily, or run `just bump-pi {latest}`."
         )
     else:
         print(f"pi pin is fresh: pinned={pinned} latest={latest}")

--- a/scripts/check_pi_pin_freshness.py
+++ b/scripts/check_pi_pin_freshness.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Report whether the pinned pi version lags the latest upstream release.
+
+Sculptor pins pi to one exact version (``PI_PINNED_VERSION`` in
+``sculptor/sculptor/services/pi_version.py``) while upstream releases several
+times a week, so the pin goes stale by design. This tool fetches the latest
+``earendil-works/pi`` release tag from the GitHub API and compares it with the
+pin. CI consumes it two ways:
+
+- ``--emit-github-warning`` (the ``checks`` workflow): a stale pin prints a
+  ``::warning::`` annotation and the step still succeeds — staleness is an
+  early signal, never a gate. Any failure degrades to a ``::notice::``.
+- ``--github-output`` (the ``pi-bump`` workflow): append ``pinned``, ``latest``,
+  and ``stale`` to ``$GITHUB_OUTPUT`` so the bump job can decide whether to
+  open a PR. Here errors do fail the step, so a broken scheduled run is
+  visible in the Actions tab instead of silently never bumping again.
+
+Reads ``GH_TOKEN`` or ``GITHUB_TOKEN`` for the API call when set; anonymous
+works but is rate-limited per IP. Stdlib-only, like its ``scripts/`` siblings.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from pathlib import Path
+
+_LATEST_RELEASE_API_URL = "https://api.github.com/repos/earendil-works/pi/releases/latest"
+_REQUEST_TIMEOUT_SECONDS = 30
+_PI_VERSION_FILE = Path("sculptor/sculptor/services/pi_version.py")
+_PINNED_VERSION_PATTERN = re.compile(r'^PI_PINNED_VERSION = "([^"]+)"$', re.MULTILINE)
+
+
+class FreshnessCheckError(RuntimeError):
+    """Raised when the pinned or latest pi version cannot be determined."""
+
+
+def read_pinned_version(repo_root: Path) -> str:
+    """Extract ``PI_PINNED_VERSION`` from its dependency-free module, textually.
+
+    Parsing the source instead of importing it keeps this script runnable with a
+    bare interpreter — the same reason the constant lives in an import-free
+    module in the first place.
+    """
+    source = (repo_root / _PI_VERSION_FILE).read_text()
+    match = _PINNED_VERSION_PATTERN.search(source)
+    if match is None:
+        raise FreshnessCheckError(f"PI_PINNED_VERSION not found in {_PI_VERSION_FILE}")
+    return match.group(1)
+
+
+def fetch_latest_release_version() -> str:
+    """Return the latest pi release version (its tag without the leading ``v``)."""
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        # The GitHub API rejects requests that send no User-Agent.
+        "User-Agent": "sculptor-pi-pin-freshness",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(_LATEST_RELEASE_API_URL, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
+            payload = json.load(response)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise FreshnessCheckError(f"Could not fetch the latest pi release: {error}") from error
+    tag = payload.get("tag_name")
+    if not isinstance(tag, str) or not tag:
+        raise FreshnessCheckError(f"Latest-release response has no tag_name: {str(payload)[:200]}")
+    return tag.removeprefix("v")
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Parse a strict ``MAJOR.MINOR.PATCH`` pi version for ordered comparison."""
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        raise FreshnessCheckError(f"Unexpected pi version format: {version!r}")
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def is_stale(pinned: str, latest: str) -> bool:
+    """True when the latest release is strictly newer than the pin.
+
+    Compares numerically, not lexically: ``0.80.10`` is newer than ``0.80.2``.
+    """
+    return parse_version(latest) > parse_version(pinned)
+
+
+def format_github_output(pinned: str, latest: str, stale: bool) -> str:
+    """Render the ``$GITHUB_OUTPUT`` lines the pi-bump workflow reads."""
+    return f"pinned={pinned}\nlatest={latest}\nstale={str(stale).lower()}\n"
+
+
+def _run_warning_mode(repo_root: Path) -> int:
+    """Annotate a stale pin without ever failing the calling check."""
+    try:
+        pinned = read_pinned_version(repo_root)
+        latest = fetch_latest_release_version()
+        stale = is_stale(pinned, latest)
+    except Exception as error:  # noqa: BLE001 - the freshness signal must never break the build.
+        print(f"::notice title=pi pin freshness::Skipped the staleness check: {error}")
+        return 0
+    if stale:
+        print(
+            f"::warning title=pi pin is stale::pi {latest} is released; Sculptor pins {pinned}. "
+            f"The pi-bump workflow opens a bump PR daily, or run `just bump-pi {latest}`."
+        )
+    else:
+        print(f"pi pin is fresh: pinned={pinned} latest={latest}")
+    return 0
+
+
+def main(argv: Sequence[str]) -> int:
+    """Parse the mode flags and run the freshness comparison."""
+    parser = argparse.ArgumentParser(description="Compare PI_PINNED_VERSION with the latest pi release.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root containing the pinned-version module (defaults to this checkout)",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--emit-github-warning",
+        action="store_true",
+        help="print a ::warning:: annotation when stale and always exit 0",
+    )
+    mode.add_argument(
+        "--github-output",
+        action="store_true",
+        help="append pinned/latest/stale to $GITHUB_OUTPUT",
+    )
+    arguments = parser.parse_args(argv)
+
+    if arguments.emit_github_warning:
+        return _run_warning_mode(arguments.repo_root)
+
+    pinned = read_pinned_version(arguments.repo_root)
+    latest = fetch_latest_release_version()
+    stale = is_stale(pinned, latest)
+    if arguments.github_output:
+        output_path = os.environ.get("GITHUB_OUTPUT")
+        if not output_path:
+            raise FreshnessCheckError("--github-output requires the GITHUB_OUTPUT environment variable")
+        with open(output_path, "a") as output_file:
+            output_file.write(format_github_output(pinned, latest, stale))
+    print(f"pinned={pinned} latest={latest} stale={str(stale).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_pi_pin_freshness_test.py
+++ b/scripts/check_pi_pin_freshness_test.py
@@ -1,0 +1,63 @@
+"""Smoke tests for the check_pi_pin_freshness dev tool, colocated with the script.
+
+Not part of `just test-unit`; the pi-bump workflow runs them before trusting the
+tooling, and they run on demand with
+`uv run python -m pytest scripts/check_pi_pin_freshness_test.py`. Covers the pure
+helpers only -- the GitHub API call is exercised by the workflows themselves.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import check_pi_pin_freshness
+
+
+def _write_pi_version_module(repo_root: Path, content: str) -> None:
+    module_path = repo_root / "sculptor" / "sculptor" / "services" / "pi_version.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text(content)
+
+
+def test_read_pinned_version_extracts_the_constant(tmp_path: Path) -> None:
+    _write_pi_version_module(tmp_path, '"""The pin."""\n\nPI_PINNED_VERSION = "0.80.10"\n')
+    assert check_pi_pin_freshness.read_pinned_version(tmp_path) == "0.80.10"
+
+
+def test_read_pinned_version_rejects_a_module_without_the_constant(tmp_path: Path) -> None:
+    _write_pi_version_module(tmp_path, '"""No pin here."""\n')
+    with pytest.raises(check_pi_pin_freshness.FreshnessCheckError):
+        check_pi_pin_freshness.read_pinned_version(tmp_path)
+
+
+def test_read_pinned_version_parses_the_real_module() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    pinned = check_pi_pin_freshness.read_pinned_version(repo_root)
+    check_pi_pin_freshness.parse_version(pinned)
+
+
+def test_is_stale_compares_numerically_not_lexically() -> None:
+    assert check_pi_pin_freshness.is_stale("0.80.2", "0.80.10")
+    assert not check_pi_pin_freshness.is_stale("0.80.10", "0.80.2")
+    assert not check_pi_pin_freshness.is_stale("0.80.10", "0.80.10")
+
+
+def test_parse_version_rejects_a_suffixed_version() -> None:
+    with pytest.raises(check_pi_pin_freshness.FreshnessCheckError):
+        check_pi_pin_freshness.parse_version("0.80.10-rc1")
+
+
+def test_parse_version_rejects_a_tag_with_the_v_prefix() -> None:
+    with pytest.raises(check_pi_pin_freshness.FreshnessCheckError):
+        check_pi_pin_freshness.parse_version("v0.80.10")
+
+
+def test_format_github_output_renders_one_key_per_line() -> None:
+    rendered = check_pi_pin_freshness.format_github_output("0.80.2", "0.80.10", True)
+    assert rendered == "pinned=0.80.2\nlatest=0.80.10\nstale=true\n"
+
+
+def test_warning_mode_never_fails_when_the_lookup_breaks(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = check_pi_pin_freshness.main(["--emit-github-warning", "--repo-root", str(tmp_path)])
+    assert exit_code == 0
+    assert "::notice" in capsys.readouterr().out

--- a/scripts/compute_pi_pin.py
+++ b/scripts/compute_pi_pin.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """Recompute pi's per-platform sha256 pin for a given pi version.
 
-pi publishes no checksums of its own, so Sculptor computes and bakes them into
-``PI_PIN`` (``sculptor/services/managed_tools.py``). This dev tool downloads each
+Sculptor bakes its own per-platform digests into ``PI_PIN``
+(``sculptor/services/managed_tools.py``); upstream's published ``SHA256SUMS`` is
+only ever a cross-check, never the source of truth. This dev tool downloads each
 supported-platform release tarball, hashes it, and prints the ``platforms={...}``
-block to paste into ``PI_PIN``. It is the single manual step at a pi version bump.
+block to paste into ``PI_PIN``. ``scripts/bump_pi_pin.py`` (``just bump-pi``)
+wraps it end-to-end at a version bump; run this directly to print the block
+without editing files.
 
 Usage:
     just compute-pi-pin 0.78.0

--- a/sculptor/frontend/src/common/useManagedDependency.test.tsx
+++ b/sculptor/frontend/src/common/useManagedDependency.test.tsx
@@ -61,7 +61,7 @@ describe("useManagedDependency", () => {
       makeStatus({
         pi: makeInfo({
           installed: true,
-          version: "0.80.2",
+          version: "0.80.10",
           mode: "MANAGED",
           source: "MANAGED",
           isVersionInRange: true,
@@ -87,7 +87,7 @@ describe("useManagedDependency", () => {
       makeStatus({
         pi: makeInfo({
           installed: true,
-          version: "0.80.2",
+          version: "0.80.10",
           mode: "MANAGED",
           source: "EXTERNAL",
           isVersionInRange: true,

--- a/sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx
+++ b/sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx
@@ -12,7 +12,7 @@ const piNotInstalled = {
   version: null,
   isOverride: false,
   mode: null,
-  versionRange: { minVersion: "0.80.2", maxVersion: "0.80.2", recommendedVersion: "0.80.2" },
+  versionRange: { minVersion: "0.80.10", maxVersion: "0.80.10", recommendedVersion: "0.80.10" },
   isVersionInRange: null,
 } as const;
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -287,7 +287,7 @@ def _make_start_env(persisted_session_id: str | None = None) -> MagicMock:
     env.get_tool_binary_path.return_value = "/bin/pi"
     version_result = MagicMock()
     version_result.stdout = ""
-    version_result.stderr = "pi 0.80.2\n"
+    version_result.stderr = "pi 0.80.10\n"
     env.run_process_to_completion.return_value = version_result
     env.get_state_path.return_value = Path("/fake/state")
     env.get_system_prompt.return_value = ""
@@ -691,7 +691,7 @@ def _make_probe_env(probe_process: MagicMock) -> MagicMock:
     env.get_tool_binary_path.return_value = "/bin/pi"
     version_result = MagicMock()
     version_result.stdout = ""
-    version_result.stderr = "pi 0.80.2\n"
+    version_result.stderr = "pi 0.80.10\n"
     env.run_process_to_completion.return_value = version_result
     env.get_state_path.return_value = Path("/fake/state")
     env.run_process_in_background.return_value = probe_process
@@ -2509,7 +2509,7 @@ class TestStartAndSessionResume:
         agent = _make_agent(env)
         with pytest.raises(PiVersionMismatchError) as exc_info:
             agent.start(secrets={})
-        assert exc_info.value.pinned_version == "0.80.2"
+        assert exc_info.value.pinned_version == "0.80.10"
         assert exc_info.value.detected_version == "0.50.0"
         # The message must point the user at the self-healing fix (managed install).
         assert "Managed" in str(exc_info.value)

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -68,15 +68,15 @@ PI_PIN = PiPin(
     platforms={
         "darwin-arm64": PlatformPin(
             asset="pi-darwin-arm64.tar.gz",
-            sha256="c7d125bbdebd863fa76d92274458ba0eb405e5cde39db34db1f49f767ed9f1dd",
+            sha256="4406ed227c486f2e3c16cf14f793dc3ad46b5d01bf69135a2424cffa58a9a34b",
         ),
         "darwin-x64": PlatformPin(
             asset="pi-darwin-x64.tar.gz",
-            sha256="d4b6b62a0c34c0f2e4cb16ee6fd4f0086b86ad70e0488fd3daa9231216d84e2b",
+            sha256="892b3f385ae6779299c07a25d9280183897fcf755f7226f6b36c70d268f321be",
         ),
         "linux-x64": PlatformPin(
             asset="pi-linux-x64.tar.gz",
-            sha256="2e68772bbeaacd73488751098193875389636b80589100609a29921ded71c984",
+            sha256="ab6604f6c3f3d050783e7abbbdd1f79b775b20f3969833ce9721740685d01e13",
         ),
     },
 )

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -51,9 +51,9 @@ class PlatformPin(FrozenModel):
 class PiPin(FrozenModel):
     """The static, in-repo source of truth for the managed pi distribution.
 
-    pi publishes no checksums, so Sculptor computes them per version
-    (``scripts/compute_pi_pin.py``) and bakes them here; the install path verifies
-    downloads against these pinned values.
+    Sculptor computes pi's digests itself per version (``just bump-pi``, which
+    cross-checks upstream's published ``SHA256SUMS``) and bakes them here; the
+    install path verifies downloads against these pinned values only.
     """
 
     version: str
@@ -187,9 +187,9 @@ def _current_pi_platform_key() -> str:
 class PiManagedTool(ManagedTool):
     """Managed-install conformer for pi.
 
-    pi publishes per-platform tarballs and no checksums of its own, so the
-    distribution descriptor is built entirely from the static ``PI_PIN`` (no network
-    to resolve it) and verified against the baked sha256 at download time.
+    pi publishes per-platform tarballs; the distribution descriptor is built
+    entirely from the static ``PI_PIN`` (no network to resolve it) and verified
+    against the baked sha256 at download time.
     """
 
     tool = Dependency.PI

--- a/sculptor/sculptor/services/managed_tools_test.py
+++ b/sculptor/sculptor/services/managed_tools_test.py
@@ -25,7 +25,7 @@ from sculptor.services.managed_tools import _PI_PLATFORM_MAP
 from sculptor.services.managed_tools import get_managed_tool
 from sculptor.services.managed_tools import get_managed_tools
 
-# Verified darwin-arm64 sha256 for pi 0.80.10; regenerate with ``just compute-pi-pin 0.80.10``.
+# Verified darwin-arm64 sha256 for pi 0.80.10; ``just bump-pi <version>`` refreshes it.
 _PI_DARWIN_ARM64_SHA256_0_80_10 = "4406ed227c486f2e3c16cf14f793dc3ad46b5d01bf69135a2424cffa58a9a34b"
 
 

--- a/sculptor/sculptor/services/managed_tools_test.py
+++ b/sculptor/sculptor/services/managed_tools_test.py
@@ -25,8 +25,8 @@ from sculptor.services.managed_tools import _PI_PLATFORM_MAP
 from sculptor.services.managed_tools import get_managed_tool
 from sculptor.services.managed_tools import get_managed_tools
 
-# Verified darwin-arm64 sha256 for pi 0.80.2; regenerate with ``just compute-pi-pin 0.80.2``.
-_PI_DARWIN_ARM64_SHA256_0_80_2 = "c7d125bbdebd863fa76d92274458ba0eb405e5cde39db34db1f49f767ed9f1dd"
+# Verified darwin-arm64 sha256 for pi 0.80.10; regenerate with ``just compute-pi-pin 0.80.10``.
+_PI_DARWIN_ARM64_SHA256_0_80_10 = "4406ed227c486f2e3c16cf14f793dc3ad46b5d01bf69135a2424cffa58a9a34b"
 
 
 def _instantiate_with_no_arguments(candidate: Callable[[], object]) -> object:
@@ -100,7 +100,7 @@ def test_pi_pin_asset_names_follow_the_pi_release_naming_for_each_platform() -> 
 
 
 def test_pi_pin_darwin_arm64_sha256_matches_the_verified_value() -> None:
-    assert PI_PIN.platforms["darwin-arm64"].sha256 == _PI_DARWIN_ARM64_SHA256_0_80_2
+    assert PI_PIN.platforms["darwin-arm64"].sha256 == _PI_DARWIN_ARM64_SHA256_0_80_10
 
 
 def test_pi_pin_platform_sha256s_are_distinct_lowercase_hex_digests() -> None:

--- a/sculptor/sculptor/services/pi_version.py
+++ b/sculptor/sculptor/services/pi_version.py
@@ -7,4 +7,4 @@ here — in its own import-free module — so the test harness's ``fake_pi`` stu
 module import-free.
 """
 
-PI_PINNED_VERSION = "0.80.2"
+PI_PINNED_VERSION = "0.80.10"


### PR DESCRIPTION
## What

Two changes, validated by CI only:

### 1. Bump the managed pi harness 0.80.2 → 0.80.10 (latest upstream release)

- `PI_PINNED_VERSION` → `0.80.10` (`sculptor/services/pi_version.py`)
- Regenerated the three per-platform sha256 pins in `PI_PIN` via `just compute-pi-pin 0.80.10`
- Refreshed the hardcoded version copies in backend/frontend tests, the Storybook fixture, and REQ-COMPAT-022 in `docs/specs/requirements.md`

### 2. Add a pipeline that keeps the pin fresh

- **`checks.yml`**: a non-blocking step annotates the run with a `::warning::` when upstream pi has released past the pin — same early-signal philosophy as the intentionally unpinned Claude Code install; it never gates.
- **`pi-bump.yml`** (new; daily schedule + manual dispatch): compares the pin with the latest `earendil-works/pi` release and opens — or force-refreshes — a single rolling `automation/pi-bump` PR with the bump fully applied. Follows the CI-opens-a-PR pattern from `approve-contributor.yml` and the workflow security rules (trusted triggers only, no `${{ }}` in `run:` bodies, minimal token scopes).
- **`scripts/bump_pi_pin.py`** (also `just bump-pi <version>`): applies a bump end-to-end — reuses `compute_pi_pin` for the digests, cross-checks them against the release's published `SHA256SUMS`, and rewrites every hardcoded copy with occurrence-count and residue tripwires so drifted literals fail the bump loudly. `scripts/check_pi_pin_freshness.py` supplies the staleness comparison to both workflows. Stdlib-only, with colocated smoke tests the pi-bump workflow runs before trusting the tooling.

## Verification

- The computed digests (darwin-arm64, darwin-x64, linux-x64) exactly match pi's published `SHA256SUMS` asset for v0.80.10 — two independent sources agree. Upstream now publishes `SHA256SUMS` on its releases (its v0.80.2 sums retro-match the pins previously baked here), so the docstrings claiming pi publishes no checksums are updated too.
- pi 0.80.8 announced breaking changes in its extension/SDK surface (`ModelRuntime` replacing `AuthStorage`/`ModelRegistry` session options). Sculptor's bundled pi extensions use none of the affected APIs (verified by search), and the `--mode rpc` protocol Sculptor drives has no announced breaking changes in 0.80.3–0.80.10.
- The freshness script was exercised once for real against the GitHub API: `pinned=0.80.10 latest=0.80.10 stale=false`.

## Notes for reviewers

- A PR opened with the workflow's `GITHUB_TOKEN` does not trigger `pull_request` CI (GitHub suppresses recursive runs), so the rolling bump PR needs a one-click close/reopen to start checks; the generated PR body says so. Swapping in a GitHub App token would remove that friction if it ever matters.
- After this merges, a manual `workflow_dispatch` of pi-bump is a safe end-to-end smoke test: with the pin already at latest, it self-tests the tooling, reports `stale=false`, and exits without opening anything.

(Sent by Claude)
