### PR TITLE
Cache the settings snapshot per process and retake it after port resolution

### DIFF
--- a/sculptor/sculptor/cli/app.py
+++ b/sculptor/sculptor/cli/app.py
@@ -54,6 +54,21 @@ class SyncCloseServer(Server):
         await super()._wait_tasks_to_complete()
 
 
+def resolve_and_publish_backend_port(port_option: int | None) -> int:
+    """Resolve the port the server will listen on and publish it process-wide.
+
+    Downstream code (agent/terminal environment setup, the service collection)
+    reads the port from the cached settings snapshot, so after publishing
+    SCULPTOR_API_PORT the snapshot must be retaken — the CLI has already primed
+    it (for logging config) before the --port option is applied. This must
+    remain the last startup write to os.environ that settings care about.
+    """
+    port = port_option or get_settings().BACKEND_PORT
+    os.environ["SCULPTOR_API_PORT"] = str(port)
+    get_settings.cache_clear()
+    return port
+
+
 def cmd_version(value: bool) -> None:
     """Print the Sculptor version."""
     if value:
@@ -118,11 +133,7 @@ def main(
     # We either successfully initialize the config from file, or need to perform onboarding.
     initialize_from_file()
 
-    # Using the globally configured user_config
-    port = port or get_settings().BACKEND_PORT
-    # Publish the resolved port so downstream code (e.g. agent environment
-    # setup) sees the actual port the server is listening on, not the default.
-    os.environ["SCULPTOR_API_PORT"] = str(port)
+    port = resolve_and_publish_backend_port(port)
 
     # Print version of Sculptor that is running
     typer.echo("Starting Sculptor server version " + sculptor_version.__version__)

--- a/sculptor/sculptor/cli/app.py
+++ b/sculptor/sculptor/cli/app.py
@@ -63,7 +63,7 @@ def resolve_and_publish_backend_port(port_option: int | None) -> int:
     it (for logging config) before the --port option is applied. This must
     remain the last startup write to os.environ that settings care about.
     """
-    port = port_option or get_settings().BACKEND_PORT
+    port = port_option if port_option is not None else get_settings().BACKEND_PORT
     os.environ["SCULPTOR_API_PORT"] = str(port)
     get_settings.cache_clear()
     return port

--- a/sculptor/sculptor/cli/app_test.py
+++ b/sculptor/sculptor/cli/app_test.py
@@ -1,0 +1,49 @@
+"""Tests for the CLI startup helpers (``sculptor.cli.app``)."""
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from sculptor.cli.app import resolve_and_publish_backend_port
+from sculptor.config.settings import DEFAULT_BACKEND_PORT
+from sculptor.web.middleware import get_settings
+
+
+@pytest.fixture
+def fresh_settings_cache() -> Iterator[None]:
+    """Isolate these tests from any get_settings() call elsewhere in the
+    pytest process, and leave no snapshot behind for later tests."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_explicit_port_is_published_and_visible_in_the_settings_snapshot(
+    fresh_settings_cache: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The CLI primes the settings cache (for logging config) before the --port
+    # option is applied. The helper must retake the snapshot afterwards, or
+    # every consumer of settings.BACKEND_PORT (agent env setup, the service
+    # collection) would see the pre-publish port instead of the one the server
+    # actually listens on.
+    monkeypatch.delenv("SCULPTOR_API_PORT", raising=False)
+    assert get_settings().BACKEND_PORT == DEFAULT_BACKEND_PORT
+
+    port = resolve_and_publish_backend_port(14242)
+
+    assert port == 14242
+    assert os.environ["SCULPTOR_API_PORT"] == "14242"
+    assert get_settings().BACKEND_PORT == 14242
+
+
+def test_default_port_comes_from_settings_and_is_republished(
+    fresh_settings_cache: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCULPTOR_API_PORT", "6060")
+
+    port = resolve_and_publish_backend_port(None)
+
+    assert port == 6060
+    assert os.environ["SCULPTOR_API_PORT"] == "6060"
+    assert get_settings().BACKEND_PORT == 6060

--- a/sculptor/sculptor/cli/app_test.py
+++ b/sculptor/sculptor/cli/app_test.py
@@ -22,11 +22,6 @@ def fresh_settings_cache() -> Iterator[None]:
 def test_explicit_port_is_published_and_visible_in_the_settings_snapshot(
     fresh_settings_cache: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The CLI primes the settings cache (for logging config) before the --port
-    # option is applied. The helper must retake the snapshot afterwards, or
-    # every consumer of settings.BACKEND_PORT (agent env setup, the service
-    # collection) would see the pre-publish port instead of the one the server
-    # actually listens on.
     monkeypatch.delenv("SCULPTOR_API_PORT", raising=False)
     assert get_settings().BACKEND_PORT == DEFAULT_BACKEND_PORT
 

--- a/sculptor/sculptor/cli/app_test.py
+++ b/sculptor/sculptor/cli/app_test.py
@@ -42,3 +42,16 @@ def test_default_port_comes_from_settings_and_is_republished(
     assert port == 6060
     assert os.environ["SCULPTOR_API_PORT"] == "6060"
     assert get_settings().BACKEND_PORT == 6060
+
+
+def test_explicit_port_zero_is_respected_not_treated_as_unset(
+    fresh_settings_cache: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SCULPTOR_API_PORT", raising=False)
+    assert get_settings().BACKEND_PORT == DEFAULT_BACKEND_PORT
+
+    port = resolve_and_publish_backend_port(0)
+
+    assert port == 0
+    assert os.environ["SCULPTOR_API_PORT"] == "0"
+    assert get_settings().BACKEND_PORT == 0

--- a/sculptor/sculptor/web/middleware.py
+++ b/sculptor/sculptor/web/middleware.py
@@ -3,6 +3,7 @@ import signal
 from collections.abc import Mapping
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
+from functools import cache
 from functools import wraps
 from threading import Event
 from threading import Thread
@@ -84,8 +85,18 @@ def mount_extension_files(app: FastAPI) -> None:
     )
 
 
-# Note that this is overridden in tests to use the test settings
+# Note that this is overridden in tests to use the test settings (FastAPI
+# dependency overrides bypass the function entirely, so the cache is inert there).
+@cache
 def get_settings() -> SculptorSettings:
+    """Parse settings from the environment once, at first request.
+
+    SculptorSettings is a frozen snapshot of server settings that "do not change
+    during runtime" (see its docstring) — but without the cache each
+    Depends(get_settings) re-parsed os.environ per request, so any runtime env
+    perturbation would silently flip settings-gated behavior mid-session (e.g.
+    the FakeClaude model gate, SCU-1809).
+    """
     return SculptorSettings()
 
 

--- a/sculptor/sculptor/web/middleware.py
+++ b/sculptor/sculptor/web/middleware.py
@@ -89,13 +89,15 @@ def mount_extension_files(app: FastAPI) -> None:
 # dependency overrides bypass the function entirely, so the cache is inert there).
 @cache
 def get_settings() -> SculptorSettings:
-    """Parse settings from the environment once, at first request.
+    """Parse settings from the environment once, at first call.
 
-    SculptorSettings is a frozen snapshot of server settings that "do not change
-    during runtime" (see its docstring) — but without the cache each
-    Depends(get_settings) re-parsed os.environ per request, so any runtime env
-    perturbation would silently flip settings-gated behavior mid-session (e.g.
-    the FakeClaude model gate, SCU-1809).
+    SculptorSettings is a process-lifetime snapshot of server settings that "do
+    not change during runtime" (see its docstring). Re-parsing os.environ on
+    every Depends(get_settings) would let a runtime env perturbation silently
+    flip settings-gated behavior mid-session (e.g. the FakeClaude model gate).
+    The CLI retakes the snapshot once after publishing the resolved port (see
+    resolve_and_publish_backend_port); nothing else may mutate settings-relevant
+    env after startup.
     """
     return SculptorSettings()
 

--- a/sculptor/sculptor/web/middleware.py
+++ b/sculptor/sculptor/web/middleware.py
@@ -85,8 +85,7 @@ def mount_extension_files(app: FastAPI) -> None:
     )
 
 
-# Note that this is overridden in tests to use the test settings (FastAPI
-# dependency overrides bypass the function entirely, so the cache is inert there).
+# Note that this is overridden in tests to use the test settings
 @cache
 def get_settings() -> SculptorSettings:
     """Parse settings from the environment once, at first call.

--- a/sculptor/sculptor/web/middleware_test.py
+++ b/sculptor/sculptor/web/middleware_test.py
@@ -1,10 +1,12 @@
+from collections.abc import Iterator
+
 import pytest
 
 from sculptor.web.middleware import get_settings
 
 
 @pytest.fixture
-def fresh_settings_cache():
+def fresh_settings_cache() -> Iterator[None]:
     """Isolate this module's tests from any get_settings() call elsewhere in the
     pytest process, and leave no snapshot behind for later tests."""
     get_settings.cache_clear()
@@ -12,12 +14,12 @@ def fresh_settings_cache():
     get_settings.cache_clear()
 
 
-def test_get_settings_returns_the_same_snapshot_every_call(fresh_settings_cache) -> None:
+def test_get_settings_returns_the_same_snapshot_every_call(fresh_settings_cache: None) -> None:
     assert get_settings() is get_settings()
 
 
 def test_get_settings_snapshot_is_immune_to_runtime_env_changes(
-    fresh_settings_cache, monkeypatch: pytest.MonkeyPatch
+    fresh_settings_cache: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Settings are parsed from the environment once; a runtime env perturbation
     # must not flip settings-gated behavior mid-session (e.g. the FakeClaude

--- a/sculptor/sculptor/web/middleware_test.py
+++ b/sculptor/sculptor/web/middleware_test.py
@@ -1,0 +1,31 @@
+import pytest
+
+from sculptor.web.middleware import get_settings
+
+
+@pytest.fixture
+def fresh_settings_cache():
+    """Isolate this module's tests from any get_settings() call elsewhere in the
+    pytest process, and leave no snapshot behind for later tests."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_get_settings_returns_the_same_snapshot_every_call(fresh_settings_cache) -> None:
+    assert get_settings() is get_settings()
+
+
+def test_get_settings_snapshot_is_immune_to_runtime_env_changes(
+    fresh_settings_cache, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Settings are parsed from the environment once; a runtime env perturbation
+    # must not flip settings-gated behavior mid-session (e.g. the FakeClaude
+    # model gate).
+    monkeypatch.setenv("TESTING__INTEGRATION_ENABLED", "true")
+    first = get_settings()
+    assert first.TESTING.INTEGRATION_ENABLED is True
+
+    monkeypatch.setenv("TESTING__INTEGRATION_ENABLED", "false")
+    assert get_settings() is first
+    assert get_settings().TESTING.INTEGRATION_ENABLED is True

--- a/sculptor/sculptor/web/middleware_test.py
+++ b/sculptor/sculptor/web/middleware_test.py
@@ -21,9 +21,6 @@ def test_get_settings_returns_the_same_snapshot_every_call(fresh_settings_cache:
 def test_get_settings_snapshot_is_immune_to_runtime_env_changes(
     fresh_settings_cache: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Settings are parsed from the environment once; a runtime env perturbation
-    # must not flip settings-gated behavior mid-session (e.g. the FakeClaude
-    # model gate).
     monkeypatch.setenv("TESTING__INTEGRATION_ENABLED", "true")
     first = get_settings()
     assert first.TESTING.INTEGRATION_ENABLED is True


### PR DESCRIPTION
## Summary

`get_settings()` previously constructed a fresh `SculptorSettings` on every
FastAPI dependency resolution, re-parsing the process environment on each
request. `SculptorSettings` documents itself as a process-lifetime snapshot of
server settings that "do not change during runtime," so re-parsing per request
was both wasteful and a latent correctness hazard: a runtime environment
perturbation could silently flip settings-gated behavior mid-session (for
example, the FakeClaude testing-model gate).

This change parses the environment once per process and caches the snapshot
(`functools.cache`). Test dependency overrides bypass the function entirely, so
they are unaffected.

Caching alone would introduce a port-ordering bug: the CLI primes the cached
snapshot early (for logging configuration) *before* the `--port` option is
applied, so on any launch that passes `--port` without the environment variable
`settings.BACKEND_PORT` would freeze at the pre-publish default. Every consumer
of `settings.BACKEND_PORT` (agent/terminal environment setup, the service
collection) would then hand agents a port pointing at the default while the
server actually listens elsewhere — this hits every `--port` launch path,
including the packaged app. The CLI now resolves the port, publishes
`SCULPTOR_API_PORT`, and retakes the snapshot as the last startup write to the
settings-relevant environment (`resolve_and_publish_backend_port`), with unit
tests pinning the ordering.

## Why

- **Performance:** the environment is parsed once per process instead of on
  every request.
- **Correctness:** settings-gated behavior can no longer be flipped by a
  mid-session environment change, and `settings.BACKEND_PORT` always matches the
  port the server actually binds.

## Provenance

Extracted from PR #383, preserving the original authorship (credit
@brydenfogelman). The two feature commits are cherry-picked unchanged with `-x`
provenance lines; no behavioral edits were made during extraction. References
SCU-1809.

Two small follow-up commits sit on top:

- **Comment cleanup** — trims a few redundant rationale comments (comment-only,
  no behavior change).
- **`--port 0` fix** — a pre-existing edge case flagged in review:
  `resolve_and_publish_backend_port` used `port_option or ...`, which treated an
  explicit `--port 0` as unset and replaced it with the default. It now guards
  on `port_option is not None` so every explicit integer port is honored, with a
  unit test pinning the zero case. (Full end-to-end `--port 0` / OS-assigned
  ephemeral-port support is intentionally out of scope — the helper still
  publishes the requested value rather than the actual bound port.)

## Verification

All commands run from the repo root:

- `just format` → OK (no changes)
- `just check` → OK (typecheck, lint, ratchets, yaml, uv-lock, shellcheck,
  file-hygiene, and the rest all pass)
- `just test-unit` → OK
  - backend: 2362 passed, 4 skipped
  - frontend: 3269 passed, 1 skipped (272 files)
  - foundation: 129 passed
  - sculpt: 381 passed
- Focused: `pytest sculptor/sculptor/web/middleware_test.py
  sculptor/sculptor/cli/app_test.py` → 5 passed

(Sent by Claude)
