### PR TITLE
Upgrade offload from 0.9.10 to 0.9.12

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.nvm/nvm.sh && nvm use $NODE_VERSION && corepack enabl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable --profile minimal \
     && . "$HOME/.cargo/env" \
-    && cargo install offload@0.9.10 \
+    && cargo install offload@0.9.12 \
     && mv /root/.cargo/bin/offload /usr/local/bin/offload \
     && rustup self uninstall -y \
     && rm -rf /root/.cargo /root/.rustup

--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  OFFLOAD_VERSION: "0.9.10"
+  OFFLOAD_VERSION: "0.9.12"
 
 jobs:
   offload-integration-tests:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  OFFLOAD_VERSION: "0.9.10"
+  OFFLOAD_VERSION: "0.9.12"
 
 permissions:
   # contents: write -> push refs/notes/perf on main. pull-requests: write ->


### PR DESCRIPTION
## Summary

Upgrades the pinned [offload](https://github.com/imbue-ai/offload) version from 0.9.10 to the latest release, 0.9.12, in all three places it is pinned:

- `.devcontainer/Dockerfile` — the offload binary installed into the Modal sandbox image
- `.github/workflows/offload.yml` — `OFFLOAD_VERSION` for the integration-test workflow
- `.github/workflows/perf.yml` — `OFFLOAD_VERSION` for the perf workflow

## What's new

- **0.9.11**: single-pass pytest discovery across pool groups (with per-group fallback), sandbox pool pre-warming overlapped with test discovery, the project virtualenv activated for pytest runs, and coverage skipped during collect-only runs
- **0.9.12**: single-pass discovery now honors `discovery_args` and environment configuration, and both discovery paths are routed through a shared collect-only base so they behave consistently

Both are backwards-compatible patch releases — no `offload.toml` changes are required.

## Notes

- `.devcontainer/Dockerfile` is listed in the offload checkpoint `build_inputs`, so the first run after merge does a full base-image rebuild once and then re-caches via git notes.

## Test plan

- `just format`, `just check`, and `just test-unit` all pass locally
- CI: the offload integration-test workflow on this PR exercises the new version end to end

(Sent by Claude)