### PR TITLE
Add Claude Opus 5 + Fable 5.1; bump managed Claude CLI to 2.1.258 and pi to 0.84.4

### DIFF
--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -352,7 +352,7 @@ choice is dropped rather than shown; the action to fix it lives on the Send butt
 effect in-session (a failed switch leaves the choice unchanged and raises an actionable error toast). An **effort**
 selector budgets how much thinking it spends per step (Low, Medium, High, Extra High, Max — Extra High
 by default); a **fast mode** toggle trades some depth for quicker output on the models that support it
-(the Opus family — Opus 5 and the pinned 4.8/4.7/4.6) and is disabled for the rest; and **plan mode** makes the agent
+(the Opus family — Opus 5 and the pinned 4.8/4.7) and is disabled for the rest; and **plan mode** makes the agent
 investigate and propose a plan for your approval before it changes anything. The **+** button opens a
 menu for adding context — point the agent at specific **files and folders**, attach **images** (you
 can also drag-and-drop or paste them), or start a **skill** (→ §7.8 Skills); with the **Entity

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -172,11 +172,11 @@ and flags the targets it does not currently define.
 - **REQ-NFR-070 (MUST).** New-agent defaults: model = the user's **configured Settings default** if
   set, else the **most-recently-used** model (recorded whenever the user switches model in chat;
   `lastUsedModelAtom`, `sculptor/frontend/src/common/state/atoms/userConfig.ts`), else a hardcoded
-  fallback of **`CLAUDE_4_OPUS` ("Opus 5 (1M)")**, the rolling 1M-context Opus variant (Fable, though listed in
-  the switcher, is disabled and so is never the fallback). Effort = **Extra High (`xhigh`)**, fast mode
+  fallback of **`CLAUDE_5_OPUS` ("Opus 5 (1M)")**, the pinned 1M-context Opus 5 variant (Fable, though listed in
+  the switcher, is not the default). Effort = **Extra High (`xhigh`)**, fast mode
   = **off** (`sculptor/sculptor/config/user_config.py`, `sculptor/sculptor/web/derived.py`). All three
   are user-overridable in Settings → Agent (`SPEC.md` §7.10). **Fast mode** is offered only on models
-  that support it — Opus 5 and the pinned Opus 4.x family (4.8/4.7/4.6, both 1M and 200K variants) — and is
+  that support it — Opus 5 and the pinned Opus 4.x family (4.8/4.7, both 1M and 200K variants) — and is
   disabled for Sonnet/Haiku/Fable (`sculptor/frontend/src/common/modelCapabilities.ts`).
 
 ---
@@ -212,14 +212,14 @@ packaging Sculptor):
 
 ### 3.3 Required external binaries
 
-- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.222,
+- **REQ-COMPAT-020 (MUST).** **Claude CLI** is required. Compatibility window: **recommended 2.1.258,
   minimum 2.1.202, maximum 2.99.99, blocked 2.1.101**; supported platforms **darwin-arm64** and
   **linux-x64** (`sculptor/sculptor/services/managed_tools.py`). Sculptor can install/manage it and can use a
   user-supplied binary (`SPEC.md` §7.1, §7.10).
 - **REQ-COMPAT-021 [Unspecified].** **Git** is required and is **runtime-detected with no
   minimum-version check** (searched; none found). The minimum supported git version is undefined
   (worktree support is the relevant capability). → OPEN-6 (§7).
-- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness pins **0.80.10**; platforms
+- **REQ-COMPAT-022 (SHOULD).** The **Pi** harness pins **0.84.4**; platforms
   darwin-arm64, darwin-x64, linux-x64, with per-platform sha256 checksums
   (`sculptor/sculptor/services/managed_tools.py`). A version mismatch fails clearly (REQ-INT-022).
 - **REQ-COMPAT-023 (MUST, conditional).** The PR surface requires **`gh`** (GitHub CLI) present and

--- a/sculptor/frontend/src/common/modelCapabilities.ts
+++ b/sculptor/frontend/src/common/modelCapabilities.ts
@@ -27,6 +27,15 @@ const MODEL_CAPABILITIES: Partial<Record<LlmModel, ModelCapabilities>> = {
     supportsFileAttachments: true,
     supportsFastMode: true,
   },
+  // Pinned Opus 5 — fast mode supported.
+  [LlmModel.CLAUDE_5_OPUS]: {
+    supportsFileAttachments: true,
+    supportsFastMode: true,
+  },
+  [LlmModel.CLAUDE_5_OPUS_200K]: {
+    supportsFileAttachments: true,
+    supportsFastMode: true,
+  },
   // Pinned Opus 4.8 — fast mode supported (SCU-1841), same as the rolling entry.
   [LlmModel.CLAUDE_4_8_OPUS]: {
     supportsFileAttachments: true,
@@ -57,6 +66,10 @@ const MODEL_CAPABILITIES: Partial<Record<LlmModel, ModelCapabilities>> = {
     supportsFastMode: false,
   },
   [LlmModel.CLAUDE_FABLE_5]: {
+    supportsFileAttachments: true,
+    supportsFastMode: false,
+  },
+  [LlmModel.CLAUDE_FABLE_5_1]: {
     supportsFileAttachments: true,
     supportsFastMode: false,
   },

--- a/sculptor/frontend/src/common/modelConstants.ts
+++ b/sculptor/frontend/src/common/modelConstants.ts
@@ -13,8 +13,14 @@ export const hasNoUsableModel = (
 ): boolean => sourcesBackendModels && Array.isArray(backendModels) && backendModels.length === 0;
 
 const modelNames: Partial<Record<LlmModel, { short: string; long: string }>> = {
-  [LlmModel.CLAUDE_4_OPUS]: { short: "Opus 5 (1M)", long: "Claude 5 Opus (1M)" },
-  [LlmModel.CLAUDE_4_OPUS_200K]: { short: "Opus 5", long: "Claude 5 Opus" },
+  // Retired rolling "latest Opus" alias — kept for load-compat and the internal
+  // auto-latest fallback, not shown in the picker. Labeled honestly so a lingering
+  // selection doesn't masquerade as a pinned version.
+  [LlmModel.CLAUDE_4_OPUS]: { short: "Opus (latest, 1M)", long: "Claude Opus (latest, 1M)" },
+  [LlmModel.CLAUDE_4_OPUS_200K]: { short: "Opus (latest)", long: "Claude Opus (latest)" },
+  // Pinned Opus generations.
+  [LlmModel.CLAUDE_5_OPUS]: { short: "Opus 5 (1M)", long: "Claude 5 Opus (1M)" },
+  [LlmModel.CLAUDE_5_OPUS_200K]: { short: "Opus 5", long: "Claude 5 Opus" },
   [LlmModel.CLAUDE_4_8_OPUS]: { short: "Opus 4.8 (1M)", long: "Claude 4.8 Opus (1M)" },
   [LlmModel.CLAUDE_4_8_OPUS_200K]: { short: "Opus 4.8", long: "Claude 4.8 Opus" },
   [LlmModel.CLAUDE_4_7_OPUS]: { short: "Opus 4.7 (1M)", long: "Claude 4.7 Opus (1M)" },
@@ -24,7 +30,8 @@ const modelNames: Partial<Record<LlmModel, { short: string; long: string }>> = {
   [LlmModel.CLAUDE_4_SONNET]: { short: "Sonnet (1M)", long: "Claude 4.6 Sonnet (1M)" },
   [LlmModel.CLAUDE_4_SONNET_200K]: { short: "Sonnet", long: "Claude 4.6 Sonnet" },
   [LlmModel.CLAUDE_4_HAIKU]: { short: "Haiku", long: "Claude 4.5 Haiku" },
-  [LlmModel.CLAUDE_FABLE_5]: { short: "Fable", long: "Fable" },
+  [LlmModel.CLAUDE_FABLE_5]: { short: "Fable 5", long: "Fable 5" },
+  [LlmModel.CLAUDE_FABLE_5_1]: { short: "Fable 5.1", long: "Fable 5.1" },
   [LlmModel.FAKE_CLAUDE]: { short: "Fake Claude", long: "Fake Claude" },
   [LlmModel.FAKE_CLAUDE_2]: { short: "Fake Claude 2", long: "Fake Claude 2" },
 } as const;
@@ -34,15 +41,14 @@ export const getModelLongName = (model: LlmModel): string => modelNames[model]?.
 
 // Models offered in production model pickers (desktop selector + mobile `+` menu).
 export const PRODUCTION_MODELS: ReadonlyArray<LlmModel> = [
+  LlmModel.CLAUDE_FABLE_5_1,
   LlmModel.CLAUDE_FABLE_5,
-  LlmModel.CLAUDE_4_OPUS_200K,
-  LlmModel.CLAUDE_4_OPUS,
+  LlmModel.CLAUDE_5_OPUS_200K,
+  LlmModel.CLAUDE_5_OPUS,
   LlmModel.CLAUDE_4_8_OPUS_200K,
   LlmModel.CLAUDE_4_8_OPUS,
   LlmModel.CLAUDE_4_7_OPUS_200K,
   LlmModel.CLAUDE_4_7_OPUS,
-  LlmModel.CLAUDE_4_6_OPUS_200K,
-  LlmModel.CLAUDE_4_6_OPUS,
   LlmModel.CLAUDE_4_SONNET_200K,
   LlmModel.CLAUDE_4_SONNET,
   LlmModel.CLAUDE_4_HAIKU,

--- a/sculptor/frontend/src/common/state/atoms/userConfig.ts
+++ b/sculptor/frontend/src/common/state/atoms/userConfig.ts
@@ -58,11 +58,10 @@ export const defaultModelAtom = atom<string>((get) => {
   if (lastUsedModel && isLlmModel(lastUsedModel)) {
     return lastUsedModel;
   }
-  // Product default when nothing else is selected. Fable is currently disabled
-  // with an indefinite timeline, so the default falls back to the 1M-context
-  // Opus (CLAUDE_4_OPUS, shown as "Opus 5 (1M)"; SCU-1576). Fable stays available
-  // in the switcher for if/when it returns.
-  return LlmModel.CLAUDE_4_OPUS;
+  // Product default when nothing else is selected: the current pinned Opus
+  // (CLAUDE_5_OPUS, the 1M-context "Opus 5 (1M)"; SCU-1576). Fable stays available
+  // in the switcher but is not the default.
+  return LlmModel.CLAUDE_5_OPUS;
 });
 
 // User identity settings

--- a/sculptor/frontend/src/common/useManagedDependency.test.tsx
+++ b/sculptor/frontend/src/common/useManagedDependency.test.tsx
@@ -62,7 +62,7 @@ describe("useManagedDependency", () => {
       makeStatus({
         pi: makeInfo({
           installed: true,
-          version: "0.80.10",
+          version: "0.84.4",
           mode: "MANAGED",
           source: "MANAGED",
           isVersionInRange: true,
@@ -88,7 +88,7 @@ describe("useManagedDependency", () => {
       makeStatus({
         pi: makeInfo({
           installed: true,
-          version: "0.80.10",
+          version: "0.84.4",
           mode: "MANAGED",
           source: "EXTERNAL",
           isVersionInRange: true,

--- a/sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx
+++ b/sculptor/frontend/src/stories/custom/DependenciesSettingsSection.stories.tsx
@@ -12,7 +12,7 @@ const piNotInstalled = {
   version: null,
   isOverride: false,
   mode: null,
-  versionRange: { minVersion: "0.80.10", maxVersion: "0.80.10", recommendedVersion: "0.80.10" },
+  versionRange: { minVersion: "0.84.4", maxVersion: "0.84.4", recommendedVersion: "0.84.4" },
   isVersionInRange: null,
 } as const;
 

--- a/sculptor/sculptor-plugin/skills/build-sculptor-extension/sdk.d.ts
+++ b/sculptor/sculptor-plugin/skills/build-sculptor-extension/sdk.d.ts
@@ -442,6 +442,8 @@ export type HarnessCapabilities = {
 declare const LlmModel: {
 	readonly CLAUDE_4_OPUS: "CLAUDE-4-OPUS";
 	readonly CLAUDE_4_OPUS_200K: "CLAUDE-4-OPUS-200K";
+	readonly CLAUDE_5_OPUS: "CLAUDE-5-OPUS";
+	readonly CLAUDE_5_OPUS_200K: "CLAUDE-5-OPUS-200K";
 	readonly CLAUDE_4_8_OPUS: "CLAUDE-4-8-OPUS";
 	readonly CLAUDE_4_8_OPUS_200K: "CLAUDE-4-8-OPUS-200K";
 	readonly CLAUDE_4_7_OPUS: "CLAUDE-4-7-OPUS";
@@ -452,11 +454,33 @@ declare const LlmModel: {
 	readonly CLAUDE_4_SONNET_200K: "CLAUDE-4-SONNET-200K";
 	readonly CLAUDE_4_HAIKU: "CLAUDE-4-HAIKU";
 	readonly CLAUDE_FABLE_5: "CLAUDE-FABLE-5";
+	readonly CLAUDE_FABLE_5_1: "CLAUDE-FABLE-5-1";
 	readonly FAKE_CLAUDE: "FAKE_CLAUDE";
 	readonly FAKE_CLAUDE_2: "FAKE_CLAUDE_2";
 };
 /**
  * LLMModel
+ *
+ * Built-in (Claude-harness) model identities.
+ *
+ * Append-only: every value is persisted (chat messages carry ``model_name``,
+ * workspaces carry ``default_model``), so a value may be RETIRED from the picker
+ * but never renamed or deleted — old rows must always deserialize. The
+ * user-facing catalog is curated separately (frontend ``PRODUCTION_MODELS`` +
+ * ``web/derived.py``), not by this enum's membership. Each member's name matches
+ * the real model; ``MODEL_SHORTNAME_MAP`` maps it to the exact ``--model`` id.
+ *
+ * Per-release runbook (surface the newest generation, drop the oldest):
+ * 1. Add explicit members here named after the real model, and map each to its
+ * exact ``--model`` id in ``MODEL_SHORTNAME_MAP`` (agents/default/constants.py).
+ * 2. Label + capability-gate them (``modelConstants.ts``, ``modelCapabilities.ts``),
+ * prepend to ``PRODUCTION_MODELS``, and add to ``derived.py``'s streaming list.
+ * 3. Point the product default at the new member (``userConfig.ts``
+ * ``defaultModelAtom`` and ``web/derived.py``'s fallback).
+ * 4. Drop the oldest generation from the picker (remove from ``PRODUCTION_MODELS``
+ * / ``derived`` lists only — keep its enum value here for load-compat).
+ * 5. Regenerate the API types + extension SDK + frozen schema, and bump the
+ * managed Claude CLI (``CLAUDE_VERSION_RANGE``) to a build that knows the id.
  */
 export type LlmModel = typeof LlmModel[keyof typeof LlmModel];
 declare const ModelCatalogState: {

--- a/sculptor/sculptor/agents/default/constants.py
+++ b/sculptor/sculptor/agents/default/constants.py
@@ -17,6 +17,8 @@ FILE_CHANGE_TOOL_NAMES: Final[tuple[AgentToolName, ...]] = (
 MODEL_SHORTNAME_MAP: Final[dict[LLMModel, str]] = {
     LLMModel.CLAUDE_4_OPUS: "opus[1m]",
     LLMModel.CLAUDE_4_OPUS_200K: "opus",
+    LLMModel.CLAUDE_5_OPUS: "claude-opus-5[1m]",
+    LLMModel.CLAUDE_5_OPUS_200K: "claude-opus-5",
     LLMModel.CLAUDE_4_8_OPUS: "claude-opus-4-8[1m]",
     LLMModel.CLAUDE_4_8_OPUS_200K: "claude-opus-4-8",
     LLMModel.CLAUDE_4_7_OPUS: "claude-opus-4-7[1m]",
@@ -27,6 +29,7 @@ MODEL_SHORTNAME_MAP: Final[dict[LLMModel, str]] = {
     LLMModel.CLAUDE_4_SONNET_200K: "sonnet",
     LLMModel.CLAUDE_4_HAIKU: "haiku",
     LLMModel.CLAUDE_FABLE_5: "claude-fable-5",
+    LLMModel.CLAUDE_FABLE_5_1: "claude-fable-5-1",
 }
 
 

--- a/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
+++ b/sculptor/sculptor/agents/pi_agent/agent_wrapper_test.py
@@ -287,7 +287,7 @@ def _make_start_env(persisted_session_id: str | None = None) -> MagicMock:
     env.get_tool_binary_path.return_value = "/bin/pi"
     version_result = MagicMock()
     version_result.stdout = ""
-    version_result.stderr = "pi 0.80.10\n"
+    version_result.stderr = "pi 0.84.4\n"
     env.run_process_to_completion.return_value = version_result
     env.get_state_path.return_value = Path("/fake/state")
     env.get_system_prompt.return_value = ""
@@ -691,7 +691,7 @@ def _make_probe_env(probe_process: MagicMock) -> MagicMock:
     env.get_tool_binary_path.return_value = "/bin/pi"
     version_result = MagicMock()
     version_result.stdout = ""
-    version_result.stderr = "pi 0.80.10\n"
+    version_result.stderr = "pi 0.84.4\n"
     env.run_process_to_completion.return_value = version_result
     env.get_state_path.return_value = Path("/fake/state")
     env.run_process_in_background.return_value = probe_process
@@ -2509,7 +2509,7 @@ class TestStartAndSessionResume:
         agent = _make_agent(env)
         with pytest.raises(PiVersionMismatchError) as exc_info:
             agent.start(secrets={})
-        assert exc_info.value.pinned_version == "0.80.10"
+        assert exc_info.value.pinned_version == "0.84.4"
         assert exc_info.value.detected_version == "0.50.0"
         # The message must point the user at the self-healing fix (managed install).
         assert "Managed" in str(exc_info.value)

--- a/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
+++ b/sculptor/sculptor/database/alembic/frozen_pydantic_schemas.json
@@ -571,9 +571,12 @@
             "type": "string"
           },
           "LLMModel": {
+            "description": "Built-in (Claude-harness) model identities.\n\nAppend-only: every value is persisted (chat messages carry ``model_name``,\nworkspaces carry ``default_model``), so a value may be RETIRED from the picker\nbut never renamed or deleted \u2014 old rows must always deserialize. The\nuser-facing catalog is curated separately (frontend ``PRODUCTION_MODELS`` +\n``web/derived.py``), not by this enum's membership. Each member's name matches\nthe real model; ``MODEL_SHORTNAME_MAP`` maps it to the exact ``--model`` id.\n\nPer-release runbook (surface the newest generation, drop the oldest):\n  1. Add explicit members here named after the real model, and map each to its\n     exact ``--model`` id in ``MODEL_SHORTNAME_MAP`` (agents/default/constants.py).\n  2. Label + capability-gate them (``modelConstants.ts``, ``modelCapabilities.ts``),\n     prepend to ``PRODUCTION_MODELS``, and add to ``derived.py``'s streaming list.\n  3. Point the product default at the new member (``userConfig.ts``\n     ``defaultModelAtom`` and ``web/derived.py``'s fallback).\n  4. Drop the oldest generation from the picker (remove from ``PRODUCTION_MODELS``\n     / ``derived`` lists only \u2014 keep its enum value here for load-compat).\n  5. Regenerate the API types + extension SDK + frozen schema, and bump the\n     managed Claude CLI (``CLAUDE_VERSION_RANGE``) to a build that knows the id.",
             "enum": [
               "CLAUDE-4-OPUS",
               "CLAUDE-4-OPUS-200K",
+              "CLAUDE-5-OPUS",
+              "CLAUDE-5-OPUS-200K",
               "CLAUDE-4-8-OPUS",
               "CLAUDE-4-8-OPUS-200K",
               "CLAUDE-4-7-OPUS",
@@ -584,6 +587,7 @@
               "CLAUDE-4-SONNET-200K",
               "CLAUDE-4-HAIKU",
               "CLAUDE-FABLE-5",
+              "CLAUDE-FABLE-5-1",
               "FAKE_CLAUDE",
               "FAKE_CLAUDE_2"
             ],
@@ -2011,9 +2015,12 @@
             ]
           },
           "LLMModel": {
+            "description": "Built-in (Claude-harness) model identities.\n\nAppend-only: every value is persisted (chat messages carry ``model_name``,\nworkspaces carry ``default_model``), so a value may be RETIRED from the picker\nbut never renamed or deleted \u2014 old rows must always deserialize. The\nuser-facing catalog is curated separately (frontend ``PRODUCTION_MODELS`` +\n``web/derived.py``), not by this enum's membership. Each member's name matches\nthe real model; ``MODEL_SHORTNAME_MAP`` maps it to the exact ``--model`` id.\n\nPer-release runbook (surface the newest generation, drop the oldest):\n  1. Add explicit members here named after the real model, and map each to its\n     exact ``--model`` id in ``MODEL_SHORTNAME_MAP`` (agents/default/constants.py).\n  2. Label + capability-gate them (``modelConstants.ts``, ``modelCapabilities.ts``),\n     prepend to ``PRODUCTION_MODELS``, and add to ``derived.py``'s streaming list.\n  3. Point the product default at the new member (``userConfig.ts``\n     ``defaultModelAtom`` and ``web/derived.py``'s fallback).\n  4. Drop the oldest generation from the picker (remove from ``PRODUCTION_MODELS``\n     / ``derived`` lists only \u2014 keep its enum value here for load-compat).\n  5. Regenerate the API types + extension SDK + frozen schema, and bump the\n     managed Claude CLI (``CLAUDE_VERSION_RANGE``) to a build that knows the id.",
             "enum": [
               "CLAUDE-4-OPUS",
               "CLAUDE-4-OPUS-200K",
+              "CLAUDE-5-OPUS",
+              "CLAUDE-5-OPUS-200K",
               "CLAUDE-4-8-OPUS",
               "CLAUDE-4-8-OPUS-200K",
               "CLAUDE-4-7-OPUS",
@@ -2024,6 +2031,7 @@
               "CLAUDE-4-SONNET-200K",
               "CLAUDE-4-HAIKU",
               "CLAUDE-FABLE-5",
+              "CLAUDE-FABLE-5-1",
               "FAKE_CLAUDE",
               "FAKE_CLAUDE_2"
             ],
@@ -2977,9 +2985,12 @@
             "type": "object"
           },
           "LLMModel": {
+            "description": "Built-in (Claude-harness) model identities.\n\nAppend-only: every value is persisted (chat messages carry ``model_name``,\nworkspaces carry ``default_model``), so a value may be RETIRED from the picker\nbut never renamed or deleted \u2014 old rows must always deserialize. The\nuser-facing catalog is curated separately (frontend ``PRODUCTION_MODELS`` +\n``web/derived.py``), not by this enum's membership. Each member's name matches\nthe real model; ``MODEL_SHORTNAME_MAP`` maps it to the exact ``--model`` id.\n\nPer-release runbook (surface the newest generation, drop the oldest):\n  1. Add explicit members here named after the real model, and map each to its\n     exact ``--model`` id in ``MODEL_SHORTNAME_MAP`` (agents/default/constants.py).\n  2. Label + capability-gate them (``modelConstants.ts``, ``modelCapabilities.ts``),\n     prepend to ``PRODUCTION_MODELS``, and add to ``derived.py``'s streaming list.\n  3. Point the product default at the new member (``userConfig.ts``\n     ``defaultModelAtom`` and ``web/derived.py``'s fallback).\n  4. Drop the oldest generation from the picker (remove from ``PRODUCTION_MODELS``\n     / ``derived`` lists only \u2014 keep its enum value here for load-compat).\n  5. Regenerate the API types + extension SDK + frozen schema, and bump the\n     managed Claude CLI (``CLAUDE_VERSION_RANGE``) to a build that knows the id.",
             "enum": [
               "CLAUDE-4-OPUS",
               "CLAUDE-4-OPUS-200K",
+              "CLAUDE-5-OPUS",
+              "CLAUDE-5-OPUS-200K",
               "CLAUDE-4-8-OPUS",
               "CLAUDE-4-8-OPUS-200K",
               "CLAUDE-4-7-OPUS",
@@ -2990,6 +3001,7 @@
               "CLAUDE-4-SONNET-200K",
               "CLAUDE-4-HAIKU",
               "CLAUDE-FABLE-5",
+              "CLAUDE-FABLE-5-1",
               "FAKE_CLAUDE",
               "FAKE_CLAUDE_2"
             ],

--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -68,15 +68,15 @@ PI_PIN = PiPin(
     platforms={
         "darwin-arm64": PlatformPin(
             asset="pi-darwin-arm64.tar.gz",
-            sha256="4406ed227c486f2e3c16cf14f793dc3ad46b5d01bf69135a2424cffa58a9a34b",
+            sha256="c68e3ac4d05b4e282aaab2e6c76f161d3e9e68f19a22e38913cbfaadb6c800f0",
         ),
         "darwin-x64": PlatformPin(
             asset="pi-darwin-x64.tar.gz",
-            sha256="892b3f385ae6779299c07a25d9280183897fcf755f7226f6b36c70d268f321be",
+            sha256="7a042d6413065421387001a4986190a1a03186c95a695f4dee0bdc76e60de8f7",
         ),
         "linux-x64": PlatformPin(
             asset="pi-linux-x64.tar.gz",
-            sha256="ab6604f6c3f3d050783e7abbbdd1f79b775b20f3969833ce9721740685d01e13",
+            sha256="c2f3c3e6a1850bd87654cc3ca8811013272397c3d042a4e2a64c43ee1b423972",
         ),
     },
 )
@@ -249,9 +249,9 @@ CLAUDE_VERSION_RANGE = VersionRange(
     # against this failure. Do not lower this without re-validating that case.
     min_version="2.1.202",
     max_version="2.99.99",
-    # Recommended is the latest validated release; bumped to pull in Claude
-    # Opus 5 support (SCU-1841).
-    recommended_version="2.1.222",
+    # Recommended is the latest validated release; bumped to 2.1.258 to pull in
+    # Claude Fable 5.1 (`claude-fable-5-1`), which earlier CLIs do not recognize.
+    recommended_version="2.1.258",
     # Blocked versions create background tool invocations that are missing events
     # describing them.
     blocked_versions=(BlockedVersionRange(min_version="2.1.101", max_version="2.1.101"),),

--- a/sculptor/sculptor/services/managed_tools_test.py
+++ b/sculptor/sculptor/services/managed_tools_test.py
@@ -25,8 +25,8 @@ from sculptor.services.managed_tools import _PI_PLATFORM_MAP
 from sculptor.services.managed_tools import get_managed_tool
 from sculptor.services.managed_tools import get_managed_tools
 
-# Verified darwin-arm64 sha256 for pi 0.80.10; ``just bump-pi <version>`` refreshes it.
-_PI_DARWIN_ARM64_SHA256_0_80_10 = "4406ed227c486f2e3c16cf14f793dc3ad46b5d01bf69135a2424cffa58a9a34b"
+# Verified darwin-arm64 sha256 for pi 0.84.4; ``just bump-pi <version>`` refreshes it.
+_PI_DARWIN_ARM64_SHA256_0_84_4 = "c68e3ac4d05b4e282aaab2e6c76f161d3e9e68f19a22e38913cbfaadb6c800f0"
 
 
 def _instantiate_with_no_arguments(candidate: Callable[[], object]) -> object:
@@ -100,7 +100,7 @@ def test_pi_pin_asset_names_follow_the_pi_release_naming_for_each_platform() -> 
 
 
 def test_pi_pin_darwin_arm64_sha256_matches_the_verified_value() -> None:
-    assert PI_PIN.platforms["darwin-arm64"].sha256 == _PI_DARWIN_ARM64_SHA256_0_80_10
+    assert PI_PIN.platforms["darwin-arm64"].sha256 == _PI_DARWIN_ARM64_SHA256_0_84_4
 
 
 def test_pi_pin_platform_sha256s_are_distinct_lowercase_hex_digests() -> None:

--- a/sculptor/sculptor/services/pi_version.py
+++ b/sculptor/sculptor/services/pi_version.py
@@ -7,4 +7,4 @@ here — in its own import-free module — so the test harness's ``fake_pi`` stu
 module import-free.
 """
 
-PI_PINNED_VERSION = "0.80.10"
+PI_PINNED_VERSION = "0.84.4"

--- a/sculptor/sculptor/state/messages.py
+++ b/sculptor/sculptor/state/messages.py
@@ -12,10 +12,37 @@ from sculptor.state.chat_state import ContentBlockTypes
 
 
 class LLMModel(StrEnum):
-    # Rolling "latest Opus" (shortnames `opus[1m]` / `opus`), relabeled per generation.
+    """Built-in (Claude-harness) model identities.
+
+    Append-only: every value is persisted (chat messages carry ``model_name``,
+    workspaces carry ``default_model``), so a value may be RETIRED from the picker
+    but never renamed or deleted — old rows must always deserialize. The
+    user-facing catalog is curated separately (frontend ``PRODUCTION_MODELS`` +
+    ``web/derived.py``), not by this enum's membership. Each member's name matches
+    the real model; ``MODEL_SHORTNAME_MAP`` maps it to the exact ``--model`` id.
+
+    Per-release runbook (surface the newest generation, drop the oldest):
+      1. Add explicit members here named after the real model, and map each to its
+         exact ``--model`` id in ``MODEL_SHORTNAME_MAP`` (agents/default/constants.py).
+      2. Label + capability-gate them (``modelConstants.ts``, ``modelCapabilities.ts``),
+         prepend to ``PRODUCTION_MODELS``, and add to ``derived.py``'s streaming list.
+      3. Point the product default at the new member (``userConfig.ts``
+         ``defaultModelAtom`` and ``web/derived.py``'s fallback).
+      4. Drop the oldest generation from the picker (remove from ``PRODUCTION_MODELS``
+         / ``derived`` lists only — keep its enum value here for load-compat).
+      5. Regenerate the API types + extension SDK + frozen schema, and bump the
+         managed Claude CLI (``CLAUDE_VERSION_RANGE``) to a build that knows the id.
+    """
+
+    # Rolling "latest Opus" alias (shortnames `opus[1m]` / `opus`). Retired from the
+    # GUI picker in favor of the explicit per-generation members below, but kept
+    # defined: old persisted rows still deserialize, and the `sculpt` CLI's `opus`
+    # alias resolves through it to whatever the CLI treats as the newest Opus.
     CLAUDE_4_OPUS = "CLAUDE-4-OPUS"
     CLAUDE_4_OPUS_200K = "CLAUDE-4-OPUS-200K"
-    # Pinned Opus generations.
+    # Pinned Opus generations (explicit `--model` ids), newest first.
+    CLAUDE_5_OPUS = "CLAUDE-5-OPUS"
+    CLAUDE_5_OPUS_200K = "CLAUDE-5-OPUS-200K"
     CLAUDE_4_8_OPUS = "CLAUDE-4-8-OPUS"
     CLAUDE_4_8_OPUS_200K = "CLAUDE-4-8-OPUS-200K"
     CLAUDE_4_7_OPUS = "CLAUDE-4-7-OPUS"
@@ -25,7 +52,9 @@ class LLMModel(StrEnum):
     CLAUDE_4_SONNET = "CLAUDE-4-SONNET"
     CLAUDE_4_SONNET_200K = "CLAUDE-4-SONNET-200K"
     CLAUDE_4_HAIKU = "CLAUDE-4-HAIKU"
+    # Fable (frontier line; single-context entries, no 1M/200K split).
     CLAUDE_FABLE_5 = "CLAUDE-FABLE-5"
+    CLAUDE_FABLE_5_1 = "CLAUDE-FABLE-5-1"
     FAKE_CLAUDE = "FAKE_CLAUDE"
     FAKE_CLAUDE_2 = "FAKE_CLAUDE_2"
 

--- a/sculptor/sculptor/web/derived.py
+++ b/sculptor/sculptor/web/derived.py
@@ -418,14 +418,12 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
             if isinstance(message, ChatInputUserMessage) and message.model_name is not None:
                 return message.model_name
         # Fall back to the model selected at agent creation time, then to the
-        # product default. Fable is currently disabled with an indefinite
-        # timeline, so the default falls back to the 1M-context Opus
-        # (CLAUDE_4_OPUS, shown as "Opus 5 (1M)"; SCU-1576); Fable stays available
-        # in the switcher for if/when it returns.
+        # product default: the pinned 1M-context Opus (CLAUDE_5_OPUS). Fable stays
+        # available in the switcher but is not the default (SCU-1576).
         input_data = self.task.input_data
         if isinstance(input_data, AgentTaskInputsV2) and input_data.default_model is not None:
             return input_data.default_model
-        return LLMModel.CLAUDE_4_OPUS
+        return LLMModel.CLAUDE_5_OPUS
 
     @computed_field
     @property
@@ -484,6 +482,8 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
             LLMModel.CLAUDE_4_SONNET_200K,
             LLMModel.CLAUDE_4_OPUS,
             LLMModel.CLAUDE_4_OPUS_200K,
+            LLMModel.CLAUDE_5_OPUS,
+            LLMModel.CLAUDE_5_OPUS_200K,
             LLMModel.CLAUDE_4_8_OPUS,
             LLMModel.CLAUDE_4_8_OPUS_200K,
             LLMModel.CLAUDE_4_7_OPUS,
@@ -492,6 +492,7 @@ class CodingAgentTaskView(TaskView[AgentTaskInputsV2, AgentTaskStateV2]):
             LLMModel.CLAUDE_4_6_OPUS_200K,
             LLMModel.CLAUDE_4_HAIKU,
             LLMModel.CLAUDE_FABLE_5,
+            LLMModel.CLAUDE_FABLE_5_1,
             LLMModel.FAKE_CLAUDE,
             LLMModel.FAKE_CLAUDE_2,
         )

--- a/sculptor/tests/integration/frontend/test_model_capability_gating.py
+++ b/sculptor/tests/integration/frontend/test_model_capability_gating.py
@@ -2,9 +2,9 @@
 
 Verifies that:
 - The fast mode toggle is capability-gated: visible for the fast-mode-capable
-  Opus generations (rolling Opus 5, pinned 4.8 and 4.6) and hidden for models
+  Opus generations (pinned Opus 5, 4.8 and 4.7) and hidden for models
   that don't support it (e.g. Sonnet)
-- The fast mode draft state is preserved when switching away from Opus 4.6 and back
+- The fast mode draft state is preserved when switching away from Opus 4.7 and back
 - The model selector is isolated per agent (changing one agent's model doesn't bleed to others)
 """
 
@@ -22,7 +22,7 @@ from sculptor.testing.user_stories import user_story
 # Long display names as they appear in the model selector dropdown (ModelSelectOptions uses getModelLongName).
 _OPUS_48_1M_MODEL_NAME = "Claude 4.8 Opus (1M)"
 _OPUS_48_MODEL_NAME = "Claude 4.8 Opus"
-_OPUS_46_MODEL_NAME = "Claude 4.6 Opus (1M)"
+_OPUS_47_MODEL_NAME = "Claude 4.7 Opus (1M)"
 _SONNET_MODEL_NAME = "Claude 4.6 Sonnet"
 _OPUS_5_1M_MODEL_NAME = "Claude 5 Opus (1M)"
 _OPUS_5_MODEL_NAME = "Claude 5 Opus"
@@ -31,12 +31,12 @@ _OPUS_5_MODEL_NAME = "Claude 5 Opus"
 @user_story("to see the fast mode toggle only for models that support fast mode")
 def test_fast_mode_toggle_gated_by_model(sculptor_instance_: SculptorInstance) -> None:
     """Fast mode toggle is gated by model capability: present for a fast-mode
-    model (Opus 4.6), absent for one that isn't (Sonnet).
+    model (Opus 4.7), absent for one that isn't (Sonnet).
 
     Steps:
     1. Start with Fake Claude (which supports fast mode for testing) — toggle visible.
     2. Switch to Sonnet — toggle must disappear.
-    3. Switch to Opus 4.6 — toggle must reappear.
+    3. Switch to Opus 4.7 — toggle must reappear.
     """
     page = sculptor_instance_.page
 
@@ -55,18 +55,18 @@ def test_fast_mode_toggle_gated_by_model(sculptor_instance_: SculptorInstance) -
     select_model_by_name(chat_panel, _SONNET_MODEL_NAME)
     expect(chat_panel.get_fast_mode_toggle()).not_to_be_visible()
 
-    # Switch to Opus 4.6 — fast mode is supported, toggle must reappear.
-    select_model_by_name(chat_panel, _OPUS_46_MODEL_NAME)
+    # Switch to Opus 4.7 — fast mode is supported, toggle must reappear.
+    select_model_by_name(chat_panel, _OPUS_47_MODEL_NAME)
     expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
 
 
 @user_story("to see the fast mode toggle when Opus 4.8 is selected")
 def test_fast_mode_toggle_visible_for_opus_48(sculptor_instance_: SculptorInstance) -> None:
-    """Fast mode toggle must be present for the pinned Opus 4.8, like 4.7 and 4.6.
+    """Fast mode toggle must be present for the pinned Opus 4.8, like 4.7.
 
-    Opus 4.8 is now the pinned CLAUDE_4_8_OPUS / CLAUDE_4_8_OPUS_200K entry (the
-    generic CLAUDE_4_OPUS values surface Opus 5; SCU-1841). Both pinned variants
-    set supportsFastMode: true in modelCapabilities.ts, so the toggle appears for
+    Opus 4.8 is the pinned CLAUDE_4_8_OPUS / CLAUDE_4_8_OPUS_200K entry (Opus 5 is
+    its own pinned CLAUDE_5_OPUS entry; SCU-1841). Both pinned 4.8 variants set
+    supportsFastMode: true in modelCapabilities.ts, so the toggle appears for
     each.
 
     Steps:
@@ -103,10 +103,10 @@ def test_fast_mode_toggle_visible_for_opus_48(sculptor_instance_: SculptorInstan
 
 @user_story("to see the fast mode toggle when Opus 5 is selected")
 def test_fast_mode_toggle_visible_for_opus_5(sculptor_instance_: SculptorInstance) -> None:
-    """Fast mode toggle must be present for the rolling Opus 5 entries (SCU-1841).
+    """Fast mode toggle must be present for the pinned Opus 5 entries (SCU-1841).
 
-    CLAUDE_4_OPUS / CLAUDE_4_OPUS_200K are the rolling "latest Opus" entries,
-    now surfaced as "Claude 5 Opus". Fast mode is supported on Opus 5, so the
+    CLAUDE_5_OPUS / CLAUDE_5_OPUS_200K are the pinned explicit "Opus 5" entries
+    (surfaced as "Claude 5 Opus"). Fast mode is supported on Opus 5, so the
     toggle must appear for both the 1M and 200K variants.
 
     Steps:
@@ -141,15 +141,15 @@ def test_fast_mode_toggle_visible_for_opus_5(sculptor_instance_: SculptorInstanc
     expect(chat_panel.get_fast_mode_toggle()).to_be_visible()
 
 
-@user_story("to have my fast mode preference remembered when switching back to Opus 4.6")
+@user_story("to have my fast mode preference remembered when switching back to Opus 4.7")
 def test_fast_mode_draft_survives_model_switch(sculptor_instance_: SculptorInstance) -> None:
-    """Fast mode draft state should be preserved when the user switches away from Opus 4.6 and back.
+    """Fast mode draft state should be preserved when the user switches away from Opus 4.7 and back.
 
     Steps:
-    1. Switch to Opus 4.6 — fast mode toggle appears (inactive by default).
+    1. Switch to Opus 4.7 — fast mode toggle appears (inactive by default).
     2. Enable fast mode.
     3. Switch to Sonnet — toggle disappears.
-    4. Switch back to Opus 4.6 — toggle reappears and should still be active.
+    4. Switch back to Opus 4.7 — toggle reappears and should still be active.
     """
     page = sculptor_instance_.page
 
@@ -161,8 +161,8 @@ def test_fast_mode_draft_survives_model_switch(sculptor_instance_: SculptorInsta
     chat_panel = task_page.get_chat_panel()
     wait_for_completed_message_count(chat_panel=chat_panel, expected_message_count=2)
 
-    # Switch to Opus 4.6 and verify the toggle is present but inactive.
-    select_model_by_name(chat_panel, _OPUS_46_MODEL_NAME)
+    # Switch to Opus 4.7 and verify the toggle is present but inactive.
+    select_model_by_name(chat_panel, _OPUS_47_MODEL_NAME)
     toggle = chat_panel.get_fast_mode_toggle()
     expect(toggle).to_be_visible()
     expect(toggle).to_have_attribute("data-active", "false")
@@ -175,8 +175,8 @@ def test_fast_mode_draft_survives_model_switch(sculptor_instance_: SculptorInsta
     select_model_by_name(chat_panel, _SONNET_MODEL_NAME)
     expect(chat_panel.get_fast_mode_toggle()).not_to_be_visible()
 
-    # Switch back to Opus 4.6 — the draft should be preserved: toggle is active.
-    select_model_by_name(chat_panel, _OPUS_46_MODEL_NAME)
+    # Switch back to Opus 4.7 — the draft should be preserved: toggle is active.
+    select_model_by_name(chat_panel, _OPUS_47_MODEL_NAME)
     expect(chat_panel.get_fast_mode_toggle()).to_have_attribute("data-active", "true")
 
 

--- a/sculptor/tests/integration/regression/test_regression_default_model_opus.py
+++ b/sculptor/tests/integration/regression/test_regression_default_model_opus.py
@@ -17,7 +17,7 @@ from sculptor.testing.sculptor_instance import SculptorInstance
 from sculptor.testing.user_stories import user_story
 
 # The chat-panel model selector renders the model's short name; "Opus 5 (1M)" is
-# the short name for CLAUDE_4_OPUS, the 1M-context Opus (see frontend
+# the short name for CLAUDE_5_OPUS, the pinned 1M-context Opus 5 (see frontend
 # modelConstants.ts). The plain "Opus 5" short name is the 200K variant.
 OPUS_MODEL_NAME = "Opus 5 (1M)"
 


### PR DESCRIPTION
## What

Move the built-in (Claude-harness) model picker to an explicit, append-only scheme and surface the newest models.

- **Add** pinned **Opus 5** (`claude-opus-5`, 1M + 200K) and **Fable 5.1** (`claude-fable-5-1`); relabel "Fable" → "Fable 5".
- **Retire** the rolling `CLAUDE_4_OPUS` alias from the picker (kept defined for DB load-compat + the `sculpt opus` shortcut), **drop Opus 4.6**, and set the product default to **Opus 5 (1M)**.
- Document a per-release runbook on the `LLMModel` enum so future model additions are mechanical.
- Regenerate API types, extension SDK (`sdk.d.ts`), and the frozen schema; update the model-capability + default-model tests, `SPEC.md`, and `requirements.md`.

## Versions

- **Claude CLI → 2.1.258** — the `latest` channel; the build that ships `claude-fable-5-1` (stable 2.1.236 does not).
- **pi → 0.84.4** — via `just bump-pi` (pin + hardcoded copies, cross-checked against upstream SHA256SUMS).

## Notes

- There is **no Opus 5.1** in any shipping client (Opus tops out at `claude-opus-5`) — hence pinning Opus 5.
- Mythos 5 / 5.1 exist in the CLI but are intentionally left off (access-gated).
- The new enum values are additive, so only the frozen JSON schema needed refreshing; no data migration.

## Verification

- `just format` / `just check` / `just test-unit` — green.
- pi 0.84.4 RPC smoke-test: `get_state` + `get_available_models` handshake OK; 333/333 model dicts map cleanly through `model_option_from_pi`.
- Manual QA (headless app): the default resolves to "Opus 5 (1M)"; the picker shows Fable 5.1 / Fable 5 / Opus 5 (1M + 200K) / 4.8 / 4.7 / Sonnet 4.6 / Haiku 4.5 with **no Opus 4.6** and no rolling entry; a real Opus 5 turn ran end-to-end via the 2.1.258 CLI (return code 0).

(Sent by Claude)
