### PR TITLE
Bump Sculptor version to v0.46.0.dev0

### DIFF
--- a/sculptor/pyproject.toml
+++ b/sculptor/pyproject.toml
@@ -7,7 +7,7 @@ name = "sculptor"
 
 # Non-release branches (including main) must always use a .dev suffix (e.g. 0.10.0.dev0).
 # Release branches set the concrete version (e.g. 0.10.0 or 0.10.0rc1).
-version = "0.45.0.dev0"
+version = "0.46.0.dev0"
 
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ dev = [
 
 [[package]]
 name = "sculptor"
-version = "0.45.0.dev0"
+version = "0.46.0.dev0"
 source = { editable = "sculptor" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Automated version bump after cutting release branch `release/sculptor-v0.45.0` (RC `0.45.0rc1`).

Note: commit 4eeb78c1249d30d284aa30d652a66c9ac5eb69cd is the last commit on main versioned as `0.45.0.dev0`. Any commits merged between that point and this MR will carry the old version.