### PR TITLE
Raise managed Claude CLI floor to 2.1.258 (0.47 release branch → rc2)

### DIFF
--- a/sculptor/sculptor/services/managed_tools.py
+++ b/sculptor/sculptor/services/managed_tools.py
@@ -240,14 +240,10 @@ _CLAUDE_MANIFEST_FETCH_TIMEOUT_SECONDS = 30.0
 # the existing service -> managed_tools edge, which would be an import cycle. The
 # service re-imports this constant for its status / version-range logic.
 CLAUDE_VERSION_RANGE = VersionRange(
-    # Floor is 2.1.202: earlier releases mishandle a session resume that carries
-    # `stopped` background-task notifications (left over from tasks killed by a
-    # prior interrupt). The CLI can deliver such a notification so that the user
-    # turn being awaited never emits its own terminating `result`, which wedges
-    # the chat in a perpetual "streaming" state. The resume-of-background-tasks
-    # path was reworked in 2.1.198; 2.1.202 is the earliest release validated
-    # against this failure. Do not lower this without re-validating that case.
-    min_version="2.1.202",
+    # Keep the floor at recommended: an in-range managed binary is never upgraded to
+    # recommended (auto-install and the "up to date" status both gate on range, not
+    # recommended), so a lower floor strands old installs.
+    min_version="2.1.258",
     max_version="2.99.99",
     # Recommended is the latest validated release; bumped to 2.1.258 to pull in
     # Claude Fable 5.1 (`claude-fable-5-1`), which earlier CLIs do not recognize.


### PR DESCRIPTION
## What

Bump `CLAUDE_VERSION_RANGE.min_version` for the managed Claude CLI from `2.1.202` to `2.1.258` (the current `recommended_version`). This PR targets the `release/sculptor-v0.47.0` branch.

## Why

The managed-binary updater gates on **version-range membership, not the recommended version**, in two places:

- **Startup auto-install** skips any binary that `is_version_in_range` (`sculptor/sculptor/services/dependency_management_service.py`) — it never pulls `recommended_version` for an already in-range binary.
- **The Settings "Up to date" label** is `mode === "MANAGED" && source === "MANAGED" && isVersionInRange` (`sculptor/frontend/src/pages/settings/hooks/useManagedDependency.ts`) — it never compares against `recommended_version` either.

The floor has been `2.1.202` since 0.42.0, so a managed binary anywhere in `[2.1.202, 2.99.99]` reads as "Up to date" indefinitely and is never auto-bumped to the recommended build. Users who installed an older in-range CLI therefore never receive `2.1.258`, and **Claude Fable 5.1 (`claude-fable-5-1`), which earlier CLIs do not recognize, cannot be used.**

Raising the floor to `2.1.258` makes stale in-range installs read as out-of-range, so startup reinstalls the recommended build and Fable works.

## Release mechanics

This targets the **release branch**. Once merged, `just fixup-release` cuts **0.47.0rc2** (bumps `rc1 → rc2` and pushes the `sculptor-v0.47.0rc2` tag that triggers the RC build), and that rc2 will include this fix. Merging alone does not push a tag.

## Test impact

No behavior tests change:

- `dependency_management_service_test.py::TestVersionRange` checks the symbolic `recommended` (in range), `2.0.0` / `3.0.0` (out of range), and `@patch.object` synthetic ranges — all unaffected by the real constant.
- `test_blocked_version.py` stubs `2.1.101`; it is now out-of-range-low rather than blocked, but the backend collapses both to `is_version_in_range=False`, so the "version mismatch" + disabled-Continue assertions still hold. `blocked_versions` is retained (that test indexes `blocked_versions[0]`).

Verified locally: `ruff format` / `ruff check` clean; `managed_tools_test.py` + `dependency_management_service_test.py` → **144 passed**.

## Follow-up

`docs/specs/requirements.md` still states "minimum 2.1.202" — left to `/update-specs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
