### PR TITLE
Fix Notes panel click target to fill the whole panel

### DIFF
--- a/sculptor/frontend/src/components/Editor.module.scss
+++ b/sculptor/frontend/src/components/Editor.module.scss
@@ -22,6 +22,31 @@
   @include thin-scrollbar;
 }
 
+// Opt-in (via the Editor's `fillHeight` prop) for hosts that stretch the editor
+// to fill a tall container. By default the contenteditable only spans its text
+// (one line when empty), leaving the rest of a stretched panel a non-editable
+// dead zone where clicks don't begin editing. TipTap nests the contenteditable
+// inside a class-less EditorContent wrapper, so make the scroll area a flex
+// column and let both the wrapper and the contenteditable grow to fill it --
+// then the whole panel is a click/focus target. `flex-shrink: 0` keeps a long
+// note growing past the panel (the scroll area scrolls) instead of being
+// squeezed to fit.
+.fill {
+  display: flex;
+  flex-direction: column;
+
+  > * {
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
+  }
+
+  // stylelint-disable-next-line selector-class-pattern -- ProseMirror library class
+  :global(.ProseMirror) {
+    flex: 1 0 auto;
+  }
+}
+
 .disabled {
   background: var(--gray-3);
   border-color: var(--gray-6);

--- a/sculptor/frontend/src/components/Editor.module.scss
+++ b/sculptor/frontend/src/components/Editor.module.scss
@@ -22,15 +22,13 @@
   @include thin-scrollbar;
 }
 
-// Opt-in (via the Editor's `fillHeight` prop) for hosts that stretch the editor
-// to fill a tall container. By default the contenteditable only spans its text
-// (one line when empty), leaving the rest of a stretched panel a non-editable
-// dead zone where clicks don't begin editing. TipTap nests the contenteditable
-// inside a class-less EditorContent wrapper, so make the scroll area a flex
-// column and let both the wrapper and the contenteditable grow to fill it --
-// then the whole panel is a click/focus target. `flex-shrink: 0` keeps a long
-// note growing past the panel (the scroll area scrolls) instead of being
-// squeezed to fit.
+// Opt-in (via the Editor's `fillHeight` prop): make the editable surface fill a
+// stretched host so the whole area is a click/focus target, not just the first
+// line. TipTap nests the contenteditable inside a class-less EditorContent
+// wrapper, so make the scroll area a flex column and let both the wrapper and
+// the contenteditable grow to fill it. `flex-shrink: 0` keeps a long note
+// growing past the panel (the scroll area scrolls) instead of being squeezed
+// to fit.
 .fill {
   display: flex;
   flex-direction: column;

--- a/sculptor/frontend/src/components/Editor.tsx
+++ b/sculptor/frontend/src/components/Editor.tsx
@@ -87,6 +87,13 @@ type EditorProps = {
   // opt out of the default `max-height: 500px` cap meant for the chat
   // input, where the editor grows with content.
   scrollAreaClassName?: string;
+  // Stretch the editable surface to fill the scroll area's height so the whole
+  // area is a click/focus target, not just the text's first line. Meant for
+  // hosts that stretch the Editor to fill a tall flex column (e.g. the Notes
+  // panel); without it the contenteditable only spans its content and clicks
+  // below it land on non-editable wrapper divs. Off by default so the
+  // content-sized hosts (chat input, action dialog) are unaffected.
+  fillHeight?: boolean;
   disabled?: boolean;
   autoFocus?: boolean;
   footer?: ReactElement | undefined;
@@ -121,6 +128,7 @@ export const Editor = ({
   onKeyDown,
   wrapperClassName,
   scrollAreaClassName,
+  fillHeight = false,
   autoFocus = true,
   disabled = false,
   footer,
@@ -406,7 +414,7 @@ export const Editor = ({
 
   return (
     <div className={mergeClasses(wrapperClassName ?? styles.editorWrapper, optional(disabled, styles.disabled))}>
-      <div className={mergeClasses(styles.scrollArea, scrollAreaClassName)}>
+      <div className={mergeClasses(styles.scrollArea, scrollAreaClassName, optional(fillHeight, styles.fill))}>
         <EditorContent editor={editor} />
       </div>
       {footer && <div className={styles.footer}>{footer}</div>}

--- a/sculptor/frontend/src/components/Editor.tsx
+++ b/sculptor/frontend/src/components/Editor.tsx
@@ -88,11 +88,9 @@ type EditorProps = {
   // input, where the editor grows with content.
   scrollAreaClassName?: string;
   // Stretch the editable surface to fill the scroll area's height so the whole
-  // area is a click/focus target, not just the text's first line. Meant for
-  // hosts that stretch the Editor to fill a tall flex column (e.g. the Notes
-  // panel); without it the contenteditable only spans its content and clicks
-  // below it land on non-editable wrapper divs. Off by default so the
-  // content-sized hosts (chat input, action dialog) are unaffected.
+  // area is a click/focus target, not just the text's first line. For a host
+  // that stretches the Editor to fill a tall flex column (e.g. the Notes
+  // panel); off by default so content-sized hosts are unaffected.
   fillHeight?: boolean;
   disabled?: boolean;
   autoFocus?: boolean;

--- a/sculptor/frontend/src/pages/workspace/panels/NotesPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/NotesPanel.tsx
@@ -66,8 +66,7 @@ export const NotesPanel = (): ReactElement => {
         value={notes}
         onChange={setNotes}
         autoFocus={false}
-        // Fill the panel so the whole area is a click target, not just the
-        // first line — clicking anywhere in the panel begins editing.
+        // Fill the panel so the whole area is a click target, not just the first line.
         fillHeight
         wrapperClassName={styles.editorWrapper}
         scrollAreaClassName={styles.scrollArea}

--- a/sculptor/frontend/src/pages/workspace/panels/NotesPanel.tsx
+++ b/sculptor/frontend/src/pages/workspace/panels/NotesPanel.tsx
@@ -66,6 +66,9 @@ export const NotesPanel = (): ReactElement => {
         value={notes}
         onChange={setNotes}
         autoFocus={false}
+        // Fill the panel so the whole area is a click target, not just the
+        // first line — clicking anywhere in the panel begins editing.
+        fillHeight
         wrapperClassName={styles.editorWrapper}
         scrollAreaClassName={styles.scrollArea}
       />

--- a/sculptor/tests/integration/frontend/test_notes_panel.py
+++ b/sculptor/tests/integration/frontend/test_notes_panel.py
@@ -7,6 +7,7 @@ These tests cover opening it and that notes content is scoped per-workspace.
 
 from playwright.sync_api import expect
 
+from sculptor.constants import ElementIDs
 from sculptor.testing.elements.base import type_into_tiptap
 from sculptor.testing.elements.notes_panel import get_notes_panel
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -26,6 +27,22 @@ def test_open_notes_panel_renders_editor(sculptor_instance_: SculptorInstance) -
     expect(notes).to_be_visible()
     editor = notes.get_editor()
     expect(editor).to_be_visible()
+
+    # The whole panel must be a click target, not just the first text line:
+    # clicking well below the placeholder must begin editing (focus the
+    # editor). Previously the contenteditable was only ~one line tall at the
+    # top of the panel, so a real click lower down landed on non-editable
+    # wrapper divs and did nothing. Assert focus (rather than typed text) so
+    # the check is purely about where the click lands, independent of any
+    # editor text-insertion path.
+    panel_box = page.get_by_test_id(ElementIDs.NOTES_PANEL).bounding_box()
+    assert panel_box is not None
+    page.mouse.click(
+        panel_box["x"] + panel_box["width"] / 2,
+        panel_box["y"] + panel_box["height"] - 40,
+    )
+    expect(editor).to_be_focused()
+
     type_into_tiptap(page, editor, "a quick note")
     expect(editor).to_contain_text("a quick note")
 

--- a/sculptor/tests/integration/frontend/test_notes_panel.py
+++ b/sculptor/tests/integration/frontend/test_notes_panel.py
@@ -7,7 +7,6 @@ These tests cover opening it and that notes content is scoped per-workspace.
 
 from playwright.sync_api import expect
 
-from sculptor.constants import ElementIDs
 from sculptor.testing.elements.base import type_into_tiptap
 from sculptor.testing.elements.notes_panel import get_notes_panel
 from sculptor.testing.playwright_utils import start_task_and_wait_for_ready
@@ -29,13 +28,10 @@ def test_open_notes_panel_renders_editor(sculptor_instance_: SculptorInstance) -
     expect(editor).to_be_visible()
 
     # The whole panel must be a click target, not just the first text line:
-    # clicking well below the placeholder must begin editing (focus the
-    # editor). Previously the contenteditable was only ~one line tall at the
-    # top of the panel, so a real click lower down landed on non-editable
-    # wrapper divs and did nothing. Assert focus (rather than typed text) so
-    # the check is purely about where the click lands, independent of any
-    # editor text-insertion path.
-    panel_box = page.get_by_test_id(ElementIDs.NOTES_PANEL).bounding_box()
+    # clicking well below the placeholder must begin editing. Assert focus
+    # (rather than typed text) so the check is purely about where the click
+    # lands, independent of any editor text-insertion path.
+    panel_box = notes.bounding_box()
     assert panel_box is not None
     page.mouse.click(
         panel_box["x"] + panel_box["width"] / 2,


### PR DESCRIPTION
## Summary

The Notes panel is now editable across its whole area. Previously only the first text line was a click target — clicking anywhere below it (e.g. ~20px down) did nothing, so you couldn't begin editing by clicking in the empty space.

## Root cause

The shared `Editor` component mounts its TipTap contenteditable (`.ProseMirror`) at the natural height of its content — one line when empty. The DOM is:

```
wrapper → scrollArea → EditorContent (class-less div) → .ProseMirror
```

Only `.ProseMirror` is focusable. Content-sized hosts (the chat input, the action dialog) wrap tightly around it, so the whole visible box is editable and there's no gap. The **Notes panel is the first host that stretches the editor to fill a tall flex column** — but the stretch stopped at the outer `scrollArea`; the editable node stayed pinned to the top. Everything below the first line was a non-editable `<div>`, so clicks there never focused the editor.

So this was a gap in the shared toolkit (it had no way to make the editable surface fill a stretched host), not a mistake in the Notes panel — which opted into the stretch the reasonable way.

## The fix

Add an opt-in `fillHeight` prop to the shared `Editor`:

- When set, the scroll area becomes a flex column and the class-less `EditorContent` wrapper + the contenteditable grow to fill it (`flex: 1 0 auto` — grow to fill, never shrink, so a long note still grows past the panel and the scroll area scrolls).
- The whole panel becomes a click/focus target.
- `NotesPanel` opts in via `fillHeight`. The chat input and action dialog pass nothing and are unchanged (the prop defaults to `false`).

Keeping the mechanism in the toolkit — rather than in the Notes panel's own CSS — keeps knowledge of TipTap's internal DOM in the one component that owns it, and lets any future stretched host reuse it.

## Testing

- Grew the existing Notes-panel e2e test: click near the bottom of the panel and assert the editor gains focus (`to_be_focused`). Verified it fails against the pre-fix behavior (the click never focuses the editor) and passes with the fix.
- For an invisible-hitbox bug the red→green e2e is stronger evidence than a screenshot (a screenshot can't show "a click here begins editing").
- `just format`, `just check` (lint, typecheck, ratchets), and `just test-unit-frontend` all pass.

## Files changed

- `sculptor/frontend/src/components/Editor.tsx` — new optional `fillHeight` prop.
- `sculptor/frontend/src/components/Editor.module.scss` — `.fill` rules.
- `sculptor/frontend/src/pages/workspace/panels/NotesPanel.tsx` — opts in.
- `sculptor/tests/integration/frontend/test_notes_panel.py` — focus-on-click regression assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Sent by Claude)
