### PR TITLE
Let sculpt create pi agents with a model from pi's catalog

### DIFF
--- a/tools/sculpt/sculpt/commands/_harness_helpers.py
+++ b/tools/sculpt/sculpt/commands/_harness_helpers.py
@@ -6,6 +6,8 @@ harnesses and the server's registered terminal agents — lives here so the two
 commands stay in lockstep.
 """
 
+from collections.abc import Sequence
+
 import httpx
 
 from sculpt.client import Client
@@ -64,6 +66,10 @@ def _pi_model_names(option: ModelOption) -> tuple[str, str, str]:
     )
 
 
+def _format_pi_model_list(options: Sequence[ModelOption]) -> str:
+    return ", ".join(f"{o.display_name} ({o.provider}/{o.model_id})" for o in options)
+
+
 def resolve_pi_backend_model(client: Client, json_output: bool, requested_model: str | None = None) -> ModelOption:
     """Pick the backend model a pi prompt runs under, from pi's own catalog.
 
@@ -87,13 +93,18 @@ def resolve_pi_backend_model(client: Client, json_output: bool, requested_model:
             return catalog.available_models[0]
     else:
         requested_lower = requested_model.lower()
-        for option in catalog.available_models:
-            if requested_lower in _pi_model_names(option):
-                return option
-        if catalog.available_models:
-            available = ", ".join(f"{o.display_name} ({o.provider}/{o.model_id})" for o in catalog.available_models)
+        matches = [o for o in catalog.available_models if requested_lower in _pi_model_names(o)]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
             cli_error(
-                f"Unknown pi model '{requested_model}'. Available pi models: {available}",
+                f"'{requested_model}' matches multiple pi models: {_format_pi_model_list(matches)}."
+                + " Use provider/model_id to pick one",
+                json_output=json_output,
+            )
+        if catalog.available_models:
+            cli_error(
+                f"Unknown pi model '{requested_model}'. Available pi models: {_format_pi_model_list(catalog.available_models)}",
                 json_output=json_output,
             )
     cli_error(

--- a/tools/sculpt/sculpt/commands/_harness_helpers.py
+++ b/tools/sculpt/sculpt/commands/_harness_helpers.py
@@ -55,13 +55,24 @@ def resolve_harness_selection(harness: str | None, client: Client, json_output: 
     return selection
 
 
-def resolve_pi_backend_model(client: Client, json_output: bool) -> ModelOption:
+def _pi_model_names(option: ModelOption) -> tuple[str, str, str]:
+    """The accepted spellings of a pi catalog model, lowercased for matching."""
+    return (
+        option.model_id.lower(),
+        option.display_name.lower(),
+        f"{option.provider}/{option.model_id}".lower(),
+    )
+
+
+def resolve_pi_backend_model(client: Client, json_output: bool, requested_model: str | None = None) -> ModelOption:
     """Pick the backend model a pi prompt runs under, from pi's own catalog.
 
     A pi prompt must name a model from pi's curated, authenticated-only catalog
     (GET /api/v1/pi/models) — the Claude ``--model`` names do not apply to pi.
-    Uses pi's own default when usable, else the newest available model; errors
-    when the catalog is empty (no authenticated provider / unusable pi).
+    A requested model matches exactly (case-insensitive) on model_id, display
+    name, or provider/model_id; with no request, uses pi's own default when
+    usable, else the newest available model. Errors when the catalog is empty
+    (no authenticated provider / unusable pi).
     """
     try:
         catalog = get_pi_models.sync(client=client)
@@ -69,10 +80,22 @@ def resolve_pi_backend_model(client: Client, json_output: bool) -> ModelOption:
         handle_connection_error(json_output)
     if catalog is None:
         cli_error("Failed to fetch pi models", detail="No response from server", json_output=json_output)
-    if catalog.default_model is not None:
-        return catalog.default_model
-    if catalog.available_models:
-        return catalog.available_models[0]
+    if requested_model is None:
+        if catalog.default_model is not None:
+            return catalog.default_model
+        if catalog.available_models:
+            return catalog.available_models[0]
+    else:
+        requested_lower = requested_model.lower()
+        for option in catalog.available_models:
+            if requested_lower in _pi_model_names(option):
+                return option
+        if catalog.available_models:
+            available = ", ".join(f"{o.display_name} ({o.provider}/{o.model_id})" for o in catalog.available_models)
+            cli_error(
+                f"Unknown pi model '{requested_model}'. Available pi models: {available}",
+                json_output=json_output,
+            )
     cli_error(
         "pi has no usable model — authenticate a provider (Sculptor Settings → Pi → Providers), then retry",
         json_output=json_output,

--- a/tools/sculpt/sculpt/commands/_harness_helpers.py
+++ b/tools/sculpt/sculpt/commands/_harness_helpers.py
@@ -1,8 +1,9 @@
-"""Shared harness (agent-type) resolution for the agent-creating commands.
+"""Shared harness and model resolution for the agent-creating commands.
 
 ``sculpt agent create`` and ``sculpt run`` both turn an optional ``--harness``
-name into the agent type to send. The resolution — validating the built-in
-harnesses and the server's registered terminal agents — lives here so the two
+name and an optional ``--model`` name into the agent type and model to send.
+The resolution — validating the built-in harnesses, the server's registered
+terminal agents, and each harness's model catalog — lives here so the two
 commands stay in lockstep.
 """
 
@@ -10,9 +11,12 @@ from collections.abc import Sequence
 
 import httpx
 
+from sculpt.auth import MODEL_MAPPING
 from sculpt.client import Client
 from sculpt.client.api.default import get_pi_models
 from sculpt.client.api.default import list_terminal_agent_registrations
+from sculpt.client.models.agent_type_name import AgentTypeName
+from sculpt.client.models.llm_model import LLMModel
 from sculpt.client.models.model_option import ModelOption
 from sculpt.client.models.terminal_agent_registration import TerminalAgentRegistration
 from sculpt.formatting import cli_error
@@ -57,6 +61,15 @@ def resolve_harness_selection(harness: str | None, client: Client, json_output: 
     return selection
 
 
+# Shared --model help so `agent create` and `run` describe the same contract.
+MODEL_HELP = (
+    "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable;"
+    + " default opus). With --harness pi, a model from pi's own catalog:"
+    + " model_id, display name, or provider/model_id (default: pi's own"
+    + " default model)."
+)
+
+
 def _pi_model_names(option: ModelOption) -> tuple[str, str, str]:
     """The accepted spellings of a pi catalog model, lowercased for matching."""
     return (
@@ -70,7 +83,7 @@ def _format_pi_model_list(options: Sequence[ModelOption]) -> str:
     return ", ".join(f"{o.display_name} ({o.provider}/{o.model_id})" for o in options)
 
 
-def resolve_pi_backend_model(client: Client, json_output: bool, requested_model: str | None = None) -> ModelOption:
+def _resolve_pi_backend_model(client: Client, json_output: bool, requested_model: str | None = None) -> ModelOption:
     """Pick the backend model a pi prompt runs under, from pi's own catalog.
 
     A pi prompt must name a model from pi's curated, authenticated-only catalog
@@ -111,3 +124,24 @@ def resolve_pi_backend_model(client: Client, json_output: bool, requested_model:
         "pi has no usable model — authenticate a provider (Sculptor Settings → Pi → Providers), then retry",
         json_output=json_output,
     )
+
+
+def resolve_prompt_models(
+    selection: HarnessSelection | None,
+    model: str | None,
+    client: Client,
+    json_output: bool,
+) -> tuple[LLMModel | None, ModelOption | None]:
+    """Resolve --model for a prompted agent against the resolved harness's catalog.
+
+    Returns ``(claude_model, pi_backend_model)`` — exactly one is set: a pi
+    harness takes a backend model from pi's own catalog, anything else a
+    Claude model from MODEL_MAPPING.
+    """
+    if selection is not None and selection.agent_type == AgentTypeName.PI:
+        return None, _resolve_pi_backend_model(client, json_output, model)
+    model_lower = "opus" if model is None else model.lower()
+    if model_lower not in MODEL_MAPPING:
+        valid = ", ".join(MODEL_MAPPING.keys())
+        cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
+    return MODEL_MAPPING[model_lower], None

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -41,8 +41,9 @@ from sculpt.commands._follow_helpers import on_reconnect_json
 from sculpt.commands._follow_helpers import on_reconnect_separator
 from sculpt.commands._follow_helpers import on_reconnect_text
 from sculpt.commands._follow_helpers import on_status_json
+from sculpt.commands._harness_helpers import MODEL_HELP
 from sculpt.commands._harness_helpers import resolve_harness_selection
-from sculpt.commands._harness_helpers import resolve_pi_backend_model
+from sculpt.commands._harness_helpers import resolve_prompt_models
 from sculpt.commands.data_types import AgentCreateOutput
 from sculpt.commands.data_types import AgentDeleteOutput
 from sculpt.commands.data_types import AgentInterruptOutput
@@ -132,12 +133,7 @@ def create(
         None,
         "--model",
         "-m",
-        help=(
-            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable;"
-            + " default opus). With --harness pi, a model from pi's own catalog:"
-            + " model_id, display name, or provider/model_id (default: pi's own"
-            + " default model)."
-        ),
+        help=MODEL_HELP,
     ),
     name: str | None = typer.Option(None, "--name", help="Agent name"),
     harness: str | None = typer.Option(
@@ -167,19 +163,12 @@ def create(
 
     llm_model = None
     backend_model = None
-    if selection is not None and selection.agent_type == AgentTypeName.PI:
-        if prompt:
-            backend_model = resolve_pi_backend_model(client, json_output, model)
-    else:
-        model_lower = "opus" if model is None else model.lower()
-        if model_lower not in MODEL_MAPPING:
-            valid = ", ".join(MODEL_MAPPING.keys())
-            cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
-        llm_model = MODEL_MAPPING[model_lower]
+    if prompt:
+        llm_model, backend_model = resolve_prompt_models(selection, model, client, json_output)
 
     request = CreateAgentRequest(
         prompt=prompt,
-        model=llm_model if prompt and backend_model is None else UNSET,
+        model=llm_model if llm_model is not None else UNSET,
         backend_model=backend_model if backend_model is not None else UNSET,
         interface="API",
         name=name,

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -133,11 +133,11 @@ def create(
         "--model",
         "-m",
         help=(
-            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)."
-            + " With --harness pi, a model from pi's own catalog: model_id, display"
-            + " name, or provider/model_id (e.g. kimi-coding/kimi-k2-0711-preview)."
+            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable;"
+            + " default opus). With --harness pi, a model from pi's own catalog:"
+            + " model_id, display name, or provider/model_id (default: pi's own"
+            + " default model)."
         ),
-        show_default="opus",
     ),
     name: str | None = typer.Option(None, "--name", help="Agent name"),
     harness: str | None = typer.Option(
@@ -165,8 +165,6 @@ def create(
     if prompt and selection is not None and selection.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
         cli_error("Terminal agents do not take an initial prompt (--prompt)", json_output=json_output)
 
-    # The pi harness takes its model from pi's own catalog, not the Claude
-    # names, so model validation depends on which harness was resolved.
     llm_model = None
     backend_model = None
     if selection is not None and selection.agent_type == AgentTypeName.PI:

--- a/tools/sculpt/sculpt/commands/agent.py
+++ b/tools/sculpt/sculpt/commands/agent.py
@@ -132,7 +132,11 @@ def create(
         None,
         "--model",
         "-m",
-        help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)",
+        help=(
+            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)."
+            + " With --harness pi, a model from pi's own catalog: model_id, display"
+            + " name, or provider/model_id (e.g. kimi-coding/kimi-k2-0711-preview)."
+        ),
         show_default="opus",
     ),
     name: str | None = typer.Option(None, "--name", help="Agent name"),
@@ -157,29 +161,27 @@ def create(
     client = get_authenticated_client(base_url, json_output)
     workspace_id = resolve_workspace(workspace, client, json_output)
 
-    model_lower = "opus" if model is None else model.lower()
-    if model_lower not in MODEL_MAPPING:
-        valid = ", ".join(MODEL_MAPPING.keys())
-        cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
-
-    llm_model = MODEL_MAPPING[model_lower]
-
     selection = resolve_harness_selection(harness, client, json_output)
     if prompt and selection is not None and selection.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
         cli_error("Terminal agents do not take an initial prompt (--prompt)", json_output=json_output)
 
+    # The pi harness takes its model from pi's own catalog, not the Claude
+    # names, so model validation depends on which harness was resolved.
+    llm_model = None
     backend_model = None
-    if prompt and selection is not None and selection.agent_type == AgentTypeName.PI:
-        if model is not None:
-            cli_error(
-                "--model does not apply to the Pi harness — pi picks from its own catalog",
-                json_output=json_output,
-            )
-        backend_model = resolve_pi_backend_model(client, json_output)
+    if selection is not None and selection.agent_type == AgentTypeName.PI:
+        if prompt:
+            backend_model = resolve_pi_backend_model(client, json_output, model)
+    else:
+        model_lower = "opus" if model is None else model.lower()
+        if model_lower not in MODEL_MAPPING:
+            valid = ", ".join(MODEL_MAPPING.keys())
+            cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
+        llm_model = MODEL_MAPPING[model_lower]
 
     request = CreateAgentRequest(
         prompt=prompt,
-        model=llm_model if prompt and backend_model is None else None,
+        model=llm_model if prompt and backend_model is None else UNSET,
         backend_model=backend_model if backend_model is not None else UNSET,
         interface="API",
         name=name,

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -1,7 +1,6 @@
 import httpx
 import typer
 
-from sculpt.auth import MODEL_MAPPING
 from sculpt.auth import get_authenticated_client
 from sculpt.auth import get_default_base_url
 from sculpt.client.api.default import create_workspace_agent
@@ -12,8 +11,9 @@ from sculpt.client.models.create_workspace_request_v2 import CreateWorkspaceRequ
 from sculpt.client.models.http_validation_error import HTTPValidationError
 from sculpt.client.types import UNSET
 from sculpt.commands._follow_helpers import follow_and_stream_messages
+from sculpt.commands._harness_helpers import MODEL_HELP
 from sculpt.commands._harness_helpers import resolve_harness_selection
-from sculpt.commands._harness_helpers import resolve_pi_backend_model
+from sculpt.commands._harness_helpers import resolve_prompt_models
 from sculpt.commands._workspace_helpers import STRATEGY_MAPPING
 from sculpt.commands._workspace_helpers import resolve_requested_branch_name
 from sculpt.commands._workspace_helpers import resolve_strategy
@@ -38,12 +38,7 @@ def run_cmd(
         None,
         "--model",
         "-m",
-        help=(
-            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable;"
-            + " default opus). With --harness pi, a model from pi's own catalog:"
-            + " model_id, display name, or provider/model_id (default: pi's own"
-            + " default model)."
-        ),
+        help=MODEL_HELP,
     ),
     strategy: str = typer.Option(
         "worktree",
@@ -94,16 +89,7 @@ def run_cmd(
             json_output=json_output,
         )
 
-    llm_model = None
-    backend_model = None
-    if selection is not None and selection.agent_type == AgentTypeName.PI:
-        backend_model = resolve_pi_backend_model(client, json_output, model)
-    else:
-        model_lower = "opus" if model is None else model.lower()
-        if model_lower not in MODEL_MAPPING:
-            valid = ", ".join(MODEL_MAPPING.keys())
-            cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
-        llm_model = MODEL_MAPPING[model_lower]
+    llm_model, backend_model = resolve_prompt_models(selection, model, client, json_output)
 
     project_id = resolve_project(repo, client, json_output)
 

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -38,7 +38,11 @@ def run_cmd(
         None,
         "--model",
         "-m",
-        help="The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)",
+        help=(
+            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)."
+            + " With --harness pi, a model from pi's own catalog: model_id, display"
+            + " name, or provider/model_id (e.g. kimi-coding/kimi-k2-0711-preview)."
+        ),
         show_default="opus",
     ),
     strategy: str = typer.Option(
@@ -76,12 +80,6 @@ def run_cmd(
     """Create a workspace and agent in one step."""
     base_url = base_url or get_default_base_url()
 
-    model_lower = "opus" if model is None else model.lower()
-    if model_lower not in MODEL_MAPPING:
-        valid = ", ".join(MODEL_MAPPING.keys())
-        cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
-
-    llm_model = MODEL_MAPPING[model_lower]
     client = get_authenticated_client(base_url, json_output)
 
     # Resolve the harness up front so a bad or terminal choice fails before we
@@ -96,14 +94,18 @@ def run_cmd(
             json_output=json_output,
         )
 
+    # The pi harness takes its model from pi's own catalog, not the Claude
+    # names, so model validation depends on which harness was resolved.
+    llm_model = None
     backend_model = None
     if selection is not None and selection.agent_type == AgentTypeName.PI:
-        if model is not None:
-            cli_error(
-                "--model does not apply to the Pi harness — pi picks from its own catalog",
-                json_output=json_output,
-            )
-        backend_model = resolve_pi_backend_model(client, json_output)
+        backend_model = resolve_pi_backend_model(client, json_output, model)
+    else:
+        model_lower = "opus" if model is None else model.lower()
+        if model_lower not in MODEL_MAPPING:
+            valid = ", ".join(MODEL_MAPPING.keys())
+            cli_error(f"Invalid model '{model}'. Valid options: {valid}", json_output=json_output)
+        llm_model = MODEL_MAPPING[model_lower]
 
     project_id = resolve_project(repo, client, json_output)
 

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -39,11 +39,11 @@ def run_cmd(
         "--model",
         "-m",
         help=(
-            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable)."
-            + " With --harness pi, a model from pi's own catalog: model_id, display"
-            + " name, or provider/model_id (e.g. kimi-coding/kimi-k2-0711-preview)."
+            "The model to use (haiku, sonnet, sonnet[1m], opus, opus[1m], fable;"
+            + " default opus). With --harness pi, a model from pi's own catalog:"
+            + " model_id, display name, or provider/model_id (default: pi's own"
+            + " default model)."
         ),
-        show_default="opus",
     ),
     strategy: str = typer.Option(
         "worktree",
@@ -94,8 +94,6 @@ def run_cmd(
             json_output=json_output,
         )
 
-    # The pi harness takes its model from pi's own catalog, not the Claude
-    # names, so model validation depends on which harness was resolved.
     llm_model = None
     backend_model = None
     if selection is not None and selection.agent_type == AgentTypeName.PI:

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -335,6 +335,22 @@ class TestAgentCreateHarness:
         assert body["backendModel"]["modelId"] == "kimi-k2-0711-preview"
 
     @respx.mock
+    def test_create_with_harness_pi_and_model_errors_when_catalog_empty(self, runner: CliRunner) -> None:
+        """--model with an empty pi catalog (no authenticated provider) fails with
+        the authenticate pointer, not an empty unknown-model list."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        _mock_pi_models([], None)
+
+        result = runner.invoke(
+            app,
+            ["agent", "create", "-w", "ws_test123", "-p", "Do something", "--harness", "Pi", "--model", "kimi-k2"],
+        )
+
+        assert result.exit_code == 1
+        assert "authenticate a provider" in result.output + (result.stderr or "")
+
+    @respx.mock
     def test_create_with_harness_pi_rejects_model_not_in_pi_catalog(self, runner: CliRunner) -> None:
         """Unknown pi models are rejected loudly — never silently swapped for the
         catalog default."""

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -255,7 +255,7 @@ class TestAgentCreateHarness:
     @respx.mock
     def test_create_with_harness_pi_and_model_id_sends_chosen_backend_model(self, runner: CliRunner) -> None:
         """--model with the Pi harness selects from pi's own catalog by model_id,
-        and the request carries it as the backend model rather than a Claude model."""
+        and the request carries it as the backend model with no Claude model field."""
         _mock_session()
         _mock_workspaces("ws_test123")
         _mock_pi_models([_ANTHROPIC_MODEL_DICT, _KIMI_MODEL_DICT], _ANTHROPIC_MODEL_DICT)
@@ -349,6 +349,35 @@ class TestAgentCreateHarness:
 
         assert result.exit_code == 1
         assert "authenticate a provider" in result.output + (result.stderr or "")
+
+    @respx.mock
+    def test_create_with_harness_pi_ambiguous_match_requires_provider_qualified_id(self, runner: CliRunner) -> None:
+        """A spelling shared by two catalog entries is an error."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        gateway_opus = {"provider": "vercel", "modelId": "claude-opus-4-8", "displayName": "Claude Opus 4.8"}
+        _mock_pi_models([_ANTHROPIC_MODEL_DICT, gateway_opus], _ANTHROPIC_MODEL_DICT)
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "create",
+                "-w",
+                "ws_test123",
+                "-p",
+                "Do something",
+                "--harness",
+                "Pi",
+                "--model",
+                "claude opus 4.8",
+            ],
+        )
+
+        assert result.exit_code == 1
+        output = result.output + (result.stderr or "")
+        assert "matches multiple pi models" in output
+        assert "vercel/claude-opus-4-8" in output
 
     @respx.mock
     def test_create_with_harness_pi_rejects_model_not_in_pi_catalog(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_agent.py
+++ b/tools/sculpt/tests/unit/test_agent.py
@@ -120,6 +120,15 @@ _CLAUDE_CLI_REGISTRATION = {
     "launchCommand": "claude",
 }
 
+_ANTHROPIC_MODEL_DICT = {"provider": "anthropic", "modelId": "claude-opus-4-8", "displayName": "Claude Opus 4.8"}
+_KIMI_MODEL_DICT = {"provider": "kimi-coding", "modelId": "kimi-k2-0711-preview", "displayName": "Kimi K2"}
+
+
+def _mock_pi_models(available: list[dict[str, Any]], default: dict[str, Any] | None) -> None:
+    respx.get("http://localhost:5050/api/v1/pi/models").mock(
+        return_value=Response(200, json={"availableModels": available, "defaultModel": default})
+    )
+
 
 def _mock_workspaces(*object_ids: str) -> None:
     workspaces = [
@@ -244,11 +253,112 @@ class TestAgentCreateHarness:
         assert body["agentType"] == "pi"
 
     @respx.mock
-    def test_create_with_harness_pi_rejects_explicit_default_model_flag(self, runner: CliRunner) -> None:
-        """--model is rejected for a pi prompt even when it names the flag's
-        default — an explicit choice is never silently ignored."""
+    def test_create_with_harness_pi_and_model_id_sends_chosen_backend_model(self, runner: CliRunner) -> None:
+        """--model with the Pi harness selects from pi's own catalog by model_id,
+        and the request carries it as the backend model rather than a Claude model."""
         _mock_session()
         _mock_workspaces("ws_test123")
+        _mock_pi_models([_ANTHROPIC_MODEL_DICT, _KIMI_MODEL_DICT], _ANTHROPIC_MODEL_DICT)
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=_task_response_dict())
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "create",
+                "-w",
+                "ws_test123",
+                "-p",
+                "Do something",
+                "--harness",
+                "Pi",
+                "--model",
+                "kimi-k2-0711-preview",
+            ],
+        )
+
+        assert result.exit_code == 0
+        body = json.loads(route.calls.last.request.content)
+        assert body["agentType"] == "pi"
+        assert body["backendModel"]["provider"] == "kimi-coding"
+        assert body["backendModel"]["modelId"] == "kimi-k2-0711-preview"
+        assert "model" not in body
+
+    @respx.mock
+    def test_create_with_harness_pi_model_matches_display_name_case_insensitively(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        _mock_pi_models([_ANTHROPIC_MODEL_DICT, _KIMI_MODEL_DICT], _ANTHROPIC_MODEL_DICT)
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=_task_response_dict())
+        )
+
+        result = runner.invoke(
+            app,
+            ["agent", "create", "-w", "ws_test123", "-p", "Do something", "--harness", "Pi", "--model", "kimi k2"],
+        )
+
+        assert result.exit_code == 0
+        body = json.loads(route.calls.last.request.content)
+        assert body["backendModel"]["modelId"] == "kimi-k2-0711-preview"
+
+    @respx.mock
+    def test_create_with_harness_pi_model_matches_provider_qualified_id(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        _mock_pi_models([_ANTHROPIC_MODEL_DICT, _KIMI_MODEL_DICT], _ANTHROPIC_MODEL_DICT)
+        route = respx.post("http://localhost:5050/api/v1/workspaces/ws_test123/agents").mock(
+            return_value=Response(200, json=_task_response_dict())
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "create",
+                "-w",
+                "ws_test123",
+                "-p",
+                "Do something",
+                "--harness",
+                "Pi",
+                "--model",
+                "kimi-coding/kimi-k2-0711-preview",
+            ],
+        )
+
+        assert result.exit_code == 0
+        body = json.loads(route.calls.last.request.content)
+        assert body["backendModel"]["provider"] == "kimi-coding"
+        assert body["backendModel"]["modelId"] == "kimi-k2-0711-preview"
+
+    @respx.mock
+    def test_create_with_harness_pi_rejects_model_not_in_pi_catalog(self, runner: CliRunner) -> None:
+        """Unknown pi models are rejected loudly — never silently swapped for the
+        catalog default."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        _mock_pi_models([_ANTHROPIC_MODEL_DICT, _KIMI_MODEL_DICT], _ANTHROPIC_MODEL_DICT)
+
+        result = runner.invoke(
+            app,
+            ["agent", "create", "-w", "ws_test123", "-p", "Do something", "--harness", "Pi", "--model", "grok"],
+        )
+
+        assert result.exit_code == 1
+        output = result.output + (result.stderr or "")
+        assert "Unknown pi model 'grok'" in output
+        assert "kimi-coding/kimi-k2-0711-preview" in output
+
+    @respx.mock
+    def test_create_with_harness_pi_rejects_claude_shorthand_names(self, runner: CliRunner) -> None:
+        """Claude shorthand names (opus, sonnet, ...) are not pi catalog entries;
+        with --harness pi they fail as unknown pi models."""
+        _mock_session()
+        _mock_workspaces("ws_test123")
+        _mock_pi_models([_ANTHROPIC_MODEL_DICT, _KIMI_MODEL_DICT], _ANTHROPIC_MODEL_DICT)
 
         result = runner.invoke(
             app,
@@ -256,7 +366,7 @@ class TestAgentCreateHarness:
         )
 
         assert result.exit_code == 1
-        assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
+        assert "Unknown pi model 'opus'" in result.output + (result.stderr or "")
 
     @respx.mock
     def test_create_with_harness_terminal_sends_terminal_agent_type(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_run.py
+++ b/tools/sculpt/tests/unit/test_run.py
@@ -404,6 +404,7 @@ _CLAUDE_CLI_REGISTRATION = {
 
 
 _PI_MODEL_DICT = {"provider": "anthropic", "modelId": "claude-opus-4-8", "displayName": "Claude Opus 4.8"}
+_KIMI_MODEL_DICT = {"provider": "kimi-coding", "modelId": "kimi-k2-0711-preview", "displayName": "Kimi K2"}
 
 
 def _mock_pi_models(available: list[dict[str, Any]], default: dict[str, Any] | None) -> None:
@@ -451,30 +452,60 @@ class TestRunHarness:
         assert "authenticate a provider" in result.output + (result.stderr or "")
 
     @respx.mock
-    def test_run_with_harness_pi_rejects_claude_model_flag(self, runner: CliRunner) -> None:
+    def test_run_with_harness_pi_and_model_selects_from_pi_catalog(self, runner: CliRunner) -> None:
+        """--model with the Pi harness selects from pi's own catalog (here by
+        display name) and is sent as the backend model."""
         _mock_session()
         _mock_initialize_project()
+        _mock_preview_branch_name()
+        _mock_pi_models([_PI_MODEL_DICT, _KIMI_MODEL_DICT], _PI_MODEL_DICT)
+        respx.post("http://localhost:5050/api/v1/workspaces").mock(
+            return_value=Response(200, json=_workspace_response_dict())
+        )
+        agent_route = respx.post("http://localhost:5050/api/v1/workspaces/ws_newrun123/agents").mock(
+            return_value=Response(200, json=_task_response_dict())
+        )
+
+        result = runner.invoke(
+            app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi", "--model", "Kimi K2"]
+        )
+
+        assert result.exit_code == 0, result.output + (result.stderr or "")
+        body = json.loads(agent_route.calls.last.request.content)
+        assert body["agentType"] == "pi"
+        assert body["backendModel"]["provider"] == "kimi-coding"
+        assert body["backendModel"]["modelId"] == "kimi-k2-0711-preview"
+        assert "model" not in body
+
+    @respx.mock
+    def test_run_with_harness_pi_rejects_model_not_in_pi_catalog(self, runner: CliRunner) -> None:
+        _mock_session()
+        _mock_initialize_project()
+        _mock_pi_models([_PI_MODEL_DICT, _KIMI_MODEL_DICT], _PI_MODEL_DICT)
+
+        result = runner.invoke(
+            app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi", "--model", "grok"]
+        )
+
+        assert result.exit_code != 0
+        output = result.output + (result.stderr or "")
+        assert "Unknown pi model 'grok'" in output
+        assert "kimi-coding/kimi-k2-0711-preview" in output
+
+    @respx.mock
+    def test_run_with_harness_pi_rejects_claude_model_flag(self, runner: CliRunner) -> None:
+        """Claude shorthand names are not pi catalog entries; with --harness pi
+        they fail as unknown pi models rather than silently selecting Claude."""
+        _mock_session()
+        _mock_initialize_project()
+        _mock_pi_models([_PI_MODEL_DICT, _KIMI_MODEL_DICT], _PI_MODEL_DICT)
 
         result = runner.invoke(
             app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi", "--model", "sonnet"]
         )
 
         assert result.exit_code != 0
-        assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
-
-    @respx.mock
-    def test_run_with_harness_pi_rejects_explicit_default_model_flag(self, runner: CliRunner) -> None:
-        """--model is rejected for pi even when it names the flag's default —
-        an explicit choice is never silently ignored."""
-        _mock_session()
-        _mock_initialize_project()
-
-        result = runner.invoke(
-            app, ["run", "Fix the bug", "--repo", "/tmp/test", "--harness", "Pi", "--model", "opus"]
-        )
-
-        assert result.exit_code != 0
-        assert "does not apply to the Pi harness" in result.output + (result.stderr or "")
+        assert "Unknown pi model 'sonnet'" in result.output + (result.stderr or "")
 
     @respx.mock
     def test_run_without_harness_omits_agent_type(self, runner: CliRunner) -> None:

--- a/tools/sculpt/tests/unit/test_run.py
+++ b/tools/sculpt/tests/unit/test_run.py
@@ -495,7 +495,7 @@ class TestRunHarness:
     @respx.mock
     def test_run_with_harness_pi_rejects_claude_model_flag(self, runner: CliRunner) -> None:
         """Claude shorthand names are not pi catalog entries; with --harness pi
-        they fail as unknown pi models rather than silently selecting Claude."""
+        they fail as unknown pi models."""
         _mock_session()
         _mock_initialize_project()
         _mock_pi_models([_PI_MODEL_DICT, _KIMI_MODEL_DICT], _PI_MODEL_DICT)


### PR DESCRIPTION
## Original bug

> sculpt can't create pi agents with Kimi (or any model for that matter).

`sculpt agent create --harness pi --model <name>` (and the identical path in `sculpt run`) failed for *every* model value, so there was no way to choose which pi model a new agent runs under — sculpt always used the server-picked default.

## Hypotheses considered

1. `--model` is validated against the Claude-only `MODEL_MAPPING` (`haiku, sonnet, sonnet[1m], opus, opus[1m], fable`) before the harness is resolved, so a pi catalog name like `kimi-k2-0711-preview` is rejected as `Invalid model` — **REPRODUCED**
2. Even for names in that map (e.g. `--model opus`), the pi branch hard-errors `--model does not apply to the Pi harness` — **REPRODUCED**

Both live in the same flow and are fixed together.

### sculpt rejects `--model` for pi harness agents

**Repro steps**

1. With a running Sculptor backend, run `sculpt agent create -w <workspace> -p "Do something" --harness pi --model kimi-k2-0711-preview`
2. Observe `Error: Invalid model 'kimi-k2-0711-preview'. Valid options: haiku, sonnet, sonnet[1m], opus, opus[1m], fable`
3. Retry with a Claude-side name: `--model opus`
4. Observe `Error: --model does not apply to the Pi harness — pi picks from its own catalog`

**Expected vs actual**
- Expected: `--model` with `--harness pi` selects from pi's own catalog (the same catalog that feeds the app's pi model picker, `GET /api/v1/pi/models`).
- Actual: every `--model` value fails — pi catalog names fail Claude-side validation, Claude names fail the pi branch's blanket rejection.

**Before**

Failing tests at commit `5ad44b23` (run: `uv run --project tools/sculpt python -m pytest tools/sculpt/tests/unit/ -k pi`):

```
FAILED test_agent.py::TestAgentCreateHarness::test_create_with_harness_pi_and_model_id_sends_chosen_backend_model
FAILED test_agent.py::TestAgentCreateHarness::test_create_with_harness_pi_model_matches_display_name_case_insensitively
FAILED test_agent.py::TestAgentCreateHarness::test_create_with_harness_pi_model_matches_provider_qualified_id
FAILED test_agent.py::TestAgentCreateHarness::test_create_with_harness_pi_rejects_model_not_in_pi_catalog
FAILED test_run.py::TestRunHarness::test_run_with_harness_pi_and_model_selects_from_pi_catalog
FAILED test_run.py::TestRunHarness::test_run_with_harness_pi_rejects_model_not_in_pi_catalog
6 failed, 6 passed, 133 deselected in 0.45s

E  assert "Unknown pi model 'grok'" in "Error: Invalid model 'grok'. Valid options: haiku, sonnet, sonnet[1m], opus, opus[1m], fable\n..."
```

**Root cause**

In `tools/sculpt/sculpt/commands/agent.py` (`create`) and `tools/sculpt/sculpt/commands/run.py` (`run_cmd`), `--model` was validated against `MODEL_MAPPING` — a Claude-only name map — before `--harness` was resolved, so pi catalog names never survived validation. Then, when the harness *was* pi, the code explicitly rejected any `--model` value, on the grounds that pi picks from its own catalog. The result was a dead end: no spelling of any model could reach a pi agent. The server already supports preselecting a pi model (`backend_model` on the create request, fed by `GET /api/v1/pi/models`); only the CLI blocked it.

**Fix**

Resolve the harness first, then validate `--model` against the right catalog for that harness. `resolve_pi_backend_model` in `_harness_helpers.py` (shared by both commands) now takes an optional requested model and matches it exactly, case-insensitively, on `model_id`, display name, or `provider/model_id` (e.g. `kimi-coding/kimi-k2-0711-preview`). A request that matches nothing fails with the list of available pi models rather than silently falling back to the default; an empty catalog (no authenticated provider) keeps the existing authenticate-a-provider error. The Claude-harness path is unchanged, and the `--model` help text now documents the pi behavior.

**Test**
- Paths: `tools/sculpt/tests/unit/test_agent.py`, `tools/sculpt/tests/unit/test_run.py`
- Kind: unit (the bug lives entirely in the sculpt CLI — a CLI-only entrypoint not reachable from any UI surface, so a Playwright e2e cannot cover it)
- Failing-test commit: `5ad44b23`
- Fix commit: `cf60b8d8`

**After**

```
380 passed in 6.47s    # just test-unit, sculpt CLI suite
```

(Full `just test-unit` green: backend 2327 passed, foundation 129, frontend 3078, sculpt 380.)

Matching semantics: exact, case-insensitive, on the three spellings above — no substring matching. If two catalog entries ever share a display name, the first match wins; disambiguate with `provider/model_id`.

## Deferred follow-ups

- `sculpt agent send --model` still validates against the Claude-only map, so follow-up messages to pi agents can't select pi catalog models (and the no-`--model` resend path can't parse a pi model id as an `LLMModel`): https://linear.app/imbue/issue/SCU-1837

## Review notes

- Exact-match ties (two catalog entries sharing a display name) resolve to the first match rather than erroring on ambiguity — accepted per the exact-match-only decision; `provider/model_id` disambiguates.
- Error precedence in `agent create` changed: an invalid workspace is now reported before an invalid Claude-side `--model` (harness/model validation moved after workspace resolution).
