### PR TITLE
Reuse one browser tab per PR/pipeline link in the web build

### DIFF
--- a/sculptor/frontend/src/common/reusableTabTarget.test.ts
+++ b/sculptor/frontend/src/common/reusableTabTarget.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openInReusableTab, reusableTabTarget } from "./reusableTabTarget.ts";
+
+const PR_URL = "https://github.com/imbue-ai/sculptor/pull/392";
+
+describe("reusableTabTarget", () => {
+  it("is stable: the same URL always maps to the same tab name", () => {
+    expect(reusableTabTarget(PR_URL)).toBe(reusableTabTarget(PR_URL));
+  });
+
+  it("is distinct: different URLs map to different tab names", () => {
+    expect(reusableTabTarget("https://github.com/o/r/pull/1")).not.toBe(
+      reusableTabTarget("https://github.com/o/r/pull/2"),
+    );
+    // Same PR number in a different repo must not collapse into one tab.
+    expect(reusableTabTarget("https://github.com/a/repo/pull/5")).not.toBe(
+      reusableTabTarget("https://github.com/b/repo/pull/5"),
+    );
+  });
+
+  it("never returns _blank, which forces a fresh tab on every click", () => {
+    expect(reusableTabTarget(PR_URL)).not.toBe("_blank");
+  });
+
+  it("namespaces the name so it can't collide with a non-Sculptor window", () => {
+    expect(reusableTabTarget(PR_URL)).toMatch(/^sculptor:/);
+  });
+});
+
+describe("openInReusableTab", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens the URL in its stable, reusable named tab", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    openInReusableTab(PR_URL);
+    expect(open).toHaveBeenCalledWith(PR_URL, reusableTabTarget(PR_URL));
+  });
+
+  it("does not pass noopener/noreferrer, which would defeat tab reuse", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    openInReusableTab(PR_URL);
+    // Exactly (url, target): a third 'features' argument with noopener/noreferrer
+    // would make the browser treat the named target as _blank and spawn a new tab.
+    const call = open.mock.calls[0];
+    expect(call).toHaveLength(2);
+    expect(call[1]).not.toBe("_blank");
+    expect(String(call[2] ?? "")).not.toContain("noopener");
+  });
+});

--- a/sculptor/frontend/src/common/reusableTabTarget.ts
+++ b/sculptor/frontend/src/common/reusableTabTarget.ts
@@ -1,0 +1,28 @@
+/**
+ * Naming for outbound-link browser tabs so that re-opening the *same* URL reuses
+ * its existing tab instead of piling up a fresh one on every click, while
+ * distinct URLs still get their own tabs. Every caller that opens a given URL
+ * must route through this so they all agree on one tab.
+ *
+ * This only takes effect in the **web build**, where the browser honours the
+ * window name and navigates (and, in most browsers, focuses) the matching tab.
+ * In the Electron desktop app every outbound link is routed through the main
+ * process to `shell.openExternal`, which drops the name and hands the OS only
+ * the URL, so a named target is a harmless no-op there.
+ *
+ * Tab reuse is mutually exclusive with `noopener` / `noreferrer`: the HTML spec
+ * treats either as forcing a fresh (`_blank`) context, so we deliberately open
+ * without them. The opened tab therefore keeps a `window.opener` back-reference,
+ * so only ever point this at trusted hosts (the user's own git provider).
+ */
+
+// Namespaced so a Sculptor tab can never collide with an unrelated window a site
+// happened to name after the same URL. The full URL keeps the name unique per
+// PR/pipeline (two repos with the same PR number don't share a tab).
+const TAB_TARGET_PREFIX = "sculptor:";
+
+export const reusableTabTarget = (url: string): string => `${TAB_TARGET_PREFIX}${url}`;
+
+export const openInReusableTab = (url: string): void => {
+  window.open(url, reusableTabTarget(url));
+};

--- a/sculptor/frontend/src/components/CommandPalette/contextActions/useGitAndOpenInRuntime.ts
+++ b/sculptor/frontend/src/components/CommandPalette/contextActions/useGitAndOpenInRuntime.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import type { ExternalApp, Workspace } from "../../../api";
 import { WorkspaceInitializationStrategy } from "../../../api";
 import { openPathInExternalApp } from "../../../common/openInApp/items.tsx";
+import { openInReusableTab } from "../../../common/reusableTabTarget.ts";
 import { getBackendCapabilities } from "../../../common/state/atoms/backendCapabilities.ts";
 import { chatActionsAtom } from "../../../common/state/atoms/chatActions.ts";
 import { prStatusAtomFamily } from "../../../common/state/atoms/prStatus.ts";
@@ -69,7 +70,7 @@ export const useGitAndOpenInRuntime = (): GitAndOpenInRuntime => {
       openMergeRequest: (ws): void => {
         const prStatus = store.get(prStatusAtomFamily(ws.objectId));
         const url = prStatus?.prWebUrl;
-        if (url) window.open(url, "_blank");
+        if (url) openInReusableTab(url);
       },
       openInApp: (ws, app): void => {
         const repoInfo = store.get(repoInfoAtomFamily(ws.projectId));

--- a/sculptor/frontend/src/pages/workspace/components/PrButton.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/PrButton.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PrStatusInfo } from "~/api";
+import { ElementIds } from "~/api";
+import { reusableTabTarget } from "~/common/reusableTabTarget.ts";
+import { prStatusAtomFamily } from "~/common/state/atoms/prStatus.ts";
+import { renderWithProviders } from "~/common/testUtils.tsx";
+
+import { PrButton } from "./PrButton.tsx";
+
+// posthog isn't initialised in tests; the button captures an analytics event
+// on click, so stub it to a no-op.
+vi.mock("posthog-js", () => ({ posthog: { capture: vi.fn() } }));
+
+const WORKSPACE_ID = "ws-pr-1";
+const PR_URL = "https://github.com/imbue-ai/sculptor/pull/392";
+
+const storeWith = (status: PrStatusInfo): ReturnType<typeof createStore> => {
+  const store = createStore();
+  store.set(prStatusAtomFamily(WORKSPACE_ID), status);
+  return store;
+};
+
+const prStatus = (overrides: Partial<PrStatusInfo>): PrStatusInfo => ({
+  workspaceId: WORKSPACE_ID,
+  prState: "open",
+  prIid: 392,
+  prWebUrl: PR_URL,
+  ...overrides,
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("PrButton opens PRs in a reusable browser tab", () => {
+  it("opens an open PR in its stable named tab, not _blank", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderWithProviders(<PrButton workspaceId={WORKSPACE_ID} targetBranch="origin/main" gitProvider="github" />, {
+      store: storeWith(prStatus({ prState: "open" })),
+    });
+
+    fireEvent.click(screen.getByTestId(ElementIds.PR_BUTTON_OPEN));
+
+    expect(open).toHaveBeenCalledWith(PR_URL, reusableTabTarget(PR_URL));
+    expect(open).not.toHaveBeenCalledWith(PR_URL, "_blank");
+  });
+
+  it("opens a merged PR in the same reusable tab as the open PR", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderWithProviders(<PrButton workspaceId={WORKSPACE_ID} targetBranch="origin/main" gitProvider="github" />, {
+      store: storeWith(prStatus({ prState: "merged" })),
+    });
+
+    fireEvent.click(screen.getByTestId(ElementIds.PR_BUTTON_MERGED));
+
+    expect(open).toHaveBeenCalledWith(PR_URL, reusableTabTarget(PR_URL));
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/components/PrButton.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/PrButton.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { PrStatusInfo } from "../../../api";
 import { ElementIds } from "../../../api";
+import { openInReusableTab } from "../../../common/reusableTabTarget.ts";
 import { chatActionsAtom } from "../../../common/state/atoms/chatActions.ts";
 import { prStatusAtomFamily } from "../../../common/state/atoms/prStatus.ts";
 import { prCreationPromptAtom } from "../../../common/state/atoms/userConfig.ts";
@@ -202,7 +203,7 @@ const OpenPrButton = ({ prStatus, isDropdownOpen, gitProvider }: OpenPrButtonPro
         git_provider: gitProvider,
         pr_state: "open",
       });
-      window.open(prStatus.prWebUrl, "_blank");
+      openInReusableTab(prStatus.prWebUrl);
     }
   };
 
@@ -251,7 +252,7 @@ const MergedPrButton = ({ prStatus, gitProvider }: MergedPrButtonProps): ReactEl
         git_provider: gitProvider,
         pr_state: "merged",
       });
-      window.open(prStatus.prWebUrl, "_blank");
+      openInReusableTab(prStatus.prWebUrl);
     }
   };
 

--- a/sculptor/frontend/src/pages/workspace/components/PrDetailDropdown.test.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/PrDetailDropdown.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, screen } from "@testing-library/react";
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { PrStatusInfo } from "~/api";
+import { reusableTabTarget } from "~/common/reusableTabTarget.ts";
+import { renderWithProviders } from "~/common/testUtils.tsx";
+
+import { PrDetailDropdown } from "./PrDetailDropdown.tsx";
+
+const WORKSPACE_ID = "ws-pr-1";
+const PR_URL = "https://github.com/imbue-ai/sculptor/pull/392";
+const PIPELINE_URL = "https://github.com/imbue-ai/sculptor/actions/runs/12345";
+
+const prStatus = (overrides: Partial<PrStatusInfo>): PrStatusInfo => ({
+  workspaceId: WORKSPACE_ID,
+  prState: "open",
+  prIid: 392,
+  prTitle: "Reuse browser tabs for PR links",
+  prWebUrl: PR_URL,
+  pipelineStatus: "passed",
+  pipelineId: 12345,
+  pipelineWebUrl: PIPELINE_URL,
+  ...overrides,
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PrDetailDropdown links target reusable tabs", () => {
+  it("points the PR title link at the PR's reusable tab, not _blank", () => {
+    renderWithProviders(<PrDetailDropdown prStatus={prStatus({})} />, { store: createStore() });
+
+    const prLink = screen.getByRole("link", { name: /Reuse browser tabs for PR links/ });
+    expect(prLink).toHaveAttribute("target", reusableTabTarget(PR_URL));
+    expect(prLink).not.toHaveAttribute("target", "_blank");
+  });
+
+  it("points the pipeline link at its own reusable tab, distinct from the PR tab", () => {
+    renderWithProviders(<PrDetailDropdown prStatus={prStatus({})} />, { store: createStore() });
+
+    const pipelineLink = screen.getByRole("link", { name: "#12345" });
+    expect(pipelineLink).toHaveAttribute("target", reusableTabTarget(PIPELINE_URL));
+    expect(reusableTabTarget(PIPELINE_URL)).not.toBe(reusableTabTarget(PR_URL));
+  });
+});

--- a/sculptor/frontend/src/pages/workspace/components/PrDetailDropdown.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/PrDetailDropdown.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 
 import type { PrStatusInfo } from "../../../api";
 import { ElementIds } from "../../../api";
+import { reusableTabTarget } from "../../../common/reusableTabTarget.ts";
 import {
   ciBabysitterStatusAtomFamily,
   fetchCiBabysitterStatusAtom,
@@ -113,7 +114,14 @@ export const PrDetailDropdown = ({ prStatus }: PrDetailDropdownProps): ReactElem
     <div className={styles.dropdown} data-testid={ElementIds.PR_DROPDOWN}>
       <Flex align="center" gap="2" mb="3">
         {prStatus.prWebUrl ? (
-          <Link size="2" weight="medium" href={prStatus.prWebUrl} target="_blank" style={{ flex: 1 }} truncate>
+          <Link
+            size="2"
+            weight="medium"
+            href={prStatus.prWebUrl}
+            target={reusableTabTarget(prStatus.prWebUrl)}
+            style={{ flex: 1 }}
+            truncate
+          >
             {prStatus.prTitle ?? `#${prStatus.prIid}`}
             <ExternalLinkIcon size={12} style={{ marginLeft: "var(--space-1)", verticalAlign: "middle" }} />
           </Link>
@@ -133,7 +141,7 @@ export const PrDetailDropdown = ({ prStatus }: PrDetailDropdownProps): ReactElem
             {getPipelineBadge(prStatus.pipelineStatus)}
             {prStatus.pipelineId != null &&
               (prStatus.pipelineWebUrl ? (
-                <Link size="1" href={prStatus.pipelineWebUrl} target="_blank">
+                <Link size="1" href={prStatus.pipelineWebUrl} target={reusableTabTarget(prStatus.pipelineWebUrl)}>
                   #{prStatus.pipelineId}
                 </Link>
               ) : (

--- a/sculptor/frontend/src/pages/workspace/components/WorkspacePeekPopover.tsx
+++ b/sculptor/frontend/src/pages/workspace/components/WorkspacePeekPopover.tsx
@@ -6,6 +6,7 @@ import { type CSSProperties, type ReactElement, useCallback, useEffect, useMemo,
 import type { CodingAgentTaskView, PrStatusInfo } from "~/api";
 import { ElementIds, WorkspacePeekAgentStatus } from "~/api";
 import { useTimedLatch } from "~/common/Hooks.ts";
+import { reusableTabTarget } from "~/common/reusableTabTarget.ts";
 import { prStatusAtomFamily } from "~/common/state/atoms/prStatus";
 import { tasksArrayAtom } from "~/common/state/atoms/tasks";
 import { useProject, useProjects } from "~/common/state/hooks/useProjects";
@@ -238,8 +239,7 @@ const PeekHeader = ({
         <a
           className={styles.mrPill}
           href={prStatus.prWebUrl ?? "#"}
-          target="_blank"
-          rel="noopener noreferrer"
+          target={reusableTabTarget(prStatus.prWebUrl ?? "#")}
           onClick={(e) => e.stopPropagation()}
         >
           PR #{prStatus.prIid}

--- a/sculptor/frontend/src/pages/workspace/mobile/ChangesPill.tsx
+++ b/sculptor/frontend/src/pages/workspace/mobile/ChangesPill.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ElementIds, type PrStatusInfo } from "~/api";
 import { useWorkspacePageParams } from "~/common/NavigateUtils.ts";
+import { openInReusableTab } from "~/common/reusableTabTarget.ts";
 import { prStatusAtomFamily } from "~/common/state/atoms/prStatus.ts";
 import { useWorkspace } from "~/common/state/hooks/useWorkspace.ts";
 import { useGitAndOpenInRuntime } from "~/components/CommandPalette/contextActions/useGitAndOpenInRuntime.ts";
@@ -134,7 +135,7 @@ export const ChangesPill = ({ onReviewAll }: ChangesPillProps): ReactElement | n
   const prPrefix = "#";
 
   const openPrUrl = (): void => {
-    if (prStatus?.prWebUrl) window.open(prStatus.prWebUrl, "_blank", "noopener,noreferrer");
+    if (prStatus?.prWebUrl) openInReusableTab(prStatus.prWebUrl);
   };
 
   const renderPrControl = (): ReactElement | null => {


### PR DESCRIPTION
## What

Opening a PR from the PR button, its detail dropdown, the pipeline link, the mobile changes pill, the command palette, or the workspace peek popover used `target="_blank"` / `window.open(url, "_blank")` — which spawns a fresh browser tab on every click. After a few rounds, duplicate tabs for the same PR pile up.

This routes every PR/pipeline open through a small shared helper (`reusableTabTarget` / `openInReusableTab`) that gives each URL a **stable, per-URL window name**. Re-opening the same URL now navigates its existing tab; distinct URLs still get their own. Two repos that happen to share a PR number don't collide, because the name is keyed on the full URL.

## Why this is web-only (and what's deliberately left out)

The change only affects the **web build**, where the browser honours the window name. In the **Electron desktop app** every outbound link is funnelled through the main process to `shell.openExternal`, which hands the OS only the URL and drops the name — so a named target is a harmless no-op there, and desktop still opens one external-browser tab per click.

Deduping tabs in the *external* browser from the desktop app is a genuinely harder problem and is **not** addressed here. A stateless "redirect through a server page" approach can't do it — verified across Chromium, Firefox, and WebKit: named-target reuse is bound to the exact tab instance that opened the window, so an ephemeral launcher can't reuse a tab a previous one created. Fixing desktop would need either an in-app browser view or a persistent relay tab; deferred as a follow-up.

## Tradeoff worth noting

Tab reuse is mutually exclusive with `noopener` / `noreferrer` — the HTML spec treats either as forcing a fresh (`_blank`) context. The two sites that set them now open without them, so the opened tab keeps a `window.opener` back-reference. That's acceptable here because the destination is always the user's own git provider (a trusted host that also sends `COOP`). The constraint is documented in the helper so it isn't "fixed" back into a regression.

## Tests

- Unit tests for the helper: stable-per-URL, distinct-across-URLs (incl. same PR number in different repos), never `_blank`, and that `openInReusableTab` passes no `noopener` features arg.
- Component tests: `PrButton` (open + merged) opens via the reusable target, not `_blank`; `PrDetailDropdown` anchors carry the reusable target and get distinct tabs.
- Full frontend unit suite green; `tsc` and eslint clean.

(Sent by Claude)
