### PR TITLE
Fix stuck pending question when the asking turn's terminal arrives detached

### DIFF
--- a/sculptor/sculptor/web/message_conversion.py
+++ b/sculptor/sculptor/web/message_conversion.py
@@ -680,6 +680,14 @@ def convert_agent_messages_to_task_update(
             # partial assembly. All of it must wait for the turn's real
             # RequestSuccess. Mirrors the can_finalize gate in the RequestStopped
             # branch below.
+            # An interrupted success is only ever emitted as a turn's terminal,
+            # so its pending AUQs are no longer answerable and must clear even
+            # when this success is not the active request — e.g. the asking
+            # turn's terminal arriving after an answer-delivery turn finalized
+            # in between detached current_request_id from it. Leaving them
+            # pending blocks every subsequent message send with a 409.
+            if msg.interrupted:
+                pending_user_questions.clear()
             can_finalize = current_request_id is not None and current_request_id == msg.request_id
             if can_finalize:
                 # When the turn was interrupted before any content was streamed, there may
@@ -701,9 +709,6 @@ def convert_agent_messages_to_task_update(
                     )
                 if msg.interrupted:
                     in_progress_chat_message = _mark_stopped(in_progress_chat_message)
-                    # Clear any pending AUQs — the agent was interrupted so the questions
-                    # are no longer valid and the chat input should reappear.
-                    pending_user_questions.clear()
                 in_progress_chat_message = _attach_turn_metrics(in_progress_chat_message, pending_turn_metrics)
                 pending_turn_metrics = None
             in_progress_chat_message, current_request_id = _finalize_request(
@@ -764,19 +769,21 @@ def convert_agent_messages_to_task_update(
             # RequestFailureAgentMessage and AgentCrashedRunnerMessage,
             # which still produce ErrorBlocks via the branches above and
             # below.
+            # Only a user-initiated stop dismisses pending AUQs — the user is
+            # moving on, so the chat input should reappear. A stop the user
+            # did not ask for (backend shutdown/restart SIGTERM) leaves the
+            # questions pending: they were reconstructed from the persisted
+            # ToolUseBlock above and remain answerable after resume via the
+            # runner's answer-after-turn-ended continuation. A user stop always
+            # terminates the asking turn, so it clears even when not the active
+            # request, like the RequestSuccess branch above.
+            if msg.stopped_by_user:
+                pending_user_questions.clear()
             can_finalize = current_request_id is not None and current_request_id == msg.request_id
             if can_finalize:
                 in_progress_chat_message = _mark_stopped(in_progress_chat_message)
                 in_progress_chat_message = _attach_turn_metrics(in_progress_chat_message, pending_turn_metrics)
                 pending_turn_metrics = None
-                # Only a user-initiated stop dismisses pending AUQs — the user is
-                # moving on, so the chat input should reappear. A stop the user
-                # did not ask for (backend shutdown/restart SIGTERM) leaves the
-                # questions pending: they were reconstructed from the persisted
-                # ToolUseBlock above and remain answerable after resume via the
-                # runner's answer-after-turn-ended continuation.
-                if msg.stopped_by_user:
-                    pending_user_questions.clear()
             in_progress_chat_message, current_request_id = _finalize_request(
                 current_request_id,
                 msg.request_id,

--- a/sculptor/sculptor/web/message_conversion_test.py
+++ b/sculptor/sculptor/web/message_conversion_test.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from sculptor.agents.default.claude_code_sdk.harness import CLAUDE_CODE_HARNESS
 from sculptor.agents.pi_agent.backchannel import build_ask_user_question_data
 from sculptor.agents.pi_agent.harness import PI_HARNESS
@@ -8,6 +10,7 @@ from sculptor.interfaces.agents.agent import BackgroundTaskNotificationAgentMess
 from sculptor.interfaces.agents.agent import BackgroundTaskStartedAgentMessage
 from sculptor.interfaces.agents.agent import ContextClearedMessage
 from sculptor.interfaces.agents.agent import PartialResponseBlockAgentMessage
+from sculptor.interfaces.agents.agent import PersistentRequestCompleteAgentMessage
 from sculptor.interfaces.agents.agent import PlanModeAgentMessage
 from sculptor.interfaces.agents.agent import RemoveQueuedMessageAgentMessage
 from sculptor.interfaces.agents.agent import RequestFailureAgentMessage
@@ -1159,6 +1162,93 @@ def test_preserved_pending_question_cleared_when_new_chat_turn_starts() -> None:
         harness=CLAUDE_CODE_HARNESS,
         completed_message_by_id=completed_by_id,
         current_state=state,
+    )
+
+    assert state.pending_user_question is None
+
+
+def _replay_two_auq_turn_answered_once(
+    make_terminal_message: Callable[[AgentMessageID], PersistentRequestCompleteAgentMessage],
+) -> TaskUpdate:
+    """Replay a pi turn whose single assistant message carries TWO
+    ask_user_question tool calls, where only the second was answered before the
+    turn terminated, and return the fully recomputed state (as the send-message
+    gate and the reload path compute it).
+
+    ``make_terminal_message`` builds the asking turn's terminal message from its
+    request id so both the interrupted-success and user-stop variants share the
+    setup.
+    """
+    task_id = TaskID()
+
+    user_message = ChatInputUserMessage(text="Ask me two questions", model_name=LLMModel.CLAUDE_4_SONNET)
+    first_tool_block = ToolUseBlock(
+        id=ToolUseID("ask_user_question:4"),
+        name="ask_user_question",
+        input={"question": "Which facets make the cut?", "options": ["All 8", "Core 5"]},
+    )
+    second_tool_block = ToolUseBlock(
+        id=ToolUseID("ask_user_question:5"),
+        name="ask_user_question",
+        input={"question": "How aggressive should the skill be?", "options": ["Full", "Partial"]},
+    )
+    response = ResponseBlockAgentMessage(
+        role="assistant",
+        assistant_message_id=AssistantMessageID("assistant-two-auqs"),
+        message_id=AgentMessageID(),
+        content=(first_tool_block, second_tool_block),
+    )
+    second_question_data = build_ask_user_question_data(
+        "How aggressive should the skill be?", ["Full", "Partial"], tool_use_id="ask_user_question:5"
+    )
+    answer = UserQuestionAnswerMessage(
+        message_id=AgentMessageID(),
+        answers={"How aggressive should the skill be?": "Partial"},
+        question_data=second_question_data,
+        tool_use_id="ask_user_question:5",
+    )
+    return convert_agent_messages_to_task_update(
+        [
+            user_message,
+            RequestStartedAgentMessage(request_id=user_message.message_id),
+            response,
+            answer,
+            RequestStartedAgentMessage(request_id=answer.message_id),
+            # The answer-delivery turn finalizes first, detaching
+            # current_request_id from the asking turn...
+            RequestSuccessAgentMessage(request_id=answer.message_id),
+            # ...so the asking turn's terminal no longer matches the active request.
+            make_terminal_message(user_message.message_id),
+        ],
+        task_id=task_id,
+        harness=PI_HARNESS,
+        completed_message_by_id={},
+        current_state=None,
+    )
+
+
+def test_unanswered_question_cleared_when_interrupted_success_detached_by_answer_turn() -> None:
+    """An interrupted RequestSuccess terminates the asking turn, so its pending
+    questions are no longer answerable and must clear — even when an
+    answer-delivery turn finalized in between and detached current_request_id
+    from the asking turn. Otherwise the unanswered question stays pending
+    forever and every subsequent message send is rejected with a 409."""
+    state = _replay_two_auq_turn_answered_once(
+        lambda request_id: RequestSuccessAgentMessage(request_id=request_id, interrupted=True)
+    )
+
+    assert state.pending_user_question is None
+
+
+def test_unanswered_question_cleared_when_user_stop_detached_by_answer_turn() -> None:
+    """Same detachment, through the user-stop terminal: an explicit Stop dismisses
+    the pending question even when an answer turn finalized in between."""
+    state = _replay_two_auq_turn_answered_once(
+        lambda request_id: RequestStoppedAgentMessage(
+            request_id=request_id,
+            error=_make_serialized_exception("Agent died with exit code 143"),
+            stopped_by_user=True,
+        )
     )
 
     assert state.pending_user_question is None


### PR DESCRIPTION
## Original bug

An agent (pi harness) became permanently unresponsive: every message send was rejected with `HTTPException: Cannot send a message while the agent is waiting for a response to AskUserQuestion.` — even though the visible question had already been answered and no question panel was showing.

## Hypotheses considered

1. The backend's send-gate (`convert_agent_messages_to_task_update` recompute in the messages endpoint) was re-pending an unanswered question from the persisted log that the UI had already dismissed — **REPRODUCED** (replayed the affected task's persisted `saved_agent_message` rows through the function: `pending_user_questions == ['ask_user_question:4']` on unfixed code, `[]` after the fix).
2. The frontend reducer was dropping a null `pendingUserQuestion` update — **DISCARDED** — the backend's authoritative recompute from the persisted log was itself stuck, so the 409 was real regardless of frontend state.

## Repro steps

1. An agent turn's single assistant message carries **two** `ask_user_question` tool calls (here via the pi harness, tool_use ids `ask_user_question:4` and `:5`).
2. Only one (`:5`) is answered by the user; the answer-delivery turn finalizes (its own `RequestStarted`/`RequestSuccess`), which detaches `current_request_id` from the asking turn.
3. The asking turn terminates (`RequestSuccess(interrupted=True)`, or a user-initiated stop).
4. Send any new message to the agent.

**Expected vs actual**
- Expected: the terminated turn's pending questions clear, the chat input is usable, message sends succeed.
- Actual: the unanswered `:4` stays pending forever; every send is rejected with a 409 and there is no way to recover.

**Before**

Reproduced end-to-end with the manual QA harness (two-subagent AUQ FakeClaude flow: answer one of two pending questions, then click Stop instead of answering the second). The question panel stays stuck open, the chat input disappears, and a direct POST returns the exact production error:

```
HTTP 409 {"detail":"Cannot send a message while the agent is waiting for a response to AskUserQuestion."}
```

## Root cause

`convert_agent_messages_to_task_update` (`sculptor/sculptor/web/message_conversion.py`) clears pending AUQs when a turn terminates interrupted (`RequestSuccess(interrupted=True)`) or is stopped by the user (`RequestStopped(stopped_by_user=True)`). Both clears were gated on `can_finalize` — `current_request_id == msg.request_id`. But `UserQuestionAnswerMessage` sets `current_request_id` to the answer's id, and the answer's own `RequestSuccess` finalizes and resets it to `None`, so the asking turn's terminal arrives with `can_finalize=False` and the clear never runs. The reconstruction from persisted `ToolUseBlock`s then re-pends the never-answered question on every recompute — including in the send-message gate, which 409s every subsequent message.

## Fix

An interrupted success and a user-initiated stop are only ever emitted as a *turn's* terminal (verified against all emit sites), so their pending-question clearing now runs even when the terminal is not the active request. The remaining side effects (stopped footer, turn metrics, streaming reset) stay behind `can_finalize`, and the SCU-1801 semantics — a stop the user did not ask for (restart SIGTERM) preserves pending questions so they stay answerable after resume — are untouched.

## Test

- Path: `sculptor/sculptor/web/message_conversion_test.py`
- Kind: backend unit (a deterministic UI repro requires a turn with two main-thread AUQ calls in one assistant message, a mid-turn answer, and an interrupt — a sequence integration tests cannot produce on demand; verified end-to-end via the nearest reachable path, two concurrent subagent AUQs, in the manual QA harness instead)
- Failing-test commit: `848fda8b`
- Fix commit: `ad6f6a92`

Failing on pre-fix code:

```
FAILED .../message_conversion_test.py::test_unanswered_question_cleared_when_interrupted_success_detached_by_answer_turn
FAILED .../message_conversion_test.py::test_unanswered_question_cleared_when_user_stop_detached_by_answer_turn
2 failed, 94 deselected
```

Passing with the fix:

```
96 passed
```

## After

Same workspace, same persisted message log, backend restarted on the fixed code: the stuck question panel is gone, the chat input is back, a sent message is accepted and answered, and the agent turn completes. Before/after screenshots were captured via the auto-QA harness and are available on request (they live on a dev machine, not attachable here). Additionally, the affected production task's real persisted message log replays to `pending_user_questions == []` under the fix, so already-stuck tasks recover on upgrade with no migration.

## Deferred follow-ups

- The pi wrapper's `_pending_backchannel_tool_call_id` (`agents/pi_agent/agent_wrapper.py`) is set per backchannel tool call and never cleared, so when one assistant message carries two AUQ calls a later dialog can adopt the other's tool-call id — the question it surfaces can then never retire the right pending entry. This is the pi-side defect that produced this incident's log shape; it needs its own fix with pi-side testing.

## Review notes

_(no outstanding review notes — one self-review pass ran; the findings acted on were comment-hygiene issues in my own additions, fixed in follow-up edits)_

(Sent by Claude)
