### PR TITLE
Add Claude Opus 5 and bump managed Claude CLI to 2.1.222

### DIFF
--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -352,7 +352,7 @@ choice is dropped rather than shown; the action to fix it lives on the Send butt
 effect in-session (a failed switch leaves the choice unchanged and raises an actionable error toast). An **effort**
 selector budgets how much thinking it spends per step (Low, Medium, High, Extra High, Max — Extra High
 by default); a **fast mode** toggle trades some depth for quicker output on the models that support it
-(the Opus family, including Opus 4.8) and is disabled for the rest; and **plan mode** makes the agent
+(the Opus family — Opus 5 and the pinned 4.8/4.7/4.6) and is disabled for the rest; and **plan mode** makes the agent
 investigate and propose a plan for your approval before it changes anything. The **+** button opens a
 menu for adding context — point the agent at specific **files and folders**, attach **images** (you
 can also drag-and-drop or paste them), or start a **skill** (→ §7.8 Skills); with the **Entity

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -172,11 +172,11 @@ and flags the targets it does not currently define.
 - **REQ-NFR-070 (MUST).** New-agent defaults: model = the user's **configured Settings default** if
   set, else the **most-recently-used** model (recorded whenever the user switches model in chat;
   `lastUsedModelAtom`, `sculptor/frontend/src/common/state/atoms/userConfig.ts`), else a hardcoded
-  fallback of **`CLAUDE_4_OPUS` ("Opus (1M)")**, the 1M-context Opus variant (Fable, though listed in
+  fallback of **`CLAUDE_4_OPUS` ("Opus 5 (1M)")**, the rolling 1M-context Opus variant (Fable, though listed in
   the switcher, is disabled and so is never the fallback). Effort = **Extra High (`xhigh`)**, fast mode
   = **off** (`sculptor/sculptor/config/user_config.py`, `sculptor/sculptor/web/derived.py`). All three
   are user-overridable in Settings → Agent (`SPEC.md` §7.10). **Fast mode** is offered only on models
-  that support it — the Opus 4.x family, including Opus 4.8 (both the 1M and 200K variants) — and is
+  that support it — Opus 5 and the pinned Opus 4.x family (4.8/4.7/4.6, both 1M and 200K variants) — and is
   disabled for Sonnet/Haiku/Fable (`sculptor/frontend/src/common/modelCapabilities.ts`).
 
 ---
@@ -212,7 +212,7 @@ packaging Sculptor):
 
 ### 3.3 Required external binaries
 
-- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.202,
+- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.222,
   minimum 2.1.202, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
   **linux-x64** (`sculptor/sculptor/services/managed_tools.py`). Sculptor can install/manage it and can use a
   user-supplied binary (`SPEC.md` §7.1, §7.10).

--- a/sculptor/frontend/src/common/modelCapabilities.ts
+++ b/sculptor/frontend/src/common/modelCapabilities.ts
@@ -14,16 +14,25 @@ const MODEL_CAPABILITIES: Partial<Record<LlmModel, ModelCapabilities>> = {
     supportsFileAttachments: true,
     supportsFastMode: true,
   },
-  // CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K are the current-generation Opus
-  // ("Claude 4.8 Opus" — see modelConstants.ts). Newer Opus generations are
+  // CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K are the rolling current-generation Opus
+  // ("Claude 5 Opus" — see modelConstants.ts). Newer Opus generations are
   // bound to these enum values by bumping the display label there, so the
   // capabilities below must be kept in sync with that label. Fast mode is
-  // supported, matching Opus 4.7 and 4.6 (SCU-1541).
+  // supported on Opus 5 (and pinned 4.8/4.7/4.6; SCU-1541, SCU-1841).
   [LlmModel.CLAUDE_4_OPUS]: {
     supportsFileAttachments: true,
     supportsFastMode: true,
   },
   [LlmModel.CLAUDE_4_OPUS_200K]: {
+    supportsFileAttachments: true,
+    supportsFastMode: true,
+  },
+  // Pinned Opus 4.8 — fast mode supported (SCU-1841), same as the rolling entry.
+  [LlmModel.CLAUDE_4_8_OPUS]: {
+    supportsFileAttachments: true,
+    supportsFastMode: true,
+  },
+  [LlmModel.CLAUDE_4_8_OPUS_200K]: {
     supportsFileAttachments: true,
     supportsFastMode: true,
   },

--- a/sculptor/frontend/src/common/modelConstants.ts
+++ b/sculptor/frontend/src/common/modelConstants.ts
@@ -13,8 +13,10 @@ export const hasNoUsableModel = (
 ): boolean => sourcesBackendModels && Array.isArray(backendModels) && backendModels.length === 0;
 
 const modelNames: Partial<Record<LlmModel, { short: string; long: string }>> = {
-  [LlmModel.CLAUDE_4_OPUS]: { short: "Opus (1M)", long: "Claude 4.8 Opus (1M)" },
-  [LlmModel.CLAUDE_4_OPUS_200K]: { short: "Opus", long: "Claude 4.8 Opus" },
+  [LlmModel.CLAUDE_4_OPUS]: { short: "Opus 5 (1M)", long: "Claude 5 Opus (1M)" },
+  [LlmModel.CLAUDE_4_OPUS_200K]: { short: "Opus 5", long: "Claude 5 Opus" },
+  [LlmModel.CLAUDE_4_8_OPUS]: { short: "Opus 4.8 (1M)", long: "Claude 4.8 Opus (1M)" },
+  [LlmModel.CLAUDE_4_8_OPUS_200K]: { short: "Opus 4.8", long: "Claude 4.8 Opus" },
   [LlmModel.CLAUDE_4_7_OPUS]: { short: "Opus 4.7 (1M)", long: "Claude 4.7 Opus (1M)" },
   [LlmModel.CLAUDE_4_7_OPUS_200K]: { short: "Opus 4.7", long: "Claude 4.7 Opus" },
   [LlmModel.CLAUDE_4_6_OPUS]: { short: "Opus 4.6 (1M)", long: "Claude 4.6 Opus (1M)" },
@@ -34,6 +36,8 @@ const PRODUCTION_MODELS: ReadonlyArray<LlmModel> = [
   LlmModel.CLAUDE_FABLE_5,
   LlmModel.CLAUDE_4_OPUS_200K,
   LlmModel.CLAUDE_4_OPUS,
+  LlmModel.CLAUDE_4_8_OPUS_200K,
+  LlmModel.CLAUDE_4_8_OPUS,
   LlmModel.CLAUDE_4_7_OPUS_200K,
   LlmModel.CLAUDE_4_7_OPUS,
   LlmModel.CLAUDE_4_6_OPUS_200K,

--- a/sculptor/frontend/src/common/state/atoms/userConfig.ts
+++ b/sculptor/frontend/src/common/state/atoms/userConfig.ts
@@ -60,7 +60,7 @@ export const defaultModelAtom = atom<string>((get) => {
   }
   // Product default when nothing else is selected. Fable is currently disabled
   // with an indefinite timeline, so the default falls back to the 1M-context
-  // Opus (CLAUDE_4_OPUS, shown as "Opus (1M)"; SCU-1576). Fable stays available
+  // Opus (CLAUDE_4_OPUS, shown as "Opus 5 (1M)"; SCU-1576). Fable stays available
   // in the switcher for if/when it returns.
   return LlmModel.CLAUDE_4_OPUS;
 });

--- a/sculptor/sculptor-plugin/skills/build-sculptor-extension/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-extension/sdk.d.ts
@@ -442,6 +442,8 @@ export type HarnessCapabilities = {
 declare const LlmModel: {
 	readonly CLAUDE_4_OPUS: "CLAUDE-4-OPUS";
 	readonly CLAUDE_4_OPUS_200K: "CLAUDE-4-OPUS-200K";
+	readonly CLAUDE_4_8_OPUS: "CLAUDE-4-8-OPUS";
+	readonly CLAUDE_4_8_OPUS_200K: "CLAUDE-4-8-OPUS-200K";
 	readonly CLAUDE_4_7_OPUS: "CLAUDE-4-7-OPUS";
 	readonly CLAUDE_4_7_OPUS_200K: "CLAUDE-4-7-OPUS-200K";
 	readonly CLAUDE_4_6_OPUS: "CLAUDE-4-6-OPUS";

--- a/sculptor/sculptor/agents/default/constants.py
+++ b/sculptor/sculptor/agents/default/constants.py
@@ -17,6 +17,8 @@ FILE_CHANGE_TOOL_NAMES: Final[tuple[AgentToolName, ...]] = (
 MODEL_SHORTNAME_MAP: Final[dict[LLMModel, str]] = {
     LLMModel.CLAUDE_4_OPUS: "opus[1m]",
     LLMModel.CLAUDE_4_OPUS_200K: "opus",
+    LLMModel.CLAUDE_4_8_OPUS: "claude-opus-4-8[1m]",
+    LLMModel.CLAUDE_4_8_OPUS_200K: "claude-opus-4-8",
     LLMModel.CLAUDE_4_7_OPUS: "claude-opus-4-7[1m]",
     LLMModel.CLAUDE_4_7_OPUS_200K: "claude-opus-4-7",
     LLMModel.CLAUDE_4_6_OPUS: "claude-opus-4-6[1m]",

--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -574,6 +574,8 @@
             "enum": [
               "CLAUDE-4-OPUS",
               "CLAUDE-4-OPUS-200K",
+              "CLAUDE-4-8-OPUS",
+              "CLAUDE-4-8-OPUS-200K",
               "CLAUDE-4-7-OPUS",
               "CLAUDE-4-7-OPUS-200K",
               "CLAUDE-4-6-OPUS",
@@ -2007,6 +2009,8 @@
             "enum": [
               "CLAUDE-4-OPUS",
               "CLAUDE-4-OPUS-200K",
+              "CLAUDE-4-8-OPUS",
+              "CLAUDE-4-8-OPUS-200K",
               "CLAUDE-4-7-OPUS",
               "CLAUDE-4-7-OPUS-200K",
               "CLAUDE-4-6-OPUS",
@@ -2971,6 +2975,8 @@
             "enum": [
               "CLAUDE-4-OPUS",
               "CLAUDE-4-OPUS-200K",
+              "CLAUDE-4-8-OPUS",
+              "CLAUDE-4-8-OPUS-200K",
               "CLAUDE-4-7-OPUS",
               "CLAUDE-4-7-OPUS-200K",
               "CLAUDE-4-6-OPUS",

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -249,7 +249,9 @@ CLAUDE_VERSION_RANGE = VersionRange(
     # against this failure. Do not lower this without re-validating that case.
     min_version="2.1.202",
     max_version="2.99.99",
-    recommended_version="2.1.202",
+    # Recommended is the latest validated release; bumped to pull in Claude
+    # Opus 5 support (SCU-1841).
+    recommended_version="2.1.222",
     # Blocked versions create background tool invocations that are missing events
     # describing them.
     blocked_versions=(BlockedVersionRange(min_version="2.1.101", max_version="2.1.101"),),

--- a/sculptor/sculptor/state/messages.py
+++ b/sculptor/sculptor/state/messages.py
@@ -12,8 +12,12 @@ from sculptor.state.chat_state import ContentBlockTypes
 
 
 class LLMModel(StrEnum):
+    # Rolling "latest Opus" (shortname `opus`), relabeled per generation.
     CLAUDE_4_OPUS = "CLAUDE-4-OPUS"
     CLAUDE_4_OPUS_200K = "CLAUDE-4-OPUS-200K"
+    # Pinned Opus generations.
+    CLAUDE_4_8_OPUS = "CLAUDE-4-8-OPUS"
+    CLAUDE_4_8_OPUS_200K = "CLAUDE-4-8-OPUS-200K"
     CLAUDE_4_7_OPUS = "CLAUDE-4-7-OPUS"
     CLAUDE_4_7_OPUS_200K = "CLAUDE-4-7-OPUS-200K"
     CLAUDE_4_6_OPUS = "CLAUDE-4-6-OPUS"

--- a/sculptor/sculptor/state/messages.py
+++ b/sculptor/sculptor/state/messages.py
@@ -12,7 +12,7 @@ from sculptor.state.chat_state import ContentBlockTypes
 
 
 class LLMModel(StrEnum):
-    # Rolling "latest Opus" (shortname `opus`), relabeled per generation.
+    # Rolling "latest Opus" (shortnames `opus[1m]` / `opus`), relabeled per generation.
     CLAUDE_4_OPUS = "CLAUDE-4-OPUS"
     CLAUDE_4_OPUS_200K = "CLAUDE-4-OPUS-200K"
     # Pinned Opus generations.

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -418,7 +418,7 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
         # Fall back to the model selected at agent creation time, then to the
         # product default. Fable is currently disabled with an indefinite
         # timeline, so the default falls back to the 1M-context Opus
-        # (CLAUDE_4_OPUS, shown as "Opus (1M)"; SCU-1576); Fable stays available
+        # (CLAUDE_4_OPUS, shown as "Opus 5 (1M)"; SCU-1576); Fable stays available
         # in the switcher for if/when it returns.
         input_data = self.task.input_data
         if isinstance(input_data, AgentTaskInputsV2) and input_data.default_model is not None:
@@ -482,6 +482,8 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
             LLMModel.CLAUDE_4_SONNET_200K,
             LLMModel.CLAUDE_4_OPUS,
             LLMModel.CLAUDE_4_OPUS_200K,
+            LLMModel.CLAUDE_4_8_OPUS,
+            LLMModel.CLAUDE_4_8_OPUS_200K,
             LLMModel.CLAUDE_4_7_OPUS,
             LLMModel.CLAUDE_4_7_OPUS_200K,
             LLMModel.CLAUDE_4_6_OPUS,

--- a/sculptor/tests/integration/frontend/test_model_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_model_capability_gating.py
@@ -1,7 +1,9 @@
 """Integration tests for model-specific capability gating in the chat input.
 
 Verifies that:
-- The fast mode toggle is only visible when Claude Opus 4.6 is selected
+- The fast mode toggle is capability-gated: visible for the fast-mode-capable
+  Opus generations (rolling Opus 5, pinned 4.8 and 4.6) and hidden for models
+  that don't support it (e.g. Sonnet)
 - The fast mode draft state is preserved when switching away from Opus 4.6 and back
 - The model selector is isolated per agent (changing one agent's model doesn't bleed to others)
 """

--- a/sculptor/tests/integration/frontend/test_model_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_model_capability_gating.py
@@ -22,6 +22,8 @@ _OPUS_48_1M_MODEL_NAME = "Claude 4.8 Opus (1M)"
 _OPUS_48_MODEL_NAME = "Claude 4.8 Opus"
 _OPUS_46_MODEL_NAME = "Claude 4.6 Opus (1M)"
 _SONNET_MODEL_NAME = "Claude 4.6 Sonnet"
+_OPUS_5_1M_MODEL_NAME = "Claude 5 Opus (1M)"
+_OPUS_5_MODEL_NAME = "Claude 5 Opus"
 
 
 @user_story("to only see the fast mode toggle when Opus 4.6 is selected")
@@ -57,13 +59,12 @@ def test_fast_mode_toggle_gated_by_model(sculptor_instance_: SculptorInstance) -
 
 @user_story("to see the fast mode toggle when Opus 4.8 is selected")
 def test_fast_mode_toggle_visible_for_opus_48(sculptor_instance_: SculptorInstance) -> None:
-    """Fast mode toggle must be present for Opus 4.8, just like 4.7 and 4.6 (SCU-1541).
+    """Fast mode toggle must be present for the pinned Opus 4.8, like 4.7 and 4.6.
 
-    Opus 4.8 reuses the generic CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K enum values
-    (only the display label in modelConstants.ts was bumped to "Claude 4.8
-    Opus"); the matching entries in modelCapabilities.ts were left at
-    supportsFastMode: false. As a result the toggle was hidden for 4.8 even
-    though it appears for 4.7/4.6.
+    Opus 4.8 is now the pinned CLAUDE_4_8_OPUS / CLAUDE_4_8_OPUS_200K entry (the
+    generic CLAUDE_4_OPUS values surface Opus 5; SCU-1841). Both pinned variants
+    set supportsFastMode: true in modelCapabilities.ts, so the toggle appears for
+    each.
 
     Steps:
     1. Start with Fake Claude (supports fast mode) — toggle visible.
@@ -94,6 +95,46 @@ def test_fast_mode_toggle_visible_for_opus_48(sculptor_instance_: SculptorInstan
 
     # Switch to Opus 4.8 (200K) — fast mode is supported, toggle must stay visible.
     select_model_by_name(chat_panel, _OPUS_48_MODEL_NAME)
+    expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
+
+
+@user_story("to see the fast mode toggle when Opus 5 is selected")
+def test_fast_mode_toggle_visible_for_opus_5(sculptor_instance_: SculptorInstance) -> None:
+    """Fast mode toggle must be present for the rolling Opus 5 entries (SCU-1841).
+
+    CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K are the rolling "latest Opus" entries,
+    now surfaced as "Claude 5 Opus". Fast mode is supported on Opus 5, so the
+    toggle must appear for both the 1M and 200K variants.
+
+    Steps:
+    1. Start with Fake Claude (supports fast mode) — toggle visible.
+    2. Switch to Sonnet — toggle must disappear (clean baseline).
+    3. Switch to Opus 5 (1M) — toggle must reappear.
+    4. Switch to Opus 5 (200K) — toggle must remain visible.
+    """
+    page = sculptor_instance_.page
+
+    task_page = start_task_and_wait_for_ready(
+        page,
+        prompt='fake_claude:text `{"text": "ready"}`',
+        workspace_name="Opus 5 Fast Mode WS",
+    )
+    chat_panel = task_page.get_chat_panel()
+    wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
+
+    # Fake Claude supports fast mode — toggle should be visible.
+    expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
+
+    # Switch to Sonnet — fast mode is not supported, toggle must disappear.
+    select_model_by_name(chat_panel, _SONNET_MODEL_NAME)
+    expect(chat_panel.get_fast_mode_toggle()).not_to_be_visible()
+
+    # Switch to Opus 5 (1M) — fast mode is supported, toggle must reappear.
+    select_model_by_name(chat_panel, _OPUS_5_1M_MODEL_NAME)
+    expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
+
+    # Switch to Opus 5 (200K) — fast mode is supported, toggle must stay visible.
+    select_model_by_name(chat_panel, _OPUS_5_MODEL_NAME)
     expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
 
 

--- a/sculptor/tests/integration/frontend/test_model_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_model_capability_gating.py
@@ -28,9 +28,10 @@ _OPUS_5_1M_MODEL_NAME = "Claude 5 Opus (1M)"
 _OPUS_5_MODEL_NAME = "Claude 5 Opus"
 
 
-@user_story("to only see the fast mode toggle when Opus 4.6 is selected")
+@user_story("to see the fast mode toggle only for models that support fast mode")
 def test_fast_mode_toggle_gated_by_model(sculptor_instance_: SculptorInstance) -> None:
-    """Fast mode toggle should only be present in the chat toolbar for Opus 4.6.
+    """Fast mode toggle is gated by model capability: present for a fast-mode
+    model (Opus 4.6), absent for one that isn't (Sonnet).
 
     Steps:
     1. Start with Fake Claude (which supports fast mode for testing) — toggle visible.

--- a/sculptor/tests/integration/regression/test_regression_default_model_opus.py
+++ b/sculptor/tests/integration/regression/test_regression_default_model_opus.py
@@ -1,4 +1,4 @@
-"""Regression test: a new workspace defaults to Opus (1M), not Fable.
+"""Regression test: a new workspace defaults to Opus 5 (1M), not Fable.
 
 SCU-1576: Fable was still shipping as the product default model even though it
 is currently disabled with an indefinite timeline. When the "Default model"
@@ -16,24 +16,24 @@ from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
 from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
-# The chat-panel model selector renders the model's short name; "Opus (1M)" is
+# The chat-panel model selector renders the model's short name; "Opus 5 (1M)" is
 # the short name for CLAUDE_4_OPUS, the 1M-context Opus (see frontend
-# modelConstants.ts). The plain "Opus" short name is the 200K variant.
-OPUS_MODEL_NAME = "Opus (1M)"
+# modelConstants.ts). The plain "Opus 5" short name is the 200K variant.
+OPUS_MODEL_NAME = "Opus 5 (1M)"
 
 
 @user_story("to have a new workspace default to Opus when I haven't picked a model")
 def test_new_workspace_defaults_to_opus(
     sculptor_instance_: SculptorInstance,
 ) -> None:
-    """A brand-new workspace defaults to Opus (1M) when nothing else is selected.
+    """A brand-new workspace defaults to Opus 5 (1M) when nothing else is selected.
 
     Steps:
     1. Create a brand-new workspace without touching its model selector
        (``model_name=None``). The "Default model" setting is the product-default
        "Most Recently Used" (``defaultLlm`` is None) and no model has been used
        yet, so the default resolves to the product fallback.
-    2. Verify the workspace's model selector shows "Opus (1M)" — the product
+    2. Verify the workspace's model selector shows "Opus 5 (1M)" — the product
        default — rather than the old Fable fallback.
     """
     page = sculptor_instance_.page


### PR DESCRIPTION
## Summary

Adds **Claude Opus 5** to Sculptor's built-in model picker and bumps the managed Claude Code CLI from `2.1.202` to `2.1.222`. Opus 5 is Anthropic's new GA model for agentic coding (Opus 4.8 is now legacy). Selecting Opus 5 needs a CLI new enough to recognize the model, so the version bump and the model addition ship together.

Linear: SCU-1841

## What changed

**Managed Claude CLI → 2.1.222**
- `managed_tools.py`: `CLAUDE_VERSION_RANGE.recommended_version` `2.1.202` → `2.1.222`. `min_version` is left unchanged — its floor is a separate resume-bug fix, unrelated to Opus 5. The 2.1.222 managed binary is present in the release bucket for `darwin-arm64` and `linux-x64`.
- `docs/specs/requirements.md`: compatibility window.

**Add Opus 5 + pin Opus 4.8**

Follows the codebase's documented "new Opus generation" convention: the rolling `CLAUDE_4_OPUS` / `CLAUDE_4_OPUS_200K` entries (shortname `opus[1m]` / `opus`, which the CLI resolves to the latest Opus) are relabeled to **"Claude 5 Opus"**, and the now-legacy **Opus 4.8** is pinned as new `CLAUDE_4_8_OPUS` / `CLAUDE_4_8_OPUS_200K` members, mirroring the existing 4.7/4.6 pins.

- Backend: `state/messages.py` (enum), `agents/default/constants.py` (`claude-opus-4-8[1m]` / `claude-opus-4-8` shortnames), `web/derived.py` (smooth-streaming set).
- Frontend: `modelConstants.ts` (display labels + `PRODUCTION_MODELS`), `modelCapabilities.ts` (fast mode + file attachments for the pinned 4.8), `userConfig.ts`.
- Regenerated: extension `sdk.d.ts` and `frozen_pydantic_schemas.json`.

pi's dynamic model catalog surfaces Opus 5 from the `pi` CLI automatically — no change needed there.

**Schema:** the new enum values are additive (existing persisted rows keep valid model values), so only the frozen JSON schema was refreshed; no data migration is required.

**Tests & docs:** added an Opus 5 fast-mode gating test and corrected the now-stale Opus 4.8 docstring (`test_model_capability_gating.py`), updated the default-model label assertion (`test_regression_default_model_opus.py`), and refreshed `SPEC.md` / `requirements.md`.

## Verification

- `just format` — clean
- `just check` — green (typecheck, lint, ratchets, `check-extension-sdk-dts`, file hygiene)
- `just test-unit` — frontend, foundation, and sculpt suites pass; backend passes (2271), including the schema-freeze test

## Reviewer notes

- **Worth a quick runtime check:** the "Opus 5" picker entry relies on the bumped CLI's `opus` / `opus[1m]` alias resolving to Opus 5 — the same mechanism used for the 4.7 → 4.8 transition. Launching with 2.1.222 and confirming the entry actually runs Opus 5 is the one thing not verifiable in CI. If the alias ever lags a release, the fallback is to pin the shortname to `claude-opus-5[1m]`.
- The two files under `tests/integration/` run via the integration harness, not `just test-unit`.
- Label style is "Claude 5 Opus" to match the sibling entries ("Claude 4.7 Opus", …) rather than the marketing name "Claude Opus 5" — trivial to change if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
