### PR TITLE
SCU-1545: drop the azure apt mirror and bound apt steps at 10 minutes

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -156,9 +156,16 @@ jobs:
 
       - name: Install Linux build dependencies
         if: matrix.os == 'linux'
+        timeout-minutes: 10
         # Electron, node-gyp, and AppImage-maker dependencies.
         run: |
           # Retry/timeout-harden apt against transient mirror stalls (SCU-1545).
+          # The azure.archive.ubuntu.com mirror can also go fully dark and hang
+          # `apt-get update` past those per-connection timeouts, so drop it and
+          # let the canonical archive.ubuntu.com mirrors serve instead.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          fi
           APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           sudo apt-get $APT_OPTS update -qq
           sudo apt-get $APT_OPTS install -y -qq \
@@ -356,12 +363,19 @@ jobs:
 
       - name: Install Linux test dependencies
         if: matrix.os == 'linux'
+        timeout-minutes: 10
         # Electron runtime libs + xvfb. The harness auto-wraps the app in
         # `xvfb-run` when no DISPLAY is set (PackagedElectronFrontend), so we
         # only need xvfb present, not a manually-started display. Package names
         # differ between 22.04 and 24.04 (t64 suffix), so fall back.
         run: |
           # Retry/timeout-harden apt against transient mirror stalls (SCU-1545).
+          # The azure.archive.ubuntu.com mirror can also go fully dark and hang
+          # `apt-get update` past those per-connection timeouts, so drop it and
+          # let the canonical archive.ubuntu.com mirrors serve instead.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          fi
           APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           sudo apt-get $APT_OPTS update -qq
           sudo apt-get $APT_OPTS install -y -qq \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,8 +60,15 @@ jobs:
           git config --global user.name "Sculptor CI"
 
       - name: Install system packages
+        timeout-minutes: 10
         run: |
           # Retry/timeout-harden apt against transient mirror stalls (SCU-1545).
+          # The azure.archive.ubuntu.com mirror can also go fully dark and hang
+          # `apt-get update` past those per-connection timeouts, so drop it and
+          # let the canonical archive.ubuntu.com mirrors serve instead.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          fi
           APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y tmux

--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -60,8 +60,15 @@ jobs:
           git config user.name "imbue-dev"
 
       - name: Install system packages
+        timeout-minutes: 10
         run: |
           # Retry/timeout-harden apt against transient mirror stalls (SCU-1545).
+          # The azure.archive.ubuntu.com mirror can also go fully dark and hang
+          # `apt-get update` past those per-connection timeouts, so drop it and
+          # let the canonical archive.ubuntu.com mirrors serve instead.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          fi
           APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y --no-install-recommends rsync jq ca-certificates
@@ -198,8 +205,15 @@ jobs:
           git config user.name "imbue-dev"
 
       - name: Install system packages
+        timeout-minutes: 10
         run: |
           # Retry/timeout-harden apt against transient mirror stalls (SCU-1545).
+          # The azure.archive.ubuntu.com mirror can also go fully dark and hang
+          # `apt-get update` past those per-connection timeouts, so drop it and
+          # let the canonical archive.ubuntu.com mirrors serve instead.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          fi
           APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y --no-install-recommends rsync jq ca-certificates

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -65,7 +65,15 @@ jobs:
           git config user.name "imbue-dev"
 
       - name: Install system packages
+        timeout-minutes: 10
         run: |
+          # Retry/timeout-harden apt against transient mirror stalls (SCU-1545).
+          # The azure.archive.ubuntu.com mirror can also go fully dark and hang
+          # `apt-get update` past those per-connection timeouts, so drop it and
+          # let the canonical archive.ubuntu.com mirrors serve instead.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+          fi
           APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y --no-install-recommends rsync jq ca-certificates


### PR DESCRIPTION
## Problem

Since Aug 17 ~21:47 UTC, the `offload integration tests` job has hung on **every run** (3/3 so far: two on #389, one on #390, and #390's run is reproducibly wedged the same way). The hang is in the `Install system packages` step, before offload or any test executes:

- `azure.archive.ubuntu.com` (the runner image's priority-1 mirror) stops responding — every fetch gets `Ign:`.
- After the InRelease files fall back to `archive.ubuntu.com`, `apt-get update` goes **completely silent for 55+ minutes** fetching package indexes, despite the SCU-1545 hardening (`Acquire::Retries=3`, `Acquire::http(s)::Timeout=30`) — consistent with apt's mirrorlist serially retrying the dead mirror per index file, each attempt burning a full timeout.
- The job then dies at its 60-minute limit having run zero tests, e.g. [this run](https://github.com/imbue-ai/sculptor/actions/runs/32072919176/job/95519851472) and its identical re-run 35 hours later.

## Fix

Applied to all six apt sites (`offload.yml` ×2, `checks.yml`, `perf.yml`, `build-desktop.yml` ×2):

1. **Drop the azure mirror** from `/etc/apt/apt-mirrors.txt` before `apt-get update` (guarded by a file-existence check). The canonical `archive.ubuntu.com` / `security.ubuntu.com` entries remain, so apt never touches the dead mirror.
2. **`timeout-minutes: 10` on each apt step** so any future stall fails the step in minutes instead of consuming the job's whole hour (a healthy run of these steps takes well under a minute).

## Validation

- All four workflows parse; `just ratchets` and `just check-file-hygiene` pass. The change is workflow-YAML-only — no code paths touched.
- The sed was verified against a replica of the runner's mirrorlist format (azure line removed, other mirrors untouched).
- This PR's own checks exercise the patched workflows (pull_request runs use the merge ref), so a green `offload integration tests` here is the end-to-end proof.

(Sent by Claude)