### PR TITLE
Add CI Babysitter help doc for general users

### DIFF
--- a/docs/help/README.md
+++ b/docs/help/README.md
@@ -28,6 +28,8 @@ This is the user guide. For contributor and developer documentation, see
 - [Agents](agents.md) — running multiple agents in parallel within one workspace.
 - [Changes](changes.md) — reviewing the agent's diff, committing, and discarding.
 - [Pull Requests](pull_requests.md) — opening a GitHub PR and tracking its status.
+- [CI Babysitter](ci_babysitter.md) — automatically fix failing CI and merge
+  conflicts on your open PRs.
 - [Skills](skills.md) — the bundled `sculptor-workflow` and `sculptor-experimental`
   skills you can run from `/`.
 - [Extensions](extensions.md) — add panels, widgets, home views, and overlays

--- a/docs/help/ci_babysitter.md
+++ b/docs/help/ci_babysitter.md
@@ -1,0 +1,118 @@
+# CI Babysitter
+
+The **CI Babysitter** watches your open pull requests and, when a PR's CI
+pipeline fails or the PR develops a merge conflict, automatically asks an AI
+agent to fix it — investigate the failure, make the change, commit, and push.
+It's designed for leaving a batch of PRs to sort themselves out while you step
+away: fire off some work, turn the babysitter on, and come back to find most of
+them green.
+
+The CI Babysitter is **experimental and off by default**. Turn it on in
+[Settings](settings.md) → **CI**.
+
+---
+
+## What it does
+
+Once enabled, the babysitter reacts to two things on each of your open PRs:
+
+- **A failed pipeline** — when the PR's CI checks go red, it asks an agent to
+  find the root cause, fix the code, and push the fix.
+- **A merge conflict** — when the PR can no longer merge cleanly into its base
+  branch, it asks an agent to rebase, resolve the conflicts, and force-push.
+
+It keeps trying, up to a limit you set (the **retry cap**), until the pipeline
+passes. PRs it can't rescue are simply left with their failing status for you to
+pick up by hand — the babysitter never merges or closes a PR itself.
+
+---
+
+## How it works
+
+You don't have to do anything once it's on. Behind the scenes:
+
+1. **Sculptor watches your PRs.** It polls GitHub for each open PR's checks and
+   merge status (roughly every 30 seconds), so it notices when a pipeline turns
+   red or a conflict appears.
+2. **It waits for a quiet moment.** The babysitter never interrupts an agent
+   that's mid-task. If any agent in that workspace is busy or waiting on you, it
+   holds off — the failure will come back around on the next push, and it'll act
+   then.
+3. **It opens a dedicated agent.** When the workspace is idle, the babysitter
+   spawns its own agent in that workspace, shown as a **"CI Babysitter"** tab.
+   This is a normal agent session — it's just started automatically and handed a
+   prompt. The same tab is reused for every retry, so it reads as one ongoing
+   conversation, and it sticks around across app restarts.
+4. **The agent does the work.** It receives the fix prompt (see below), then
+   investigates, edits, commits, and pushes just like an agent you'd drive
+   yourself. The babysitter only sends the prompt; the agent makes and pushes the
+   changes.
+5. **It retries until green — or gives up.** Each attempt counts against the
+   retry cap. When the pipeline finally passes, the counter resets, so a future
+   failure gets a fresh set of attempts. Once the cap is reached, it stops
+   prompting for that PR until the pipeline next passes on its own.
+
+A couple of details worth knowing:
+
+- It won't fire twice for the same failing run — only a **new** pipeline run that
+  fails re-arms it. This also means a PR that's *already* red when you turn the
+  babysitter on won't consume a retry until its next run fails.
+- When a PR is **merged or closed**, the babysitter retires for that workspace
+  and stops watching.
+
+---
+
+## Turning it on and configuring it
+
+All of the babysitter's settings live in [Settings](settings.md) → **CI**, and
+apply across every workspace:
+
+- **Enable CI Babysitter** — the master switch. Off by default.
+- **Babysitter agent** — which agent does the fixing:
+  - **Most recently used** (the default) — matches whatever kind of agent you
+    last used in that workspace.
+  - **Claude** or **Pi** — always use that harness.
+  - **A specific agent** — any registered agent that accepts automated prompts.
+    Plain terminals and agents that don't opt in won't appear here.
+- **Retry Cap** — how many times the babysitter will prompt for one PR before
+  giving up (until the pipeline next passes). Default **3**; you can set anywhere
+  from **1 to 10**.
+- **Pipeline Failed Prompt** — the instruction sent when a pipeline fails. The
+  default asks the agent to *"Investigate the failing pipeline for this PR,
+  identify the root cause, fix the code, commit, and push."* Edit it to fit your
+  project, or reset it to the default.
+- **Merge Conflict Prompt** — the instruction sent when a conflict appears. The
+  default asks the agent to fetch, rebase against the base branch, resolve the
+  conflicts, and force-push. Also editable and resettable.
+
+---
+
+## Pausing it for one PR
+
+You don't have to turn the whole feature off to stop it on a single PR. Open the
+PR's status button (see [Pull Requests](pull_requests.md)) and use the
+**pause/resume** switch there. Pausing is **per workspace** and is remembered
+across restarts, so a PR you've paused stays paused until you resume it.
+
+If the babysitter can't run for a workspace — for example, its chosen agent type
+isn't available — the switch shows a short reason instead of a status.
+
+---
+
+## Requirements and limits
+
+- **GitHub pull requests only.** PR status comes from the GitHub CLI (`gh`), so
+  the babysitter only works in repos with a GitHub remote and a `gh` that's
+  installed and signed in. See [Pull Requests](pull_requests.md) for setup.
+- **Sculptor has to be running.** The babysitter is part of your local Sculptor
+  app, not a cloud service. It only watches and fixes PRs while the app is open
+  and your machine is on.
+- **It shares your GitHub rate limit.** Status polling counts against your
+  personal GitHub API budget across all your workspaces. If that budget runs low,
+  Sculptor automatically slows its polling down, which means it may take longer to
+  notice a new failure.
+- **It respects your in-progress work.** Because it waits for the workspace to be
+  idle, a failure that lands while you're actively working is skipped for now
+  rather than queued — it re-arms on the next push.
+- **It won't rescue everything.** Once a PR hits the retry cap, it's left flagged
+  with its failing status for you to take over manually.

--- a/docs/help/settings.md
+++ b/docs/help/settings.md
@@ -33,9 +33,9 @@ Under **Project**:
 - **Git** — the pull-request creation prompt, PR status polling, default
   target branch, default branch-naming pattern, and the branch-deletion
   policy for removed workspaces.
-- **CI** — the CI Babysitter: when enabled, Sculptor watches open PRs and
-  asks an agent to fix CI failures and merge conflicts, with a configurable
-  agent, retry cap, and prompts.
+- **CI** — the [CI Babysitter](ci_babysitter.md): when enabled, Sculptor
+  watches open PRs and asks an agent to fix CI failures and merge conflicts,
+  with a configurable agent, retry cap, and prompts.
 - **File browser** — line wrapping, the default diff view (unified vs.
   split), and the commit prompt.
 - **Environment variables** — the global (`~/.sculptor/.env`) and per-repo


### PR DESCRIPTION
## What

Adds a user-facing help page for the **CI Babysitter** at
`docs/help/ci_babysitter.md`, written for general (non-developer) users.

It covers:

- **What it does** — watches your open PRs and asks an AI agent to fix failed
  CI pipelines and merge conflicts (investigate → fix → commit → push, or
  rebase → resolve → force-push).
- **How it works** — polls PR status, waits until the workspace's agents are
  idle so it never interrupts work in progress, spawns a dedicated
  "CI Babysitter" agent, and retries up to the configurable cap, resetting the
  count when the pipeline next passes.
- **Settings** — the enable toggle, the babysitter-agent picker (most recently
  used / Claude / Pi / a registered agent), the retry cap (default 3, range
  1–10), and the editable pipeline-failure and merge-conflict prompts.
- **Pausing** — the per-workspace pause/resume on the PR status button, which is
  remembered across restarts.
- **Requirements & limits** — GitHub PRs via `gh`, the app must be running, the
  shared GitHub rate limit, and that the feature is experimental and off by
  default.

## Also

- Adds the page to the help index (`docs/help/README.md`).
- Turns the existing "CI Babysitter" mention in `docs/help/settings.md` into a
  link to the new page.

Docs-only change. The behavior described was verified against the Settings
component, the config defaults, and the babysitter service and product specs.

(Sent by Claude)
