### PR TITLE
Use honest HTTP status codes for hand-raised API rejections (400/409)

### DIFF
--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.tsx
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.test.tsx
@@ -223,7 +223,7 @@ describe("useCreateWorkspace agent-type gating", () => {
 
     const body = getAgentRequestBody();
     expect(body.agentType).toBe("terminal");
-    // The backend rejects a prompt for terminal/registered agents (422), so it must never be sent.
+    // The backend rejects a prompt for terminal/registered agents (400), so it must never be sent.
     expect(body.prompt).toBeUndefined();
     expect(body.model).toBeUndefined();
   });

--- a/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
+++ b/sculptor/frontend/src/common/state/hooks/useCreateWorkspace.ts
@@ -146,7 +146,7 @@ export const useCreateWorkspace = (): UseCreateWorkspaceReturn => {
         navigateToWorkspace(workspaceId);
 
         // Claude and pi both take an initial prompt; terminal/registered agents
-        // do not — the backend rejects a prompt for them (422), which would fail
+        // do not — the backend rejects a prompt for them (400), which would fail
         // the agent create after the workspace already exists and orphan it.
         const isClaudeAgent = effectiveAgentType === "claude";
         const isPiAgent = effectiveAgentType === "pi";

--- a/sculptor/sculptor/web/app.py
+++ b/sculptor/sculptor/web/app.py
@@ -658,7 +658,7 @@ def start_task(
             interface = TaskInterface(interface)
         except ValueError as e:
             raise HTTPException(
-                status_code=422,
+                status_code=400,
                 detail=f"Invalid interface: {interface}. Must be 'terminal' or 'api'",
             ) from e
 
@@ -668,7 +668,7 @@ def start_task(
 
         if model in (LLMModel.FAKE_CLAUDE, LLMModel.FAKE_CLAUDE_2) and not settings.TESTING.INTEGRATION_ENABLED:
             raise HTTPException(
-                status_code=422,
+                status_code=400,
                 detail="Testing model is only available when integration testing is enabled",
             )
 
@@ -705,7 +705,7 @@ def start_task(
             # terminal type; an omitted type resolves to the user's MRU, where a
             # terminal default falls back to Claude.
             if task_request.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
-                raise HTTPException(status_code=422, detail="terminal agents do not take an initial prompt")
+                raise HTTPException(status_code=400, detail="terminal agents do not take an initial prompt")
             resolved_agent_type, _ = _resolve_requested_agent_type(task_request.agent_type, None, has_prompt=True)
             _validate_prompt_model_selection(resolved_agent_type, model, task_request.backend_model)
             agent_config = _agent_config_for_request(resolved_agent_type, None)
@@ -1006,7 +1006,7 @@ def rerun_workspace_setup(
         # stored value runs the current default and `""` (user-cleared) blocks.
         command = resolve_workspace_setup_command(project.workspace_setup_command) if project is not None else None
     if command is None or not command.strip():
-        raise HTTPException(status_code=422, detail={"error": "no setup command configured"})
+        raise HTTPException(status_code=409, detail={"error": "no setup command configured"})
     if environment_id is None or project_id is None or project_path is None:
         raise HTTPException(status_code=409, detail={"error": "environment not ready"})
     if workspace_service.setup_runner.get_state(workspace_id) is not None:
@@ -2165,12 +2165,12 @@ def _agent_config_for_request(
         return TerminalAgentConfig()
     if agent_type == AgentTypeName.REGISTERED:
         if registration_id is None:
-            raise HTTPException(status_code=422, detail="registered terminal agents require a registration_id")
+            raise HTTPException(status_code=400, detail="registered terminal agents require a registration_id")
         registration = get_registration(registration_id)
         if registration is None:
             # The menu may have raced a registration-file deletion.
             raise HTTPException(
-                status_code=422,
+                status_code=400,
                 detail=f"Terminal-agent registration '{registration_id}' not found",
             )
         # Stamped at creation so the task stays self-describing even if the
@@ -2284,7 +2284,7 @@ def create_workspace_agent(
 
         if agent_request.prompt:
             if agent_request.agent_type in (AgentTypeName.TERMINAL, AgentTypeName.REGISTERED):
-                raise HTTPException(status_code=422, detail="terminal agents do not take an initial prompt")
+                raise HTTPException(status_code=400, detail="terminal agents do not take an initial prompt")
             # Delegate to existing start_task logic, which validates the
             # model/backend_model pair against the resolved harness
             # (`_validate_prompt_model_selection`).
@@ -3074,7 +3074,7 @@ def _prevent_action_if_out_of_free_space(services: CompleteServiceCollection) ->
     if user_config is not None and free_gb < user_config.min_free_disk_gb:
         logger.warning("Cannot start a task if you have insufficient free space")
         raise HTTPException(
-            status_code=422,
+            status_code=400,
             detail=f"Insufficient disk space ({user_config.min_free_disk_gb} GB free space required to prevent filling your disk)\nPlease either free some space (eg, by deleting old tasks) or increase min_free_disk_gb in settings.",
         )
 
@@ -3942,7 +3942,7 @@ def post_agent_signal(
             session_id = signal_request.session_id
             if session_id is None or _TERMINAL_SESSION_ID_PATTERN.fullmatch(session_id) is None:
                 raise HTTPException(
-                    status_code=422,
+                    status_code=400,
                     detail="session-id event requires a session_id matching [A-Za-z0-9._-]{1,128}",
                 )
             # Evolve only this field; the immediate transaction (above) keeps
@@ -5007,7 +5007,7 @@ def post_trace_start(
     tracer_entries = payload.tracer_entries if payload.tracer_entries is not None else DEFAULT_ADHOC_TRACER_ENTRIES
     if tracer_entries <= 0 or tracer_entries > DEFAULT_TRACER_ENTRIES:
         raise HTTPException(
-            status_code=422,
+            status_code=400,
             detail=f"tracer_entries must be in 1..{DEFAULT_TRACER_ENTRIES}",
         )
 

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -1193,7 +1193,7 @@ def test_agent_config_for_request_resolves_each_type() -> None:
     assert isinstance(_agent_config_for_request(AgentTypeName.TERMINAL, None), TerminalAgentConfig)
     with pytest.raises(HTTPException) as exc_info:
         _agent_config_for_request(AgentTypeName.REGISTERED, "some-registration")
-    assert exc_info.value.status_code == 422
+    assert exc_info.value.status_code == 400
     assert isinstance(_agent_config_for_request(AgentTypeName.CLAUDE, None), ClaudeCodeSDKAgentConfig)
     assert isinstance(_agent_config_for_request(AgentTypeName.PI, None), PiAgentConfig)
 
@@ -1236,7 +1236,7 @@ def test_start_task_resolves_agent_type(
             is_camel_case=True,
         ),
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
 
 
 def _post_agent(client: TestClient, workspace: Workspace, body: dict) -> httpx.Response:
@@ -1378,7 +1378,7 @@ def test_start_task_terminal_mru_falls_back_to_claude_for_prompt(
     test_project: Project,
     isolated_user_config: None,
 ) -> None:
-    """A prompt-ful create with a terminal MRU uses Claude rather than 422ing."""
+    """A prompt-ful create with a terminal MRU uses Claude rather than being rejected."""
     _set_user_config_with(last_used_agent_type="terminal")
     response = client.post(
         f"/api/v1/projects/{test_project.object_id}/tasks",
@@ -1399,9 +1399,9 @@ def test_create_terminal_agent_with_prompt_is_rejected(
         workspace = _create_workspace(transaction, test_services, test_project)
 
     response = _post_agent(client, workspace, {"agentType": "terminal", "prompt": "hi"})
-    assert response.status_code == 422
+    assert response.status_code == 400
     response = _post_agent(client, workspace, {"agentType": "registered", "prompt": "hi"})
-    assert response.status_code == 422
+    assert response.status_code == 400
 
 
 # Terminal-agent registrations.
@@ -1484,7 +1484,7 @@ def test_create_registered_agent_with_unknown_or_deleted_registration_fails(
     with user_session.open_transaction(test_services) as transaction:
         workspace = _create_workspace(transaction, test_services, test_project)
 
-    assert _post_agent(client, workspace, {"agentType": "registered", "registrationId": "nope"}).status_code == 422
+    assert _post_agent(client, workspace, {"agentType": "registered", "registrationId": "nope"}).status_code == 400
 
     # Menu-raced deletion: the file existed when the menu listed it but is
     # gone by creation time.
@@ -1493,5 +1493,5 @@ def test_create_registered_agent_with_unknown_or_deleted_registration_fails(
     assert client.get("/api/v1/terminal-agent-registrations").json()["registrations"]
     path.unlink()
     response = _post_agent(client, workspace, {"agentType": "registered", "registrationId": "fleeting"})
-    assert response.status_code == 422
+    assert response.status_code == 400
     assert "fleeting" in response.json()["detail"]

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -1495,3 +1495,23 @@ def test_create_registered_agent_with_unknown_or_deleted_registration_fails(
     response = _post_agent(client, workspace, {"agentType": "registered", "registrationId": "fleeting"})
     assert response.status_code == 400
     assert "fleeting" in response.json()["detail"]
+
+
+# Workspace setup rerun.
+
+
+def test_setup_rerun_conflicts_when_setup_command_is_cleared(
+    client: TestClient, test_services: CompleteServiceCollection, test_project: Project
+) -> None:
+    """A user-cleared ("") setup command blocks reruns with a 409, matching the
+    endpoint's other precondition conflicts (environment not ready, already
+    running)."""
+    user_session = authenticate_anonymous(test_services, RequestID())
+    with user_session.open_transaction(test_services) as transaction:
+        workspace = _create_workspace(transaction, test_services, test_project)
+        transaction.update_project_fields(test_project.object_id, workspace_setup_command="")
+
+    response = client.post(f"/api/v1/workspaces/{workspace.object_id}/setup/rerun")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {"error": "no setup command configured"}

--- a/sculptor/sculptor/web/app_basic_test.py
+++ b/sculptor/sculptor/web/app_basic_test.py
@@ -1497,15 +1497,11 @@ def test_create_registered_agent_with_unknown_or_deleted_registration_fails(
     assert "fleeting" in response.json()["detail"]
 
 
-# Workspace setup rerun.
-
-
 def test_setup_rerun_conflicts_when_setup_command_is_cleared(
     client: TestClient, test_services: CompleteServiceCollection, test_project: Project
 ) -> None:
-    """A user-cleared ("") setup command blocks reruns with a 409, matching the
-    endpoint's other precondition conflicts (environment not ready, already
-    running)."""
+    """A user-cleared ("") setup command blocks a rerun with a 409, consistent
+    with the endpoint's other precondition conflicts rather than a 400."""
     user_session = authenticate_anonymous(test_services, RequestID())
     with user_session.open_transaction(test_services) as transaction:
         workspace = _create_workspace(transaction, test_services, test_project)

--- a/sculptor/sculptor/web/terminal_signal_test.py
+++ b/sculptor/sculptor/web/terminal_signal_test.py
@@ -179,7 +179,7 @@ def test_session_id_rejects_unsafe_values(
         body["sessionId"] = bad_session_id
     response = _post_signal(client, task, body)
 
-    assert response.status_code == 422
+    assert response.status_code == 400
     assert _current_state(services, task.object_id).terminal_session_id is None
 
 

--- a/sculptor/sculptor/web/trace_endpoint_test.py
+++ b/sculptor/sculptor/web/trace_endpoint_test.py
@@ -178,8 +178,8 @@ def test_trace_stop_conflicts_when_not_running(client: TestClient) -> None:
 
 
 def test_trace_start_rejects_out_of_range_tracer_entries(client: TestClient) -> None:
-    assert client.post("/api/v1/trace/start", json={"tracer_entries": 0}).status_code == 422
-    assert client.post("/api/v1/trace/start", json={"tracer_entries": 10**12}).status_code == 422
+    assert client.post("/api/v1/trace/start", json={"tracer_entries": 0}).status_code == 400
+    assert client.post("/api/v1/trace/start", json={"tracer_entries": 10**12}).status_code == 400
     # The rejected starts must not have armed anything.
     assert client.get("/api/v1/trace/status").json()["enabled"] is False
 

--- a/sculptor/tests/integration/frontend/test_workspace_setup_status.py
+++ b/sculptor/tests/integration/frontend/test_workspace_setup_status.py
@@ -170,7 +170,7 @@ def test_setup_config_prompt_when_no_command(sculptor_instance_: SculptorInstanc
 def test_setup_rerun_hidden_when_command_cleared_after_run(
     sculptor_instance_: SculptorInstance,
 ) -> None:
-    """A rerun would 422 on the backend when the project no longer has a
+    """A rerun would 409 on the backend when the project no longer has a
     command configured. Hide the button so users aren't offered a no-op.
     """
     page = sculptor_instance_.page

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -19,6 +19,7 @@ from sculpt.commands._workspace_helpers import resolve_requested_branch_name
 from sculpt.commands._workspace_helpers import resolve_strategy
 from sculpt.commands.data_types import RunOutput
 from sculpt.formatting import cli_error
+from sculpt.formatting import extract_error_detail
 from sculpt.formatting import handle_connection_error
 from sculpt.resolve import resolve_project
 
@@ -115,15 +116,23 @@ def run_cmd(
     )
 
     try:
-        ws_result = create_workspace_v2.sync(client=client, body=ws_request)  # type: ignore[arg-type]
+        ws_response = create_workspace_v2.sync_detailed(client=client, body=ws_request)  # type: ignore[arg-type]
     except httpx.ConnectError:
         handle_connection_error(json_output)
 
-    if ws_result is None:
-        cli_error("Failed to create workspace", detail="No response from server", json_output=json_output)
-
+    ws_result = ws_response.parsed
     if isinstance(ws_result, HTTPValidationError):
         cli_error("Validation error", detail=str(ws_result), json_output=json_output)
+
+    if ws_result is None:
+        # Hand-raised errors (400/409) are not parsed by the generated client;
+        # surface their detail from the raw body.
+        detail = extract_error_detail(ws_response.content)
+        cli_error(
+            "Failed to create workspace",
+            detail=detail or f"No response from server (status {ws_response.status_code})",
+            json_output=json_output,
+        )
 
     workspace_id = ws_result.object_id
 
@@ -142,15 +151,26 @@ def run_cmd(
     )
 
     try:
-        agent_result = create_workspace_agent.sync(workspace_id=workspace_id, client=client, body=agent_request)
+        agent_response = create_workspace_agent.sync_detailed(
+            workspace_id=workspace_id, client=client, body=agent_request
+        )
     except httpx.ConnectError:
         handle_connection_error(json_output)
 
-    if agent_result is None:
-        cli_error("Failed to create agent", detail="No response from server", json_output=json_output)
-
+    agent_result = agent_response.parsed
     if isinstance(agent_result, HTTPValidationError):
         cli_error("Validation error", detail=str(agent_result), json_output=json_output)
+
+    if agent_result is None:
+        # Same shape as the workspace create above: hand-raised errors (e.g.
+        # the testing-model gate, a prompt sent to a terminal agent) return
+        # 400 with a string detail the generated client does not parse.
+        detail = extract_error_detail(agent_response.content)
+        cli_error(
+            "Failed to create agent",
+            detail=detail or f"No response from server (status {agent_response.status_code})",
+            json_output=json_output,
+        )
 
     if json_output:
         output = RunOutput(

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -128,7 +128,7 @@ def run_cmd(
         detail = extract_error_detail(ws_response.content)
         cli_error(
             "Failed to create workspace",
-            detail=detail or f"No response from server (status {ws_response.status_code})",
+            detail=detail or f"Unexpected response from server (status {ws_response.status_code})",
             json_output=json_output,
         )
 
@@ -163,7 +163,7 @@ def run_cmd(
         detail = extract_error_detail(agent_response.content)
         cli_error(
             "Failed to create agent",
-            detail=detail or f"No response from server (status {agent_response.status_code})",
+            detail=detail or f"Unexpected response from server (status {agent_response.status_code})",
             json_output=json_output,
         )
 

--- a/tools/sculpt/sculpt/commands/run.py
+++ b/tools/sculpt/sculpt/commands/run.py
@@ -125,8 +125,6 @@ def run_cmd(
         cli_error("Validation error", detail=str(ws_result), json_output=json_output)
 
     if ws_result is None:
-        # Hand-raised errors (400/409) are not parsed by the generated client;
-        # surface their detail from the raw body.
         detail = extract_error_detail(ws_response.content)
         cli_error(
             "Failed to create workspace",
@@ -162,9 +160,6 @@ def run_cmd(
         cli_error("Validation error", detail=str(agent_result), json_output=json_output)
 
     if agent_result is None:
-        # Same shape as the workspace create above: hand-raised errors (e.g.
-        # the testing-model gate, a prompt sent to a terminal agent) return
-        # 400 with a string detail the generated client does not parse.
         detail = extract_error_detail(agent_response.content)
         cli_error(
             "Failed to create agent",

--- a/tools/sculpt/sculpt/formatting.py
+++ b/tools/sculpt/sculpt/formatting.py
@@ -1,6 +1,7 @@
 """Output formatting utilities for the sculpt CLI."""
 
 import datetime
+import json
 import sys
 from collections.abc import Sequence
 from typing import NoReturn
@@ -8,6 +9,25 @@ from typing import NoReturn
 import typer
 
 from sculpt.commands.data_types import ErrorOutput
+
+
+def extract_error_detail(body: bytes) -> str | None:
+    """Pull the FastAPI HTTPException `detail` out of an error response body.
+
+    The generated client only parses response bodies for the statuses declared
+    in the OpenAPI schema (200 and 422), so hand-raised errors (400/404/409)
+    arrive unparsed and their detail must be read from the raw body.
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(parsed, dict):
+        detail = parsed.get("detail")
+        if isinstance(detail, str):
+            return detail
+    return None
+
 
 _ELLIPSIS = "..."
 

--- a/tools/sculpt/sculpt/resolve.py
+++ b/tools/sculpt/sculpt/resolve.py
@@ -1,6 +1,5 @@
 """Repo resolution and prefix matching utilities for the sculpt CLI."""
 
-import json
 import os
 import subprocess
 from collections.abc import Callable
@@ -21,23 +20,11 @@ from sculpt.client.models.http_validation_error import HTTPValidationError
 from sculpt.client.models.project import Project
 from sculpt.client.models.project_initialization_request import ProjectInitializationRequest
 from sculpt.formatting import cli_error
+from sculpt.formatting import extract_error_detail
 from sculpt.formatting import handle_connection_error
 from sculpt.formatting import truncate
 
 T = TypeVar("T")
-
-
-def _extract_detail(body: bytes) -> str | None:
-    """Pull the FastAPI HTTPException `detail` out of an error response body."""
-    try:
-        parsed = json.loads(body)
-    except (ValueError, TypeError):
-        return None
-    if isinstance(parsed, dict):
-        detail = parsed.get("detail")
-        if isinstance(detail, str):
-            return detail
-    return None
 
 
 def resolve_agent_id(base_url: str, prefix_or_id: str, json_output: bool) -> str:
@@ -65,7 +52,9 @@ def resolve_agent_id(base_url: str, prefix_or_id: str, json_output: bool) -> str
     if response.status_code == HTTPStatus.CONFLICT:
         # The server's detail string includes the matching ids; surface the full
         # message verbatim so the user can pick a longer prefix.
-        cli_error(_extract_detail(response.content) or f"Ambiguous prefix '{prefix_or_id}'", json_output=json_output)
+        cli_error(
+            extract_error_detail(response.content) or f"Ambiguous prefix '{prefix_or_id}'", json_output=json_output
+        )
     if response.status_code != HTTPStatus.OK or response.parsed is None:
         cli_error(f"Failed to resolve agent prefix (status {response.status_code})", json_output=json_output)
     parsed = response.parsed
@@ -144,7 +133,7 @@ def _resolve_from_repo(repo: str, client: Client, json_output: bool = False) -> 
             typer.echo(f"Initialized repo for {absolute_path}", err=True)
             return parsed.object_id
 
-    detail = _extract_detail(response.content)
+    detail = extract_error_detail(response.content)
 
     if response.status_code == HTTPStatus.CONFLICT and detail is not None and "already added" in detail:
         # The server has the repo registered under a (possibly worktree-resolved)

--- a/tools/sculpt/tests/unit/test_http_validation_error.py
+++ b/tools/sculpt/tests/unit/test_http_validation_error.py
@@ -1,10 +1,10 @@
 """Unit tests for parsing 422 response bodies in the generated sculpt client.
 
-FastAPI serves 422 bodies with `detail` in more than one shape: request
-validation failures carry a list of structured errors, while a hand-raised
-`HTTPException(422, detail=...)` carries whatever was passed — a plain string,
-or a structured object. The generated `HTTPValidationError.from_dict` must
-tolerate any of these so a non-list detail surfaces instead of crashing.
+FastAPI's request-validation 422s carry a list of structured errors, but
+`detail` is not guaranteed to be list-shaped: any endpoint can hand-raise
+`HTTPException(422, detail=...)` with a plain string or a structured object.
+The generated `HTTPValidationError.from_dict` must tolerate every shape so an
+unexpected detail surfaces instead of crashing the client.
 """
 
 from sculpt.client.models.http_validation_error import HTTPValidationError
@@ -12,7 +12,7 @@ from sculpt.client.models.validation_error import ValidationError
 
 
 def test_from_dict_tolerates_string_detail() -> None:
-    message = "Testing model is only available when integration testing is enabled"
+    message = "this endpoint hand-raised a plain-string detail"
 
     result = HTTPValidationError.from_dict({"detail": message})
 
@@ -32,8 +32,8 @@ def test_from_dict_parses_list_detail() -> None:
 
 
 def test_from_dict_tolerates_object_detail() -> None:
-    # Some endpoints raise `HTTPException(422, detail={...})`, so a `detail`
-    # object must surface its content rather than crash the client.
-    result = HTTPValidationError.from_dict({"detail": {"error": "no setup command configured"}})
+    # A hand-raised `detail` object must surface its content rather than
+    # crash the client.
+    result = HTTPValidationError.from_dict({"detail": {"error": "environment not ready"}})
 
-    assert "no setup command configured" in str(result)
+    assert "environment not ready" in str(result)

--- a/tools/sculpt/tests/unit/test_http_validation_error.py
+++ b/tools/sculpt/tests/unit/test_http_validation_error.py
@@ -32,8 +32,6 @@ def test_from_dict_parses_list_detail() -> None:
 
 
 def test_from_dict_tolerates_object_detail() -> None:
-    # A hand-raised `detail` object must surface its content rather than
-    # crash the client.
     result = HTTPValidationError.from_dict({"detail": {"error": "environment not ready"}})
 
     assert "environment not ready" in str(result)

--- a/tools/sculpt/tests/unit/test_run.py
+++ b/tools/sculpt/tests/unit/test_run.py
@@ -354,6 +354,49 @@ class TestRun:
         assert result.exit_code == 1
 
     @respx.mock
+    def test_run_workspace_creation_surfaces_hand_raised_detail(self, runner: CliRunner) -> None:
+        """A hand-raised 400/409 carries a plain-string `detail` the generated
+        client does not parse. sculpt run surfaces it instead of the misleading
+        "No response from server" fallback (the server did respond)."""
+        _mock_session()
+        _mock_initialize_project()
+        _mock_preview_branch_name()
+        respx.post("http://localhost:5050/api/v1/workspaces").mock(
+            return_value=Response(
+                400,
+                json={"detail": "Testing model is only available when integration testing is enabled"},
+            )
+        )
+
+        result = runner.invoke(app, ["run", "Fix the bug", "--repo", "/tmp/test"])
+
+        assert result.exit_code == 1
+        output = result.output + (result.stderr or "")
+        assert "Testing model is only available when integration testing is enabled" in output
+        assert "No response from server" not in output
+
+    @respx.mock
+    def test_run_agent_creation_surfaces_hand_raised_detail(self, runner: CliRunner) -> None:
+        """The agent-create path surfaces a hand-raised 400 `detail` the same way
+        the workspace-create path does."""
+        _mock_session()
+        _mock_initialize_project()
+        _mock_preview_branch_name()
+        respx.post("http://localhost:5050/api/v1/workspaces").mock(
+            return_value=Response(200, json=_workspace_response_dict())
+        )
+        respx.post("http://localhost:5050/api/v1/workspaces/ws_newrun123/agents").mock(
+            return_value=Response(400, json={"detail": "terminal agents do not take an initial prompt"})
+        )
+
+        result = runner.invoke(app, ["run", "Fix the bug", "--repo", "/tmp/test"])
+
+        assert result.exit_code == 1
+        output = result.output + (result.stderr or "")
+        assert "terminal agents do not take an initial prompt" in output
+        assert "No response from server" not in output
+
+    @respx.mock
     def test_run_connection_error(self, runner: CliRunner) -> None:
         _mock_session()
         _mock_initialize_project()


### PR DESCRIPTION
## Summary

Several of the backend API's hand-raised rejections returned HTTP `422
Unprocessable Entity` — the status FastAPI reserves for Pydantic
request-validation failures, whose body carries a **list-shaped** `detail`.
Generated OpenAPI clients parse `422` bodies expecting that list shape, so
these string- and object-detail `422`s were a trap: the real error message
was mangled or swallowed by every client generated from the schema.

This PR gives those hand-raised rejections honest status codes:

- **400 Bad Request** for bad input — invalid interface, a prompt sent to a
  terminal/registered agent, a missing or unknown terminal-agent
  registration, the gated testing model, malformed trace/signal parameters,
  and insufficient free disk space.
- **409 Conflict** for the "no setup command configured" setup-rerun
  rejection, matching its sibling precondition conflicts (environment not
  ready, setup already running).

Genuine Pydantic validation `422`s are untouched.

`sculpt run` previously reported a misleading "No response from server" for
these rejections, because the generated client only parses bodies for the
statuses declared in the OpenAPI schema (200 and 422). It now reads the
`detail` from the raw body of a hand-raised 400/409 and surfaces it to the
user. (This is why the `sculpt run` change depends on the status-code
change: until the statuses are honest, the client cannot tell these
responses apart from a dropped connection.)

## API-visible behavior change

Response status codes on the endpoints above change from `422` to
`400`/`409`. The API's consumers are in this repo and updated in the same
PR:

- the frontend `useCreateWorkspace` hook already discriminates on the
  `detail` shape rather than the status code, so only its explanatory
  comments changed; and
- the `sculpt` CLI (`sculpt run`) now surfaces the hand-raised detail.

Both generated clients (frontend TypeScript and the `sculpt` Python client)
were regenerated from the schema and produced **no diff** — the hand-raised
statuses never appeared in the OpenAPI schema, which is exactly why they
were a client trap in the first place.

## Provenance

Extracted from #383 (closed unmerged) — original work by @brydenfogelman,
authorship preserved via `git cherry-pick -x`. A final commit prunes a few
redundant comments from the slice (a crispy-comments pass); it carries a
`Co-authored-by: Sculptor` trailer. Relates to SCU-1809.

## Verification

- `just format` — clean, no changes.
- `just check` — all checks pass (typecheck, lint, ratchets, file hygiene,
  codegen).
- `just test-unit` — backend 2358 passed / 4 skipped; frontend 3269 passed /
  1 skipped; foundation 127 passed; sculpt 381 passed. (A handful of
  load-induced worker-timeout flakes in unrelated frontend/foundation files
  all pass in isolation.)
- Focused: backend web tests (`app_basic_test.py`, `terminal_signal_test.py`,
  `trace_endpoint_test.py`) 96 passed / 1 skipped; sculpt unit tests
  including `test_http_validation_error.py` 381 passed; frontend
  `useCreateWorkspace` tests 9 passed.
- `test_workspace_setup_status.py` is an integration test (docstring-only
  change here) and is covered by CI rather than run locally.

(Sent by Claude)
