### PR TITLE
ci: bump pinned offload 0.9.12 → 0.9.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,7 +45,7 @@ RUN bash -c "source /root/.nvm/nvm.sh && nvm use $NODE_VERSION && corepack enabl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable --profile minimal \
     && . "$HOME/.cargo/env" \
-    && cargo install offload@0.9.12 \
+    && cargo install offload@0.9.13 \
     && mv /root/.cargo/bin/offload /usr/local/bin/offload \
     && rustup self uninstall -y \
     && rm -rf /root/.cargo /root/.rustup

--- a/.github/workflows/offload.yml
+++ b/.github/workflows/offload.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  OFFLOAD_VERSION: "0.9.12"
+  OFFLOAD_VERSION: "0.9.13"
 
 jobs:
   offload-integration-tests:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  OFFLOAD_VERSION: "0.9.12"
+  OFFLOAD_VERSION: "0.9.13"
 
 permissions:
   # contents: write -> push refs/notes/perf on main. pull-requests: write ->


### PR DESCRIPTION
## Summary

Bump the pinned `offload` version from **0.9.12** to **0.9.13** everywhere it is installed, so the devcontainer image and the offload/perf CI workflows all run the same, newer offload release.

## Changes

| File | Change |
|---|---|
| `.devcontainer/Dockerfile` | `cargo install offload@0.9.12` → `@0.9.13` |
| `.github/workflows/offload.yml` | `OFFLOAD_VERSION: "0.9.12"` → `"0.9.13"` |
| `.github/workflows/perf.yml` | `OFFLOAD_VERSION: "0.9.12"` → `"0.9.13"` |

The other `OFFLOAD_VERSION` references in those workflows read the env var, so they update automatically. A repo-wide sweep confirms no other `0.9.12` pins remain.

## Notes

- Change is limited to CI config and the devcontainer image — no application code is touched.
- `just check-file-hygiene` passes. `just check-yaml` reports a pre-existing failure that also affects files unrelated to this change (and files on `main`); it is not introduced by this PR.

(Sent by Claude)
