### PR TITLE
Deprecate help-docs updates and add a manifest-verification field note

### DIFF
--- a/.claude/skills/promote-release/SKILL.md
+++ b/.claude/skills/promote-release/SKILL.md
@@ -158,7 +158,10 @@ Follow-ups this skill does **not** do:
   `gh release edit <tag> --notes-file <file>`. Do **not** sign a published product
   changelog `(Sent by Claude)` — CLAUDE.md's transparency rule targets PR, issue,
   and chat messages, not user-facing release copy.
-- **`update-help-docs`** for the release (run it from the release branch).
+- **`update-help-docs`** — **optional / deprecated.** The help docs
+  (`docs/help/`) are no longer actively maintained, so refreshing them is no
+  longer part of the promotion follow-up. Skip it by default; only run it (from
+  the release branch) if you specifically want to update a page.
 - **Linear** hygiene for the tickets that shipped.
 - Slack needs nothing: the pipeline posts to `#sculptor-release` automatically on
   a successful publish.

--- a/.claude/skills/update-help-docs/SKILL.md
+++ b/.claude/skills/update-help-docs/SKILL.md
@@ -15,7 +15,13 @@ description: |
 
 # Update Sculptor Help Docs
 
-> **Note: docs live in this repo at `docs/help/`.** The Sculptor help docs are maintained here, alongside the code. This skill edits the markdown and images under `docs/help/` in the current checkout.
+> **⚠️ Deprecated / optional — the help docs are no longer actively maintained.**
+> Refreshing `docs/help/` is **not** a required release step and is no longer part
+> of the promote-release follow-up. This skill still works if you deliberately
+> want to update a specific page, but treat any run as optional — don't run it
+> just because a release went out.
+
+> **Note: docs live in this repo at `docs/help/`.** The Sculptor help docs live here, alongside the code. This skill edits the markdown and images under `docs/help/` in the current checkout.
 >
 > **Publishing:** `/sculptor:help` fetches the docs live from `imbue-ai/sculptor` on GitHub, so edits you make here go live to users once they land on `main` there. Editing `docs/help/` in a local checkout does not by itself change what `/sculptor:help` returns.
 

--- a/docs/development/release_ci_playbook.md
+++ b/docs/development/release_ci_playbook.md
@@ -322,8 +322,9 @@ Append dated, specific learnings here. Keep them short.
   in that instance — already merged — but not intended). Push a specific deletion
   with `jj git push -b <bookmark>` instead, or check what is pending first.
 - **2026-09-01 — verify all three auto-update manifests, not just linux-x64
-  (promoting 0.46.0).** Step 5 lists only `slim/AppImage/x64/latest-linux.yml`,
-  which leaves macOS and arm64-linux unchecked. Verify all three channels:
+  (promoting 0.46.0).** The `promote-release` skill's Step 5 lists only
+  `slim/AppImage/x64/latest-linux.yml`, which leaves macOS and arm64-linux
+  unchecked. Verify all three channels:
   `slim/AppImage/x64/latest-linux.yml`,
   `slim/AppImage/arm64/latest-linux-arm64.yml`, and
   `slim/zip/darwin/arm64/latest-mac.yml`. The mac manifest lives under

--- a/docs/development/release_ci_playbook.md
+++ b/docs/development/release_ci_playbook.md
@@ -321,3 +321,14 @@ Append dated, specific learnings here. Keep them short.
   merged branch also deleted an unrelated stale branch from the remote (harmless
   in that instance — already merged — but not intended). Push a specific deletion
   with `jj git push -b <bookmark>` instead, or check what is pending first.
+- **2026-09-01 — verify all three auto-update manifests, not just linux-x64
+  (promoting 0.46.0).** Step 5 lists only `slim/AppImage/x64/latest-linux.yml`,
+  which leaves macOS and arm64-linux unchecked. Verify all three channels:
+  `slim/AppImage/x64/latest-linux.yml`,
+  `slim/AppImage/arm64/latest-linux-arm64.yml`, and
+  `slim/zip/darwin/arm64/latest-mac.yml`. The mac manifest lives under
+  `zip/darwin/arm64/` (matching the publish paths in
+  `sculptor/builder/artifacts.py`), **not** `dmg/` — guessing a `dmg/…` path
+  returns a spurious "not found" on a perfectly good release. 0.46.0 was
+  otherwise textbook: a clean, fully-green build (arm64 included) that parked at
+  the gate ~42 min after the tag push.


### PR DESCRIPTION
## What

Two small documentation follow-ups from promoting Sculptor 0.46.0:

1. **Release-CI playbook field note** (`docs/development/release_ci_playbook.md`) — record that promotion verification should check **all three** auto-update manifests (linux-x64, linux-arm64, macOS-arm64), not just linux-x64. The macOS manifest lives at `slim/zip/darwin/arm64/latest-mac.yml` (matching the publish paths in `sculptor/builder/artifacts.py`), **not** under `dmg/` — guessing a `dmg/` path returns a spurious "not found" even on a perfectly good release.

2. **Deprecate help-docs updates** — mark the help docs (`docs/help/`) as no longer actively maintained:
   - Add a deprecation banner to the `update-help-docs` skill, and adjust the adjacent line so it no longer claims the docs are actively maintained.
   - Change the `update-help-docs` entry in the `promote-release` skill's follow-ups to **optional / deprecated**, so refreshing help docs is no longer a standard promotion step.

## Why

Promoting 0.46.0 surfaced that the documented publish-verification step covered only the linux-x64 manifest, leaving macOS and arm64-linux unverified, and that the macOS manifest path is non-obvious. Separately, the help docs are no longer actively maintained, so the release follow-up guidance should say so rather than implying a per-release update is expected.

## Notes

- Docs / markdown only — no code paths touched.
- `just format` passes for Python (ruff, clean). Its JS/TS step requires frontend `node_modules` that aren't installed in this worktree, and no formatter or linter covers the changed markdown, so the format failure is environmental and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
