### PR TITLE
Add release skills + playbook, and stop a non-blocking build failure from breaking the publish

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: cut-release
+description: |
+  Cut a new Sculptor release candidate from main: run `just cut-release` (which
+  creates the release/sculptor-vX.Y.0 branch at X.Y.0rc1, pushes the tag that
+  triggers the RC build, and opens a PR bumping main to the next .dev0), then
+  land the version-bump PR and babysit the RC build up to its manual approval
+  gate. Handles the colocated jj + git working-copy setup and the CI
+  flake/outage/zombie recovery playbook. Stops AT the approval gate — never
+  approves it for you. Use when asked to "cut a release", "cut an RC", or start
+  a new Sculptor release.
+argument-hint: "(no args; operates on main's current .dev0 version)"
+---
+
+# Cut a Sculptor Release
+
+Turn `main`'s current `X.Y.0.dev0` into a published release candidate and reset
+`main` for the next cycle. Read **`docs/development/release_ci_playbook.md`**
+first — it holds the shared version model, the approval-gate policy, the
+flake-vs-outage triage, zombie-run recovery, and the jj working-copy rules that
+this skill leans on. That playbook is a **living document**: if you learn
+something new during a cut, add it there and commit it in the same change.
+
+The end state of a successful cut:
+
+- `release/sculptor-vX.Y.0` exists at `X.Y.0rc1`, tag `sculptor-vX.Y.0rc1`
+  pushed, RC build running and **parked at its approval gate** for the user.
+- `main` bumped to `X.(Y+1).0.dev0` via a merged version-bump PR.
+
+## Step 1 — Preflight
+
+Confirm the ground is clean before touching anything (see the playbook's
+"Working in this colocated jj + git repo" section):
+
+```bash
+jj st                                   # working copy should be clean/empty
+git fetch origin main --tags
+git rev-parse origin/main               # note the tip
+cd sculptor && python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"; cd ..
+```
+
+- The version must be a `.dev0` (e.g. `0.44.0.dev0`). If it isn't, someone
+  forgot to bump after the last release — stop and sort that out first.
+- `cut-release` refuses a **detached HEAD** (the normal jj state). If `jj st` is
+  clean/empty, `git checkout main`. If the working copy has unrelated changes,
+  **preserve them first** — bookmark + `jj new` per the playbook — then
+  `git checkout main`.
+
+## Step 2 — Run the cut
+
+```bash
+just cut-release
+```
+
+This creates and pushes `release/sculptor-vX.Y.0` at `X.Y.0rc1`, pushes tag
+`sculptor-vX.Y.0rc1` (triggering the RC build), and opens the `main`-bump PR to
+`X.(Y+1).0.dev0` with squash auto-merge enabled. Capture the release version,
+the RC tag, and the bump PR number from the output.
+
+`cut-release` leaves git on the transient `automated/bump-sculptor-v*` branch.
+Return to a sane state: `git checkout main` and let jj re-import.
+
+## Step 3 — Land the version-bump PR
+
+The bump PR has auto-merge armed; your job is to get it green (never to force
+it). Follow the playbook's **flake-vs-outage triage** and **zombie-run**
+sections:
+
+- Check its required checks: `gh pr checks <bump_pr>`.
+- Infra flake → `gh run rerun <run_id> --failed`, then let auto-merge land it.
+- Several checks red at setup/infra steps at once → check `githubstatus.com`; if
+  Actions is down, **back off and wait**, don't retry into an outage.
+- Checks wedged as zombies after an outage → close/reopen the PR to get fresh
+  runs (`gh pr close <n> && sleep 3 && gh pr reopen <n>`, then re-arm auto-merge).
+- **Never admin-merge past a failing required check.** If it genuinely needs a
+  bypass, refuse and hand it to the user.
+
+Confirm it landed and `origin/main` advanced to `X.(Y+1).0.dev0`:
+
+```bash
+gh pr view <bump_pr> --json state -q '.state'          # MERGED
+git fetch origin main && git show origin/main:sculptor/pyproject.toml | grep -m1 '^version'
+```
+
+## Step 4 — Babysit the RC build to the approval gate
+
+Find the run for the RC tag and poll it (playbook: "Polling a build"):
+
+```bash
+gh run list --workflow=build-desktop.yml --limit 5   # find the sculptor-vX.Y.0rcN run
+```
+
+Poll in a bounded background loop, breaking when the run **completes** or a
+**pending deployment** appears:
+
+```bash
+gh run view <run_id> --json status,conclusion -q '.status + " / " + (.conclusion // "running")'
+gh api repos/imbue-ai/sculptor/actions/runs/<run_id>/pending_deployments -q 'length'
+```
+
+- Build fails on an **infra flake / cancellation** → retry (`gh run rerun
+  <run_id> --failed`, or a full `gh run rerun <run_id>` if a cancellation left
+  partial artifacts).
+- A red `linux-arm64` won't sink the RC: it is `allow-failure: true`, and the
+  publisher skips a non-blocking target whose artifacts are missing. The RC just
+  ships without that architecture — rerun the job if QA needs an arm64 build.
+- Build is **wedged as a zombie** after an outage → don't fight it: cut a fresh
+  RC with `just fixup-release` (bumps `rcN → rc(N+1)`) from the release branch.
+  (To run it you must `git checkout release/sculptor-vX.Y.0` on a clean tree —
+  preserve any stray working-copy work first, per the playbook.)
+- Build reaches the **approval gate** (`pending_deployments` ≥ 1, job
+  `release desktop (S3 publish + gh release)` = `waiting`) → **stop here.**
+
+## Step 5 — Hand off at the gate
+
+First **check what will ship** — `allow-failure` jobs report success to `needs`, so
+the gate can open with a red `linux-arm64`:
+
+```bash
+gh run view <run_id> --json jobs -q '.jobs[] | .name + " -> " + (.conclusion // "—")'
+```
+
+Then report that the RC build is green and parked at the `release` environment
+approval gate, and **do not approve it**. Per the playbook's approval policy:
+surface it, show the user how to approve (UI **Review deployments**, or the
+`gh api ... pending_deployments ... state=approved` command with the env id from
+`pending_deployments`), and if they ask you to approve, gently push back once,
+then comply if they insist.
+
+After they approve, the RC publishes (S3 + a `prerelease` GitHub release). Next
+in the release process: **QA the RC**, then `promote-release` (see the
+`promote-release` skill).
+
+## Before you finish
+
+If this cut taught you anything the playbook didn't already cover — a new flake
+signature, a new recovery step, a sharper command — **add it to
+`docs/development/release_ci_playbook.md` (Field notes) and commit it.** You have
+write access; the next person cutting a release inherits what you write down.

--- a/.claude/skills/promote-release/SKILL.md
+++ b/.claude/skills/promote-release/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: promote-release
+description: |
+  Promote a QA'd Sculptor release candidate to a full production release: verify
+  the RC build is green and has been QA'd, then from the release branch run
+  `just promote-release` (which strips the rcN suffix, commits X.Y.0, and pushes
+  the sculptor-vX.Y.0 tag that triggers the production build) and babysit that
+  build up to its manual approval gate. Handles the colocated jj + git working
+  copy and the CI flake/outage/zombie recovery playbook. Stops AT the approval
+  gate — never approves it for you. Use when asked to "promote a release",
+  "ship the release", or turn an RC into the real release.
+argument-hint: "[release-version, e.g. 0.44] (optional; inferred from the release branch)"
+---
+
+# Promote a Sculptor Release
+
+Turn a release candidate on `release/sculptor-vX.Y.0` into the promoted `X.Y.0`
+release. Read **`docs/development/release_ci_playbook.md`** first — the version
+model, approval-gate policy, flake-vs-outage triage, zombie recovery, and jj
+working-copy rules all live there and this skill depends on them. That playbook
+is a **living document**: anything new you learn promoting a release goes back
+into it in the same change.
+
+**Gate before you start:** promotion publishes the real thing. Confirm the RC
+build for the current `rcN` went **green and was actually QA'd** before running
+anything here. If it wasn't QA'd, stop and get that done first.
+
+## Step 0 — Work out what to promote
+
+Don't assume the newest release branch is the one to ship. Branches get cut and
+abandoned: 0.41 and 0.43 were both cut and never promoted, so production went
+0.42.0 → 0.44.0 directly.
+
+```bash
+git fetch origin --tags --prune
+git branch -r --list 'origin/release/*' | sort -V | tail -5    # candidate branches
+git tag -l 'sculptor-v*' --sort=-v:refname | head              # rcN tags
+gh release list --limit 10                                     # what actually shipped
+```
+
+Read those together:
+
+- The branch to promote is the one whose **`rcN` prerelease appears in
+  `gh release list`**. That publication is proof the RC build went green *and* a
+  human approved its gate — stronger evidence than "the build was green".
+- The newest non-prerelease (`Latest`) entry is what production runs today.
+- A release branch with no published prerelease was abandoned; leave it alone.
+
+## Step 1 — Get onto the release branch, clean
+
+`promote-release` runs `git checkout`-based checks and needs a **real git
+branch** (`release/sculptor-vX.Y.0`) with a **clean tree** — not the usual jj
+detached HEAD.
+
+```bash
+jj st                                   # working copy clean/empty?
+git fetch origin release/sculptor-vX.Y.0
+git checkout release/sculptor-vX.Y.0
+cd sculptor && python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"; cd ..   # expect X.Y.0rcN
+```
+
+If `jj st` shows unrelated working-copy work, **preserve it first** (bookmark +
+`jj new`, per the playbook) before the checkout — never discard it.
+
+Sanity checks the recipe also enforces, worth confirming yourself:
+
+- You're on `release/sculptor-vX.Y.0` and the version is an `rcN` pre-release.
+- The branch is **not behind** its upstream:
+  ```bash
+  git fetch --prune && git status --porcelain=2 --branch | grep '^# branch.ab'
+  ```
+  If behind, pull/rebase before promoting.
+
+## Step 2 — Promote
+
+```bash
+just promote-release
+```
+
+This strips the pre-release suffix (`X.Y.0rcN → X.Y.0`), commits the version on
+the release branch, and pushes tag `sculptor-vX.Y.0` — which triggers the
+production release build. Capture the release version and tag from the output.
+
+Two outputs look wrong but are normal (playbook field notes, 2026-08-14):
+
+- `Releasing Sculptor <old rcN version> from git sha ...` — a stale
+  `pyproject_version()` echo. The version actually released is the stripped one.
+- `Bypassed rule violations for refs/tags/... creations being restricted` on the
+  tag push. Expected — but it means you need **tag-creation bypass** on the repo
+  ruleset; without it the promotion fails right here.
+
+## Step 3 — Babysit the production build to the approval gate
+
+Same polling and recovery as an RC build (playbook: "Polling a build",
+"Flake vs. outage", "Zombie runs"):
+
+```bash
+gh run list --workflow=build-desktop.yml --limit 5    # find the sculptor-vX.Y.0 run
+gh run view <run_id> --json status,conclusion -q '.status + " / " + (.conclusion // "running")'
+gh api repos/imbue-ai/sculptor/actions/runs/<run_id>/pending_deployments -q 'length'
+```
+
+- Infra flake / cancellation → retry (`gh run rerun <run_id> --failed`, or a
+  full rerun after a cancellation).
+- A red `linux-arm64` is survivable: it is `allow-failure: true`, and the publisher
+  skips a non-blocking target whose artifacts are missing. The release ships
+  without that architecture — rerun the job if you want arm64 included.
+- Outage → check `githubstatus.com`, back off, don't retry into it.
+- **Never admin-merge / force a bad required check.** Refuse and hand back.
+- Gate reached (`pending_deployments` ≥ 1, run `status` = `waiting`, `release
+  desktop (S3 publish + gh release)` = `waiting`) → verify, then **stop.**
+
+Note: if the production build is unrecoverable but the RC was fine, promotion
+isn't the place to cut a new RC — that's `fixup-release` on the RC side. A
+promoted release that later needs patching uses `just hotfix-release` (see the
+playbook's version model).
+
+## Step 4 — Verify at the gate, then hand off
+
+Check what will actually ship before handing it over — `allow-failure` jobs report
+success to `needs`, so the gate can open with a red `linux-arm64`:
+
+```bash
+gh run view <run_id> --json jobs -q '.jobs[] | .name + " -> " + (.conclusion // "—")'
+```
+
+Then report that the build is parked at the `release` environment approval gate,
+and **do not approve it.** Per the playbook: surface it, give the user the run URL
+plus the env id, show them how to approve themselves (UI **Review deployments**, or
+the `gh api ... pending_deployments ... state=approved` command), and if asked to
+approve, push back gently once, then comply if they insist.
+
+If arm64 is red, rerun it first when you want that architecture in the release —
+and either way, tell the user which architectures this release will contain.
+
+## Step 5 — After they approve
+
+Confirm the publish actually landed; don't trust the job status alone:
+
+```bash
+gh run view <run_id> --json conclusion -q .conclusion             # success
+gh release view sculptor-vX.Y.0 --json isPrerelease,isDraft       # false / false
+curl -s https://imbue-sculptor-releases.s3.amazonaws.com/slim/AppImage/x64/latest-linux.yml | grep '^version:'
+```
+
+That last one matters most — the auto-update manifests are the channel that
+actually reaches users. (A release with **0 assets is normal**: artifacts live in
+S3 and the release body just links them.)
+
+Follow-ups this skill does **not** do:
+
+- **Release notes** (`write-release-notes`). The range starts at the prior
+  *promoted* tag, which may be several minors back — 0.44.0's notes had to cover
+  0.42.0 → 0.44.0 because 0.43 never shipped. Scoping to the previous release
+  *branch* silently drops half of what users are receiving. The release body is
+  pipeline boilerplate (title + `## Assets`); splice notes in **above** `## Assets`
+  and preserve that block verbatim, via
+  `gh release edit <tag> --notes-file <file>`. Do **not** sign a published product
+  changelog `(Sent by Claude)` — CLAUDE.md's transparency rule targets PR, issue,
+  and chat messages, not user-facing release copy.
+- **`update-help-docs`** for the release (run it from the release branch).
+- **Linear** hygiene for the tickets that shipped.
+- Slack needs nothing: the pipeline posts to `#sculptor-release` automatically on
+  a successful publish.
+
+## Before you finish
+
+Learned something the playbook doesn't cover? **Add it to
+`docs/development/release_ci_playbook.md` (Field notes) and commit it** in the
+same change. You have write access — write it down for the next promoter.

--- a/docs/development/release_ci_playbook.md
+++ b/docs/development/release_ci_playbook.md
@@ -1,0 +1,265 @@
+# Release CI Playbook
+
+Shared operational knowledge for cutting and promoting Sculptor releases. The
+`cut-release` and `promote-release` skills both point here so the hard-won
+recovery lore lives in one place.
+
+> **This is a living playbook.** Everyone who runs these skills can commit to
+> this repo. When you hit a new failure mode, a new flake, or a better recovery
+> step, **add it here in the same change** and commit it. A fix you keep in your
+> head helps nobody; a fix you write down here helps the next person cutting a
+> release. Prefer appending a short, dated bullet under "Field notes" over
+> rewriting sections wholesale.
+
+## The version model
+
+`sculptor/pyproject.toml` `[project].version` drives everything. The builder CLI
+(`uv run --project sculptor builder ...`, wrapped by `just` recipes in the root
+`justfile`) does the arithmetic in `sculptor/sculptor/version.py`.
+
+| State | Version shape | Where |
+| --- | --- | --- |
+| Active development | `X.Y.0.dev0` | `main` |
+| Release candidate | `X.Y.0rcN` | `release/sculptor-vX.Y.0` |
+| Promoted release | `X.Y.0` | `release/sculptor-vX.Y.0` (tagged) |
+| Hotfix | `X.Y.(Z+1)` | `release/sculptor-vX.Y.(Z+1)` |
+
+The `just` recipes and what they do:
+
+- **`just cut-release`** — from `main` (or any branch at `origin/main`'s tip):
+  creates `release/sculptor-vX.Y.0` at `X.Y.0rc1`, pushes tag
+  `sculptor-vX.Y.0rc1` (this triggers the release build), and opens a PR bumping
+  `main` to `X.(Y+1).0.dev0` with squash auto-merge enabled.
+- **`just fixup-release`** — from the release branch: bumps `rcN → rc(N+1)`,
+  commits, pushes tag `sculptor-vX.Y.0rc(N+1)` → a fresh RC build. This is the
+  "the last RC build was bad / wedged, cut another" button.
+- **`just promote-release`** — from the release branch: strips the `rcN` suffix
+  (`X.Y.0rcN → X.Y.0`), commits, pushes tag `sculptor-vX.Y.0` → the production
+  release build.
+- **`just hotfix-release`** — from an already-promoted release branch: bumps the
+  patch component to `X.Y.(Z+1)` and starts a new release branch for it.
+- **`just bump-version`** — opens a manual `.dev0` version-bump PR on `main`.
+
+A tag push matching `sculptor-v*` is what triggers `build-desktop.yml`. That
+workflow runs under the `release-build` GitHub Environment for tag builds and
+ends in a **manual approval gate** (the `release` environment) before it
+publishes artifacts.
+
+## The GitHub Actions approval gate
+
+The final `release desktop (S3 publish + gh release)` job waits on the `release`
+environment's required-reviewer rule. Polling shows up as a pending deployment:
+
+```bash
+# Is the run parked at the gate?
+gh api repos/imbue-ai/sculptor/actions/runs/<run_id>/pending_deployments -q 'length'   # 0 = no gate / already approved
+# Which environment, and can I approve?
+gh api repos/imbue-ai/sculptor/actions/runs/<run_id>/pending_deployments \
+  -q '.[] | "env=" + .environment.name + " id=" + (.environment.id|tostring) + " can_approve=" + (.current_user_can_approve|tostring)'
+```
+
+**Approval policy — do not approve the gate on the user's behalf.** Approving is
+a human sign-off that the RC/release is good to publish. When running as a skill:
+
+- **Never offer to auto-approve.** Surface that the gate is reached, then stop.
+- If the user explicitly asks you to approve, **don't refuse** — but gently push
+  back first (it's a real sign-off, not a rubber stamp; the artifacts go out).
+  If they still want it, proceed.
+- Show them how to do it themselves:
+  - **UI:** open the run, click **Review deployments**, check `release`, **Approve and deploy**.
+  - **CLI:** `gh api --method POST repos/imbue-ai/sculptor/actions/runs/<run_id>/pending_deployments -f 'environment_ids[]=<env_id>' -f state=approved -f comment='...'`
+
+### Before you approve: check what will actually ship
+
+`allow-failure` jobs report success to `needs`, so a run can reach the gate with a
+red `linux-arm64` build. That doesn't break the publish — the publisher skips a
+non-blocking target whose artifacts are missing — but it does mean that
+architecture sits out the release. Look before handing the gate to a human:
+
+```bash
+# Every job's real conclusion (allow-failure reds show up here, not in `needs`)
+gh run view <run_id> --json jobs -q '.jobs[] | .name + " -> " + (.conclusion // "—")'
+```
+
+If arm64 is red and you want it included, `gh run rerun <run_id> --failed` first —
+otherwise say plainly which architectures the release will contain when you hand
+off.
+
+## Polling a build
+
+```bash
+# Find the run for a freshly pushed tag:
+gh run list --workflow=build-desktop.yml --limit 5
+# Status of a run:
+gh run view <run_id> --json status,conclusion -q '.status + " / " + (.conclusion // "running")'
+# Per-job breakdown (find the failing job + step):
+gh run view <run_id> --json jobs -q '.jobs[] | .name + " -> " + .status + "/" + (.conclusion // "—")'
+gh run view <run_id> --json jobs -q '.jobs[] | select(.conclusion=="failure") | .name + " :: " + ((.steps[]? | select(.conclusion=="failure") | .name) // "?")'
+```
+
+Poll in a bounded background loop (60s cadence), breaking when the run completes
+**or** a pending deployment appears. `build-desktop.yml` sets
+`cancel-in-progress: false`, so builds are never auto-cancelled — a stuck run is
+stuck, not racing. Expect roughly **20–25 minutes** from tag push to the gate.
+
+Ready-made loop — run it in the background rather than blocking on it:
+
+```bash
+RUN=<run_id>
+for i in $(seq 1 70); do
+  st=$(gh run view $RUN --json status,conclusion -q '.status + " / " + (.conclusion // "running")')
+  pd=$(gh api repos/imbue-ai/sculptor/actions/runs/$RUN/pending_deployments -q 'length' 2>/dev/null || echo 0)
+  echo "[$i] $(date -u +%H:%M:%S) status=$st pending=$pd"
+  case "$st" in completed*) echo "RUN COMPLETED"; break;; esac
+  [ "${pd:-0}" -ge 1 ] && { echo "GATE REACHED"; break; }
+  sleep 60
+done
+```
+
+When a run parks at the gate its `status` becomes `waiting` (not `completed`) —
+that, plus `pending_deployments >= 1`, is the signal. Note also that a rerun of
+only the failed jobs is much faster than the original build, because GitHub reuses
+the already-green jobs instead of re-running them.
+
+Finding your run: stale zombie runs can sit in `gh run list` as `queued`
+indefinitely (one wedged RC run was still listed a week later). Match on the
+tag/branch column, not on list position.
+
+`linux-arm64` is non-blocking end to end: it is `allow-failure: true` in the build
+and packaged-test matrices, and `publish-build-artifacts` skips any non-blocking
+target whose artifacts are absent (`NON_BLOCKING_TARGETS` in
+`sculptor/builder/artifacts.py`). A red arm64 build costs that one architecture and
+nothing else — its previous artifacts stay in place, so arm64 Linux simply isn't
+offered this update. Rerun the job if you want arm64 in the release. `linux-x64`
+and `macos-arm64` are required and fail the run outright.
+
+## Flake vs. outage: triage before you retry
+
+When a required check fails, decide which world you're in **before** hammering
+retries:
+
+1. **Look at the failing step.** A failure in `Set up job`, runner acquisition
+   ("job was not acquired by Runner of type hosted"), `Export AWS credentials`,
+   `Export Modal credentials`, `Download build artifacts`, or a cache
+   save/restore error is **infrastructure**, not your code — especially on a
+   diff (like a version bump) that can't affect tests.
+2. **When several independent required checks fail at once at setup/infra
+   steps, suspect a platform incident.** Check GitHub's status:
+   ```bash
+   curl -s https://www.githubstatus.com/api/v2/components.json | \
+     python3 -c "import sys,json; d=json.load(sys.stdin); [print(c['name'],'->',c['status']) for c in d['components'] if c['name']=='Actions']"
+   curl -s https://www.githubstatus.com/api/v2/incidents/unresolved.json | \
+     python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d['incidents']),'unresolved'); [print('-',i['name'],'::',i['status']) for i in d['incidents']]"
+   ```
+   The status **page lags real recovery** — trust an empirical signal (a
+   `Set up job` step actually succeeding) over the component color.
+
+**Then act:**
+
+- **Isolated flake** → retry to green, then let auto-merge take over:
+  `gh run rerun <run_id> --failed` (or a full `gh run rerun <run_id>` when a
+  cancellation left partial/inconsistent artifacts).
+- **Active outage** → **back off and wait.** Retrying into an outage just burns
+  attempts and muddies history; queued runs pick up on their own once capacity
+  returns. Retry cadence during recovery can still hit residual infra flakes, so
+  bound your retries and re-check that the failing step is still infra (and that
+  another arch/job is passing) rather than assuming one retry restores green.
+- **Genuine, reproducing failure on a non-infra step** → stop and escalate. Do
+  not paper over a real red.
+
+**Never admin-merge / force past a failing *required* check.** (Aspirational but
+firm: we should never *need* to.) If a merge genuinely requires bypassing a
+required check, **refuse and hand it back to the user to do by hand** — don't do
+it for them.
+
+Required checks on `main` come from the repo ruleset (currently `checks + unit
+tests` and `offload integration tests`); confirm with:
+```bash
+gh api repos/imbue-ai/sculptor/rules/branches/main -q '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+## Zombie runs after an outage
+
+Runs that were **queued during** an incident can wedge into a limbo state: GitHub
+refuses to cancel them (`gh run cancel` → "Cannot cancel a workflow run that is
+completed") **and** refuses to rerun them (`gh run rerun` → "already running"),
+and `gh run view` may disagree with itself about the status. They will not
+self-heal. Don't fight them — **supersede** them:
+
+- **`pull_request` checks (e.g. the version-bump PR):** close and reopen the PR
+  to retrigger fresh runs with new IDs:
+  ```bash
+  gh pr close <n> && sleep 3 && gh pr reopen <n>
+  gh pr merge <n> --auto --squash   # re-arm auto-merge; a merge queue may report "strategy set by the merge queue" — that's fine
+  ```
+- **Tag-triggered release build:** you can't cheaply re-dispatch a tag build.
+  Cut a fresh RC instead — **`just fixup-release`** (`rcN → rc(N+1)`) pushes a new
+  tag and a new, healthy build. It costs one RC number and sidesteps the zombie.
+
+## Working in this colocated jj + git repo
+
+This repo is **colocated** (`.jj/` and `.git/` both exist) and normally sits on a
+**detached git HEAD** under jj. The release recipes run `git checkout` internally
+and need a **real git branch** with a **clean working tree**:
+
+- `cut-release` refuses a detached HEAD → `git checkout main` first (safe only
+  when `jj st` shows the working copy clean/empty).
+- `fixup-release`/`promote-release` need to be on `release/sculptor-vX.Y.0` →
+  `git checkout release/sculptor-vX.Y.0`.
+
+**Preserve unrelated working-copy work before checking out.** If `jj st` shows
+changes that aren't part of the release, don't discard them — bookmark and step
+off so the git tree goes clean:
+
+```bash
+jj bookmark create wip-<name> -r @   # pin the work at a findable name
+jj new                               # empty change on top → advances git_head, working tree is now clean
+git status --short                   # should be empty
+git checkout <target-branch>         # now safe
+# recover later with: jj edit wip-<name>
+```
+
+After a recipe finishes it may leave git on a transient branch (e.g.
+`automated/bump-sculptor-v*`). Return to a sane state with `git checkout main`
+(or the release branch) and let jj re-import. Never discard work you didn't
+create — surface it.
+
+## Field notes
+
+Append dated, specific learnings here. Keep them short.
+
+- **2026-08-06/07 — GitHub Actions major outage mid-cut.** Runner acquisition
+  failed ("job was not acquired by Runner of type hosted"), credential-export
+  and cache steps flaked, and jobs queued during the incident wedged into the
+  uncancellable-and-un-rerunnable zombie state. Recovery: waited for
+  `githubstatus.com` Actions to return to operational, then superseded the
+  zombies — close/reopen for the version-bump PR, `just fixup-release` (`rc1 →
+  rc2`) for the release build. Both went green on healthy runners. Lesson:
+  triage flake-vs-outage before retrying; the status page lags; supersede, don't
+  fight, zombie runs.
+- **2026-08-14 — an arm64 build flake, and the publisher bug it exposed
+  (promoting 0.44.0).** `build linux-arm64` died 76s in on a transient uv download
+  (`Failed to download viztracer`, `stream error received: unspecific protocol
+  error detected`), preceded by `Cache service responded with 400`. At the time
+  `publish-build-artifacts` demanded all three targets, so the run reached the gate
+  looking green, the human approved, and the publish then hard-failed on the
+  missing `AppImage/arm64/*` artifacts. **Nothing was published** — verification
+  runs before any `s3_copy`, so there was no partial release and no GitHub release
+  object. Recovery was `gh run rerun <run_id> --failed`, which rebuilt arm64 only
+  (~10 min, since the green x64/macOS packaged tests were reused), then a second
+  approval published cleanly. The publisher now skips a non-blocking target whose
+  artifacts are absent, so a flaky arm64 build can no longer waste an approval;
+  what remains is that a red arm64 means that architecture sits out the release.
+- **2026-08-14 — two alarming-but-normal outputs from `just promote-release`.**
+  It prints `Releasing Sculptor <old rcN version> from git sha ...` — a stale
+  `pyproject_version()` read taken before the bump; the version actually released
+  is the stripped one. The tag push prints `Bypassed rule violations for
+  refs/tags/sculptor-vX.Y.0: Cannot create ref due to creations being restricted`
+  — also expected, but it reveals a real prerequisite: **you need tag-creation
+  bypass on the repo ruleset**, or the promotion dies at the push.
+- **2026-08-14 — release branches get abandoned; don't infer the target from the
+  newest branch.** 0.41 and 0.43 were both cut and never promoted, so production
+  went 0.42.0 → 0.44.0 directly. The reliable signal for "which RC is real" is a
+  published `rcN` prerelease in `gh release list` — that means its build went green
+  *and* a human approved its gate. This also sets the release-notes range: it
+  starts at the prior **promoted** tag, which may be several minors back.

--- a/sculptor/builder/artifacts.py
+++ b/sculptor/builder/artifacts.py
@@ -43,6 +43,13 @@ TARGET_TO_PLATFORM_ARCH = {
 
 PLATFORM_ARCH_TO_TARGET = {v: k for (k, v) in TARGET_TO_PLATFORM_ARCH.items()}
 
+# Targets whose build may fail without holding up a release. This mirrors the
+# `allow-failure` entries in build-desktop.yml's build matrix: an arm64 runner
+# preemption should cost that one architecture, not the whole release. Keep the
+# two in sync — a target that is non-blocking in CI but required here silently
+# converts a tolerated build failure into a failed publish.
+NON_BLOCKING_TARGETS: frozenset[Target] = frozenset({Target.LINUX_ARM64})
+
 
 class BuildStage(enum.StrEnum):
     # Built artifacts are keyed by Git SHA, and have not yet been tested.

--- a/sculptor/builder/cli.py
+++ b/sculptor/builder/cli.py
@@ -25,7 +25,9 @@ import typer
 from builder import darwin
 from builder.artifacts import ArtifactFile
 from builder.artifacts import BuildStage
+from builder.artifacts import NON_BLOCKING_TARGETS
 from builder.artifacts import PLATFORM_ARCH_TO_TARGET
+from builder.artifacts import Target
 from builder.artifacts import artifacts_for_target_and_stage
 from packaging.version import InvalidVersion
 from packaging.version import Version
@@ -442,7 +444,7 @@ def publish_build_artifacts(
         fg=typer.colors.YELLOW,
     )
 
-    files_to_copy: list[ArtifactFile] = []
+    artifacts_by_target: dict[Target, list[ArtifactFile]] = {}
     for stage in stages:
         for target in PLATFORM_ARCH_TO_TARGET.values():
             artifacts = artifacts_for_target_and_stage(
@@ -450,33 +452,37 @@ def publish_build_artifacts(
                 stage,
                 pipeline_id=os.environ.get("CI_PIPELINE_ID", ""),
             )
-            files_to_copy.extend(artifacts)
+            artifacts_by_target.setdefault(target, []).extend(artifacts)
 
     if not bypass_checks:
         typer.echo("  • Verifying source artifacts exist in S3")
-        are_artifacts_missing = False
-        for artifact in files_to_copy:
-            # Run s3 ls to verify the file exists
-            try:
-                _run_out(
-                    [
-                        "uv",
-                        "tool",
-                        "run",
-                        "--from",
-                        "awscli==1.41.12",
-                        "--refresh",
-                        "aws",
-                        "s3",
-                        "ls",
-                        artifact.input_path,
-                    ]
-                )
-            except subprocess.CalledProcessError:
+        blocked_targets: list[Target] = []
+        skipped_targets: list[Target] = []
+        for target, artifacts in artifacts_by_target.items():
+            missing = [artifact for artifact in artifacts if not _s3_object_exists(artifact.input_path)]
+            if not missing:
+                continue
+            for artifact in missing:
                 typer.secho(f"Source artifact not found: {artifact.input_path}", fg=typer.colors.RED)
-                are_artifacts_missing = True
-        if are_artifacts_missing:
+            (skipped_targets if target in NON_BLOCKING_TARGETS else blocked_targets).append(target)
+
+        if blocked_targets:
             raise typer.Exit(code=1)
+
+        for target in skipped_targets:
+            # Drop the target wholesale rather than publishing what did survive: a
+            # half-published target would leave its auto-update manifest pointing at
+            # binaries that aren't there. Skipping leaves the previous release's
+            # artifacts in place, so that architecture simply isn't offered an update.
+            typer.secho(
+                f"Skipping {target.value}: its build is non-blocking and its artifacts are absent.",
+                fg=typer.colors.YELLOW,
+            )
+            artifacts_by_target[target] = []
+
+    files_to_copy: list[ArtifactFile] = [
+        artifact for artifacts in artifacts_by_target.values() for artifact in artifacts
+    ]
 
     versioned_urls: list[str] = []
 
@@ -976,6 +982,15 @@ def s3_uri_to_https(s3_uri: str) -> str:
     without_scheme = s3_uri[len("s3://") :]
     bucket, _, key = without_scheme.partition("/")
     return f"https://{bucket}.s3.amazonaws.com/{key}"
+
+
+def _s3_object_exists(s3_uri: str) -> bool:
+    """Returns whether `aws s3 ls` can see an object at `s3_uri`."""
+    try:
+        _run_out(["uv", "tool", "run", "--from", "awscli==1.41.12", "--refresh", "aws", "s3", "ls", s3_uri])
+    except subprocess.CalledProcessError:
+        return False
+    return True
 
 
 def s3_copy(source: str, destination: str, dry_run: bool = False) -> None:

--- a/sculptor/builder/test_cli.py
+++ b/sculptor/builder/test_cli.py
@@ -231,3 +231,64 @@ def test_generate_autoupdate_manifest_linux(tmp_path: Path) -> None:
     assert manifest["files"][0]["sha512"] == LINUX_ARTIFACT_SHA512
     assert manifest["files"][0]["size"] == len(LINUX_ARTIFACT_CONTENT)
     assert "releaseDate" in manifest
+
+
+def _invoke_publish(missing_substrings: tuple[str, ...]) -> tuple[int, list[tuple[str, str]], str]:
+    """Run publish-build-artifacts with S3 faked out.
+
+    Any `aws s3 ls` for a URI containing one of `missing_substrings` reports the
+    object as absent; every `aws s3 cp` is recorded instead of performed. Returns
+    the exit code, the (source, destination) copies attempted, and the output.
+    """
+    copies: list[tuple[str, str]] = []
+
+    def fake_run_out(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if "ls" in cmd:
+            uri = cmd[-1]
+            if any(substring in uri for substring in missing_substrings):
+                raise subprocess.CalledProcessError(1, cmd)
+        elif "cp" in cmd:
+            copies.append((cmd[-2], cmd[-1]))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    runner = CliRunner()
+    with (
+        patch("builder.cli._run_out", side_effect=fake_run_out),
+        patch("builder.cli.ensure_clean_tree"),
+        patch("builder.cli.pyproject_version", return_value="0.44.0"),
+        patch("builder.cli.dev_git_sha", return_value="1f1d00c0"),
+        # artifacts.py resolves the version and SHA itself when interpolating the
+        # S3 keys; patch it too so the paths under test don't drift with the repo.
+        patch("builder.artifacts.pyproject_version", return_value="0.44.0"),
+        patch("builder.artifacts.dev_git_sha", return_value="1f1d00c0"),
+    ):
+        result = runner.invoke(app, ["publish-build-artifacts", "--no-dry-run"])
+
+    return result.exit_code, copies, result.output
+
+
+def test_publish_skips_a_missing_non_blocking_target() -> None:
+    """A absent non-blocking (linux/arm64) build must not sink the whole release.
+
+    build-desktop.yml marks the linux-arm64 build `allow-failure`, so an arm64
+    runner preemption is expected to cost that one architecture and nothing else.
+    Publishing must therefore ship x64 and macOS rather than refusing outright.
+    """
+    exit_code, copies, output = _invoke_publish(missing_substrings=("AppImage/arm64/",))
+
+    assert exit_code == 0, f"publish should have succeeded without arm64:\n{output}"
+    assert copies, "expected the surviving targets to be published"
+    # Scope this to the Linux arm64 keys: the macOS artifacts are arm64 too.
+    assert not [dst for _, dst in copies if "AppImage/arm64/" in dst], (
+        "a target with missing artifacts must be skipped entirely, not partially published"
+    )
+    assert [dst for _, dst in copies if "AppImage/x64/" in dst], "x64 should still publish"
+    assert [dst for _, dst in copies if "darwin" in dst or dst.endswith(".dmg")], "macOS should still publish"
+
+
+def test_publish_fails_when_a_required_target_is_missing() -> None:
+    """A missing *blocking* target still aborts the publish, copying nothing."""
+    exit_code, copies, output = _invoke_publish(missing_substrings=("AppImage/x64/",))
+
+    assert exit_code == 1, f"publish should have refused to run:\n{output}"
+    assert copies == [], "nothing may be published once a required artifact is missing"


### PR DESCRIPTION
Two commits, split by concern but landing together (the playbook's field note describes the fix in the second commit).

## 1. Add `cut-release` and `promote-release` skills + a shared CI playbook

Documents the release process end to end: the version model and what each `just` recipe does, the approval-gate policy (surface the gate, never approve on someone's behalf), flake-vs-outage triage, zombie-run recovery, and the working-copy rules for this colocated repo. Both skills point at `docs/development/release_ci_playbook.md` so the recovery lore lives in one place, and the playbook is explicitly a living document.

Written from actually running a release, so it captures things that aren't obvious from the code:

- **Work out what to promote from the published prereleases, not the newest branch.** Release branches get cut and abandoned — production went 0.42.0 → 0.44.0 directly, skipping two cut-but-never-promoted branches. A published `rcN` prerelease is proof its build went green *and* a human approved its gate.
- **Release notes start at the prior *promoted* tag**, which may be several minors back. Scoping to the previous release branch silently drops half of what users receive.
- Two alarming-but-normal outputs from `just promote-release`: a stale version string in its final echo, and a ruleset-bypass message on the tag push (which reveals a real prerequisite — you need tag-creation bypass, or promotion fails at the push).
- A ready-made bounded poller, the ~20–25 min expectation to the gate, and the fact that a run's status becomes `waiting` when it parks.

## 2. Publish a release when a non-blocking target's artifacts are missing

`build-desktop.yml` marks `linux-arm64` `allow-failure` in both the build and packaged-test matrices, on the stated grounds that an arm64 runner preemption shouldn't hold up a release. `publish-build-artifacts` didn't honour that: it verified **every** target and hard-failed on any missing artifact.

The two disagreeing produced a bad failure mode. A red arm64 build reports success to `needs`, so the run reaches the approval gate looking green; a human approves; and only then does the publish abort on the absent arm64 artifacts. The failure is invisible until it has already spent someone's sign-off. This happened promoting 0.44.0, off a transient dependency-download flake in the arm64 build.

This resolves it in favour of the workflow's stated intent:

- `NON_BLOCKING_TARGETS` in `builder/artifacts.py`, commented to stay in sync with the `allow-failure` matrix entries.
- Verification is now per-target. A missing **blocking** target still exits before anything is copied; a missing **non-blocking** target is skipped and the rest of the release publishes.
- A skipped target is dropped **wholesale** rather than partially published — a half-published target would leave its auto-update manifest pointing at binaries that aren't there. Skipping leaves the previous release's artifacts in place, so that architecture simply isn't offered an update.
- Extracted `_s3_object_exists()` so the check reads as a predicate rather than an inline `try`/`except`.

### Tests

Written test-first; the failing test reproduced the incident (the same two missing arm64 keys). Two cases pinned:

- a missing non-blocking target publishes the surviving architectures and copies nothing for the skipped one;
- a missing required target still aborts with zero copies.

`just format`, `just check`, and `just test-unit` all pass.

(Sent by Claude)
