### PR TITLE
Drop the "(Sent by Claude)" external-message sign-off rule from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,6 @@ convention read the same content. Edit CLAUDE.md and .claude/, not the aliases.
 - When the task is ambiguous, pause and ask the user how to proceed before taking action.
 - When the user expects you to check with them before proceeding, wait for their explicit confirmation. Do not continue with the task until they confirm.
 
-# Transparency: Signing Off as Claude
-
-When posting any message, comment, or content to services outside the local machine — including GitHub, GitLab, Slack, Linear, email, or any other external system — always sign off so it is transparent that the message was written by an agent rather than a person. End every such message with the following on its own final line:
-
-```
-(Sent by Claude)
-```
-
-This applies to MR/PR descriptions and comments, issue comments, Slack messages, Linear comments, and any other communication sent to a service outside this machine. It does NOT apply to code, commit messages (which use the existing `Co-authored-by` trailer), or local files.
-
 # Public Visibility: Commit Messages and PR Descriptions
 
 Treat every commit message and every MR/PR title and description as **permanently, world-readable**. This is a public repo, so write them for an outside reader who has no access to any private context, and never include anything private.


### PR DESCRIPTION
## What

Removes the **"Transparency: Signing Off as Claude"** section from `CLAUDE.md`. That section required agents to append `(Sent by Claude)` as the final line of every message posted to a service outside the local machine — PR/issue descriptions and comments, Slack, Linear, email, and similar.

## Why

This external-message sign-off is no longer wanted. `CLAUDE.md` is the canonical agent-instructions file (also surfaced as `AGENTS.md` via symlink), so removing the section here stops agents from adding the `(Sent by Claude)` line going forward.

## Scope

- Only `CLAUDE.md` changes (10 lines removed).
- **Commit authorship is unaffected.** The `Co-authored-by: Sculptor` trailer — defined separately in the agent harness, not in this file — remains the mechanism for disclosing AI involvement.

## Known follow-ups (not in this PR)

Two files still reference the removed rule and now point at guidance that no longer exists:

- `.claude/skills/promote-release/SKILL.md` — live guidance that carves out an exception to the sign-off rule; likely worth updating.
- `agent_docs/terminal-agents/review.md` — a historical review artifact that mentions the rule.

Left out pending a decision on whether to touch them.
